### PR TITLE
Remove hardcoded kafka topics from CacheTopology

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/cache/CacheTopology.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/cache/CacheTopology.java
@@ -28,10 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class CacheTopology extends AbstractTopology {
-    static final String STATE_DUMP_TOPIC = "kilda.wfm.topo.dump";
-    static final String STATE_UPDATE_TOPIC = "kilda.wfm.topo.updown";
-    private static final String STATE_TPE_TOPIC = "kilda-test";
-
     private static final Logger logger = LoggerFactory.getLogger(CacheTopology.class);
 
     public CacheTopology(LaunchEnvironment env) throws ConfigurationException {
@@ -49,7 +45,7 @@ public class CacheTopology extends AbstractTopology {
     public StormTopology createTopology() {
         logger.info("Creating Topology: {}", topologyName);
 
-        initKafka();
+        initKafkaTopics();
 
         Integer parallelism = config.getParallelism();
 
@@ -58,13 +54,15 @@ public class CacheTopology extends AbstractTopology {
        /*
          * Receives cache from storage.
          */
-        KafkaSpout storageSpout = createKafkaSpout(STATE_TPE_TOPIC, ComponentType.TPE_KAFKA_SPOUT.toString());
+        KafkaSpout storageSpout = createKafkaSpout(
+                config.getKafkaInputTopic(), ComponentType.TPE_KAFKA_SPOUT.toString());
         builder.setSpout(ComponentType.TPE_KAFKA_SPOUT.toString(), storageSpout, parallelism);
 
         /*
          * Receives cache updates from WFM topology.
          */
-        KafkaSpout stateSpout = createKafkaSpout(STATE_UPDATE_TOPIC, ComponentType.WFM_UPDATE_KAFKA_SPOUT.toString());
+        KafkaSpout stateSpout = createKafkaSpout(
+                config.getKafkaOutputTopic(), ComponentType.WFM_UPDATE_KAFKA_SPOUT.toString());
         builder.setSpout(ComponentType.WFM_UPDATE_KAFKA_SPOUT.toString(), stateSpout, parallelism);
 
         /*
@@ -78,14 +76,14 @@ public class CacheTopology extends AbstractTopology {
         /*
          * Sends network events to storage.
          */
-        KafkaBolt storageBolt = createKafkaBolt(STATE_TPE_TOPIC);
+        KafkaBolt storageBolt = createKafkaBolt(config.getKafkaInputTopic());
         builder.setBolt(ComponentType.TPE_KAFKA_BOLT.toString(), storageBolt, parallelism)
                 .shuffleGrouping(ComponentType.CACHE_BOLT.toString(), StreamType.TPE.toString());
 
         /*
          * Sends cache dump to WFM topology.
          */
-        KafkaBolt stateDump = createKafkaBolt(STATE_DUMP_TOPIC);
+        KafkaBolt stateDump = createKafkaBolt(config.getKafkaNetCacheTopic());
         builder.setBolt(ComponentType.WFM_DUMP_KAFKA_BOLT.toString(), stateDump, parallelism)
                 .shuffleGrouping(ComponentType.CACHE_BOLT.toString(), StreamType.WFM_DUMP.toString());
 
@@ -94,10 +92,10 @@ public class CacheTopology extends AbstractTopology {
         return builder.createTopology();
     }
 
-    private void initKafka() {
-        checkAndCreateTopic(STATE_TPE_TOPIC);
-        checkAndCreateTopic(STATE_UPDATE_TOPIC);
-        checkAndCreateTopic(STATE_DUMP_TOPIC);
+    private void initKafkaTopics() {
+        checkAndCreateTopic(config.getKafkaInputTopic());
+        checkAndCreateTopic(config.getKafkaOutputTopic());
+        checkAndCreateTopic(config.getKafkaNetCacheTopic());
     }
 
     public static void main(String[] args) {

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/event/OFEventWFMTopology.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/event/OFEventWFMTopology.java
@@ -95,7 +95,7 @@ public class OFEventWFMTopology extends AbstractTopology {
             // NB: with shuffleGrouping, we can't maintain state .. would need to parse first
             //      just to pull out switchID.
             tbolt[i] = builder.setBolt(boltName, bolts[i], config.getParallelism()).shuffleGrouping(spoutName);
-            kbolt = kbolt.shuffleGrouping(boltName, kafkaOutputTopic);
+            kbolt.shuffleGrouping(boltName, kafkaOutputTopic);
         }
 
         // now hookup switch and port to the link bolt so that it can take appropriate action


### PR DESCRIPTION
CacheTopology was unintentionally skipped during implementing #48. This
patch eliminate that gap.