### PR TITLE
Test refactoring

### DIFF
--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/stats/FlowStatsEntry.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/stats/FlowStatsEntry.java
@@ -17,10 +17,12 @@ package org.openkilda.messaging.info.stats;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
+
 /**
  * TODO: add javadoc.
  */
-public class FlowStatsEntry {
+public class FlowStatsEntry implements Serializable {
 
     @JsonProperty
     private int tableId;

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/stats/FlowStatsReply.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/stats/FlowStatsReply.java
@@ -17,12 +17,13 @@ package org.openkilda.messaging.info.stats;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
  * TODO: add javadoc.
  */
-public class FlowStatsReply {
+public class FlowStatsReply implements Serializable {
 
     @JsonProperty
     private long xid;

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/stats/MeterConfigReply.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/stats/MeterConfigReply.java
@@ -18,12 +18,13 @@ package org.openkilda.messaging.info.stats;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
  * TODO: add javadoc.
  */
-public class MeterConfigReply {
+public class MeterConfigReply implements Serializable {
 
     @JsonProperty
     private long xid;

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/stats/PortStatsEntry.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/stats/PortStatsEntry.java
@@ -18,10 +18,12 @@ package org.openkilda.messaging.info.stats;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
+
 /**
  * TODO: add javadoc.
  */
-public class PortStatsEntry {
+public class PortStatsEntry implements Serializable {
 
     @JsonProperty
     private int portNo;

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/stats/PortStatsReply.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/stats/PortStatsReply.java
@@ -18,12 +18,13 @@ package org.openkilda.messaging.info.stats;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
  * TODO: add javadoc.
  */
-public class PortStatsReply {
+public class PortStatsReply implements Serializable {
 
     @JsonProperty
     private long xid;

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/StatsTopology.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/StatsTopology.java
@@ -21,7 +21,6 @@ import static org.openkilda.wfm.topology.stats.StatsComponentType.PORT_STATS_MET
 
 import org.apache.storm.generated.StormTopology;
 import org.apache.storm.kafka.KafkaSpout;
-import org.apache.storm.kafka.bolt.KafkaBolt;
 import org.apache.storm.topology.TopologyBuilder;
 import org.openkilda.messaging.ServiceType;
 import org.openkilda.wfm.ConfigurationException;

--- a/services/wfm/src/test/java/org/openkilda/wfm/AbstractStormTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/AbstractStormTest.java
@@ -15,17 +15,13 @@
 
 package org.openkilda.wfm;
 
-import org.kohsuke.args4j.CmdLineException;
-import org.openkilda.wfm.topology.TestKafkaProducer;
-
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.storm.Config;
-import org.apache.storm.LocalCluster;
-import org.junit.AfterClass;
+import org.apache.storm.testing.CompleteTopologyParam;
+import org.apache.storm.testing.MkClusterParam;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
+import org.kohsuke.args4j.CmdLineException;
 import org.openkilda.wfm.topology.TopologyConfig;
 
 import java.io.File;
@@ -37,61 +33,30 @@ import java.util.Properties;
  * Created by carmine on 4/4/17.
  */
 public class AbstractStormTest {
-    protected static String CONFIG_NAME = "class-level-overlay.properties";
+    private static final String CONFIG_NAME = "class-level-overlay.properties";
 
-    protected static TestKafkaProducer kProducer;
-    protected static LocalCluster cluster;
-    static TestUtils.KafkaTestFixture server;
+    protected static CompleteTopologyParam completeTopologyParam;
+    protected static MkClusterParam clusterParam;
 
     @ClassRule
     public static TemporaryFolder fsData = new TemporaryFolder();
-
-    protected static Properties kafkaProperties() throws ConfigurationException, CmdLineException {
-        Properties properties = new Properties();
-        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, makeUnboundConfig().getKafkaHosts());
-        properties.put(ConsumerConfig.GROUP_ID_CONFIG, "test");
-        properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
-        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
-        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
-        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
-        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
-        properties.put("request.required.acks", "1");
-        return properties;
-    }
-
-    protected static Properties kafkaProperties(final String groupId) throws ConfigurationException, CmdLineException {
-        Properties properties = kafkaProperties();
-        properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-        return properties;
-    }
-
-    protected static Config stormConfig() {
-        Config config = new Config();
-        config.setDebug(false);
-        config.setMaxTaskParallelism(1);
-        config.setNumWorkers(1);
-        return config;
-    }
 
     @BeforeClass
     public static void setupOnce() throws Exception {
         System.out.println("------> Creating Sheep \uD83D\uDC11\n");
 
+        clusterParam = new MkClusterParam();
+        clusterParam.setSupervisors(1);
+        Config daemonConfig = new Config();
+        daemonConfig.put(Config.STORM_LOCAL_MODE_ZMQ, false);
+        clusterParam.setDaemonConf(daemonConfig);
         makeConfigFile();
 
-        server = new TestUtils.KafkaTestFixture(makeUnboundConfig());
-        server.start();
+        Config conf = new Config();
+        conf.setNumWorkers(1);
 
-        cluster = new LocalCluster();
-        kProducer = new TestKafkaProducer(kafkaProperties());
-    }
-
-    @AfterClass
-    public static void teardownOnce() throws Exception {
-        System.out.println("------> Killing Sheep \uD83D\uDC11\n");
-        kProducer.close();
-        cluster.shutdown();
-        server.stop();
+        completeTopologyParam = new CompleteTopologyParam();
+        completeTopologyParam.setStormConf(conf);
     }
 
     protected static TopologyConfig makeUnboundConfig() throws ConfigurationException, CmdLineException {
@@ -103,6 +68,7 @@ public class AbstractStormTest {
         String args[] = makeLaunchArgs();
         return new LaunchEnvironment(args);
     }
+
     protected static LaunchEnvironment makeLaunchEnvironment(Properties overlay)
             throws CmdLineException, ConfigurationException, IOException {
         String extra = fsData.newFile().getName();

--- a/services/wfm/src/test/java/org/openkilda/wfm/StableAbstractStormTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/StableAbstractStormTest.java
@@ -1,0 +1,35 @@
+package org.openkilda.wfm;
+
+
+import org.apache.storm.Config;
+import org.apache.storm.testing.CompleteTopologyParam;
+import org.apache.storm.testing.MkClusterParam;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+//todo: should be removed when all tests will be free from kafka usages
+public class StableAbstractStormTest extends AbstractStormTest {
+    @BeforeClass
+    public static void setupOnce() throws Exception {
+        System.out.println("------> Creating Sheep \uD83D\uDC11\n");
+
+        clusterParam = new MkClusterParam();
+        clusterParam.setSupervisors(1);
+        Config daemonConfig = new Config();
+        daemonConfig.put(Config.STORM_LOCAL_MODE_ZMQ, false);
+        clusterParam.setDaemonConf(daemonConfig);
+        makeConfigFile();
+
+        Config conf = new Config();
+        conf.setNumWorkers(1);
+
+        completeTopologyParam = new CompleteTopologyParam();
+        completeTopologyParam.setStormConf(conf);
+    }
+
+
+    @AfterClass
+    public static void teardownOnce() throws Exception {
+    }
+
+}

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/TestingKafkaBolt.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/TestingKafkaBolt.java
@@ -1,0 +1,50 @@
+/* Copyright 2017 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology;
+
+import org.apache.storm.kafka.bolt.KafkaBolt;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.tuple.Tuple;
+
+import java.util.Map;
+
+/**
+ * Overridden {@link KafkaBolt} for testing purposes. It doesn't need any configurations and is easy to integrate with
+ * storm junit tests.
+ */
+public class TestingKafkaBolt extends KafkaBolt {
+
+    public TestingKafkaBolt() {
+    }
+
+    @Override
+    protected void process(Tuple input) {
+    }
+
+    @Override
+    public void execute(Tuple tuple) {
+    }
+
+    @Override
+    public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
+    }
+
+    @Override
+    public void cleanup() {
+    }
+
+}

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java
@@ -16,9 +16,23 @@
 package org.openkilda.wfm.topology.stats;
 
 import static java.util.stream.Collectors.toList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.openkilda.messaging.Utils.CORRELATION_ID;
+import static org.openkilda.messaging.Utils.MAPPER;
 
+import org.apache.storm.Testing;
+import org.apache.storm.generated.StormTopology;
+import org.apache.storm.kafka.bolt.KafkaBolt;
+import org.apache.storm.testing.FixedTuple;
+import org.apache.storm.testing.MockedSources;
+import org.apache.storm.topology.TopologyBuilder;
+import org.apache.storm.tuple.Values;
+import org.junit.Test;
 import org.openkilda.messaging.Destination;
+import org.openkilda.messaging.Utils;
+import org.openkilda.messaging.info.Datapoint;
 import org.openkilda.messaging.info.InfoMessage;
 import org.openkilda.messaging.info.stats.FlowStatsData;
 import org.openkilda.messaging.info.stats.FlowStatsEntry;
@@ -29,46 +43,23 @@ import org.openkilda.messaging.info.stats.PortStatsData;
 import org.openkilda.messaging.info.stats.PortStatsEntry;
 import org.openkilda.messaging.info.stats.PortStatsReply;
 import org.openkilda.wfm.AbstractStormTest;
+import org.openkilda.wfm.topology.TestingKafkaBolt;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.storm.Config;
-import org.apache.storm.generated.StormTopology;
-import org.apache.storm.utils.Utils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.IntStream;
 
 public class StatsTopologyTest extends AbstractStormTest {
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-    private static final String TOPIC = "kilda-test";
+
     private static final long timestamp = System.currentTimeMillis();
-
-    @BeforeClass
-    public static void setupOnce() throws Exception {
-        AbstractStormTest.setupOnce();
-
-        StatsTopology topology = new StatsTopology(makeLaunchEnvironment());
-        StormTopology stormTopology = topology.createTopology();
-        Config config = stormConfig();
-        cluster.submitTopology(StatsTopologyTest.class.getSimpleName(), config, stormTopology);
-
-        Utils.sleep(10000);
-    }
-
-    @AfterClass
-    public static void teardownOnce() throws Exception {
-        cluster.killTopology(StatsTopologyTest.class.getSimpleName());
-        Utils.sleep(4 * 1000);
-        AbstractStormTest.teardownOnce();
-    }
 
     @Test
     public void portStatsTest() throws Exception {
+        final String switchId = "00:00:00:00:00:00:00:01";
         final List<PortStatsEntry> entries = IntStream.range(1, 53).boxed().map(port -> {
             int baseCount = port * 20;
             return new PortStatsEntry(port, baseCount, baseCount + 1, baseCount + 2, baseCount + 3,
@@ -76,25 +67,138 @@ public class StatsTopologyTest extends AbstractStormTest {
                     baseCount + 8, baseCount + 9, baseCount + 10, baseCount + 11);
         }).collect(toList());
         final List<PortStatsReply> replies = Collections.singletonList(new PortStatsReply(1, entries));
-        InfoMessage message = new InfoMessage(new PortStatsData("00:00:00:00:00:00:00:01", replies),
-                timestamp, CORRELATION_ID, Destination.WFM_STATS);
-        kProducer.pushMessage(TOPIC, objectMapper.writeValueAsString(message));
+        InfoMessage message = new InfoMessage(new PortStatsData(switchId, replies), timestamp, CORRELATION_ID,
+                Destination.WFM_STATS);
+
+        //mock kafka spout
+        MockedSources sources = new MockedSources();
+        sources.addMockData(StatsComponentType.STATS_OFS_KAFKA_SPOUT.toString(),
+                new Values(MAPPER.writeValueAsString(message)));
+        completeTopologyParam.setMockedSources(sources);
+
+        //execute topology
+        Testing.withTrackedCluster(clusterParam, (cluster) ->  {
+            StatsTopology topology = new TestingTargetTopology(new TestingKafkaBolt());
+            StormTopology stormTopology = topology.createTopology();
+
+            //verify results
+            Map result = Testing.completeTopology(cluster, stormTopology, completeTopologyParam);
+            ArrayList<FixedTuple> tuples =
+                    (ArrayList<FixedTuple>) result.get(StatsComponentType.PORT_STATS_METRIC_GEN.name());
+            assertThat(tuples.size(), is(728));
+            tuples.stream()
+                    .map(this::readFromJson)
+                    .forEach(datapoint -> {
+                        assertThat(datapoint.getTags().get("switchId"), is(switchId.replaceAll(":", "")));
+                        assertThat(datapoint.getTimestamp(), is(timestamp));
+                        assertThat(datapoint.getMetric(), startsWith("pen.switch"));
+                    });
+        });
     }
 
     @Test
     public void meterConfigStatsTest() throws Exception {
+        final String switchId = "00:00:00:00:00:00:00:01";
         final List<MeterConfigReply> stats = Collections.singletonList(new MeterConfigReply(2, Arrays.asList(1L, 2L, 3L)));
-        InfoMessage message = new InfoMessage(new MeterConfigStatsData("00:00:00:00:00:00:00:01", stats),
-                timestamp, CORRELATION_ID, Destination.WFM_STATS);
-        kProducer.pushMessage(TOPIC, objectMapper.writeValueAsString(message));
+        InfoMessage message = new InfoMessage(new MeterConfigStatsData(switchId, stats), timestamp, CORRELATION_ID,
+                Destination.WFM_STATS);
+
+        //mock kafka spout
+        MockedSources sources = new MockedSources();
+        sources.addMockData(StatsComponentType.STATS_OFS_KAFKA_SPOUT.toString(),
+                new Values(MAPPER.writeValueAsString(message)));
+        completeTopologyParam.setMockedSources(sources);
+
+        //execute topology
+        Testing.withTrackedCluster(clusterParam, (cluster) ->  {
+            StatsTopology topology = new TestingTargetTopology(new TestingKafkaBolt());
+            StormTopology stormTopology = topology.createTopology();
+
+            //verify results
+            Map result = Testing.completeTopology(cluster, stormTopology, completeTopologyParam);
+            ArrayList<FixedTuple> tuples =
+                    (ArrayList<FixedTuple>) result.get(StatsComponentType.METER_CFG_STATS_METRIC_GEN.name());
+            assertThat(tuples.size(), is(3));
+            tuples.stream()
+                    .map(this::readFromJson)
+                    .forEach(datapoint -> {
+                        assertThat(datapoint.getTags().get("switchid"), is(switchId.replaceAll(":", "")));
+                        assertThat(datapoint.getTimestamp(), is(timestamp));
+                        assertThat(datapoint.getMetric(), is("pen.switch.meters"));
+                    });
+        });
     }
 
     @Test
     public void flowStatsTest() throws Exception {
+        final String switchId = "00:00:00:00:00:00:00:01";
+
         List<FlowStatsEntry> entries = Collections.singletonList(new FlowStatsEntry((short) 1, 0x1FFFFFFFFL, 1500L, 3000L));
         final List<FlowStatsReply> stats = Collections.singletonList(new FlowStatsReply(3, entries));
-        InfoMessage message = new InfoMessage(new FlowStatsData("00:00:00:00:00:00:00:01", stats),
+        InfoMessage message = new InfoMessage(new FlowStatsData(switchId, stats),
                 timestamp, CORRELATION_ID, Destination.WFM_STATS);
-        kProducer.pushMessage(TOPIC, objectMapper.writeValueAsString(message));
+
+        //mock kafka spout
+        MockedSources sources = new MockedSources();
+        sources.addMockData(StatsComponentType.STATS_OFS_KAFKA_SPOUT.toString(),
+                new Values(MAPPER.writeValueAsString(message)));
+        completeTopologyParam.setMockedSources(sources);
+
+        //execute topology
+        Testing.withTrackedCluster(clusterParam, (cluster) ->  {
+            StatsTopology topology = new TestingTargetTopology(new TestingKafkaBolt());
+            StormTopology stormTopology = topology.createTopology();
+
+            Map result = Testing.completeTopology(cluster, stormTopology, completeTopologyParam);
+
+            //verify results which were sent to Kafka bold
+            ArrayList<FixedTuple> tuples =
+                    (ArrayList<FixedTuple>) result.get(StatsComponentType.FLOW_STATS_METRIC_GEN.name());
+            assertThat(tuples.size(), is(4));
+            tuples.stream()
+                    .map(this::readFromJson)
+                    .forEach(datapoint -> {
+                        assertThat(datapoint.getTags().get("switchid"), is(switchId.replaceAll(":", "")));
+                        assertThat(datapoint.getTimestamp(), is(timestamp));
+                    });
+        });
+    }
+
+    private Datapoint readFromJson(FixedTuple tuple) {
+        try {
+            return Utils.MAPPER.readValue(tuple.values.get(0).toString(), Datapoint.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    private class TestingTargetTopology extends StatsTopology {
+
+        private KafkaBolt kafkaBolt;
+
+        TestingTargetTopology(KafkaBolt kafkaBolt) throws Exception {
+            super(makeLaunchEnvironment());
+
+            this.kafkaBolt = kafkaBolt;
+        }
+
+        @Override
+        protected void checkAndCreateTopic(String topic) {
+        }
+
+        @Override
+        protected void createHealthCheckHandler(TopologyBuilder builder, String prefix) {
+        }
+
+        @Override
+        public String makeTopologyName() {
+            return StatsTopology.class.getSimpleName().toLowerCase();
+        }
+
+        @Override
+        protected KafkaBolt createKafkaBolt(String topic) {
+            return kafkaBolt;
+        }
     }
 }

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java
@@ -42,7 +42,7 @@ import org.openkilda.messaging.info.stats.MeterConfigStatsData;
 import org.openkilda.messaging.info.stats.PortStatsData;
 import org.openkilda.messaging.info.stats.PortStatsEntry;
 import org.openkilda.messaging.info.stats.PortStatsReply;
-import org.openkilda.wfm.AbstractStormTest;
+import org.openkilda.wfm.StableAbstractStormTest;
 import org.openkilda.wfm.topology.TestingKafkaBolt;
 
 import java.io.IOException;
@@ -53,7 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 
-public class StatsTopologyTest extends AbstractStormTest {
+public class StatsTopologyTest extends StableAbstractStormTest {
 
     private static final long timestamp = System.currentTimeMillis();
 
@@ -173,6 +173,9 @@ public class StatsTopologyTest extends AbstractStormTest {
         return null;
     }
 
+    /**
+     * We should create child with these overridden methods because we don't want to use real kafka instance,
+     */
     private class TestingTargetTopology extends StatsTopology {
 
         private KafkaBolt kafkaBolt;


### PR DESCRIPTION
Refactoring junit tests that use kafka. 
Found the way how to test topologies without stateful bolts. Currently it looks like it is simpler to test stateful topologies dividing topology by bolts and test every bolt separately, but when we will have enough time for investigating I think we should find out the way how to tests such topologies entirely.
For that tests that are not refactored I'll create new GH issue.

closes #10 