### PR TITLE
Add retry mechanis for py2neo calls

### DIFF
--- a/services/topology-engine-rest/Dockerfile
+++ b/services/topology-engine-rest/Dockerfile
@@ -37,12 +37,10 @@ RUN pip install \
     py2neo \
     requests \
     python-logstash
-#RUN chown www-data:www-data /var/data
-RUN chmod +x /usr/local/bin/uwsgi
+ADD nginx/sites/ /etc/nginx/sites-available/
+ADD supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+ADD db/database.db /var/data/
 ADD app/ /app
 RUN mkdir -p /app/logs/uwsgi
-ADD supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-ADD nginx/sites/ /etc/nginx/sites-available/
-ADD db/database.db /var/data/
 
 CMD /usr/bin/supervisord

--- a/services/topology-engine-rest/app/app/exc.py
+++ b/services/topology-engine-rest/app/app/exc.py
@@ -1,0 +1,6 @@
+
+class ConfigError(Exception):
+    def __init__(self, section, option, error):
+        message = 'There is an issue with option [{}]{!r}: {}'.format(
+                section, option, error)
+        super(ConfigError, self).__init__(message)

--- a/services/topology-engine-rest/app/app/neo4j_tools.py
+++ b/services/topology-engine-rest/app/app/neo4j_tools.py
@@ -1,12 +1,71 @@
+from __future__ import absolute_import
+
+import ConfigParser
 import logging
 import os
+import time
 
+import py2neo.database
+import py2neo.database.status
 from py2neo import Graph
+
+from . import exc
 
 logger = logging.getLogger(__name__)
 
 
+class RetryConfig(object):
+    iteration = 0
+    max_attempts = 3
+    delay = 0.1
+
+    @classmethod
+    def configure(cls, config):
+        for attr, conv in (
+                ('max_attempts', int),
+                ('delay', float)):
+            key = 'retry.' + attr
+            try:
+                value = config.get('neo4j', key)
+                value = conv(value)
+            except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
+                continue
+            except TypeError as e:
+                raise exc.ConfigError('neo4j', key, e)
+
+            setattr(cls, attr, value)
+
+    def can_retry(self):
+        if self.max_attempts < 0:
+            return True
+        return self.iteration < self.max_attempts
+
+    def sleep(self):
+        self.iteration += 1
+        if 0 < self.delay:
+            time.sleep(self.delay)
+
+
+class BoltTransactionPatch(py2neo.database.BoltTransaction):
+    def run(self, statement, parameters=None, **kwparameters):
+        retry = RetryConfig()
+
+        while retry.can_retry():
+            try:
+                result = super(BoltTransactionPatch, self).run(
+                        statement, parameters, **kwparameters)
+            except py2neo.database.status.TransientError:
+                if not self.autocommit:
+                    raise
+                retry.sleep()
+                continue
+
+            return result
+
+
 def connect(config):
+    RetryConfig.configure(config)
+
     env_keys_map = {
         'host': 'neo4host',
         'login': 'neo4usr',
@@ -36,3 +95,7 @@ def connect(config):
     args['password'] = '*' * 5
     logger.info('NEO4j connect %s', uri_format(**args))
     return Graph(uri)
+
+
+# monkeypatching py2neo.database to inject our retry mechanism
+py2neo.database.BoltTransaction = BoltTransactionPatch

--- a/services/topology-engine-rest/app/topology_engine_rest.ini
+++ b/services/topology-engine-rest/app/topology_engine_rest.ini
@@ -7,3 +7,6 @@ bootstrap.servers=kafka.pendev:9092
 host=neo4j
 user=neo4j
 pass=temppass
+# -1 mean infinite attempts
+retry.max_attempts = 3
+retry.delay = 0.1

--- a/templates/templates/topology-engine-rest/topology_engine_rest.ini.j2
+++ b/templates/templates/topology-engine-rest/topology_engine_rest.ini.j2
@@ -7,3 +7,5 @@ bootstrap.servers={{ kafka_hosts }}
 host={{ neo4j_host }}
 user={{ neo4j_user }}
 pass={{ neo4j_password }}
+retry.max_attempts = 3
+retry.delay = 0.1

--- a/templates/vars/path.yaml
+++ b/templates/vars/path.yaml
@@ -17,7 +17,7 @@ path:
     tmpl: templates/topology-engine/log.json.j2
   - topology_engine_rest_properties:
     dest: services/topology-engine-rest/app/topology_engine_rest.ini
-    tmpl: templates/topology-engine-rest/topology_engine_rest.properties.j2
+    tmpl: templates/topology-engine-rest/topology_engine_rest.ini.j2
   - topology_engine_rest_log_json:
     dest: services/topology-engine-rest/app/log.json
     tmpl: templates/topology-engine-rest/log.json.j2


### PR DESCRIPTION
py2neo call can throw py2neo.database.status.TransientError.
Documentation recoment to retry request in this case. But py2neo don't
provive any tools to make a retry.

Invent simple retry mechanism via subclassing
py2neo.database.BoltTransaction and injecting it into py2neo via
monkeypatching.

Close #254