### PR TITLE
Implement "ignore bandwidth" feature

### DIFF
--- a/services/src/atdd/src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java
+++ b/services/src/atdd/src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java
@@ -66,7 +66,7 @@ public class FlowCrudBasicRunTest {
         flowPayload = new FlowPayload(FlowUtils.getFlowName(flowId),
                 new FlowEndpointPayload(sourceSwitch, sourcePort, sourceVlan),
                 new FlowEndpointPayload(destinationSwitch, destinationPort, destinationVlan),
-                bandwidth, flowId, null);
+                bandwidth, false, flowId, null);
 
         FlowPayload response = FlowUtils.putFlow(flowPayload);
         assertNotNull(response);
@@ -82,7 +82,7 @@ public class FlowCrudBasicRunTest {
         flowPayload = new FlowPayload(FlowUtils.getFlowName(flowId),
                 new FlowEndpointPayload(sourceSwitch, sourcePort, sourceVlan),
                 new FlowEndpointPayload(destinationSwitch, destinationPort, destinationVlan),
-                bandwidth, flowId, null);
+                bandwidth, false, flowId, null);
 
         FlowPayload response = FlowUtils.putFlow(flowPayload);
 
@@ -93,7 +93,7 @@ public class FlowCrudBasicRunTest {
     public void checkFlowCreation(final String flowId, final String sourceSwitch, final int sourcePort,
                                   final int sourceVlan, final String destinationSwitch, final int destinationPort,
                                   final int destinationVlan, final int bandwidth) throws Exception {
-        Flow expectedFlow = new Flow(FlowUtils.getFlowName(flowId), bandwidth, 0, flowId, null, sourceSwitch,
+        Flow expectedFlow = new Flow(FlowUtils.getFlowName(flowId), bandwidth, false, 0, flowId, null, sourceSwitch,
                 destinationSwitch, sourcePort, destinationPort, sourceVlan, destinationVlan, 0, 0, null, null);
 
         List<Flow> flows = validateFlowStored(expectedFlow);

--- a/services/src/atdd/src/test/java/org/openkilda/atdd/FlowFFRTest.java
+++ b/services/src/atdd/src/test/java/org/openkilda/atdd/FlowFFRTest.java
@@ -29,7 +29,6 @@ import org.openkilda.messaging.info.event.PathInfoData;
 import org.openkilda.messaging.payload.flow.FlowEndpointPayload;
 import org.openkilda.messaging.payload.flow.FlowPathPayload;
 import org.openkilda.messaging.payload.flow.FlowPayload;
-import org.openkilda.topo.TestUtils;
 import org.openkilda.topo.TopologyHelp;
 
 import cucumber.api.java.en.Given;
@@ -77,7 +76,7 @@ public class FlowFFRTest {
         FlowPayload flowPayload = new FlowPayload(FlowUtils.getFlowName(flowId),
                 new FlowEndpointPayload(sourceSwitch, sourcePort, sourceVlan),
                 new FlowEndpointPayload(destinationSwitch, destinationPort, destinationVlan),
-                bandwidth, flowId, null);
+                bandwidth, false, flowId, null);
 
         FlowPayload response = FlowUtils.putFlow(flowPayload);
         assertNotNull(response);

--- a/services/src/atdd/src/test/java/org/openkilda/atdd/FlowIgnoreBandwidthTest.java
+++ b/services/src/atdd/src/test/java/org/openkilda/atdd/FlowIgnoreBandwidthTest.java
@@ -1,0 +1,108 @@
+package org.openkilda.atdd;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.openkilda.LinksUtils;
+import org.openkilda.flow.FlowUtils;
+import org.openkilda.messaging.info.event.IslInfoData;
+import org.openkilda.messaging.info.event.PathNode;
+import org.openkilda.messaging.payload.flow.FlowEndpointPayload;
+import org.openkilda.messaging.payload.flow.FlowIdStatusPayload;
+import org.openkilda.messaging.payload.flow.FlowPayload;
+import org.openkilda.messaging.payload.flow.FlowState;
+
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import org.junit.Assert;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FlowIgnoreBandwidthTest {
+    private final Map<String, String> createdFlows;
+
+    public FlowIgnoreBandwidthTest() {
+        createdFlows = new HashMap<>();
+    }
+
+    @Then("^available ISL's bandwidths between ([0-9a-f]{2}(?::[0-9a-f]{2}){7}) and ([0-9a-f]{2}(?::[0-9a-f]{2}){7}) is (\\d+)$")
+    public void available_ISL_bandwidths_between_switches(String source, String dest, long expected) throws Throwable {
+        List<IslInfoData> islLinks = LinksUtils.dumpLinks();
+
+        Long actual = null;
+        for (IslInfoData link : islLinks) {
+            if (link.getPath().size() != 2) {
+                throw new RuntimeException(
+                        String.format("ISL's link path contain %d records, expect 2", link.getPath().size()));
+            }
+            PathNode left = link.getPath().get(0);
+            PathNode right = link.getPath().get(1);
+
+            if (! source.equals(left.getSwitchId())) {
+                continue;
+            }
+
+            if (! dest.equals(right.getSwitchId())) {
+                continue;
+            }
+
+            actual = link.getAvailableBandwidth();
+            break;
+        }
+
+        Assert.assertNotNull(actual);
+        Assert.assertEquals("Actual bandwidth does not match expectations.", expected, (long)actual);
+        System.out.println(String.format("Available bandwidth between %s and %s is %d", source, dest, actual));
+    }
+
+    @When("^flow ignore bandwidth between ([0-9a-f]{2}(?::[0-9a-f]{2}){7}) and ([0-9a-f]{2}(?::[0-9a-f]{2}){7}) with (\\d+) bandwidth is created$")
+    public void flow_ignore_bandwidth_between_switches_with_bandwidth_is_created(String source, String dest, int bandwidth) throws Throwable {
+        String flowId = FlowUtils.getFlowName("flowId");
+        FlowEndpointPayload sourcePoint = new FlowEndpointPayload(source, 1, 0);
+        FlowEndpointPayload destPoint = new FlowEndpointPayload(dest, 2, 0);
+        FlowPayload requestPayload = new FlowPayload(
+                flowId, sourcePoint, destPoint, bandwidth, true, "Flow that ignore ISL bandwidth", null);
+
+        System.out.println(String.format("==> Send flow CREATE request (%s <--> %s)", source, dest));
+        FlowPayload response = FlowUtils.putFlow(requestPayload);
+        Assert.assertNotNull(response);
+        response.setLastUpdated(null);
+
+        System.out.println(String.format("==> Wait till flow become \"UP\" (%s <--> %s)", source, dest));
+        FlowIdStatusPayload status = FlowUtils.waitFlowStatus(flowId, FlowState.UP);
+        assertNotNull(status);
+        assertEquals(FlowState.UP, status.getStatus());
+
+        saveCreatedFlowId(source, dest, flowId);
+    }
+
+    @When("^drop created flow between ([0-9a-f]{2}(?::[0-9a-f]{2}){7}) and ([0-9a-f]{2}(?::[0-9a-f]{2}){7})$")
+    public void drop_created_early_flow(String source, String dest) throws Exception {
+        String flowId = lookupCreatedFlowId(source, dest);
+
+        System.out.println(String.format("==> Send flow DELETE request (%s <--> %s)", source, dest));
+        FlowPayload response = FlowUtils.deleteFlow(flowId);
+        assertNotNull(response);
+
+        System.out.println(String.format("==> Wait till flow become \"DOWN\" (%s <--> %s)", source, dest));
+        FlowUtils.waitFlowDeletion(flowId);
+    }
+
+    private void saveCreatedFlowId(String source, String dest, String flowId) {
+        createdFlows.put(makeCreatedFlowIdKey(source, dest), flowId);
+    }
+
+    private String lookupCreatedFlowId(String source, String dest) throws IllegalAccessException {
+        String key = makeCreatedFlowIdKey(source, dest);
+        if (! createdFlows.containsKey(key)) {
+            throw new IllegalAccessException(String.format("There is no known flows between %s and %s", source, dest));
+        }
+        return createdFlows.get(key);
+    }
+
+    private String makeCreatedFlowIdKey(String source, String dest) {
+        return String.join("<-->", source, dest);
+    }
+}

--- a/services/src/atdd/src/test/java/org/openkilda/atdd/FlowPathTest.java
+++ b/services/src/atdd/src/test/java/org/openkilda/atdd/FlowPathTest.java
@@ -133,7 +133,7 @@ public class FlowPathTest {
     public void flowPathCorrect(String flowId, String sourceSwitch, int sourcePort, int sourceVlan,
                                 String destinationSwitch, int destinationPort, int destinationVlan, int bandwidth)
             throws Exception {
-        Flow flow = new Flow(FlowUtils.getFlowName(flowId), bandwidth, flowId, sourceSwitch,
+        Flow flow = new Flow(FlowUtils.getFlowName(flowId), bandwidth, false, flowId, sourceSwitch,
                 sourcePort, sourceVlan, destinationSwitch, destinationPort, destinationVlan);
         ImmutablePair<PathInfoData, PathInfoData> path = FlowUtils.getFlowPath(flow);
         System.out.println(path);

--- a/services/src/atdd/src/test/java/org/openkilda/atdd/NorthboundRunTest.java
+++ b/services/src/atdd/src/test/java/org/openkilda/atdd/NorthboundRunTest.java
@@ -16,9 +16,9 @@
 package org.openkilda.atdd;
 
 
-import static org.openkilda.flow.FlowUtils.getHealthCheck;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.openkilda.flow.FlowUtils.getHealthCheck;
 
 import org.openkilda.flow.FlowUtils;
 import org.openkilda.messaging.info.event.PathInfoData;
@@ -33,7 +33,6 @@ import cucumber.api.java.en.Then;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 public class NorthboundRunTest {
     private static final FlowState expectedFlowStatus = FlowState.UP;
@@ -57,7 +56,7 @@ public class NorthboundRunTest {
     @Then("^status of flow (.*) could be read$")
     public void checkFlowStatus(final String flowId) throws Exception {
         String flowName = FlowUtils.getFlowName(flowId);
-        FlowIdStatusPayload payload = getFlowState(flowName, expectedFlowStatus);
+        FlowIdStatusPayload payload = FlowUtils.waitFlowStatus(flowName, expectedFlowStatus);
 
         assertNotNull(payload);
 
@@ -82,24 +81,9 @@ public class NorthboundRunTest {
     public void flowState(String flowId, String state) throws Throwable {
         String flowName = FlowUtils.getFlowName(flowId);
         FlowState flowState = FlowState.valueOf(state);
-        FlowIdStatusPayload payload = getFlowState(flowName, flowState);
+        FlowIdStatusPayload payload = FlowUtils.waitFlowStatus(flowName, flowState);
         assertNotNull(payload);
         assertEquals(flowName, payload.getId());
         assertEquals(flowState, payload.getStatus());
-    }
-
-    /**
-     * TODO: Why do we loop for 10 and sleep for 2? (ie why what for 20 seconds for flow state?)
-     */
-    private FlowIdStatusPayload getFlowState(String flowName, FlowState expectedFlowStatus) throws Exception {
-        FlowIdStatusPayload payload = FlowUtils.getFlowStatus(flowName);
-        for (int i = 0; i < 10; i++) {
-            payload = FlowUtils.getFlowStatus(flowName);
-            if (payload != null && expectedFlowStatus.equals(payload.getStatus())) {
-                break;
-            }
-            TimeUnit.SECONDS.sleep(2);
-        }
-        return payload;
     }
 }

--- a/services/src/atdd/src/test/java/org/openkilda/atdd/StormTopologyLCM.java
+++ b/services/src/atdd/src/test/java/org/openkilda/atdd/StormTopologyLCM.java
@@ -108,7 +108,7 @@ public class StormTopologyLCM {
         FlowPayload flowPayload = new FlowPayload(flowId,
                 new FlowEndpointPayload("00:01:00:00:00:00:00:01", 1, 100),
                 new FlowEndpointPayload("00:01:00:00:00:00:00:02", 1, 100),
-                10000, flowId, null);
+                10000, false, flowId, null);
 
         FlowPayload response = null;
         for (int i = 0; i < 10; ++i) {

--- a/services/src/atdd/src/test/java/org/openkilda/flow/FlowOperationException.java
+++ b/services/src/atdd/src/test/java/org/openkilda/flow/FlowOperationException.java
@@ -1,0 +1,17 @@
+package org.openkilda.flow;
+
+import javax.ws.rs.core.Response;
+
+public class FlowOperationException extends Exception {
+    private final Response restResponse;
+
+    public FlowOperationException(Response restResponse, String s) {
+        super(s);
+
+        this.restResponse = restResponse;
+    }
+
+    public Response getRestResponse() {
+        return restResponse;
+    }
+}

--- a/services/src/atdd/src/test/resources/features/mvp.1/FlowIgnoreBandwidth.feature
+++ b/services/src/atdd/src/test/resources/features/mvp.1/FlowIgnoreBandwidth.feature
@@ -1,0 +1,17 @@
+@MVP1
+Feature: Flow can be marked as flow that ignore available ISL bandwidth.
+
+  Such flow's paths must be computed without consideration of available ISL's bandwidth. Also this flow's bandwidth
+  shouldn't be included in ISL's allocated bandwidth on flow creation and deallocated on flow deletion.
+
+  Scenario: create flow ignore ISL's bandwidth
+    Given a clean controller
+    And a nonrandom linear topology of 7 switches
+    And topology contains 12 links
+    And available ISL's bandwidths between de:ad:be:ef:00:00:00:02 and de:ad:be:ef:00:00:00:03 is 9000000
+
+    When flow ignore bandwidth between de:ad:be:ef:00:00:00:02 and de:ad:be:ef:00:00:00:03 with 1000000 bandwidth is created
+    Then available ISL's bandwidths between de:ad:be:ef:00:00:00:02 and de:ad:be:ef:00:00:00:03 is 9000000
+
+    When drop created flow between de:ad:be:ef:00:00:00:02 and de:ad:be:ef:00:00:00:03
+    Then available ISL's bandwidths between de:ad:be:ef:00:00:00:02 and de:ad:be:ef:00:00:00:03 is 9000000

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/model/Flow.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/model/Flow.java
@@ -22,6 +22,7 @@ import org.openkilda.messaging.info.event.PathInfoData;
 import org.openkilda.messaging.payload.flow.FlowState;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
@@ -49,6 +50,12 @@ public class Flow implements Serializable {
      */
     @JsonProperty("bandwidth")
     private int bandwidth;
+
+    /**
+     * Should flow ignore bandwidth in path computation?
+     */
+    @JsonProperty("ignore-bandwidth")
+    private boolean ignoreBandwidth;
 
     /**
      * Flow cookie.
@@ -162,6 +169,7 @@ public class Flow implements Serializable {
      *
      * @param flowId            flow id
      * @param bandwidth         bandwidth
+     * @param ignoreBandwidth   ignore bandwidth flag
      * @param cookie            cookie
      * @param description       description
      * @param lastUpdated       last updated timestamp
@@ -171,14 +179,15 @@ public class Flow implements Serializable {
      * @param destinationPort   destination port
      * @param sourceVlan        source vlan id
      * @param destinationVlan   destination vlan id
-     * @param transitVlan       transit vlan id
      * @param meterId           meter id
+     * @param transitVlan       transit vlan id
      * @param flowPath          flow switch path
      * @param state             flow state
      */
     @JsonCreator
     public Flow(@JsonProperty(Utils.FLOW_ID) final String flowId,
                 @JsonProperty("bandwidth") final int bandwidth,
+                @JsonProperty("ignore-bandwidth") Boolean ignoreBandwidth,
                 @JsonProperty("cookie") final long cookie,
                 @JsonProperty("description") final String description,
                 @JsonProperty("last_updated") final String lastUpdated,
@@ -194,6 +203,7 @@ public class Flow implements Serializable {
                 @JsonProperty("state") FlowState state) {
         this.flowId = flowId;
         this.bandwidth = bandwidth;
+        setIgnoreBandwidth(ignoreBandwidth);
         this.cookie = cookie;
         this.description = description;
         this.lastUpdated = lastUpdated;
@@ -214,6 +224,7 @@ public class Flow implements Serializable {
      *
      * @param flowId            flow id
      * @param bandwidth         bandwidth
+     * @param ignoreBandwidth   ignore bandwidth flag
      * @param description       description
      * @param sourceSwitch      source switch
      * @param sourcePort        source port
@@ -222,11 +233,12 @@ public class Flow implements Serializable {
      * @param destinationPort   destination port
      * @param destinationVlan   destination vlan id
      */
-    public Flow(String flowId, int bandwidth, String description,
-                String sourceSwitch, int sourcePort, int sourceVlan,
-                String destinationSwitch, int destinationPort, int destinationVlan) {
+    public Flow(String flowId, int bandwidth, boolean ignoreBandwidth, String description,
+            String sourceSwitch, int sourcePort, int sourceVlan,
+            String destinationSwitch, int destinationPort, int destinationVlan) {
         this.flowId = flowId;
         this.bandwidth = bandwidth;
+        this.ignoreBandwidth = ignoreBandwidth;
         this.description = description;
         this.sourceSwitch = sourceSwitch;
         this.destinationSwitch = destinationSwitch;
@@ -279,6 +291,25 @@ public class Flow implements Serializable {
      */
     public int getBandwidth() {
         return bandwidth;
+    }
+
+    /**
+     *
+     * @return ignore bandwidth flag
+     */
+    public boolean isIgnoreBandwidth() {
+        return ignoreBandwidth;
+    }
+
+    /**
+     *
+     * @param ignoreBandwidth ignore bandwidth flag
+     */
+    public void setIgnoreBandwidth(Boolean ignoreBandwidth) {
+        if (ignoreBandwidth == null) {
+            ignoreBandwidth = false;
+        }
+        this.ignoreBandwidth = ignoreBandwidth;
     }
 
     /**
@@ -504,6 +535,19 @@ public class Flow implements Serializable {
      */
     public void setFlowPath(PathInfoData flowPath) {
         this.flowPath = flowPath;
+    }
+
+    /**
+     *
+     * @return is this is single switch flow
+     */
+    @JsonIgnore
+    public boolean isOneSwitchFlow() {
+        // TODO(surabujin): there is no decision how it should react on null values in source/dest switches
+        if (sourceSwitch == null || destinationSwitch == null) {
+            return sourceSwitch == null && destinationSwitch == null;
+        }
+        return sourceSwitch.equals(destinationSwitch);
     }
 
     /**

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/payload/flow/FlowPayload.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/payload/flow/FlowPayload.java
@@ -71,6 +71,12 @@ public class FlowPayload implements Serializable {
     private int maximumBandwidth;
 
     /**
+     * If SET ignore bandwidth in path computation
+     */
+    @JsonProperty("ignore-bandwidth")
+    private boolean ignoreBandwidth = false;
+
+    /**
      * FlowPayload description.
      */
     @JsonProperty("description")
@@ -89,6 +95,7 @@ public class FlowPayload implements Serializable {
      * @param source           flow source
      * @param destination      flow destination
      * @param maximumBandwidth flow maximum bandwidth
+     * @param ignoreBandwidth  should ignore bandwidth in path computation
      * @param description      flow description
      * @param lastUpdated      flow last updated timestamp
      */
@@ -97,12 +104,14 @@ public class FlowPayload implements Serializable {
                        @JsonProperty("source") FlowEndpointPayload source,
                        @JsonProperty("destination") FlowEndpointPayload destination,
                        @JsonProperty("maximum-bandwidth") int maximumBandwidth,
+                       @JsonProperty("ignore-bandwidth") Boolean ignoreBandwidth,
                        @JsonProperty("description") String description,
                        @JsonProperty("last-updated") String lastUpdated) {
         setId(id);
         setSource(source);
         setDestination(destination);
         setMaximumBandwidth(maximumBandwidth);
+        setIgnoreBandwidth(ignoreBandwidth);
         setDescription(description);
         setLastUpdated(lastUpdated);
     }
@@ -191,6 +200,26 @@ public class FlowPayload implements Serializable {
             throw new IllegalArgumentException("need to set non negative bandwidth");
         }
         this.maximumBandwidth = maximumBandwidth;
+    }
+
+    /**
+     *
+     * @return ignore bandwidth flag
+     */
+    public boolean isIgnoreBandwidth() {
+        return ignoreBandwidth;
+    }
+
+    /**
+     * Sets ignore bandwidth flag
+     *
+     * @param ignoreBandwidth flag value
+     */
+    public void setIgnoreBandwidth(Boolean ignoreBandwidth) {
+        if (ignoreBandwidth == null) {
+            ignoreBandwidth = false;
+        }
+        this.ignoreBandwidth = ignoreBandwidth;
     }
 
     /**

--- a/services/src/messaging/src/test/java/org/openkilda/messaging/command/flow/AbstractSerializerTest.java
+++ b/services/src/messaging/src/test/java/org/openkilda/messaging/command/flow/AbstractSerializerTest.java
@@ -92,7 +92,7 @@ public abstract class AbstractSerializerTest implements AbstractSerializer {
             new PathNode("sw2", 2, 1, 0L));
     private static final IslInfoData isl = new IslInfoData(0L, nodes, 1000L, IslChangeType.DISCOVERED, 900L);
     private static final PathInfoData path = new PathInfoData(0L, nodes);
-    private static final Flow flowModel = new Flow(FLOW_NAME, 1000, COOKIE, FLOW_NAME, String.valueOf(TIMESTAMP),
+    private static final Flow flowModel = new Flow(FLOW_NAME, 1000, false, COOKIE, FLOW_NAME, String.valueOf(TIMESTAMP),
             "sw1", "sw2", 10, 20, 100, 200, 1, 1024, path, FLOW_STATUS);
 
     @Test

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/utils/Converter.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/utils/Converter.java
@@ -38,6 +38,7 @@ public final class Converter {
         return new Flow(
                 flowPayload.getId(),
                 flowPayload.getMaximumBandwidth(),
+                flowPayload.isIgnoreBandwidth(),
                 flowPayload.getDescription(),
                 flowPayload.getSource().getSwitchId(),
                 flowPayload.getSource().getPortId(),
@@ -65,6 +66,7 @@ public final class Converter {
                         flow.getDestinationPort(),
                         flow.getDestinationVlan()),
                 flow.getBandwidth(),
+                flow.isIgnoreBandwidth(),
                 flow.getDescription(),
                 flow.getLastUpdated());
     }

--- a/services/src/northbound/src/test/java/org/openkilda/northbound/controller/TestMessageMock.java
+++ b/services/src/northbound/src/test/java/org/openkilda/northbound/controller/TestMessageMock.java
@@ -64,11 +64,11 @@ public class TestMessageMock implements MessageProducer, MessageConsumer<Object>
     static final String FLOW_ID = "test-flow";
     static final String ERROR_FLOW_ID = "error-flow";
     static final FlowEndpointPayload flowEndpoint = new FlowEndpointPayload(FLOW_ID, 1, 1);
-    static final FlowPayload flow = new FlowPayload(FLOW_ID, flowEndpoint, flowEndpoint, 10000, FLOW_ID, null);
+    static final FlowPayload flow = new FlowPayload(FLOW_ID, flowEndpoint, flowEndpoint, 10000, false, FLOW_ID, null);
     static final FlowIdStatusPayload flowStatus = new FlowIdStatusPayload(FLOW_ID, FlowState.IN_PROGRESS);
     static final PathInfoData path = new PathInfoData(0L, Collections.emptyList());
     static final FlowPathPayload flowPath = new FlowPathPayload(FLOW_ID, path);
-    static final Flow flowModel = new Flow(FLOW_ID, 10000, FLOW_ID, FLOW_ID, 1, 1, FLOW_ID, 1, 1);
+    static final Flow flowModel = new Flow(FLOW_ID, 10000, false, FLOW_ID, FLOW_ID, 1, 1, FLOW_ID, 1, 1);
     private static final FlowResponse flowResponse = new FlowResponse(flowModel);
     private static final FlowsResponse flowsResponse = new FlowsResponse(Collections.singletonList(flowModel));
     private static final FlowPathResponse flowPathResponse = new FlowPathResponse(path);

--- a/services/src/pce/src/main/java/org/openkilda/pce/cache/FlowCache.java
+++ b/services/src/pce/src/main/java/org/openkilda/pce/cache/FlowCache.java
@@ -384,7 +384,7 @@ public class FlowCache extends Cache {
         Flow forward = new Flow(
                 flow.getLeft().getFlowId(),
                 flow.getLeft().getBandwidth(),
-                cookie | ResourceCache.FORWARD_FLOW_COOKIE_MASK,
+                false, cookie | ResourceCache.FORWARD_FLOW_COOKIE_MASK,
                 flow.getLeft().getDescription(),
                 timestamp,
                 flow.getLeft().getSourceSwitch(),
@@ -401,7 +401,7 @@ public class FlowCache extends Cache {
         Flow reverse = new Flow(
                 flow.getRight().getFlowId(),
                 flow.getRight().getBandwidth(),
-                cookie | ResourceCache.REVERSE_FLOW_COOKIE_MASK,
+                false, cookie | ResourceCache.REVERSE_FLOW_COOKIE_MASK,
                 flow.getRight().getDescription(),
                 timestamp,
                 flow.getRight().getSourceSwitch(),
@@ -435,6 +435,7 @@ public class FlowCache extends Cache {
         Flow forward = new Flow(
                 flow.getFlowId(),
                 flow.getBandwidth(),
+                flow.isIgnoreBandwidth(),
                 cookie | ResourceCache.FORWARD_FLOW_COOKIE_MASK,
                 flow.getDescription(),
                 timestamp,
@@ -452,6 +453,7 @@ public class FlowCache extends Cache {
         Flow reverse = new Flow(
                 flow.getFlowId(),
                 flow.getBandwidth(),
+                flow.isIgnoreBandwidth(),
                 cookie | ResourceCache.REVERSE_FLOW_COOKIE_MASK,
                 flow.getDescription(),
                 timestamp,
@@ -474,6 +476,8 @@ public class FlowCache extends Cache {
      *
      * @param flow flow
      * @return true if source and destination switches are same for specified flow, otherwise false
+     *
+     * FIXME(surabujin): looks extremely over engineered. Can be replaces with org.openkilda.messaging.model.Flow#isOneSwitchFlow()
      */
     public boolean isOneSwitchFlow(ImmutablePair<Flow, Flow> flow) {
         return flow.getLeft().getSourceSwitch().equals(flow.getLeft().getDestinationSwitch())

--- a/services/src/pce/src/main/java/org/openkilda/pce/provider/NeoDriver.java
+++ b/services/src/pce/src/main/java/org/openkilda/pce/provider/NeoDriver.java
@@ -17,7 +17,6 @@ package org.openkilda.pce.provider;
 
 import org.openkilda.messaging.info.event.PathInfoData;
 import org.openkilda.messaging.info.event.PathNode;
-import org.openkilda.messaging.info.event.SwitchInfoData;
 import org.openkilda.messaging.model.Flow;
 import org.openkilda.messaging.model.ImmutablePair;
 
@@ -34,8 +33,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.StringJoiner;
 
 public class NeoDriver implements PathComputer {
     /**
@@ -47,16 +48,6 @@ public class NeoDriver implements PathComputer {
      * Clean database query.
      */
     private static final String CLEAN_FORMATTER_PATTERN = "MATCH (n) DETACH DELETE n";
-
-    /**
-     * Path query formatter pattern.
-     */
-    private static final String PATH_QUERY_FORMATTER_PATTERN =
-            "MATCH (a:switch{name:{src_switch}}),(b:switch{name:{dst_switch}}), " +
-                    "p = shortestPath((a)-[r:isl*..100]->(b)) " +
-                    "where ALL(x in nodes(p) WHERE x.state = 'active') " +
-                    "AND ALL(y in r WHERE y.available_bandwidth >= {bandwidth} AND y.status = 'active') " +
-                    "RETURN p";
 
     /**
      * {@link Driver} instance.
@@ -90,35 +81,18 @@ public class NeoDriver implements PathComputer {
      * {@inheritDoc}
      */
     @Override
-    public ImmutablePair<PathInfoData, PathInfoData> getPath(Flow flow, Strategy strategy) throws UnroutablePathException {
-        return getPath(flow.getSourceSwitch(), flow.getDestinationSwitch(), flow.getBandwidth(), strategy);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public ImmutablePair<PathInfoData, PathInfoData> getPath(SwitchInfoData source, SwitchInfoData destination,
-                                                             int bandwidth, Strategy strategy) throws UnroutablePathException {
-        return getPath(source.getSwitchId(), destination.getSwitchId(), bandwidth, strategy);
-    }
-
-    private ImmutablePair<PathInfoData, PathInfoData> getPath(String srcSwitch, String dstSwitch, int bandwidth, Strategy strategy)
+    public ImmutablePair<PathInfoData, PathInfoData> getPath(Flow flow, Strategy strategy)
             throws UnroutablePathException {
         /*
          * TODO: implement strategy
          */
 
-
         long latency = 0L;
         List<PathNode> forwardNodes = new LinkedList<>();
         List<PathNode> reverseNodes = new LinkedList<>();
 
-        if (!srcSwitch.equals(dstSwitch)) {
-            Statement pathStatement = new Statement(PATH_QUERY_FORMATTER_PATTERN);
-            Value value = Values.parameters("src_switch", srcSwitch, "dst_switch", dstSwitch, "bandwidth", bandwidth);
-
-            Statement statement = pathStatement.withParameters(value);
+        if (! flow.isOneSwitchFlow()) {
+            Statement statement = makePathQuery(flow);
             logger.debug("QUERY: {}", statement.toString());
 
             try (Session session = driver.session()) {
@@ -156,7 +130,7 @@ public class NeoDriver implements PathComputer {
                         seqId++;
                     }
                 } catch (NoSuchRecordException e) {
-                    throw new UnroutablePathException(srcSwitch, dstSwitch, bandwidth);
+                    throw new UnroutablePathException(flow);
                 }
             }
         } else {
@@ -166,4 +140,27 @@ public class NeoDriver implements PathComputer {
         return new ImmutablePair<>(new PathInfoData(latency, forwardNodes), new PathInfoData(latency, reverseNodes));
     }
 
+    private Statement makePathQuery(Flow flow) {
+        HashMap<String,Value> parameters = new HashMap<>();
+
+        String subject =
+                "MATCH (a:switch{name:{src_switch}}),(b:switch{name:{dst_switch}}), " +
+                "p = shortestPath((a)-[r:isl*..100]->(b))";
+        parameters.put("src_switch", Values.value(flow.getSourceSwitch()));
+        parameters.put("dst_switch", Values.value(flow.getDestinationSwitch()));
+
+        StringJoiner where = new StringJoiner("\n    AND ", "where ", "");
+        where.add("ALL(x in nodes(p) WHERE x.state = 'active')");
+        if (flow.isIgnoreBandwidth()) {
+            where.add("ALL(y in r WHERE y.status = 'active')");
+        } else {
+            where.add("ALL(y in r WHERE y.available_bandwidth >= {bandwidth} AND y.status = 'active')");
+            parameters.put("bandwidth", Values.value(flow.getBandwidth()));
+        }
+
+        String result = "RETURN p";
+
+        String query = String.join("\n", subject, where.toString(), result);
+        return new Statement(query, Values.value(parameters));
+    }
 }

--- a/services/src/pce/src/main/java/org/openkilda/pce/provider/PathComputer.java
+++ b/services/src/pce/src/main/java/org/openkilda/pce/provider/PathComputer.java
@@ -17,11 +17,8 @@ package org.openkilda.pce.provider;
 
 import org.openkilda.messaging.info.event.IslInfoData;
 import org.openkilda.messaging.info.event.PathInfoData;
-import org.openkilda.messaging.info.event.SwitchInfoData;
 import org.openkilda.messaging.model.Flow;
 import org.openkilda.messaging.model.ImmutablePair;
-
-import com.google.common.graph.MutableNetwork;
 
 import java.io.Serializable;
 
@@ -56,14 +53,4 @@ public interface PathComputer extends Serializable {
      */
     ImmutablePair<PathInfoData, PathInfoData> getPath(Flow flow, Strategy strategy) throws UnroutablePathException;
 
-    /**
-     * Gets path between source and destination switch.
-     *
-     * @param source      source {@link SwitchInfoData} instance
-     * @param destination source {@link SwitchInfoData} instance
-     * @param bandwidth   available bandwidth
-     * @return {@link PathInfoData} instances
-     */
-    ImmutablePair<PathInfoData, PathInfoData> getPath(SwitchInfoData source, SwitchInfoData destination,
-                                                      int bandwidth, Strategy strategy) throws UnroutablePathException;
 }

--- a/services/src/pce/src/main/java/org/openkilda/pce/provider/UnroutablePathException.java
+++ b/services/src/pce/src/main/java/org/openkilda/pce/provider/UnroutablePathException.java
@@ -1,27 +1,20 @@
 package org.openkilda.pce.provider;
 
+import org.openkilda.messaging.model.Flow;
+
 public class UnroutablePathException extends Exception {
-    private final String srcSwitch;
-    private final String dstSwitch;
-    private final int bandwidth;
+    private final Flow flow;
 
-    public UnroutablePathException(String srcSwitch, String dstSwitch, int bandwidth) {
-        super(String.format("Can't make flow from %s to %s (bandwidth=%d", srcSwitch, dstSwitch, bandwidth));
+    public UnroutablePathException(Flow flow) {
+        super(String.format(
+                "Can't make flow from %s to %s (bandwidth=%d%s)",
+                flow.getSourceSwitch(), flow.getDestinationSwitch(), flow.getBandwidth(),
+                flow.isIgnoreBandwidth() ? " ignored" : ""));
 
-        this.srcSwitch = srcSwitch;
-        this.dstSwitch = dstSwitch;
-        this.bandwidth = bandwidth;
+        this.flow = flow;
     }
 
-    public String getSrcSwitch() {
-        return srcSwitch;
-    }
-
-    public String getDstSwitch() {
-        return dstSwitch;
-    }
-
-    public int getBandwidth() {
-        return bandwidth;
+    public Flow getFlow() {
+        return flow;
     }
 }

--- a/services/src/pce/src/test/java/org/openkilda/pce/cache/ResourceCacheTest.java
+++ b/services/src/pce/src/test/java/org/openkilda/pce/cache/ResourceCacheTest.java
@@ -34,9 +34,9 @@ import java.util.Set;
 
 public class ResourceCacheTest {
     private static final String SWITCH_ID = "switch-id";
-    private final Flow forwardCreatedFlow = new Flow("created-flow", 0, 10L, "description",
+    private final Flow forwardCreatedFlow = new Flow("created-flow", 0, false, 10L, "description",
             "timestamp", "sw3", "sw3", 21, 22, 100, 200, 4, 4, new PathInfoData(), FlowState.ALLOCATED);
-    private final Flow reverseCreatedFlow = new Flow("created-flow", 0, 10L, "description",
+    private final Flow reverseCreatedFlow = new Flow("created-flow", 0, false, 10L, "description",
             "timestamp", "sw3", "sw3", 22, 21, 200, 100, 5, 5, new PathInfoData(), FlowState.ALLOCATED);
     private ResourceCache resourceCache;
 

--- a/services/src/pce/src/test/java/org/openkilda/pce/provider/PathComputerMock.java
+++ b/services/src/pce/src/test/java/org/openkilda/pce/provider/PathComputerMock.java
@@ -70,14 +70,6 @@ public class PathComputerMock implements PathComputer {
                 path(destination, source, flow.getBandwidth()));
     }
 
-    @Override
-    public ImmutablePair<PathInfoData, PathInfoData> getPath(SwitchInfoData source, SwitchInfoData destination,
-                                                             int bandwidth, Strategy strategy) {
-        PathInfoData forwardPath = path(source, destination, bandwidth);
-        PathInfoData reversePath = path(destination, source, bandwidth);
-        return new ImmutablePair<>(forwardPath, reversePath);
-    }
-
     private PathInfoData path(SwitchInfoData srcSwitch, SwitchInfoData dstSwitch, int bandwidth) {
         System.out.println("Get Path By Switch Instances " + bandwidth + ": " + srcSwitch + " - " + dstSwitch);
 

--- a/services/topology-engine/queue-engine/topologylistener/flow_utils.py
+++ b/services/topology-engine/queue-engine/topologylistener/flow_utils.py
@@ -108,7 +108,7 @@ def remove_flow(flow, flow_path):
             "WHERE r.cookie = {} DELETE r"
     graph.run(query.format(flow['flowid'], int(flow['cookie']))).data()
 
-    if is_forward_cookie(flow['cookie']):
+    if not flow['ignore-bandwidth'] and is_forward_cookie(flow['cookie']):
             update_path_bandwidth(flow_path, -int(flow['bandwidth']))
 
 
@@ -138,7 +138,7 @@ def store_flow(flow):
     graph.run(query.format(**flow_data))
 
     # the path is bidirectional .. only deduct bandwidth once (in forward direction)
-    if is_forward_cookie(flow_data['cookie']):
+    if not flow['ignore-bandwidth'] and is_forward_cookie(flow_data['cookie']):
         update_path_bandwidth(path, int(flow_data['bandwidth']))
 
 

--- a/services/topology-engine/queue-engine/topologylistener/message_utils.py
+++ b/services/topology-engine/queue-engine/topologylistener/message_utils.py
@@ -190,6 +190,7 @@ def send_install_commands(flow_rules, correlation_id):
     for flow_rule in flow_rules:
         send_to_topic(flow_rule, correlation_id, MT_COMMAND,
                       destination="CONTROLLER", topic=config.KAFKA_SPEAKER_TOPIC)
+        # FIXME(surabujin): WFM reroute this message into CONTROLLER
         send_to_topic(flow_rule, correlation_id, MT_COMMAND,
                       destination="WFM", topic=config.KAFKA_FLOW_TOPIC)
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/cache/CacheTopology.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/cache/CacheTopology.java
@@ -15,17 +15,18 @@
 
 package org.openkilda.wfm.topology.cache;
 
-import org.apache.storm.generated.StormTopology;
-import org.apache.storm.kafka.bolt.KafkaBolt;
-import org.apache.storm.kafka.spout.KafkaSpout;
-import org.apache.storm.topology.BoltDeclarer;
-import org.apache.storm.topology.TopologyBuilder;
 import org.openkilda.messaging.ServiceType;
 import org.openkilda.wfm.ConfigurationException;
 import org.openkilda.wfm.CtrlBoltRef;
 import org.openkilda.wfm.LaunchEnvironment;
 import org.openkilda.wfm.NameCollisionException;
 import org.openkilda.wfm.topology.AbstractTopology;
+
+import org.apache.storm.generated.StormTopology;
+import org.apache.storm.kafka.bolt.KafkaBolt;
+import org.apache.storm.kafka.spout.KafkaSpout;
+import org.apache.storm.topology.BoltDeclarer;
+import org.apache.storm.topology.TopologyBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,6 +109,7 @@ public class CacheTopology extends AbstractTopology {
         /*
          * Sends requests for ISL to OFE topology.
          */
+        // FIXME(surabjin): 2 kafka bold with same topic (see previous bolt)
         KafkaBolt oFEKafkaBolt = createKafkaBolt(config.getKafkaFlowTopic());
         builder.setBolt(BOLT_ID_OFE, oFEKafkaBolt, parallelism)
                 .shuffleGrouping(BOLT_ID_CACHE, StreamType.OFE.toString());

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/SpeakerBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/SpeakerBolt.java
@@ -86,6 +86,7 @@ public class SpeakerBolt extends BaseRichBolt {
 
                     message.setDestination(Destination.TOPOLOGY_ENGINE);
                     values = new Values(MAPPER.writeValueAsString(message), switchId, flowId, transactionId);
+                    // FIXME(surabujin): looks like TE ignore this messages
                     outputCollector.emit(StreamType.CREATE.toString(), tuple, values);
 
                 } else if (data instanceof RemoveFlow) {

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/TopologyEngineBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/TopologyEngineBolt.java
@@ -85,6 +85,7 @@ public class TopologyEngineBolt extends BaseRichBolt {
                             Utils.CORRELATION_ID, message.getCorrelationId(), switchId,
                             Utils.FLOW_ID, flowId, Utils.TRANSACTION_ID, transactionId, request);
 
+                    // FIXME(surabujin): send here and in TE
                     message.setDestination(Destination.CONTROLLER);
                     values = new Values(MAPPER.writeValueAsString(message), switchId, flowId, transactionId);
                     outputCollector.emit(StreamType.CREATE.toString(), tuple, values);

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/TransactionBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/TransactionBolt.java
@@ -62,6 +62,8 @@ public class TransactionBolt
 
     /**
      * Transaction ids state.
+     *
+     * FIXME(surabujin) in memory status lead to disaster when system restarts during any transition
      */
     private InMemoryKeyValueState<String, Map<String, Set<Long>>> transactions;
 

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/cache/CacheTopologyTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/cache/CacheTopologyTest.java
@@ -31,7 +31,6 @@ import org.apache.storm.utils.Utils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openkilda.messaging.Destination;
 import org.openkilda.messaging.Message;
@@ -78,14 +77,14 @@ public class CacheTopologyTest extends AbstractStormTest {
     private static final SwitchInfoData sw = new SwitchInfoData("sw",
             SwitchState.ADDED, "127.0.0.1", "localhost", "test switch", "kilda");
     private static final ImmutablePair<Flow, Flow> firstFlow = new ImmutablePair<>(
-            new Flow(firstFlowId, 10000, "", sw.getSwitchId(), 1, 2, sw.getSwitchId(), 1, 2),
-            new Flow(firstFlowId, 10000, "", sw.getSwitchId(), 1, 2, sw.getSwitchId(), 1, 2));
+            new Flow(firstFlowId, 10000, false, "", sw.getSwitchId(), 1, 2, sw.getSwitchId(), 1, 2),
+            new Flow(firstFlowId, 10000, false, "", sw.getSwitchId(), 1, 2, sw.getSwitchId(), 1, 2));
     private static final ImmutablePair<Flow, Flow> secondFlow = new ImmutablePair<>(
-            new Flow(secondFlowId, 10000, "", "test-switch", 1, 2, "test-switch", 1, 2),
-            new Flow(secondFlowId, 10000, "", "test-switch", 1, 2, "test-switch", 1, 2));
+            new Flow(secondFlowId, 10000, false, "", "test-switch", 1, 2, "test-switch", 1, 2),
+            new Flow(secondFlowId, 10000, false, "", "test-switch", 1, 2, "test-switch", 1, 2));
     private static final ImmutablePair<Flow, Flow> thirdFlow = new ImmutablePair<>(
-            new Flow(thirdFlowId, 10000, "", "test-switch", 1, 2, "test-switch", 1, 2),
-            new Flow(thirdFlowId, 10000, "", "test-switch", 1, 2, "test-switch", 1, 2));
+            new Flow(thirdFlowId, 10000, false, "", "test-switch", 1, 2, "test-switch", 1, 2),
+            new Flow(thirdFlowId, 10000, false, "", "test-switch", 1, 2, "test-switch", 1, 2));
     private static final Set<ImmutablePair<Flow, Flow>> flows = new HashSet<>();
     private static final NetworkInfoData dump = new NetworkInfoData(
             "test", Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), flows);

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flow/FlowTopologyTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flow/FlowTopologyTest.java
@@ -1021,7 +1021,7 @@ public class FlowTopologyTest extends AbstractStormTest {
 
     private Flow createFlow(final String flowId) throws IOException {
         System.out.println("NORTHBOUND: Create flow");
-        Flow flowPayload = new Flow(flowId, 10000, "", "test-switch", 1, 2, "test-switch", 1, 2);
+        Flow flowPayload = new Flow(flowId, 10000, false, "", "test-switch", 1, 2, "test-switch", 1, 2);
         FlowCreateRequest commandData = new FlowCreateRequest(flowPayload);
         CommandMessage message = new CommandMessage(commandData, 0, "create-flow", Destination.WFM);
         //sendNorthboundMessage(message);
@@ -1031,7 +1031,7 @@ public class FlowTopologyTest extends AbstractStormTest {
 
     private Flow updateFlow(final String flowId) throws IOException {
         System.out.println("NORTHBOUND: Update flow");
-        Flow flowPayload = new Flow(flowId, 10000, "", "test-switch", 1, 2, "test-switch", 1, 2);
+        Flow flowPayload = new Flow(flowId, 10000, false, "", "test-switch", 1, 2, "test-switch", 1, 2);
         FlowUpdateRequest commandData = new FlowUpdateRequest(flowPayload);
         CommandMessage message = new CommandMessage(commandData, 0, "update-flow", Destination.WFM);
 //        sendNorthboundMessage(message);
@@ -1106,7 +1106,7 @@ public class FlowTopologyTest extends AbstractStormTest {
 
     private Flow getFlowCommand(final String flowId) throws IOException {
         System.out.println("TOPOLOGY: Get flow");
-        Flow flowPayload = new Flow(flowId, 10000, "", "test-switch", 1, 2, "test-switch", 1, 2);
+        Flow flowPayload = new Flow(flowId, 10000, false, "", "test-switch", 1, 2, "test-switch", 1, 2);
         FlowResponse infoData = new FlowResponse(flowPayload);
         InfoMessage infoMessage = new InfoMessage(infoData, 0, "get-flow", Destination.WFM);
         sendTopologyEngineMessage(infoMessage);
@@ -1115,7 +1115,7 @@ public class FlowTopologyTest extends AbstractStormTest {
 
     private List<Flow> dumpFlowCommand(final String flowId) throws IOException {
         System.out.println("TOPOLOGY: Get flows");
-        Flow flow = new Flow(flowId, 10000, "", "test-switch", 1, 2, "test-switch", 1, 2);
+        Flow flow = new Flow(flowId, 10000, false, "", "test-switch", 1, 2, "test-switch", 1, 2);
         List<Flow> payload = Collections.singletonList(flow);
         FlowsResponse infoData = new FlowsResponse(payload);
         InfoMessage infoMessage = new InfoMessage(infoData, 0, "dump-flows", Destination.WFM);

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flow/PathComputerMock.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flow/PathComputerMock.java
@@ -15,29 +15,16 @@
 
 package org.openkilda.wfm.topology.flow;
 
-import org.openkilda.messaging.info.event.IslInfoData;
 import org.openkilda.messaging.info.event.PathInfoData;
-import org.openkilda.messaging.info.event.SwitchInfoData;
 import org.openkilda.messaging.model.Flow;
 import org.openkilda.messaging.model.ImmutablePair;
 import org.openkilda.pce.provider.PathComputer;
-import org.openkilda.pce.provider.PathComputer.Strategy;
-
-import com.google.common.graph.MutableNetwork;
 
 import java.util.Collections;
 
 public class PathComputerMock implements PathComputer {
     @Override
     public ImmutablePair<PathInfoData, PathInfoData> getPath(Flow flow, Strategy strategy) {
-        return emptyPath();
-    }
-
-    @Override
-    public ImmutablePair<PathInfoData, PathInfoData> getPath(SwitchInfoData source,
-                                                             SwitchInfoData destination,
-                                                             int bandwidth,
-                                                             Strategy strategy) {
         return emptyPath();
     }
 


### PR DESCRIPTION
Flow can be marked with "ignore-bandwidth" flag. If it set ISL bandwidth
will be ignored during path computation.

Close #235