### PR TITLE
Direct connect to Neo4j into PathComputer

### DIFF
--- a/services/src/atdd/src/test/java/org/openkilda/DefaultParameters.java
+++ b/services/src/atdd/src/test/java/org/openkilda/DefaultParameters.java
@@ -17,7 +17,7 @@ package org.openkilda;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
-import org.openkilda.pce.provider.NeoDriver;
+import org.openkilda.pce.provider.AuthNeo4j;
 import org.openkilda.pce.provider.PathComputer;
 
 public final class DefaultParameters {
@@ -34,7 +34,7 @@ public final class DefaultParameters {
     public static final String topologyEndpoint = String.format("http://%s:%s", host, topologyPort);
     public static final String northboundEndpoint = String.format("http://%s:%s", host, northboundPort);
     public static final String opentsdbEndpoint = String.format("http://%s:%s", host, opentsdbPort);
-    public static final PathComputer pathComputer = new NeoDriver(host, "neo4j", "temppass");
+    public static final PathComputer pathComputer = new AuthNeo4j(host, "neo4j", "temppass").connect();
     public static final String FLOODLIGHT_ENDPOINT = String.format("http://%s:%s", host, FLOODLIGHT_PORT);
 
     static {

--- a/services/src/pce/src/main/java/org/openkilda/pce/cache/FlowCache.java
+++ b/services/src/pce/src/main/java/org/openkilda/pce/cache/FlowCache.java
@@ -481,16 +481,6 @@ public class FlowCache extends Cache {
     }
 
     /**
-     * Checks if flow is through single switch.
-     *
-     * @param flow flow
-     * @return true if source and destination switches are same for specified flow, otherwise false
-     */
-    public boolean isOneSwitchFlow(Flow flow) {
-        return flow.getSourceSwitch().equals(flow.getDestinationSwitch());
-    }
-
-    /**
      * Gets flow linked with specified switch id.
      *
      * @param flow     flow

--- a/services/src/pce/src/main/java/org/openkilda/pce/provider/Auth.java
+++ b/services/src/pce/src/main/java/org/openkilda/pce/provider/Auth.java
@@ -1,0 +1,7 @@
+package org.openkilda.pce.provider;
+
+import java.io.Serializable;
+
+public interface Auth extends Serializable {
+    PathComputer connect();
+}

--- a/services/src/pce/src/main/java/org/openkilda/pce/provider/AuthNeo4j.java
+++ b/services/src/pce/src/main/java/org/openkilda/pce/provider/AuthNeo4j.java
@@ -1,0 +1,28 @@
+package org.openkilda.pce.provider;
+
+import org.neo4j.driver.v1.AuthTokens;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AuthNeo4j implements Auth {
+    private static final Logger logger = LoggerFactory.getLogger(AuthNeo4j.class);
+
+    private final String host;
+    private final String login;
+    private final String password;
+
+    public AuthNeo4j(String host, String login, String password) {
+        this.host = host;
+        this.login = login;
+        this.password = password;
+    }
+
+    @Override
+    public NeoDriver connect() {
+        String address = String.format("bolt://%s", host);
+
+        logger.info("NEO4J connect {} (login=\"{}\", password=\"*****\")", address, login);
+        return new NeoDriver(GraphDatabase.driver(address, AuthTokens.basic(login, password)));
+    }
+}

--- a/services/src/pce/src/main/java/org/openkilda/pce/provider/PathComputer.java
+++ b/services/src/pce/src/main/java/org/openkilda/pce/provider/PathComputer.java
@@ -49,22 +49,12 @@ public interface PathComputer extends Serializable {
     }
 
     /**
-     * Checks is path empty.
-     *
-     * @param path path
-     * @return true if path is empty. otherwise false
-     */
-    default boolean isEmpty(ImmutablePair<PathInfoData, PathInfoData> path) {
-        return path.getLeft().getPath().isEmpty() || path.getRight().getPath().isEmpty();
-    }
-
-    /**
      * Gets path between source and destination switch.
      *
      * @param flow {@link Flow} instances
      * @return {@link PathInfoData} instances
      */
-    ImmutablePair<PathInfoData, PathInfoData> getPath(Flow flow, Strategy strategy);
+    ImmutablePair<PathInfoData, PathInfoData> getPath(Flow flow, Strategy strategy) throws UnroutablePathException;
 
     /**
      * Gets path between source and destination switch.
@@ -75,5 +65,5 @@ public interface PathComputer extends Serializable {
      * @return {@link PathInfoData} instances
      */
     ImmutablePair<PathInfoData, PathInfoData> getPath(SwitchInfoData source, SwitchInfoData destination,
-                                                      int bandwidth, Strategy strategy);
+                                                      int bandwidth, Strategy strategy) throws UnroutablePathException;
 }

--- a/services/src/pce/src/main/java/org/openkilda/pce/provider/UnroutablePathException.java
+++ b/services/src/pce/src/main/java/org/openkilda/pce/provider/UnroutablePathException.java
@@ -1,0 +1,27 @@
+package org.openkilda.pce.provider;
+
+public class UnroutablePathException extends Exception {
+    private final String srcSwitch;
+    private final String dstSwitch;
+    private final int bandwidth;
+
+    public UnroutablePathException(String srcSwitch, String dstSwitch, int bandwidth) {
+        super(String.format("Can't make flow from %s to %s (bandwidth=%d", srcSwitch, dstSwitch, bandwidth));
+
+        this.srcSwitch = srcSwitch;
+        this.dstSwitch = dstSwitch;
+        this.bandwidth = bandwidth;
+    }
+
+    public String getSrcSwitch() {
+        return srcSwitch;
+    }
+
+    public String getDstSwitch() {
+        return dstSwitch;
+    }
+
+    public int getBandwidth() {
+        return bandwidth;
+    }
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/AbstractTopology.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/AbstractTopology.java
@@ -15,14 +15,13 @@
 
 package org.openkilda.wfm.topology;
 
-import org.apache.storm.topology.BoltDeclarer;
-import org.openkilda.wfm.NameCollisionException;
-import org.openkilda.wfm.StreamNameCollisionException;
 import org.openkilda.messaging.Topic;
 import org.openkilda.wfm.ConfigurationException;
-import org.openkilda.wfm.LaunchEnvironment;
-import org.openkilda.wfm.PropertiesReader;
 import org.openkilda.wfm.CtrlBoltRef;
+import org.openkilda.wfm.LaunchEnvironment;
+import org.openkilda.wfm.NameCollisionException;
+import org.openkilda.wfm.PropertiesReader;
+import org.openkilda.wfm.StreamNameCollisionException;
 import org.openkilda.wfm.ctrl.RouteBolt;
 import org.openkilda.wfm.topology.utils.HealthCheckBolt;
 
@@ -46,6 +45,7 @@ import org.apache.storm.kafka.bolt.selector.DefaultTopicSelector;
 import org.apache.storm.kafka.spout.KafkaSpout;
 import org.apache.storm.spout.SchemeAsMultiScheme;
 import org.apache.storm.thrift.TException;
+import org.apache.storm.topology.BoltDeclarer;
 import org.apache.storm.topology.TopologyBuilder;
 import org.apache.storm.tuple.Fields;
 import org.kohsuke.args4j.CmdLineException;
@@ -136,6 +136,7 @@ public abstract class AbstractTopology implements Topology {
             logger.error("Unable to complete topology setup: {}", e.getMessage());
             errorCode = 4;
         } catch (Exception e) {
+            logger.error("Unhandled exception", e);
             errorCode = 1;
         }
 

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flow/FlowTopologyTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flow/FlowTopologyTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.openkilda.messaging.Destination;
 import org.openkilda.messaging.Message;
-import org.openkilda.messaging.Topic;
 import org.openkilda.messaging.command.CommandMessage;
 import org.openkilda.messaging.command.flow.FlowCreateRequest;
 import org.openkilda.messaging.command.flow.FlowDeleteRequest;
@@ -57,6 +56,7 @@ import org.openkilda.messaging.payload.flow.FlowState;
 import org.openkilda.messaging.payload.flow.OutputVlanType;
 import org.openkilda.wfm.AbstractStormTest;
 import org.openkilda.wfm.topology.TestKafkaConsumer;
+import org.openkilda.wfm.topology.TopologyConfig;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -69,7 +69,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.openkilda.wfm.topology.TopologyConfig;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -91,7 +90,7 @@ public class FlowTopologyTest extends AbstractStormTest {
     public static void setupOnce() throws Exception {
         AbstractStormTest.setupOnce();
 
-        flowTopology = new FlowTopology(makeLaunchEnvironment(), new PathComputerMock());
+        flowTopology = new FlowTopology(makeLaunchEnvironment(), new PathComputerAuth());
         topologyConfig = flowTopology.getConfig();
 
         StormTopology stormTopology = flowTopology.createTopology();

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flow/PathComputerAuth.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flow/PathComputerAuth.java
@@ -1,0 +1,10 @@
+package org.openkilda.wfm.topology.flow;
+
+import org.openkilda.pce.provider.Auth;
+
+public class PathComputerAuth implements Auth {
+    @Override
+    public PathComputerMock connect() {
+        return new PathComputerMock();
+    }
+}


### PR DESCRIPTION
Till now PathComputer kept auth info and made lazy connect to neo4j.

Because of this trait the neo4j connect must be validated before each
call. Also it masks(postpone) potential authentication errors to the
moment of first Neo4j call.

Redesign PathComputer to eliminate this trait.