### PR TITLE
Hardening FloodLight config usage

### DIFF
--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/KafkaMessageCollector.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/KafkaMessageCollector.java
@@ -69,7 +69,7 @@ public class KafkaMessageCollector implements IFloodlightModule {
             ExecutorService parseRecordExecutor = Executors.newFixedThreadPool(EXEC_POOL_SIZE);
 
             Consumer consumer;
-            if (!context.configLookup("testing-mode").equals("YES")) {
+            if (! "YES".equals(context.configLookup("testing-mode"))) {
                 consumer = new Consumer(context, parseRecordExecutor, handlerFactory, INPUT_TOPIC);
             } else {
                 consumer = new TestAwareConsumer(context, parseRecordExecutor, handlerFactory, INPUT_TOPIC);

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/KafkaMessageProducer.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/KafkaMessageProducer.java
@@ -88,7 +88,7 @@ public class KafkaMessageProducer implements IFloodlightModule, IFloodlightServi
     }
 
     private void initProducer(Context context) {
-        if (! context.configLookup("testing-mode").equals("YES")) {
+        if (! "YES".equals(context.configLookup("testing-mode"))) {
             producer = new Producer(context);
         } else {
             producer = new TestAwareProducer(context);


### PR DESCRIPTION
Switch "sides" of "equals" call to avoid potential NullPointerException.