### PR TITLE
Add discovery.speaker-failure-timeout int wfm properties

### DIFF
--- a/services/wfm/src/test/resources/topology.properties
+++ b/services/wfm/src/test/resources/topology.properties
@@ -55,9 +55,12 @@ logger.watermark =
 # - discovery.timeout = at which point do we send an ISL Failure (if it is an ISL)
 #       - NB: the number is in "ticks", not "attempts" .. attempts = timeout/interval
 # - discovery.limit = at what point do we stop sending? -1 means never ..
+# - discovery.speaker-failure-timeout - after this amount of seconds without a
+#   message from speaker it will be marked as unavailable
 discovery.interval = 3
 discovery.timeout = 9
 discovery.limit = -1
+discovery.speaker-failure-timeout = 5
 
 local = no
 local.execution.time = 10


### PR DESCRIPTION
This property wasn't added into test's properties in
https://github.com/telstra/open-kilda/pull/263