### PR TITLE
ISL health check policy

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/isl/DiscoveryNode.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/isl/DiscoveryNode.java
@@ -4,26 +4,74 @@ import java.io.Serializable;
 import java.util.Objects;
 
 public class DiscoveryNode implements Serializable {
+    private final static int NEVER = 999999;
     private final String switchId;
     private final String portId;
     private int age;
+    private int timeCounter;
+    private int checkInterval;
+    private int consequitiveFailures;
+    private int forlornThreshold;
 
-    public DiscoveryNode(String switchId, String portId) {
+
+    public DiscoveryNode(String switchId, String portId, int checkInterval, int forlornThreshold) {
         this.switchId = switchId;
         this.portId = portId;
         this.age = 0;
+        this.timeCounter = 0;
+        this.checkInterval = checkInterval;
+        this.forlornThreshold = forlornThreshold;
+        consequitiveFailures = 0;
+    }
+
+    public DiscoveryNode(String switchId, String portId) {
+        //FIXME: extract checkInterval & forlornThreshold from a config.
+        this(switchId, portId, 1, NEVER);
+    }
+
+    public DiscoveryNode(String switchId) {
+        //FIXME: extract checkInterval & forlornThreshold from a config.
+        this(switchId, "", 1, NEVER);
     }
 
     public void renew() {
         age = 0;
+        timeCounter = 0;
+    }
+
+    public boolean forlorn() {
+        if (forlornThreshold == NEVER) { // never gonna give a link up.
+             return false;
+        }
+        return consequitiveFailures >= forlornThreshold;
+    }
+
+    public void redeem() {
+        consequitiveFailures = 0;
     }
 
     public void incAge() {
         age++;
     }
 
+    public void logTick() {
+        timeCounter++;
+    }
+
+    public void resetTickCounter() {
+        timeCounter = 0;
+    }
+
     public boolean isStale(Integer ageLimit) {
         return ageLimit <= age;
+    }
+
+    public void countFailure() {
+        consequitiveFailures++;
+    }
+
+    public boolean timeToCheck() {
+        return timeCounter >= checkInterval;
     }
 
     public String getSwitchId() {

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java
@@ -215,6 +215,7 @@ public class OFELinkBolt
         String discoFail = OFEMessageUtils.createIslFail(switchId, portId);
         Values dataVal = new Values(PAYLOAD, discoFail, switchId, portId, OFEMessageUtils.LINK_DOWN);
         collector.emit(outputStreamId, tuple, dataVal);
+        discovery.handleFailed(switchId, portId);
         logger.warn("LINK: Send ISL discovery failure message={}", discoFail);
     }
 


### PR DESCRIPTION
This commit enables finer grained approach to
ISL health check allowing to determine health
check interval on per-ISL basis as well as
adds handles for manual trigering of checks.

Closes #57 #58