### PR TITLE
Avoid multiple call to collector.ack(tuple)

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/AbstractAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/AbstractAction.java
@@ -45,7 +45,7 @@ public abstract class AbstractAction implements Runnable {
     }
 
     protected void rollback() {
-        bolt.getOutput().fail(tuple);
+        getOutputCollector().fail(tuple);
     }
 
     public IKildaBolt getBolt() {

--- a/services/wfm/src/main/java/org/openkilda/wfm/AbstractEmbeddedAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/AbstractEmbeddedAction.java
@@ -1,0 +1,12 @@
+package org.openkilda.wfm;
+
+import org.apache.storm.tuple.Tuple;
+
+public abstract class AbstractEmbeddedAction extends AbstractAction {
+    public AbstractEmbeddedAction(IKildaBolt bolt, Tuple tuple) {
+        super(bolt, tuple);
+    }
+
+    @Override
+    protected void commit() {}
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/ctrl/CtrlAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/ctrl/CtrlAction.java
@@ -44,6 +44,14 @@ public class CtrlAction extends AbstractAction {
         action.run();
     }
 
+    @Override
+    protected void commit() {
+        if (! isHandled) {
+            return;
+        }
+        super.commit();
+    }
+
     public Boolean getHandled() {
         return isHandled;
     }

--- a/services/wfm/src/main/java/org/openkilda/wfm/ctrl/CtrlEmbeddedAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/ctrl/CtrlEmbeddedAction.java
@@ -1,17 +1,18 @@
 package org.openkilda.wfm.ctrl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.openkilda.messaging.Destination;
 import org.openkilda.messaging.ctrl.CtrlResponse;
 import org.openkilda.messaging.ctrl.ResponseData;
-import org.openkilda.wfm.AbstractAction;
+import org.openkilda.wfm.AbstractEmbeddedAction;
 import org.openkilda.wfm.protocol.KafkaMessage;
 
-public abstract class CtrlSubAction extends AbstractAction {
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public abstract class CtrlEmbeddedAction extends AbstractEmbeddedAction {
     private final CtrlAction master;
     private final RouteMessage message;
 
-    public CtrlSubAction(CtrlAction master, RouteMessage message) {
+    public CtrlEmbeddedAction(CtrlAction master, RouteMessage message) {
         super(master.getBolt(), master.getTuple());
         this.master = master;
         this.message = message;

--- a/services/wfm/src/main/java/org/openkilda/wfm/ctrl/DumpStateAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/ctrl/DumpStateAction.java
@@ -6,7 +6,7 @@ import org.openkilda.messaging.ctrl.DumpStateResponseData;
 import org.openkilda.wfm.MessageFormatException;
 import org.openkilda.wfm.UnsupportedActionException;
 
-public class DumpStateAction extends CtrlSubAction {
+public class DumpStateAction extends CtrlEmbeddedAction {
     public DumpStateAction(CtrlAction master, RouteMessage message) {
         super(master, message);
     }

--- a/services/wfm/src/main/java/org/openkilda/wfm/ctrl/ListAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/ctrl/ListAction.java
@@ -5,7 +5,7 @@ import org.openkilda.messaging.ctrl.ResponseData;
 import org.openkilda.wfm.MessageFormatException;
 import org.openkilda.wfm.UnsupportedActionException;
 
-public class ListAction extends CtrlSubAction {
+public class ListAction extends CtrlEmbeddedAction {
     public ListAction(CtrlAction master, RouteMessage message) {
         super(master, message);
     }


### PR DESCRIPTION
If some action called from other action, "ack" will be called twice.
Once in outter action and ance into embedded action. Or even worse
embedded action can call fail(tuble) and outter action call ack(tuple).

This change eliminate such possibilities.