### PR TITLE
Remove jar builds within containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build-base:
 	docker build -t kilda/opentsdb:latest services/opentsdb
 	docker build -t kilda/mininet:latest services/mininet
 
-build-latest: build-base
+build-latest: build-base compile
 	docker-compose build
 
 run-dev:
@@ -36,10 +36,21 @@ clean-sources:
 	$(MAKE) -C services/src clean
 	mvn -f services/wfm/pom.xml clean
 
-update:
-	mvn --non-recursive -f services/src/pom.xml clean install
-	mvn -f services/src/messaging/pom.xml clean install
-	mvn -f services/src/pce/pom.xml clean install
+update-parent:
+	mvn --non-recursive -f services/src/pom.xml install -DskipTests
+
+update-pce:
+	mvn -f services/src/pce/pom.xml install -DskipTests
+
+update-msg:
+	mvn -f services/src/messaging/pom.xml install -DskipTests
+
+update: update-parent update-msg update-pce
+
+
+compile:
+	$(MAKE) -C services/src
+	$(MAKE) -C services/wfm all-in-one
 
 unit:
 	$(MAKE) -C services/src

--- a/base/kilda-base-ubuntu/Dockerfile
+++ b/base/kilda-base-ubuntu/Dockerfile
@@ -53,6 +53,8 @@ ENV JAVA_VER 8
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 RUN echo "export JAVA_HOME=/usr/lib/jvm/java-8-oracle" >> ~/.bashrc
 
