### PR TITLE
Use properties instead of hardcoded "options"

### DIFF
--- a/services/wfm/Makefile
+++ b/services/wfm/Makefile
@@ -25,7 +25,7 @@ all-in-one:
 deploy-splitter:
 	storm jar target/WorkflowManager-1.0-SNAPSHOT-jar-with-dependencies.jar \
         org.openkilda.wfm.topology.splitter.OFEventSplitterTopology \
-        splitter ${config}
+        --name=splitter ${config}
 
 kill-splitter:
 	storm kill splitter >/dev/null 2>&1
@@ -33,7 +33,7 @@ kill-splitter:
 deploy-wfm:
 	storm jar target/WorkflowManager-1.0-SNAPSHOT-jar-with-dependencies.jar \
         org.openkilda.wfm.topology.event.OFEventWFMTopology \
-        wfm ${config}
+        --name=wfm ${config}
 
 kill-wfm:
 	storm kill wfm >/dev/null 2>&1
@@ -41,7 +41,7 @@ kill-wfm:
 deploy-flow:
 	storm jar target/WorkflowManager-1.0-SNAPSHOT-jar-with-dependencies.jar \
         org.openkilda.wfm.topology.flow.FlowTopology \
-        flow ${config}
+        --name=flow ${config}
 
 kill-flow:
 	storm kill flow >/dev/null 2>&1
@@ -49,7 +49,7 @@ kill-flow:
 deploy-stats:
 	storm jar target/WorkflowManager-1.0-SNAPSHOT-jar-with-dependencies.jar \
         org.openkilda.wfm.topology.stats.StatsTopology \
-        stats ${config}
+        --name=stats ${config}
 
 kill-stats:
 	storm kill stats >/dev/null 2>&1
@@ -57,7 +57,7 @@ kill-stats:
 deploy-cache:
 	storm jar target/WorkflowManager-1.0-SNAPSHOT-jar-with-dependencies.jar \
         org.openkilda.wfm.topology.cache.CacheTopology \
-        cache ${config}
+        --name=cache ${config}
 
 kill-cache:
 	storm kill cache >/dev/null 2>&1
@@ -65,15 +65,15 @@ kill-cache:
 deploy-islstats:
 	storm jar target/WorkflowManager-1.0-SNAPSHOT-jar-with-dependencies.jar \
 		org.openkilda.wfm.topology.islstats.IslStatsTopology \
-		islstats ${config}
+		--name=islstats ${config}
 
 kill-islstats:
 	storm kill islstats >/dev/null 2>&1
 
 deploy-opentsdb:
 	storm jar target/WorkflowManager-1.0-SNAPSHOT-jar-with-dependencies.jar \
-    		org.openkilda.wfm.topology.opentsdb.OpenTSDBTopology \
-    		opentsdb ${config}
+		org.openkilda.wfm.topology.opentsdb.OpenTSDBTopology \
+		--name=opentsdb ${config}
 
 kill-opentsdb:
 	storm kill opentsdb >/dev/null 2>&1

--- a/services/wfm/README.md
+++ b/services/wfm/README.md
@@ -3,6 +3,46 @@
 This project holds the Storm topologies that are used to implement
 the workflow management aspects of Kilda.
 
+# Deployment
+
+To start topology in `local` mode:
+```bash
+java -cp JAR.FILE CLASS --local arguments...
+```
+
+To submit topology into storm:
+```bash
+storm jar JAR.FILE class arguments...
+```
+
+## Topology CLI arguments
+
+In topology submit command you can pass arguments that will be passed into "main" call. 
+
+Supported arguments list:
+* `--name=NAME` - override topology name. If don't passed topology name constructed from topology class name.
+* `--local` - inform topology that is must run into "local" mode. I.e. submit topology into 
+  org.apache.storm.LocalCluster.
+* `--local-execution-time=TIME` - used only in combination with `--local`. Define how long (in seconds) topology will be
+  executed. `TIME` argument parsed as float number.
+* `CONFIG` - path to properties file. This properties will override compiled in properties. You can pass more than one
+  file to pass override on override on override... and so on. 
+
+## Configuration
+
+All topology options are defined as properties. There is compiled in JAR set of properties that provide a reasonable
+default values. You can pass more properties files(via CLI) to override this defaults. 
+
+Properties have different scope that depends from used prefix. Lets show it on option `opentsdb.hosts`.
+* `opentsdb.hosts` - this is `global` scope that will be used by all topologies
+* `$name.opentsdb.hosts` - this is `name` scope.  $name is passed from CLI `--name` argument. Or constructed from
+  topology class name if `--name` is missing.
+* `defaults.statstopology.opentsdb.hosts` - this `topology` scope. In this scope, option `opentsdb.hosts` will be used 
+  only by StatsTopology. Topology name `statstopology` constructed from topology class name.
+  
+Property lookup done in following order: `name scope`, `topology scope`. `global scope`. First found is used. This 
+approach allow to pass options bounded to specific name, to specific topology and unbounded/globally. 
+
 # Developers
 
 ## Debugging Tips
