### PR TITLE
[MAINT] Refactor FL - sendDiscoveryMessage, simplify

### DIFF
--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/pathverification/PathVerificationPacketOutTest.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/pathverification/PathVerificationPacketOutTest.java
@@ -119,7 +119,7 @@ public class PathVerificationPacketOutTest extends FloodlightTestCase {
     @Test
     public void testUncastPacket() {
         // Generate the VerificationPacket
-        OFPacketOut packet = pvs.generateVerificationPacket(sw1, OFPort.of(1), sw2);
+        OFPacketOut packet = pvs.generateVerificationPacket(sw1, OFPort.of(1), sw2, true);
 
         // Source MAC will always be that of sw1 for both Unicast and Broadcast
         byte[] srcMacActual = Arrays.copyOfRange(packet.getData(), 6, 12);


### PR DESCRIPTION
The code was simplified a little bit wrt the number of methods we have
for sendDiscoveryMessage and generateVerificationPacket.

This was to ensure there weren't duplicate code paths to test.