### PR TITLE
[MAINT] Fix test bugs due to Splitter deprecation

### DIFF
--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/KafkaMessageCollector.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/KafkaMessageCollector.java
@@ -21,7 +21,7 @@ import org.openkilda.floodlight.pathverification.IPathVerificationService;
 import org.openkilda.floodlight.switchmanager.ISwitchManager;
 import org.openkilda.floodlight.switchmanager.MeterPool;
 import org.openkilda.messaging.Destination;
-import org.openkilda.messaging.Message;
+import org.openkilda.messaging.BaseMessage;
 import org.openkilda.messaging.command.CommandData;
 import org.openkilda.messaging.command.CommandMessage;
 import org.openkilda.messaging.command.discovery.DiscoverIslCommandData;
@@ -360,13 +360,12 @@ public class KafkaMessageCollector implements IFloodlightModule {
             try {
                 if (record.value() instanceof String) {
                     String value = (String) record.value();
-                    BaseMessage message = MAPPER.readValue(value, BaseMessage.class);
-                    if (message instanceof CommandMessage) {
-                        logger.debug("Got a command message for controller: {}", value);
-                        doControllerMsg((CommandMessage) message);
-                    } else {
-                        logger.trace("Skip message: {}", message);
-                    }
+                    // TODO: Prior to Message changes, this MAPPER would read Message ..
+                    //          but, changed to BaseMessage and got an error wrt "timestamp" ..
+                    //          so, need to experiment with why CommandMessage can't be read as
+                    //          a BaseMessage
+                    CommandMessage message = MAPPER.readValue(value, CommandMessage.class);
+                    doControllerMsg((CommandMessage) message);
                 } else {
                     logger.error("{} not of type String", record.value());
                 }

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/kafka/ReplaceInstallFlowTest.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/kafka/ReplaceInstallFlowTest.java
@@ -32,7 +32,7 @@ import org.openkilda.floodlight.pathverification.PathVerificationService;
 import org.openkilda.floodlight.switchmanager.ISwitchManager;
 import org.openkilda.floodlight.switchmanager.SwitchEventCollector;
 import org.openkilda.floodlight.switchmanager.SwitchManager;
-import org.openkilda.messaging.Message;
+import org.openkilda.messaging.BaseMessage;
 import org.openkilda.messaging.command.CommandData;
 import org.openkilda.messaging.command.CommandMessage;
 import org.openkilda.messaging.command.flow.InstallEgressFlow;
@@ -79,9 +79,8 @@ public class ReplaceInstallFlowTest {
      * @throws IOException if mapping fails
      */
     private static CommandData prepareData(String value) throws IOException {
-        Message message = MAPPER.readValue(value, Message.class);
-        CommandMessage commandMessage = (CommandMessage) message;
-        return commandMessage.getData();
+        CommandMessage message = MAPPER.readValue(value, CommandMessage.class);
+        return message.getData();
     }
 
     @Before
@@ -266,6 +265,9 @@ public class ReplaceInstallFlowTest {
 
         // verify results
         if (meterCommand != null) {
+            System.out.println("meterCommand    = " + meterCommand);
+            System.out.println("meterAddCapture = " + meterAddCapture.getValues());
+
             assertEquals(meterCommand, meterAddCapture.getValues().get(0));
             if (reverseMeterCommand != null) {
                 assertEquals(reverseMeterCommand, meterAddCapture.getValues().get(1));


### PR DESCRIPTION
The previous commit deprecated the Splitter topology and classes,
but there where still some (outdated) dependencies in some
currently @ignore test cases.

These are now fixed.