### PR TITLE
Fix RC on CacheBolt execute tuples before internal state were restored

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/ctrl/ClearStateAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/ctrl/ClearStateAction.java
@@ -1,0 +1,19 @@
+package org.openkilda.wfm.ctrl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.annotations.VisibleForTesting;
+import org.openkilda.wfm.MessageFormatException;
+import org.openkilda.wfm.UnsupportedActionException;
+
+@VisibleForTesting
+class ClearStateAction extends CtrlEmbeddedAction {
+    ClearStateAction(CtrlAction master, RouteMessage message) {
+        super(master, message);
+    }
+
+    @Override
+    protected void handle()
+            throws MessageFormatException, UnsupportedActionException, JsonProcessingException {
+        getMaster().getBolt().clearState();
+    }
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/ctrl/CtrlAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/ctrl/CtrlAction.java
@@ -37,6 +37,9 @@ public class CtrlAction extends AbstractAction {
             case "dump":
                 action = new DumpStateAction(this, message);
                 break;
+            case "clearState":
+                action = new ClearStateAction(this, message);
+                break;
             default:
                 throw new UnsupportedActionException(payload.getAction());
         }

--- a/services/wfm/src/main/java/org/openkilda/wfm/ctrl/ICtrlBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/ctrl/ICtrlBolt.java
@@ -1,5 +1,6 @@
 package org.openkilda.wfm.ctrl;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.openkilda.messaging.ctrl.AbstractDumpState;
 import org.openkilda.wfm.IKildaBolt;
 
@@ -7,4 +8,7 @@ public interface ICtrlBolt extends IKildaBolt {
     AbstractDumpState dumpState();
 
     String getCtrlStreamId();
+
+    @VisibleForTesting
+    default void clearState() { }
 }

--- a/services/wfm/src/test/resources/log4j2.xml
+++ b/services/wfm/src/test/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="trace">
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="org.openkilda.wfm.simulator" level="warn" additivity="false">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+        <Root level="DEBUG">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
We mark tuples as failed while state is not restored