### PR TITLE
Fix for traffic sending ATs

### DIFF
--- a/services/src/atdd/src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java
+++ b/services/src/atdd/src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java
@@ -183,23 +183,40 @@ public class FlowCrudBasicRunTest {
         // TODO: implement
     }
 
-    private int checkTraffic(int sourceVlan, int destinationVlan, int expectedStatus) {
+    private int checkTraffic(String sourceSwitch, String destSwitch, int sourceVlan, int destinationVlan, int expectedStatus) {
         if (isTrafficTestsEnabled()) {
             System.out.println("=====> Send traffic");
 
             long current = System.currentTimeMillis();
             Client client = ClientBuilder.newClient(new ClientConfig());
+
+            // NOTE: current implementation requires two auxiliary switches in
+            // topology, one for generating traffic, another for receiving it.
+            // Originaly smallest meaningful topology was supposed to consist
+            // of three switches, thus switches 1 and 5 were used as auxiliary.
+            // Now some scenarios require even smaller topologies and at the same
+            // time they reuse small linear topology. This leads to shutting off of
+            // switches 1 and 5 from flows and to test failures. Since topology
+            // reuse speeds testing up the code below determines which switch:port
+            // pairs should be used as source and drains for traffic while keepig
+            // small linear topology in use.
+            String from = "0000000" + (Integer.parseInt(sourceSwitch.substring(sourceSwitch.length() -1 )) - 1);
+            String to = "0000000" + (Integer.parseInt(destSwitch.substring(destSwitch.length() -1 )) + 1);
+            int fromPort = from.equals("00000001") ? 1 : 2;
+            int toPort = 1;
+
             Response result = client
                     .target(trafficEndpoint)
                     .path("/checkflowtraffic")
-                    .queryParam("srcswitch", "00000001")
-                    .queryParam("dstswitch", "00000005")
-                    .queryParam("srcport", 1)
-                    .queryParam("dstport", 1)
+                    .queryParam("srcswitch", from)
+                    .queryParam("dstswitch", to)
+                    .queryParam("srcport", fromPort)
+                    .queryParam("dstport", toPort)
                     .queryParam("srcvlan", sourceVlan)
                     .queryParam("dstvlan", destinationVlan)
                     .request()
                     .get();
+
             System.out.println(String.format("======> Response = %s", result.toString()));
             System.out.println(String.format("======> Send traffic Time: %,.3f", getTimeDuration(current)));
 
@@ -214,7 +231,7 @@ public class FlowCrudBasicRunTest {
                                         final String destinationSwitch, final int destinationPort,
                                         final int destinationVlan, final int bandwidth) throws Throwable {
         TimeUnit.SECONDS.sleep(2);
-        int status = checkTraffic(sourceVlan, destinationVlan, 200);
+        int status = checkTraffic(sourceSwitch, destinationSwitch, sourceVlan, destinationVlan, 200);
         assertEquals(200, status);
     }
 
@@ -223,7 +240,7 @@ public class FlowCrudBasicRunTest {
                                            final String destinationSwitch, final int destinationPort,
                                            final int destinationVlan, final int bandwidth) throws Throwable {
         TimeUnit.SECONDS.sleep(2);
-        int status = checkTraffic(sourceVlan, destinationVlan, 503);
+        int status = checkTraffic(sourceSwitch, destinationSwitch, sourceVlan, destinationVlan, 503);
         assertNotEquals(200, status);
     }
 

--- a/services/src/atdd/src/test/resources/features/mvp.1/FlowCrudBasicRun.feature
+++ b/services/src/atdd/src/test/resources/features/mvp.1/FlowCrudBasicRun.feature
@@ -34,11 +34,9 @@ Feature: Basic Flow CRUD
       # flows with transit vlans and intermediate switches
       | c3none  | de:ad:be:ef:00:00:00:02 |      1      |      0      | de:ad:be:ef:00:00:00:04 |         2        |        0         |   10000   |
       # flows with transit vlans and without intermediate switches
-# This test is failing on 2018.01.06 - it is failing
-#      | c2none  | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:04 |         2        |        0         |   10000   |
+      | c2none  | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:04 |         2        |        0         |   10000   |
       # flows without transit vlans and intermediate switches
-# This test is failing on 2018.01.06 - it is failing
-#      | c1none  | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:03 |         2        |        0         |   10000   |
+      | c1none  | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:03 |         2        |        0         |   10000   |
 
 
 
@@ -76,7 +74,7 @@ Feature: Basic Flow CRUD
       | c3pop   | de:ad:be:ef:00:00:00:02 |      1      |     100     | de:ad:be:ef:00:00:00:04 |         2        |        0         |   10000   |
       | c3swap  | de:ad:be:ef:00:00:00:02 |      1      |     100     | de:ad:be:ef:00:00:00:04 |         2        |       200        |   10000   |
 
-  @MVP1.1 @CRUD_CREATE
+  @MVP1 @CRUD_CREATE
   Scenario Outline: Flow Creation - flows with transit vlans and without intermediate switches
 
     This scenario setups flows across the entire set of switches and checks that these flows were stored in database
@@ -107,7 +105,7 @@ Feature: Basic Flow CRUD
       | c2pop   | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:04 |         2        |        0         |   10000   |
       | c2swap  | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:04 |         2        |       200        |   10000   |
 
-  @MVP1.1 @CRUD_CREATE
+  @MVP1 @CRUD_CREATE
   Scenario Outline: Flow Creation - flows without transit vlans and intermediate switches
 
     This scenario setups flows across the entire set of switches and checks that these flows were stored in database
@@ -139,7 +137,7 @@ Feature: Basic Flow CRUD
       | c1swap  | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:03 |         2        |       200        |   10000   |
 
 
-  @MVP1.1 @CRUD_UPDATE
+  @MVP1 @CRUD_UPDATE
   Scenario Outline: Flow Updating on Small Linear Network Topology
 
   This scenario setups flows across the entire set of switches, then updates them and checks that flows were updated in database


### PR DESCRIPTION
Newer ATs which relied on sending traffic across flows
were neither using proper topologies nor setting proper
source and destination switches for shorter flows which
resulted in false failures. This commit fixes the issue
by providing code to supply porper switch:port pairs
to traffic sending tool.