+RUN rm -rf /var/lib/apt/lists/*
 RUN apt-get clean
+RUN apt clean
 ADD app /app
 RUN chmod 777 /app/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,33 +97,6 @@ services:
       neo4j:
         condition: service_healthy
 
-####
-#### java-based topology-engine. It could replace python-based topology-engine.
-#### (carmine 17.06.07 - commenting out, migrate back to python based solution)
-#### -- This block is left here for reference.
-####
-#  topology:
-#    build:
-#      context: services
-#      dockerfile:  topology/Dockerfile
-#    image: "kilda/topology:${full_build_number:-latest}"
-#    command: java -jar /app/topology/target/topology.jar
-#    ports:
-#      - "80:80"
-#    links:
-#      - neo4j
-#      - kafka:kafka.pendev
-#    environment:
-#      NEO4J_USERNAME: 'neo4j'
-#      NEO4J_PASSWORD: 'temppass'
-#      REST_USERNAME: 'kilda'
-#      REST_PASSWORD: 'kilda'
-#    depends_on:
-#      kafka:
-#        condition: service_healthy
-#      neo4j:
-#        condition: service_healthy
-
   zookeeper:
     container_name: zookeeper
     image: "kilda/zookeeper:${full_build_number:-latest}"
@@ -163,11 +136,8 @@ services:
   wfm:
     container_name: wfm
     build:
-      context: services
-      dockerfile:  wfm/Dockerfile
+      context: services/wfm
     image: "kilda/wfm:${full_build_number:-latest}"
-    #command: /app/wfm-poc.py kafka.pendev:9092 kilda-test
-    command: /app/deploy_topos_and_monitor.sh topology.properties
     depends_on:
       kafka:
         condition: service_healthy
@@ -318,10 +288,8 @@ services:
 
   floodlight:
     build:
-      context: services
-      dockerfile:  floodlight/Dockerfile
+      context: services/src/floodlight-modules
     image: "kilda/floodlight:${full_build_number:-latest}"
-    command: java -Dlogback.configurationFile=/app/logback.xml -cp /app/floodlight/target/floodlight.jar:/app/floodlight-modules/target/floodlight-modules.jar net.floodlightcontroller.core.Main -cf /app/floodlightkilda.properties
     ports:
       - "6653:6653"
       - "8180:8080"
@@ -336,10 +304,7 @@ services:
 
   northbound:
     build:
-      context: services/
-      dockerfile:  northbound/Dockerfile
-    image: "kilda/northbound:${full_build_number:-latest}"
-    command: java -jar /app/northbound/target/northbound.jar
+      context: services/src/northbound/
     ports:
       - "8088:8080"
     links:

--- a/services/src/Makefile
+++ b/services/src/Makefile
@@ -9,6 +9,18 @@ projectfloodlight:
 build: projectfloodlight
 	mvn clean install
 
+build-pce:
+	mvn install -pl pce -am -DskipTests
+
+build-atdd:
+	mvn install -pl atdd -am -DskipTests
+
+build-northbound:
+	mvn install -pl northbound -am -DskipTests
+
+build-messaging:
+	mvn install -pl messaging -am -DskipTests
+
 clean:
 	mvn clean
 	$(MAKE) -C projectfloodlight clean

--- a/services/src/floodlight-modules/Dockerfile
+++ b/services/src/floodlight-modules/Dockerfile
@@ -15,11 +15,11 @@
 
 FROM kilda/base-floodlight
 
-ADD src/pom.xml /app/pom.xml
-ADD src/checkstyle.xml /app/checkstyle.xml
-ADD src/messaging /app/messaging
-RUN mvn -f /app/pom.xml --non-recursive clean install
-RUN mvn -f /app/messaging/pom.xml clean install
+ADD src/main/resources/floodlightkilda.properties /app
+ADD src/test/resources/logback.xml /app
+ADD target/floodlight-modules.jar /app/floodlight-modules/target/
 
-ADD src/northbound /app/northbound
-RUN mvn -f /app/northbound/pom.xml clean package
+CMD ["java", "-Dlogback.configurationFile=/app/logback.xml", "-cp", \
+     "/app/floodlight/target/floodlight.jar:/app/floodlight-modules/target/floodlight-modules.jar", \
+     "net.floodlightcontroller.core.Main", "-cf", "/app/floodlightkilda.properties"]
+

--- a/services/src/northbound/Dockerfile
+++ b/services/src/northbound/Dockerfile
@@ -15,12 +15,6 @@
 
 FROM kilda/base-floodlight
 
-ADD src/pom.xml /app/pom.xml
-ADD src/checkstyle.xml /app/checkstyle.xml
-ADD src/messaging /app/messaging
-RUN mvn -f /app/pom.xml --non-recursive clean install
-RUN mvn -f /app/messaging/pom.xml clean install
-
-ADD src/floodlight-modules /app/floodlight-modules
-RUN (cp /app/floodlight-modules/src/main/resources/floodlightkilda.properties /app && cp /app/floodlight-modules/src/test/resources/logback.xml /app)
-RUN mvn -f /app/floodlight-modules/pom.xml clean package
+ADD target/northbound.jar /app/
+WORKDIR /app
+CMD ["java","-jar","northbound.jar"]

--- a/services/topology-engine-rest/Dockerfile
+++ b/services/topology-engine-rest/Dockerfile
@@ -17,6 +17,7 @@ FROM kilda/base-ubuntu
 
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN apt-get update
 RUN apt-get install -y python-pip
 RUN apt-get install -y supervisor
 RUN apt-get install -y nginx

--- a/services/wfm/Dockerfile
+++ b/services/wfm/Dockerfile
@@ -13,40 +13,23 @@
 #   limitations under the License.
 #
 
-#FROM kilda/base-ubuntu
 FROM kilda/storm:latest
 
 ENV DEBIAN_FRONTEND noninteractive
 
-## MAVEN
 RUN apt-get update
-RUN apt-get install -y maven
-ENV MAVEN_VERSION 3.3.9
-ENV MAVEN_HOME /usr/share/maven
-
 RUN pip install kafka
-ADD wfm/app /app
-RUN chmod 777 /app/*
-
 RUN echo "PATH=$PATH:/opt/storm/bin" >> ~/.bashrc
 
-ADD src/pom.xml /app/pom.xml
-ADD src/checkstyle.xml /app/checkstyle.xml
-ADD src/messaging /app/messaging
-ADD src/pce /app/pce
-RUN mvn -f /app/pom.xml --non-recursive clean install
-RUN mvn -f /app/messaging/pom.xml clean install
-RUN mvn -f /app/pce/pom.xml clean install
 
-ADD wfm /app/wfm
-RUN mvn -f /app/wfm assembly:assembly -DskipTests
-RUN cp /app/wfm/src/main/resources/topology.properties /app/wfm/
-
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-WORKDIR /app/wfm
-
+ADD app/deploy_topos_and_monitor.sh /app/
+RUN chmod 777 /app/deploy_topos_and_monitor.sh
+ADD Makefile /app/
+ADD target/WorkflowManager-1.0-SNAPSHOT-jar-with-dependencies.jar /app/target/
+ADD src/main/resources/topology.properties /app/
 RUN TZ=Australia/Melbourne date >> /container_baked_on.txt
 
+WORKDIR /app
+
 # Default command.
-CMD ["/bin/bash"]
+CMD ["/app/deploy_topos_and_monitor.sh", "topology.properties"]

--- a/services/wfm/app/deploy_topos_and_monitor.sh
+++ b/services/wfm/app/deploy_topos_and_monitor.sh
@@ -15,7 +15,7 @@
 #
 
 
-cd /app/wfm
+cd /app
 
 ##
 ## Add all topologies here .. so that kilda comes up with them.


### PR DESCRIPTION
The jar's are built in the client machine, not the containers.

Also fixed a "bug" in base-ubuntu - clearing some apt package lists that can cause problems in downstream containers (the containers could remove at the beginning as well, but that violates the DRY principle.