### PR TITLE
Handle json deserrialisation error

### DIFF
--- a/services/topology-engine/queue-engine/topologies/example-topology-prepopulation.json
+++ b/services/topology-engine/queue-engine/topologies/example-topology-prepopulation.json
@@ -39,7 +39,6 @@
     ],
     "flows": [
         {
-            "flowid": "pre-populated-1",
             "forward": {
                 "flowid": "pre-populated-frw1",
                 "cookie": 22213,

--- a/services/wfm/src/main/java/org/openkilda/wfm/isl/DiscoveryManager.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/isl/DiscoveryManager.java
@@ -103,7 +103,7 @@ public class DiscoveryManager {
             return;
         }
 
-        subject = new DiscoveryNode(node.switchId);
+        subject = new DiscoveryNode(node.switchId, node.portId);
         pollQueue.add(subject);
         logger.info("New {}", subject);
     }

--- a/services/wfm/src/main/java/org/openkilda/wfm/isl/DiscoveryNode.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/isl/DiscoveryNode.java
@@ -4,13 +4,14 @@ import java.io.Serializable;
 import java.util.Objects;
 
 public class DiscoveryNode implements Serializable {
+    // FIXME(surabujin): ... is there any better way to define this value?
     private final static int NEVER = 999999;
     private final String switchId;
     private final String portId;
     private int age;
     private int timeCounter;
     private int checkInterval;
-    private int consequitiveFailures;
+    private int consecutiveFailures;
     private int forlornThreshold;
 
 
@@ -21,17 +22,17 @@ public class DiscoveryNode implements Serializable {
         this.timeCounter = 0;
         this.checkInterval = checkInterval;
         this.forlornThreshold = forlornThreshold;
-        consequitiveFailures = 0;
+        consecutiveFailures = 0;
     }
 
     public DiscoveryNode(String switchId, String portId) {
         //FIXME: extract checkInterval & forlornThreshold from a config.
-        this(switchId, portId, 1, NEVER);
+        this(switchId, portId, 0, NEVER);
     }
 
     public DiscoveryNode(String switchId) {
         //FIXME: extract checkInterval & forlornThreshold from a config.
-        this(switchId, "", 1, NEVER);
+        this(switchId, "", 0, NEVER);
     }
 
     public void renew() {
@@ -43,11 +44,11 @@ public class DiscoveryNode implements Serializable {
         if (forlornThreshold == NEVER) { // never gonna give a link up.
              return false;
         }
-        return consequitiveFailures >= forlornThreshold;
+        return consecutiveFailures >= forlornThreshold;
     }
 
     public void redeem() {
-        consequitiveFailures = 0;
+        consecutiveFailures = 0;
     }
 
     public void incAge() {
@@ -67,7 +68,7 @@ public class DiscoveryNode implements Serializable {
     }
 
     public void countFailure() {
-        consequitiveFailures++;
+        consecutiveFailures++;
     }
 
     public boolean timeToCheck() {

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/event/PopulateIslFilterAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/event/PopulateIslFilterAction.java
@@ -1,7 +1,5 @@
 package org.openkilda.wfm.topology.event;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.storm.tuple.Tuple;
 import org.openkilda.messaging.Destination;
 import org.openkilda.messaging.Message;
 import org.openkilda.messaging.command.CommandMessage;
@@ -13,6 +11,9 @@ import org.openkilda.wfm.MessageFormatException;
 import org.openkilda.wfm.UnsupportedActionException;
 import org.openkilda.wfm.isl.DummyIIslFilter;
 import org.openkilda.wfm.protocol.KafkaMessage;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.storm.tuple.Tuple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,5 +51,24 @@ public class PopulateIslFilterAction extends AbstractAction {
             logger.info("Add ISL filter record - switcID=\"{}\" portId=\"{}\"", entity.switchId, entity.portId);
             filter.add(entity.switchId, entity.portId);
         }
+    }
+
+    @Override
+    protected Boolean handleError(Exception e) {
+        boolean isHandled = true;
+
+        try {
+            throw e;
+        } catch (MessageFormatException exc) {
+            logger.error("Can\'t unpack input tuple: {}", exc.getCause().getMessage());
+
+            for (int i = 0; i < getTuple().size(); i++) {
+                logger.error("Field #{}: {}", i, getTuple().getValue(i));
+            }
+        } catch (Exception exc) {
+            isHandled = false;
+        }
+
+        return isHandled;
     }
 }

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/event/OFELinkBoltTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/event/OFELinkBoltTest.java
@@ -1,0 +1,48 @@
+package org.openkilda.wfm.topology.event;
+
+import org.openkilda.wfm.AbstractStormTest;
+import org.openkilda.wfm.ConfigurationException;
+import org.openkilda.wfm.protocol.KafkaMessage;
+import org.openkilda.wfm.topology.OutputCollectorMock;
+import org.openkilda.wfm.topology.TopologyConfig;
+
+import org.apache.storm.state.InMemoryKeyValueState;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.TupleImpl;
+import org.apache.storm.tuple.Values;
+import org.junit.Test;
+import org.kohsuke.args4j.CmdLineException;
+import org.mockito.Mockito;
+
+public class OFELinkBoltTest extends AbstractStormTest {
+    private static final Integer TASK_ID_BOLT = 0;
+    private static final String COMPONENT_ID_SOURCE = OFEventWFMTopology.SPOUT_ID_INPUT;
+    private static final String STREAM_ID_INPUT = "input";
+
+    @Test
+    public void invalidJsonForDiscoveryFilter() throws CmdLineException, ConfigurationException {
+        OFEventWFMTopology manager = new OFEventWFMTopology(makeLaunchEnvironment());
+        TopologyConfig config = manager.getConfig();
+        OFELinkBolt bolt = new OFELinkBolt(config);
+
+        TopologyContext context = Mockito.mock(TopologyContext.class);
+
+        Mockito.when(context.getComponentId(TASK_ID_BOLT))
+                .thenReturn(COMPONENT_ID_SOURCE);
+        Mockito.when(context.getComponentOutputFields(COMPONENT_ID_SOURCE, STREAM_ID_INPUT))
+                .thenReturn(KafkaMessage.FORMAT);
+
+        OutputCollectorMock outputDelegate = Mockito.spy(new OutputCollectorMock());
+        OutputCollector output = new OutputCollector(outputDelegate);
+
+        bolt.prepare(stormConfig(), context, output);
+        bolt.initState(new InMemoryKeyValueState<>());
+
+        Tuple tuple = new TupleImpl(context, new Values("{\"corrupted-json"), TASK_ID_BOLT, STREAM_ID_INPUT);
+        bolt.doWork(tuple);
+
+        Mockito.verify(outputDelegate).ack(tuple);
+    }
+}


### PR DESCRIPTION
Add handler for JSON deserrialisation errors into "port discovery"
filter configurator.

Current issue with JSON format comes from messege created by TE during
injecting of prepopulated topology.

Closes #113