@@ -20,7 +60,7 @@ A lot of message passing is done through kafka topics.
     ```
     storm jar target/WorkflowManager-1.0-SNAPSHOT-jar-with-dependencies.jar \
     org.openkilda.wfm.topology.event.OFEventSplitterTopology \
-    splitter-1
+    --name splitter-1
     ```
 
 ### Kafka Debugging
@@ -52,7 +92,7 @@ One way to look at what is going on in a topic:
 * With the CLI installed, you should be able to run the following kinds of commands:
     ```
     storm list
-    storm jar ..  # ie deploy a topology
+    storm jar <jar.file> <class> [arguments]  # ie deploy a topology
     stork kill <topology name>
     ```
 

--- a/services/wfm/pom.xml
+++ b/services/wfm/pom.xml
@@ -139,6 +139,12 @@
             <version>${jersey.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>args4j</groupId>
+            <artifactId>args4j</artifactId>
+            <version>2.33</version>
+        </dependency>
+
         <!-- TODO: kafka_2.10 holds the old clients, replace with kafka-clients -->
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/services/wfm/src/main/java/org/openkilda/wfm/CliArguments.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/CliArguments.java
@@ -1,0 +1,81 @@
+package org.openkilda.wfm;
+
+import org.codehaus.plexus.util.PropertyUtils;
+import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+import org.openkilda.wfm.topology.Topology;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+public class CliArguments {
+    @Option(name = "--local", usage = "Do not push topology onto storm server, execute it local.")
+    private Boolean isLocal = false;
+
+    @Option(name="--name", usage="Set topology name.")
+    protected String topologyName;
+
+    @Option(name="--local-execution-time", usage="Work time limit, when started in \"local\" execution mode.")
+    protected Integer localExecutionTime;
+
+    @Argument(metaVar="CONFIG", multiValued=true, usage="Extra configuration file(s) (can accept multiple paths).")
+    private File extraConfiguration[] = {};
+
+    protected Properties properties;
+
+    public CliArguments(String[] args) throws CmdLineException, ConfigurationException {
+        CmdLineParser parser = new CmdLineParser(this);
+        parser.parseArgument(args);
+
+        topologyName = fixTopologyName();
+
+        loadExtraConfig();
+    }
+
+    public Boolean getIsLocal() {
+        return isLocal;
+    }
+
+    public String getTopologyName() {
+        return topologyName;
+    }
+
+    public Integer getLocalExecutionTime() {
+        return localExecutionTime;
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+
+    private String fixTopologyName() {
+        String value = getTopologyName();
+        if (value == null) {
+            return null;
+        }
+        if (value.isEmpty()) {
+            return null;
+        }
+        return value;
+    }
+
+    private void loadExtraConfig() throws ConfigurationException {
+        properties = PropertyUtils.loadProperties(this.getClass().getResource(Topology.TOPOLOGY_PROPERTIES));
+
+        for (File path : extraConfiguration) {
+            Properties override = new Properties(properties);
+            try {
+                FileInputStream source = new FileInputStream(path);
+                override.load(source);
+            } catch (IOException e) {
+                throw new ConfigurationException(String.format("Unable to load properties from %s", path), e);
+            }
+
+            properties = override;
+        }
+    }
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/ConfigurationException.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/ConfigurationException.java
@@ -1,0 +1,11 @@
+package org.openkilda.wfm;
+
+public class ConfigurationException extends Exception {
+    public ConfigurationException(String s) {
+        super(s);
+    }
+
+    public ConfigurationException(String s, Throwable throwable) {
+        super(s, throwable);
+    }
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/LaunchEnvironment.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/LaunchEnvironment.java
@@ -1,0 +1,47 @@
+package org.openkilda.wfm;
+
+import org.kohsuke.args4j.CmdLineException;
+import org.openkilda.wfm.topology.Topology;
+
+import java.util.Properties;
+
+public class LaunchEnvironment {
+    private static String CLI_OVERLAY = "cli";
+
+    private CliArguments cli;
+    private Properties properties;
+
+    public LaunchEnvironment(String args[]) throws CmdLineException, ConfigurationException {
+        this.cli = new CliArguments(args);
+        properties = cli.getProperties();
+        properties = makeCliOverlay();
+    }
+
+    public String getTopologyName() {
+        return cli.getTopologyName();
+    }
+
+    public PropertiesReader makePropertiesReader() {
+        return new PropertiesReader(getProperties(), CLI_OVERLAY, "");
+    }
+
+    public PropertiesReader makePropertiesReader(String ownSection, String defaults) {
+        defaults = Topology.TOPOLOGY_PROPERTIES_DEFAULTS_PREFIX + defaults;
+        return new PropertiesReader(getProperties(), CLI_OVERLAY, ownSection, defaults, "");
+    }
+
+    private Properties makeCliOverlay() {
+        Properties overlay = new Properties(getProperties());
+
+        overlay.setProperty(CLI_OVERLAY + ".local", cli.getIsLocal() ? "yes" : "no");
+        if (cli.getLocalExecutionTime() != null) {
+            overlay.setProperty(CLI_OVERLAY + ".local.execution.time", cli.getLocalExecutionTime().toString());
+        }
+
+        return overlay;
+    }
+
+    protected Properties getProperties() {
+        return properties;
+    }
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/PropertiesReader.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/PropertiesReader.java
@@ -1,0 +1,59 @@
+package org.openkilda.wfm;
+
+import java.util.Properties;
+
+public class PropertiesReader {
+    private Properties payload;
+    private String prefixes[];
+
+    public PropertiesReader(Properties payload) {
+        this(payload, "");
+    }
+
+    public PropertiesReader(Properties payload, String ...prefixes) {
+        this.payload = payload;
+        this.prefixes = new String[prefixes.length];
+
+        int idx;
+        for (idx = 0; idx < prefixes.length; idx++) {
+            String value = prefixes[idx];
+            if (! value.equals("")) {
+                value += ".";
+            }
+            this.prefixes[idx] = value;
+        }
+    }
+
+    public String getString(String key) throws ConfigurationException {
+        return getKey(key);
+    }
+
+    public Integer getInteger(String key) throws ConfigurationException {
+        return new Integer(getKey(key));
+    }
+
+    public Float getFloat(String key) throws ConfigurationException {
+        return new Float(getKey(key));
+    }
+
+    public Boolean getBoolean(String key) throws ConfigurationException {
+        return Boolean.valueOf(getKey(key));
+    }
+
+    private String getKey(String key) throws ConfigurationException {
+        String value = null;
+
+        for (String head : prefixes) {
+            value = payload.getProperty(head + key);
+            if (value != null) {
+                break;
+            }
+        }
+
+        if (value == null) {
+            throw new ConfigurationException(String.format("There is no property %s", key));
+        }
+
+        return value;
+    }
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/Topology.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/Topology.java
@@ -22,44 +22,12 @@ import org.apache.storm.generated.StormTopology;
  */
 public interface Topology {
     /**
-     * Zookeeper hosts property name.
-     */
-    String PROPERTY_ZOOKEEPER = "zookeeper.hosts";
-
-    /**
-     * Kafka hosts property name.
-     */
-    String PROPERTY_KAFKA = "kafka.hosts";
-
-    /**
-     * Neo4J host property name.
-     */
-    String PROPERTY_NEO4J_URL = "neo4j.hosts";
-
-    /**
-     * Neo4J user property name.
-     */
-    String PROPERTY_NEO4J_USER = "neo4j.user";
-
-    /**
-     * Neo4J password property name.
-     */
-    String PROPERTY_NEO4J_PSWD = "neo4j.pswd";
-
-    /**
-     * Parallelism value property name.
-     */
-    String PROPERTY_PARALLELISM = "parallelism";
-
-    /**
-     * Workers value property name.
-     */
-    String PROPERTY_WORKERS = "workers";
-
-    /**
      * Default topologies configuration file.
      */
     String TOPOLOGY_PROPERTIES = "/topology.properties";
+    String TOPOLOGY_PROPERTIES_DEFAULTS_PREFIX = "defaults.";
+
+    String getTopologyName();
 
     /**
      * Topology creator.
@@ -75,19 +43,7 @@ public interface Topology {
      *
      * @return topology name
      */
-    default String getTopologyName() {
+    default String makeTopologyName() {
         return getClass().getSimpleName().toLowerCase();
-    }
-
-    /**
-     * Returns topology specific property name.
-     * Adds topology name to property name.
-     * Default implementation.
-     *
-     * @param propertyName property name
-     * @return topology specific property name
-     */
-    default String getTopologyPropertyName(final String propertyName) {
-        return String.format("%s.%s", getTopologyName(), propertyName);
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/TopologyConfig.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/TopologyConfig.java
@@ -1,0 +1,170 @@
+package org.openkilda.wfm.topology;
+
+import org.apache.logging.log4j.Level;
+import org.openkilda.wfm.ConfigurationException;
+import org.openkilda.wfm.PropertiesReader;
+
+public class TopologyConfig {
+    private Boolean isLocal;
+    private Integer localExecutionTime;
+
+    private Integer parallelism;
+    private Integer workers;
+    private Integer discoveryInterval;
+    private Integer discoveryTimeout;
+    private String filterDirectory;
+    private Level loggerLevel;
+    private String loggerWatermark;
+
+    private String zookeeperHosts;
+    private Integer zookeeperSessionTimeout;
+    private Integer zookeeperConnectTimeout;
+
+    private String kafkaHosts;
+    private String kafkaInputTopic;
+    private String kafkaOutputTopic;
+    private String kafkaNetCacheTopic;
+    private String kafkaSpeakerTopic;
+    private String kafkaSimulatorTopic;
+    private String kafkaTsdbTopic;
+    private String kafkaDiscoveryTopic;
+
+    private String openTsDBHosts;
+    private Integer openTsdbTimeout;
+
+    private String neo4jHost;
+    private String neo4jLogin;
+    private String neo4jPassword;
+
+    public TopologyConfig(PropertiesReader config) throws ConfigurationException {
+        isLocal = config.getBoolean("local");
+        localExecutionTime = (int)(config.getFloat("local.execution.time") * 1000);
+
+        parallelism = config.getInteger("parallelism");
+        workers = config.getInteger("workers");
+        discoveryInterval = config.getInteger("discovery.interval");
+        discoveryTimeout = config.getInteger("discovery.timeout");
+        filterDirectory = config.getString("filter.directory");
+        loggerLevel = Level.valueOf(config.getString("logger.level"));
+        loggerWatermark = config.getString("logger.watermark");
+
+        zookeeperHosts = config.getString("zookeeper.hosts");
+        zookeeperSessionTimeout = (int)(config.getFloat("zookeeper.session.timeout") * 1000);
+        zookeeperConnectTimeout = (int)(config.getFloat("zookeeper.connect.timeout") * 1000);
+        kafkaHosts = config.getString("kafka.hosts");
+        kafkaInputTopic = config.getString("kafka.topic.input");
+        kafkaOutputTopic = config.getString("kafka.topic.output");
+        kafkaNetCacheTopic = config.getString("kafka.topic.netcache");
+        kafkaSpeakerTopic = config.getString("kafka.topic.speaker");
+        kafkaSimulatorTopic = config.getString("kafka.topic.simulator");
+        kafkaTsdbTopic = config.getString("kafka.topic.opentsdb");
+        kafkaDiscoveryTopic = config.getString("kafka.topic.discovery");
+
+        openTsDBHosts = config.getString("opentsdb.hosts");
+        openTsdbTimeout = (int)(config.getFloat("opentsdb.timeout") * 1000);
+
+        neo4jHost = config.getString("neo4j.hosts");
+        neo4jLogin = config.getString("neo4j.user");
+        neo4jPassword = config.getString("neo4j.pswd");
+    }
+
+    public Boolean getLocal() {
+        return isLocal;
+    }
+
+    public Integer getLocalExecutionTime() {
+        return localExecutionTime;
+    }
+
+    public Integer getParallelism() {
+        return parallelism;
+    }
+
+    public Integer getWorkers() {
+        return workers;
+    }
+
+    public Integer getDiscoveryInterval() {
+        return discoveryInterval;
+    }
+
+    public Integer getDiscoveryTimeout() {
+        return discoveryTimeout;
+    }
+
+    public String getFilterDirectory() {
+        return filterDirectory;
+    }
+
+    public Level getLoggerLevel() {
+        return loggerLevel;
+    }
+
+    public String getLoggerWatermark() {
+        return loggerWatermark;
+    }
+
+    public String getZookeeperHosts() {
+        return zookeeperHosts;
+    }
+
+    public Integer getZookeeperSessionTimeout() {
+        return zookeeperSessionTimeout;
+    }
+
+    public Integer getZookeeperConnectTimeout() {
+        return zookeeperConnectTimeout;
+    }
+
+    public String getKafkaHosts() {
+        return kafkaHosts;
+    }
+
+    public String getKafkaInputTopic() {
+        return kafkaInputTopic;
+    }
+
+    public String getKafkaOutputTopic() {
+        return kafkaOutputTopic;
+    }
+
+    public String getKafkaNetCacheTopic() {
+        return kafkaNetCacheTopic;
+    }
+
+    public String getKafkaSpeakerTopic() {
+        return kafkaSpeakerTopic;
+    }
+
+    public String getKafkaSimulatorTopic() {
+        return kafkaSimulatorTopic;
+    }
+
+    public String getKafkaTsdbTopic() {
+        return kafkaTsdbTopic;
+    }
+
+    public String getKafkaDiscoveryTopic() {
+        return kafkaDiscoveryTopic;
+    }
+
+    public String getOpenTsDBHosts() {
+        return openTsDBHosts;
+    }
+
+    public Integer getOpenTsdbTimeout() {
+        return openTsdbTimeout;
+    }
+
+    public String getNeo4jHost() {
+        return neo4jHost;
+    }
+
+    public String getNeo4jLogin() {
+        return neo4jLogin;
+    }
+
+    public String getNeo4jPassword() {
+        return neo4jPassword;
+    }
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/islstats/IslStatsTopology.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/islstats/IslStatsTopology.java
@@ -15,94 +15,63 @@
 
 package org.openkilda.wfm.topology.islstats;
 
+import org.openkilda.wfm.ConfigurationException;
+import org.openkilda.wfm.topology.AbstractTopology;
+import org.openkilda.wfm.LaunchEnvironment;
+import org.openkilda.wfm.topology.islstats.bolts.IslStatsBolt;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.storm.Config;
-import org.apache.storm.LocalCluster;
-import org.apache.storm.StormSubmitter;
 import org.apache.storm.generated.StormTopology;
 import org.apache.storm.opentsdb.bolt.OpenTsdbBolt;
 import org.apache.storm.opentsdb.bolt.TupleOpenTsdbDatapointMapper;
 import org.apache.storm.opentsdb.client.OpenTsdbClient;
 import org.apache.storm.topology.TopologyBuilder;
 
-import org.openkilda.wfm.topology.AbstractTopology;
-import org.openkilda.wfm.topology.Topology;
-import org.openkilda.wfm.topology.islstats.bolts.IslStatsBolt;
-
-
-import java.io.File;
-
-
 public class IslStatsTopology extends AbstractTopology {
     private static final Logger logger = LogManager.getLogger(IslStatsTopology.class);
 
-    private final String topoName = "IslStatsTopology";
-    private final int parallelism = 1;
-
-    private final String topic = "kilda-test";
-    public static final String SPOUT_NAME = "islstats-spout";
-
-    public IslStatsTopology(File file) {
-        super(file);
+    public IslStatsTopology(LaunchEnvironment env) throws ConfigurationException {
+        super(env);
     }
-
-    public static void main(String[] args) throws Exception {
-
-        //If there are arguments, we are running on a cluster; otherwise, we are running locally
-        if (args != null && args.length > 0) {
-            File file = new File(args[1]);
-            Config conf = new Config();
-            conf.setDebug(false);
-            IslStatsTopology statsTopology = new IslStatsTopology(file);
-            StormTopology topo = statsTopology.createTopology();
-
-            conf.setNumWorkers(statsTopology.parallelism);
-            StormSubmitter.submitTopology(args[0], conf, topo);
-        } else {
-            logger.info("starting islStatsTopo in local mode");
-            File file = new File(IslStatsTopology.class.getResource(Topology.TOPOLOGY_PROPERTIES).getFile());
-            Config conf = new Config();
-            conf.setDebug(false);
-            IslStatsTopology statsTopology = new IslStatsTopology(file);
-            StormTopology topo = statsTopology.createTopology();
-
-            conf.setMaxTaskParallelism(3);
-
-            LocalCluster cluster = new LocalCluster();
-            cluster.submitTopology(statsTopology.topologyName, conf, topo);
-
-            Thread.sleep(60000000);
-            cluster.shutdown();
-        }
-    }
-
 
     public StormTopology createTopology() {
         final String clazzName = this.getClass().getSimpleName();
-        logger.debug("Building Topology - " + clazzName );
+        final String spoutName = "islstats-spout";
+        logger.debug("Building Topology - {}", clazzName);
 
         TopologyBuilder builder = new TopologyBuilder();
 
+        String topic = config.getKafkaInputTopic();
         checkAndCreateTopic(topic);
 
-        logger.debug("connecting to " + topic + " topic");
-        builder.setSpout(SPOUT_NAME, createKafkaSpout(topic, clazzName));
+        logger.debug("connecting to {} topic", topic);
+        builder.setSpout(spoutName, createKafkaSpout(topic, clazzName));
 
         final String verifyIslStatsBoltName = IslStatsBolt.class.getSimpleName();
         IslStatsBolt verifyIslStatsBolt = new IslStatsBolt();
-        logger.debug("starting " + verifyIslStatsBoltName + " bolt");
-        builder.setBolt(verifyIslStatsBoltName, verifyIslStatsBolt, parallelism).shuffleGrouping(SPOUT_NAME);
+        logger.debug("starting {} bolt", verifyIslStatsBoltName);
+        builder.setBolt(verifyIslStatsBoltName, verifyIslStatsBolt, config.getParallelism())
+                .shuffleGrouping(spoutName);
 
-        //TODO: fix this such that it is not hardcoded
-        OpenTsdbClient.Builder tsdbBuilder = OpenTsdbClient.newBuilder("http://opentsdb.pendev:4242")
+        OpenTsdbClient.Builder tsdbBuilder = OpenTsdbClient.newBuilder(config.getOpenTsDBHosts())
                 .sync(30_000).returnDetails();
         OpenTsdbBolt openTsdbBolt = new OpenTsdbBolt(tsdbBuilder, TupleOpenTsdbDatapointMapper.DEFAULT_MAPPER)
                 .withBatchSize(10)
                 .withFlushInterval(2)
                 .failTupleForFailedMetrics();
-        builder.setBolt("opentsdb", openTsdbBolt, parallelism).shuffleGrouping(verifyIslStatsBoltName);
+        builder.setBolt("opentsdb", openTsdbBolt, config.getParallelism())
+                .shuffleGrouping(verifyIslStatsBoltName);
 
         return builder.createTopology();
+    }
+
+    public static void main(String[] args) {
+        try {
+            LaunchEnvironment env = new LaunchEnvironment(args);
+            (new IslStatsTopology(env)).setup();
+        } catch (Exception e) {
+            System.exit(handleLaunchException(e));
+        }
     }
 }

--- a/services/wfm/src/main/resources/topology.properties
+++ b/services/wfm/src/main/resources/topology.properties
@@ -1,10 +1,32 @@
-zookeeper.hosts=zookeeper.pendev:2181
-kafka.hosts=kafka.pendev:9092
-statstopology.openTsdbUrl=http://opentsdb.pendev:4242
-neo4j.hosts=neo4j.pendev:7687
-neo4j.user=neo4j
-neo4j.pswd=temppass
+parallelism = 1
+workers = 1
 
-opentsdbtopology.kafka.opentsdb-topic=opentsdb-topic
-opentsdbtopology.open-tsdb.url=http://opentsdb.pendev:4242
-opentsdbtopology.open-tsdb.timeout=30000
+zookeeper.hosts = zookeeper.pendev:2181
+zookeeper.session.timeout = 5
+zookeeper.connect.timeout = 5
+
+kafka.hosts = kafka.pendev:9092
+kafka.topic.input = kilda-test
+kafka.topic.output = kilda.wfm.topo.updown
+kafka.topic.netcache = kilda.wfm.topo.dump
+kafka.topic.speaker = kilda.speaker
+kafka.topic.simulator = kilda-simulator
+kafka.topic.opentsdb = opentsdb-topic
+kafka.topic.discovery = kilda-test
+
+opentsdb.hosts = http://opentsdb.pendev:4242
+opentsdb.timeout = 30
+
+neo4j.hosts = neo4j.pendev:7687
+neo4j.user = neo4j
+neo4j.pswd = temppass
+
+filter.directory =
+logger.level = INFO
+logger.watermark =
+
+discovery.interval = 3
+discovery.timeout = 9
+
+local = no
+local.execution.time = 10

--- a/services/wfm/src/test/java/org/openkilda/wfm/AbstractStormTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/AbstractStormTest.java
@@ -15,6 +15,7 @@
 
 package org.openkilda.wfm;
 
+import org.kohsuke.args4j.CmdLineException;
 import org.openkilda.wfm.topology.TestKafkaProducer;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -23,20 +24,31 @@ import org.apache.storm.Config;
 import org.apache.storm.LocalCluster;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+import org.openkilda.wfm.topology.TopologyConfig;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.util.Properties;
 
 /**
  * Created by carmine on 4/4/17.
  */
 public class AbstractStormTest {
+    protected static String CONFIG_NAME = "class-level-overlay.properties";
+
     protected static TestKafkaProducer kProducer;
     protected static LocalCluster cluster;
     static TestUtils.KafkaTestFixture server;
 
-    protected static Properties kafkaProperties() {
+    @ClassRule
+    public static TemporaryFolder fsData = new TemporaryFolder();
+
+    protected static Properties kafkaProperties() throws ConfigurationException, CmdLineException {
         Properties properties = new Properties();
-        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, TestUtils.kafkaHosts);
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, makeUnboundConfig().getKafkaHosts());
         properties.put(ConsumerConfig.GROUP_ID_CONFIG, "test");
         properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
         properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
@@ -47,7 +59,7 @@ public class AbstractStormTest {
         return properties;
     }
 
-    protected static Properties kafkaProperties(final String groupId) {
+    protected static Properties kafkaProperties(final String groupId) throws ConfigurationException, CmdLineException {
         Properties properties = kafkaProperties();
         properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         return properties;
@@ -64,9 +76,13 @@ public class AbstractStormTest {
     @BeforeClass
     public static void setupOnce() throws Exception {
         System.out.println("------> Creating Sheep \uD83D\uDC11\n");
-        cluster = new LocalCluster();
-        server = new TestUtils.KafkaTestFixture();
+
+        makeConfigFile();
+
+        server = new TestUtils.KafkaTestFixture(makeUnboundConfig());
         server.start();
+
+        cluster = new LocalCluster();
         kProducer = new TestKafkaProducer(kafkaProperties());
     }
 
@@ -76,5 +92,48 @@ public class AbstractStormTest {
         kProducer.close();
         cluster.shutdown();
         server.stop();
+    }
+
+    protected static TopologyConfig makeUnboundConfig() throws ConfigurationException, CmdLineException {
+        LaunchEnvironment env = makeLaunchEnvironment();
+        return new TopologyConfig(env.makePropertiesReader());
+    }
+
+    protected static LaunchEnvironment makeLaunchEnvironment() throws CmdLineException, ConfigurationException {
+        String args[] = makeLaunchArgs();
+        return new LaunchEnvironment(args);
+    }
+    protected static LaunchEnvironment makeLaunchEnvironment(Properties overlay)
+            throws CmdLineException, ConfigurationException, IOException {
+        String extra = fsData.newFile().getName();
+        makeConfigFile(overlay, extra);
+
+        String args[] = makeLaunchArgs(extra);
+        return new LaunchEnvironment(args);
+    }
+
+    protected static String[] makeLaunchArgs(String ...extraConfig) {
+        String args[] = new String[extraConfig.length + 1];
+
+        File root = fsData.getRoot();
+        args[0] = new File(root, CONFIG_NAME).toString();
+        for (int idx = 0; idx < extraConfig.length; idx += 1) {
+            args[idx + 1] = new File(root, extraConfig[idx]).toString();
+        }
+
+        return args;
+    }
+
+    protected static void makeConfigFile() throws IOException {
+        makeConfigFile(makeConfigOverlay(), CONFIG_NAME);
+    }
+
+    protected static void makeConfigFile(Properties overlay, String location) throws IOException {
+        File path = new File(fsData.getRoot(), location);
+        overlay.store(new FileWriter(path), null);
+    }
+
+    protected static Properties makeConfigOverlay() {
+        return new Properties();
     }
 }

--- a/services/wfm/src/test/java/org/openkilda/wfm/TestUtils.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/TestUtils.java
@@ -15,14 +15,13 @@
 
 package org.openkilda.wfm;
 
-import org.openkilda.wfm.topology.Topology;
+import org.openkilda.wfm.topology.TopologyConfig;
 
 import com.google.common.io.Files;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServerStartable;
 import org.apache.curator.test.TestingServer;
 import org.apache.storm.Config;
-import org.codehaus.plexus.util.PropertyUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,22 +33,11 @@ import java.util.Properties;
  * Key Utilities:
  */
 public class TestUtils {
-
-    public static final String zookeeperHosts;
-    public static final String kafkaHosts;
-
-    static {
-        File file = new File(TestUtils.class.getResource(Topology.TOPOLOGY_PROPERTIES).getFile());
-        Properties properties = PropertyUtils.loadProperties(file);
-        zookeeperHosts = properties.getProperty(Topology.PROPERTY_ZOOKEEPER);
-        kafkaHosts = properties.getProperty(Topology.PROPERTY_KAFKA);
-    }
-
-    public static Properties serverProperties() {
+    public static Properties serverProperties(TopologyConfig config) {
         Properties props = new Properties();
-        props.put("zookeeper.connect", zookeeperHosts);
-        props.put("broker.id", "1");
-        props.put("delete.topic.enable", "true");
+        props.setProperty("zookeeper.connect", config.getZookeeperHosts());
+        props.setProperty("broker.id", "1");
+        props.setProperty("delete.topic.enable", "true");
         return props;
     }
 
@@ -64,10 +52,15 @@ public class TestUtils {
         public TestingServer zk;
         public KafkaServerStartable kafka;
         public File tempDir = Files.createTempDir();
+        private TopologyConfig config;
 
+        public KafkaTestFixture(TopologyConfig config) throws ConfigurationException {
+            this.config = config;
+        }
 
         public void start() throws Exception {
-            this.start(serverProperties());
+            Properties props = serverProperties(config);
+            this.start(props);
         }
 
         public void start(Properties props) throws Exception {

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/cache/CacheTopologyTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/cache/CacheTopologyTest.java
@@ -81,8 +81,8 @@ public class CacheTopologyTest extends AbstractStormTest {
     @BeforeClass
     public static void setupOnce() throws Exception {
         AbstractStormTest.setupOnce();
-        File file = new File(CacheTopologyTest.class.getResource(Topology.TOPOLOGY_PROPERTIES).getFile());
-        CacheTopology cacheTopology = new CacheTopology(file);
+
+        CacheTopology cacheTopology = new CacheTopology(makeLaunchEnvironment());
         StormTopology stormTopology = cacheTopology.createTopology();
         Config config = stormConfig();
         cluster.submitTopology(CacheTopologyTest.class.getSimpleName(), config, stormTopology);
@@ -98,7 +98,7 @@ public class CacheTopologyTest extends AbstractStormTest {
         Utils.sleep(10000);
 
         System.out.println("Waiting For Dump Request");
-        TimeUnit.SECONDS.sleep(OFEventWFMTopology.DEFAULT_DISCOVERY_TIMEOUT);
+        TimeUnit.SECONDS.sleep(cacheTopology.getConfig().getDiscoveryTimeout());
 
         System.out.println("Waited For Dump Request");
         teConsumer.pollMessage();

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flow/FlowTopologyTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flow/FlowTopologyTest.java
@@ -15,7 +15,6 @@
 
 package org.openkilda.wfm.topology.flow;
 
-import static org.openkilda.wfm.topology.flow.FlowTopology.STATE_UPDATE_TOPIC;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -52,7 +51,6 @@ import org.openkilda.messaging.payload.flow.FlowState;
 import org.openkilda.messaging.payload.flow.OutputVlanType;
 import org.openkilda.wfm.AbstractStormTest;
 import org.openkilda.wfm.topology.TestKafkaConsumer;
-import org.openkilda.wfm.topology.Topology;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -65,8 +63,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.openkilda.wfm.topology.TopologyConfig;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -84,8 +82,10 @@ public class FlowTopologyTest extends AbstractStormTest {
     @BeforeClass
     public static void setupOnce() throws Exception {
         AbstractStormTest.setupOnce();
-        File file = new File(FlowTopologyTest.class.getResource(Topology.TOPOLOGY_PROPERTIES).getFile());
-        flowTopology = new FlowTopology(file, new PathComputerMock());
+
+        flowTopology = new FlowTopology(makeLaunchEnvironment(), new PathComputerMock());
+        TopologyConfig topologyConfig = flowTopology.getConfig();
+
         StormTopology stormTopology = flowTopology.createTopology();
         Config config = stormConfig();
         cluster.submitTopology(FlowTopologyTest.class.getSimpleName(), config, stormTopology);
@@ -98,7 +98,7 @@ public class FlowTopologyTest extends AbstractStormTest {
                 kafkaProperties(UUID.nameUUIDFromBytes(Destination.CONTROLLER.toString().getBytes()).toString()));
         ofsConsumer.start();
 
-        cacheConsumer = new TestKafkaConsumer(STATE_UPDATE_TOPIC, null,
+        cacheConsumer = new TestKafkaConsumer(topologyConfig.getKafkaOutputTopic(), null,
                 kafkaProperties(UUID.nameUUIDFromBytes(Destination.TOPOLOGY_ENGINE.toString().getBytes()).toString()));
         cacheConsumer.start();
 

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopologyTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopologyTest.java
@@ -38,8 +38,7 @@ public class OpenTSDBTopologyTest extends AbstractStormTest {
             .respond(HttpResponse.response());
 
         AbstractStormTest.setupOnce();
-        File file = new File(OpenTSDBTopologyTest.class.getResource(Topology.TOPOLOGY_PROPERTIES).getFile());
-        OpenTSDBTopology topology = new OpenTSDBTopology(file);
+        OpenTSDBTopology topology = new OpenTSDBTopology(makeLaunchEnvironment());
         StormTopology stormTopology = topology.createTopology();
         Config config = stormConfig();
         config.setMaxTaskParallelism(1);

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java
@@ -29,7 +29,6 @@ import org.openkilda.messaging.info.stats.PortStatsData;
 import org.openkilda.messaging.info.stats.PortStatsEntry;
 import org.openkilda.messaging.info.stats.PortStatsReply;
 import org.openkilda.wfm.AbstractStormTest;
-import org.openkilda.wfm.topology.Topology;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.storm.Config;
@@ -39,7 +38,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -53,8 +51,8 @@ public class StatsTopologyTest extends AbstractStormTest {
     @BeforeClass
     public static void setupOnce() throws Exception {
         AbstractStormTest.setupOnce();
-        File file = new File(StatsTopologyTest.class.getResource(Topology.TOPOLOGY_PROPERTIES).getFile());
-        StatsTopology topology = new StatsTopology(file);
+
+        StatsTopology topology = new StatsTopology(makeLaunchEnvironment());
         StormTopology stormTopology = topology.createTopology();
         Config config = stormConfig();
         cluster.submitTopology(StatsTopologyTest.class.getSimpleName(), config, stormTopology);

--- a/services/wfm/src/test/resources/topology.properties
+++ b/services/wfm/src/test/resources/topology.properties
@@ -1,7 +1,33 @@
-zookeeper.hosts=localhost:2181
-kafka.hosts=localhost:9092
-statstopology.openTsdbUrl=http://localhost:4242
+parallelism = 1
+workers = 1
 
-opentsdbtopology.kafka.opentsdb-topic=opentsdb-topic
-opentsdbtopology.open-tsdb.url=http://localhost:4242
-opentsdbtopology.open-tsdb.timeout=30000
+zookeeper.hosts=localhost:2181
+zookeeper.session.timeout = 5
+zookeeper.connect.timeout = 5
+
+kafka.hosts=localhost:9092
+
+kafka.topic.input = kilda-test
+kafka.topic.output = kilda.wfm.topo.updown
+kafka.topic.netcache = kilda.wfm.topo.dump
+kafka.topic.speaker = kilda.speaker
+kafka.topic.simulator = kilda-simulator
+kafka.topic.opentsdb = opentsdb-topic
+kafka.topic.discovery = kilda-test
+
+opentsdb.hosts = http://localhost:4242
+opentsdb.timeout = 30
+
+neo4j.hosts = neo4j.pendev:7687
+neo4j.user = neo4j
+neo4j.pswd = temppass
+
+filter.directory =
+logger.level = INFO
+logger.watermark =
+
+discovery.interval = 3
+discovery.timeout = 9
+
+local = no
+local.execution.time = 10


### PR DESCRIPTION
Add reasonable defaults for all options into compilled in properties.
Add tools to read properties from external files(pointed by CLI
arguments). Add ability to override any options for specific topology by
adding topology name as propertry name prefix.

Collect all options into TopologyConfig object, that responsible for
initial type conversions.