### PR TITLE
[MAINT] Remove Splitter from Health Checks .. closes issue #144

### DIFF
--- a/docs/design/usecase/storm-topology-management.md
+++ b/docs/design/usecase/storm-topology-management.md
@@ -1,0 +1,26 @@
+# Storm Topology Management
+
+## Introduction
+
+There are a few patterns to how the Storm Topologies work in Kilda. This document will do its best to describe the patterns. If what you're looking for isn't documented yet, please add to this document.
+
+## Removing a Storm Topology
+
+### Removing Topology Makefile Targets
+
+Each topology has a start/stop target in the wfm Makefile. Please remove the topology targets:
+
+    services/wfm/Makefile
+
+### Removing Topology Health Checks
+
+The Northbound API has a target for reporting back on the health of storm topologies. Initially this is just operational/non-operational status.
+
+The call to Northbound uses the following enum type to figure out which services to call:
+
+    org.openkilda.messaging.ServiceType
+
+That enum is leveraged by:
+
+     org.openkilda.northbound.service.impl.HealthCheckImpl
+     

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/kafka/ReplaceInstallFlowTest.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/kafka/ReplaceInstallFlowTest.java
@@ -265,9 +265,6 @@ public class ReplaceInstallFlowTest {
 
         // verify results
         if (meterCommand != null) {
-            System.out.println("meterCommand    = " + meterCommand);
-            System.out.println("meterAddCapture = " + meterAddCapture.getValues());
-
             assertEquals(meterCommand, meterAddCapture.getValues().get(0));
             if (reverseMeterCommand != null) {
                 assertEquals(reverseMeterCommand, meterAddCapture.getValues().get(1));

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/ServiceType.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/ServiceType.java
@@ -19,7 +19,6 @@ public enum ServiceType {
     FLOW_TOPOLOGY("flow-storm-topology"),
     STATS_TOPOLOGY("statistics-storm-topology"),
     CACHE_TOPOLOGY("cache-storm-topology"),
-    SPLITTER_TOPOLOGY("event-splitter-storm-topology"),
     WFM_TOPOLOGY("event-wfm-storm-topology");
 
     private final String id;


### PR DESCRIPTION
The Storm Topologies are "registered" in ServiceType.java,
and used in the NB to loop through who to call. Removed
the splitter from that list.