### PR TITLE
Fix NullPointerException into FL

### DIFF
--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/FlowCommandException.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/FlowCommandException.java
@@ -1,0 +1,28 @@
+package org.openkilda.floodlight.kafka;
+
+import org.openkilda.floodlight.switchmanager.SwitchOperationException;
+import org.openkilda.messaging.error.ErrorData;
+import org.openkilda.messaging.error.ErrorType;
+
+public class FlowCommandException extends Exception {
+    private final String flowId;
+    private final ErrorType type;
+
+    public FlowCommandException(String flowId, ErrorType type, SwitchOperationException cause) {
+        super(cause);
+        this.flowId = flowId;
+        this.type = type;
+    }
+
+    public ErrorData makeErrorResponse() {
+        return new ErrorData(getType(), getCause().getMessage(), getFlowId());
+    }
+
+    public String getFlowId() {
+        return flowId;
+    }
+
+    public ErrorType getType() {
+        return type;
+    }
+}

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/ISwitchManager.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/ISwitchManager.java
@@ -15,10 +15,9 @@
 
 package org.openkilda.floodlight.switchmanager;
 
-import net.floodlightcontroller.core.IOFSwitch;
-import org.openkilda.messaging.model.ImmutablePair;
 import org.openkilda.messaging.payload.flow.OutputVlanType;
 
+import net.floodlightcontroller.core.IOFSwitch;
 import net.floodlightcontroller.core.module.IFloodlightService;
 import org.projectfloodlight.openflow.protocol.OFFlowStatsReply;
 import org.projectfloodlight.openflow.protocol.OFMeterConfigStatsReply;
@@ -37,10 +36,9 @@ public interface ISwitchManager extends IFloodlightService {
      * Adds default rules to install verification rules and final drop rule.
      *
      * @param dpid datapathId of switch
-     * @return true if the command was accepted to be sent to switch, false otherwise - switch is disconnected or in
-     * SLAVE mode
+     * @throws SwitchOperationException in case of errors
      */
-    boolean installDefaultRules(final DatapathId dpid);
+    void installDefaultRules(final DatapathId dpid) throws SwitchOperationException;
 
     /**
      * Installs an flow on ingress switch.
@@ -51,13 +49,12 @@ public interface ISwitchManager extends IFloodlightService {
      * @param outputPort    port to forward the packet out
      * @param inputVlanId   input vlan to match on, 0 means not to match on vlan
      * @param transitVlanId vlan to add before outputing on outputPort
-     * @return {@link ImmutablePair}<Long, Boolean>, where key is OF transaction id and value is true if the command was
-     * accepted to be sent to switch, false otherwise - switch is disconnected or in SLAVE mode
+     * @return transaction id
      */
-    ImmutablePair<Long, Boolean> installIngressFlow(final DatapathId dpid, final String flowId, final Long cookie,
+    long installIngressFlow(final DatapathId dpid, final String flowId, final Long cookie,
                                                     final int inputPort, final int outputPort, final int inputVlanId,
                                                     final int transitVlanId, final OutputVlanType outputVlanType,
-                                                    final long meterId);
+                                                    final long meterId) throws SwitchOperationException;
 
     /**
      * Installs flow on egress swtich.
@@ -69,12 +66,12 @@ public interface ISwitchManager extends IFloodlightService {
      * @param transitVlanId  vlan to match on the ingressPort
      * @param outputVlanId   set vlan on packet before forwarding via outputPort; 0 means not to set
      * @param outputVlanType type of action to apply to the outputVlanId if greater than 0
-     * @return {@link ImmutablePair}<Long, Boolean>, where key is OF transaction id and value is true if the command was
-     * accepted to be sent to switch, false otherwise - switch is disconnected or in SLAVE mode
+     * @return transaction id
      */
-    ImmutablePair<Long, Boolean> installEgressFlow(final DatapathId dpid, final String flowId, final Long cookie,
+    long installEgressFlow(final DatapathId dpid, final String flowId, final Long cookie,
                                                    final int inputPort, final int outputPort, final int transitVlanId,
-                                                   final int outputVlanId, final OutputVlanType outputVlanType);
+                                                   final int outputVlanId, final OutputVlanType outputVlanType)
+            throws SwitchOperationException;
 
     /**
      * Installs flow on a transit switch.
@@ -84,11 +81,11 @@ public interface ISwitchManager extends IFloodlightService {
      * @param inputPort     port to expect packet on
      * @param outputPort    port to forward packet out
      * @param transitVlanId vlan to match on inputPort
-     * @return {@link ImmutablePair}<Long, Boolean>, where key is OF transaction id and value is true if the command was
-     * accepted to be sent to switch, false otherwise - switch is disconnected or in SLAVE mode
+     * @return transaction id
      */
-    ImmutablePair<Long, Boolean> installTransitFlow(final DatapathId dpid, final String flowId, final Long cookie,
-                                                    final int inputPort, final int outputPort, final int transitVlanId);
+    long installTransitFlow(final DatapathId dpid, final String flowId, final Long cookie,
+                                                    final int inputPort, final int outputPort, final int transitVlanId)
+            throws SwitchOperationException;
 
     /**
      * Installs flow through one switch.
@@ -100,13 +97,12 @@ public interface ISwitchManager extends IFloodlightService {
      * @param inputVlanId    vlan to match on inputPort
      * @param outputVlanId   set vlan on packet before forwarding via outputPort; 0 means not to set
      * @param outputVlanType type of action to apply to the outputVlanId if greater than 0
-     * @return {@link ImmutablePair}<Long, Boolean>, where key is OF transaction id and value is true if the command was
-     * accepted to be sent to switch, false otherwise - switch is disconnected or in SLAVE mode
+     * @return transaction id
      */
-    ImmutablePair<Long, Boolean> installOneSwitchFlow(final DatapathId dpid, final String flowId, final Long cookie,
+    long installOneSwitchFlow(final DatapathId dpid, final String flowId, final Long cookie,
                                                       final int inputPort, final int outputPort, int inputVlanId,
                                                       int outputVlanId, final OutputVlanType outputVlanType,
-                                                      final long meterId);
+                                                      final long meterId) throws SwitchOperationException;
 
     /**
      * Returns list of installed flows
@@ -122,7 +118,7 @@ public interface ISwitchManager extends IFloodlightService {
      * @param dpid switch id
      * @return OF meter config stats entries
      */
-    OFMeterConfigStatsReply dumpMeters(final DatapathId dpid);
+    OFMeterConfigStatsReply dumpMeters(final DatapathId dpid) throws SwitchOperationException;
 
     /**
      * Installs a meter on ingress switch OF_13.
@@ -132,31 +128,29 @@ public interface ISwitchManager extends IFloodlightService {
      * @param bandwidth the bandwidth limit value
      * @param burstSize the size of the burst
      * @param meterId   the meter ID
-     * @return {@link ImmutablePair}<Long, Boolean>, where key is OF transaction id and value is true if the command was
-     * accepted to be sent to switch, false otherwise - switch is disconnected or in SLAVE mode
+     * @return transaction id
      */
-    ImmutablePair<Long, Boolean> installMeter(final DatapathId dpid, final long bandwidth, final long burstSize,
-                                              final long meterId);
+    long installMeter(final DatapathId dpid, final long bandwidth, final long burstSize,
+                                              final long meterId) throws SwitchOperationException;
 
     /**
      * Deletes the flow from the switch
      *
      * @param dpid   datapath ID of the switch
      * @param flowId flow id
-     * @return {@link ImmutablePair}<Long, Boolean>, where key is OF transaction id and value is true if the command was
-     * accepted to be sent to switch, false otherwise - switch is disconnected or in SLAVE mode
+     * @return transaction id
      */
-    ImmutablePair<Long, Boolean> deleteFlow(final DatapathId dpid, final String flowId, final Long cookie);
+    long deleteFlow(final DatapathId dpid, final String flowId, final Long cookie)
+            throws SwitchOperationException;
 
     /**
      * Deletes the meter from the switch OF_13.
      *
      * @param dpid    datapath ID of the switch
      * @param meterId meter identifier
-     * @return {@link ImmutablePair}<Long, Boolean>, where key is OF transaction id and value is true if the command was
-     * accepted to be sent to switch, false otherwise - switch is disconnected or in SLAVE mode
+     * @return transaction id
      */
-    ImmutablePair<Long, Boolean> deleteMeter(final DatapathId dpid, final long meterId);
+    long deleteMeter(final DatapathId dpid, final long meterId) throws SwitchOperationException;
 
 
     Map<DatapathId, IOFSwitch> getAllSwitchMap();

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/OFInstallException.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/OFInstallException.java
@@ -1,0 +1,17 @@
+package org.openkilda.floodlight.switchmanager;
+
+import org.projectfloodlight.openflow.protocol.OFMessage;
+import org.projectfloodlight.openflow.types.DatapathId;
+
+public class OFInstallException extends SwitchOperationException {
+    OFMessage ofMessage;
+
+    public OFInstallException(DatapathId dpId, OFMessage ofMessage) {
+        super(dpId, String.format("Error during install OFRule into switch \"%s\"", dpId));
+        this.ofMessage = ofMessage;
+    }
+
+    public OFMessage getOfMessage() {
+        return ofMessage;
+    }
+}

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
@@ -24,6 +24,14 @@ import static org.projectfloodlight.openflow.protocol.OFVersion.OF_12;
 import static org.projectfloodlight.openflow.protocol.OFVersion.OF_13;
 import static org.projectfloodlight.openflow.protocol.OFVersion.OF_15;
 
+import org.openkilda.floodlight.kafka.KafkaMessageProducer;
+import org.openkilda.floodlight.switchmanager.web.SwitchManagerWebRoutable;
+import org.openkilda.messaging.Destination;
+import org.openkilda.messaging.error.ErrorData;
+import org.openkilda.messaging.error.ErrorMessage;
+import org.openkilda.messaging.error.ErrorType;
+import org.openkilda.messaging.payload.flow.OutputVlanType;
+
 import com.google.common.util.concurrent.ListenableFuture;
 import net.floodlightcontroller.core.FloodlightContext;
 import net.floodlightcontroller.core.IFloodlightProviderService;
@@ -36,14 +44,6 @@ import net.floodlightcontroller.core.module.IFloodlightModule;
 import net.floodlightcontroller.core.module.IFloodlightService;
 import net.floodlightcontroller.restserver.IRestApiService;
 import net.floodlightcontroller.util.FlowModUtils;
-import org.openkilda.floodlight.kafka.KafkaMessageProducer;
-import org.openkilda.floodlight.switchmanager.web.SwitchManagerWebRoutable;
-import org.openkilda.messaging.Destination;
-import org.openkilda.messaging.error.ErrorData;
-import org.openkilda.messaging.error.ErrorMessage;
-import org.openkilda.messaging.error.ErrorType;
-import org.openkilda.messaging.model.ImmutablePair;
-import org.openkilda.messaging.payload.flow.OutputVlanType;
 import org.projectfloodlight.openflow.protocol.OFErrorMsg;
 import org.projectfloodlight.openflow.protocol.OFFactory;
 import org.projectfloodlight.openflow.protocol.OFFlowDelete;
@@ -235,16 +235,15 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
      * {@inheritDoc}
      */
     @Override
-    public boolean installDefaultRules(final DatapathId dpid) {
-        final boolean dropFlow = installDropFlow(dpid);
-        final boolean broadcastVerification = installVerificationRule(dpid, true);
-        if (ofSwitchService.getSwitch(dpid).getOFFactory().getVersion().compareTo(OF_12) > 0) {
+    public void installDefaultRules(final DatapathId dpid) throws SwitchOperationException {
+        installDropFlow(dpid);
+
+        IOFSwitch sw = lookupSwitch(dpid);
+        if (sw.getOFFactory().getVersion().compareTo(OF_12) > 0) {
             logger.debug("installing unicast verification match for {}", dpid.toString());
-            final boolean unicastVerification = installVerificationRule(dpid, false);
-            return dropFlow & broadcastVerification & unicastVerification;
+            installVerificationRule(dpid, true);
         } else {
             logger.debug("not installing unicast verification match for {}", dpid.toString());
-            return dropFlow & broadcastVerification;
         }
     }
 
@@ -252,12 +251,13 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
      * {@inheritDoc}
      */
     @Override
-    public ImmutablePair<Long, Boolean> installIngressFlow(final DatapathId dpid, final String flowId,
-                                                           final Long cookie, final int inputPort, final int outputPort,
-                                                           final int inputVlanId, final int transitVlanId,
-                                                           final OutputVlanType outputVlanType, final long meterId) {
+    public long installIngressFlow(
+            final DatapathId dpid, final String flowId,
+            final Long cookie, final int inputPort, final int outputPort,
+            final int inputVlanId, final int transitVlanId,
+            final OutputVlanType outputVlanType, final long meterId) throws SwitchOperationException {
         List<OFAction> actionList = new ArrayList<>();
-        IOFSwitch sw = ofSwitchService.getSwitch(dpid);
+        IOFSwitch sw = lookupSwitch(dpid);
 
         // build match by input port and input vlan id
         Match match = matchFlow(sw, inputPort, inputVlanId);
@@ -287,21 +287,20 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
         OFFlowMod flowMod = buildFlowMod(sw, match, meter, actions,
                 cookie & FLOW_COOKIE_MASK, FlowModUtils.PRIORITY_VERY_HIGH);
 
-        // send FLOW_MOD to the switch
-        boolean response = pushFlow(flowId, dpid, flowMod);
-        return new ImmutablePair<>(flowMod.getXid(), response);
+        return pushFlow(sw, "--InstallIngressFlow--", flowMod);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public ImmutablePair<Long, Boolean> installEgressFlow(final DatapathId dpid, String flowId, final Long cookie,
-                                                          final int inputPort, final int outputPort,
-                                                          final int transitVlanId, final int outputVlanId,
-                                                          final OutputVlanType outputVlanType) {
+    public long installEgressFlow(
+            final DatapathId dpid, String flowId, final Long cookie,
+            final int inputPort, final int outputPort,
+            final int transitVlanId, final int outputVlanId,
+            final OutputVlanType outputVlanType) throws SwitchOperationException {
         List<OFAction> actionList = new ArrayList<>();
-        IOFSwitch sw = ofSwitchService.getSwitch(dpid);
+        IOFSwitch sw = lookupSwitch(dpid);
 
         // build match by input port and transit vlan id
         Match match = matchFlow(sw, inputPort, transitVlanId);
@@ -319,20 +318,19 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
         OFFlowMod flowMod = buildFlowMod(sw, match, null, actions,
                 cookie & FLOW_COOKIE_MASK, FlowModUtils.PRIORITY_VERY_HIGH);
 
-        // send FLOW_MOD to the switch
-        boolean response = pushFlow(flowId, dpid, flowMod);
-        return new ImmutablePair<>(flowMod.getXid(), response);
+        return pushFlow(sw, "--InstallEgressFlow--", flowMod);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public ImmutablePair<Long, Boolean> installTransitFlow(final DatapathId dpid, final String flowId,
-                                                           final Long cookie, final int inputPort, final int outputPort,
-                                                           final int transitVlanId) {
+    public long installTransitFlow(
+            final DatapathId dpid, final String flowId,
+            final Long cookie, final int inputPort, final int outputPort,
+            final int transitVlanId) throws SwitchOperationException {
         List<OFAction> actionList = new ArrayList<>();
-        IOFSwitch sw = ofSwitchService.getSwitch(dpid);
+        IOFSwitch sw = lookupSwitch(dpid);
 
         // build match by input port and transit vlan id
         Match match = matchFlow(sw, inputPort, transitVlanId);
@@ -347,26 +345,25 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
         OFFlowMod flowMod = buildFlowMod(sw, match, null, actions,
                 cookie & FLOW_COOKIE_MASK, FlowModUtils.PRIORITY_VERY_HIGH);
 
-        // send FLOW_MOD to the switch
-        boolean response = pushFlow(flowId, dpid, flowMod);
-        return new ImmutablePair<>(flowMod.getXid(), response);
+        return pushFlow(sw, flowId, flowMod);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public ImmutablePair<Long, Boolean> installOneSwitchFlow(final DatapathId dpid, final String flowId,
-                                                             final Long cookie, final int inputPort,
-                                                             final int outputPort, final int inputVlanId,
-                                                             final int outputVlanId,
-                                                             final OutputVlanType outputVlanType, final long meterId) {
+    public long installOneSwitchFlow(
+            final DatapathId dpid, final String flowId,
+            final Long cookie, final int inputPort,
+            final int outputPort, final int inputVlanId,
+            final int outputVlanId,
+            final OutputVlanType outputVlanType, final long meterId) throws SwitchOperationException {
         // TODO: As per other locations, how different is this to IngressFlow? Why separate code path?
         //          As with any set of tests, the more we test the same code path, the better.
         //          Based on brief glance, this looks 90% the same as IngressFlow.
 
         List<OFAction> actionList = new ArrayList<>();
-        IOFSwitch sw = ofSwitchService.getSwitch(dpid);
+        IOFSwitch sw = lookupSwitch(dpid);
 
         // build match by input port and transit vlan id
         Match match = matchFlow(sw, inputPort, inputVlanId);
@@ -395,9 +392,9 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
         OFFlowMod flowMod = buildFlowMod(sw, match, meter, actions,
                 cookie & FLOW_COOKIE_MASK, FlowModUtils.PRIORITY_VERY_HIGH);
 
-        // send FLOW_MOD to the switch
-        boolean response = pushFlow(flowId, dpid, flowMod);
-        return new ImmutablePair<>(flowMod.getXid(), response);
+        pushFlow(sw, flowId, flowMod);
+
+        return flowMod.getXid();
     }
 
     /**
@@ -434,9 +431,9 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
      * {@inheritDoc}
      */
     @Override
-    public OFMeterConfigStatsReply dumpMeters(final DatapathId dpid) {
+    public OFMeterConfigStatsReply dumpMeters(final DatapathId dpid) throws SwitchOperationException {
         OFMeterConfigStatsReply values = null;
-        IOFSwitch sw = ofSwitchService.getSwitch(dpid);
+        IOFSwitch sw = lookupSwitch(dpid);
         if (sw == null) {
             throw new IllegalArgumentException(String.format("Switch %s was not found", dpid.toString()));
         }
@@ -460,18 +457,18 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
      * {@inheritDoc}
      */
     @Override
-    public ImmutablePair<Long, Boolean> installMeter(final DatapathId dpid, final long bandwidth,
-                                                      final long burstSize, final long meterId) {
+    public long installMeter(final DatapathId dpid, final long bandwidth, final long burstSize, final long meterId)
+            throws SwitchOperationException {
         if (meterId == 0) {
             logger.info("skip installing meter {} on switch {} width bandwidth {}", meterId, dpid, bandwidth);
-            return new ImmutablePair<>(0L, true);
+            return 0L;
         }
 
-        IOFSwitch sw = ofSwitchService.getSwitch(dpid);
+        IOFSwitch sw = lookupSwitch(dpid);
 
         if (OVS_MANUFACTURER.equals(sw.getSwitchDescription().getManufacturerDescription())) {
             logger.info("skip installing meter {} on OVS switch {} width bandwidth {}", meterId, dpid, bandwidth);
-            return new ImmutablePair<>(0L, true);
+            return 0L;
         }
 
         if (sw.getOFFactory().getVersion().compareTo(OF_12) <= 0) {
@@ -488,8 +485,9 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
     }
 
 
-    private ImmutablePair<Long, Boolean> installMeter(final IOFSwitch sw, final DatapathId dpid, final long bandwidth,
-                                                     final long burstSize, final long meterId) {
+    private long installMeter(final IOFSwitch sw, final DatapathId dpid, final long bandwidth,
+                                                     final long burstSize, final long meterId)
+            throws OFInstallException {
         logger.debug("installing meter {} on switch {} width bandwidth {}", meterId, dpid, bandwidth);
 
         Set<OFMeterFlags> flags = new HashSet<>(Arrays.asList(OFMeterFlags.KBPS, OFMeterFlags.BURST));
@@ -513,13 +511,13 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
 
         OFMeterMod meterMod = meterModBuilder.build();
 
-        boolean response = sw.write(meterMod);
-        return new ImmutablePair<>(meterMod.getXid(), response);
+        return pushFlow(sw, "--InstallMeter--", meterMod);
     }
 
-    private ImmutablePair<Long, Boolean> installLegacyMeter(final IOFSwitch sw, final DatapathId dpid,
-                                                            final long bandwidth, final long burstSize,
-                                                            final long meterId) {
+    private long installLegacyMeter(
+            final IOFSwitch sw, final DatapathId dpid,
+            final long bandwidth, final long burstSize, final long meterId)
+            throws OFInstallException {
         logger.debug("installing legacy meter {} on OVS switch {} width bandwidth {}", meterId, dpid, bandwidth);
 
         Set<OFLegacyMeterFlags> flags = new HashSet<>(Arrays.asList(OFLegacyMeterFlags.KBPS, OFLegacyMeterFlags.BURST));
@@ -534,8 +532,7 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
                 .setFlags(flags)
                 .build();
 
-        boolean response = sw.write(meterMod);
-        return new ImmutablePair<>(meterMod.getXid(), response);
+        return pushFlow(sw, "--InstallMeter", meterMod);
     }
 
     // Utility Methods
@@ -544,35 +541,35 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
      * {@inheritDoc}
      */
     @Override
-    public ImmutablePair<Long, Boolean> deleteFlow(final DatapathId dpid, final String flowId, final Long cookie) {
+    public long deleteFlow(final DatapathId dpid, final String flowId, final Long cookie)
+            throws SwitchOperationException {
         logger.info("deleting flows {} from switch {}", flowId, dpid.toString());
 
-        IOFSwitch sw = ofSwitchService.getSwitch(dpid);
+        IOFSwitch sw = lookupSwitch(dpid);
         OFFactory ofFactory = sw.getOFFactory();
         OFFlowDelete flowDelete = ofFactory.buildFlowDelete()
                 .setCookie(U64.of(cookie))
                 .setCookieMask(NON_SYSTEM_MASK)
                 .build();
 
-        boolean response = sw.write(flowDelete);
-        return new ImmutablePair<>(flowDelete.getXid(), response);
+        return pushFlow(sw, "--DeleteFlow--", flowDelete);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public ImmutablePair<Long, Boolean> deleteMeter(final DatapathId dpid, final long meterId) {
+    public long deleteMeter(final DatapathId dpid, final long meterId)
+            throws SwitchOperationException {
         if (meterId == 0) {
             logger.info("skip deleting meter {} from switch {}", meterId, dpid);
-            return new ImmutablePair<>(0L, true);
+            return 0L;
         }
 
-        IOFSwitch sw = ofSwitchService.getSwitch(dpid);
-
+        IOFSwitch sw = lookupSwitch(dpid);
         if (OVS_MANUFACTURER.equals(sw.getSwitchDescription().getManufacturerDescription())) {
             logger.info("skip deleting meter {} from OVS switch {}", meterId, dpid);
-            return new ImmutablePair<>(0L, true);
+            return 0L;
         }
 
         if (sw.getOFFactory().getVersion().compareTo(OF_12) <= 0) {
@@ -582,7 +579,8 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
         }
     }
 
-    public ImmutablePair<Long, Boolean> deleteMeter(IOFSwitch sw, final DatapathId dpid, final long meterId) {
+    public long deleteMeter(IOFSwitch sw, final DatapathId dpid, final long meterId)
+            throws OFInstallException {
         logger.debug("deleting meter {} from switch {}", meterId, dpid);
 
         OFFactory ofFactory = sw.getOFFactory();
@@ -599,11 +597,11 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
 
         OFMeterMod meterDelete = meterDeleteBuilder.build();
 
-        boolean response = sw.write(meterDelete);
-        return new ImmutablePair<>(meterDelete.getXid(), response);
+        return pushFlow(sw, "--DeleteMeter--", meterDelete);
     }
 
-    public ImmutablePair<Long, Boolean> deleteLegacyMeter(final IOFSwitch sw, final DatapathId dpid, final long meterId) {
+    public long deleteLegacyMeter(final IOFSwitch sw, final DatapathId dpid, final long meterId)
+            throws OFInstallException {
         logger.debug("deleting legacy meter {} from switch {}", meterId, dpid);
 
         OFFactory ofFactory = sw.getOFFactory();
@@ -614,8 +612,7 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
                 .setCommand(OFLegacyMeterModCommand.DELETE)
                 .build();
 
-        boolean response = sw.write(meterDelete);
-        return new ImmutablePair<>(meterDelete.getXid(), response);
+        return pushFlow(sw, "--DeleteMeter--", meterDelete);
     }
 
     /**
@@ -884,11 +881,11 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
      *
      * @param dpid        datapathId of switch
      * @param isBroadcast if broadcast then set a generic match; else specific to switch Id
-     * @return true if the command is accepted to be sent to switch, false otherwise - switch is disconnected or in
-     * SLAVE mode
+     * @throws SwitchOperationException
      */
-    private boolean installVerificationRule(final DatapathId dpid, final boolean isBroadcast) {
-        IOFSwitch sw = ofSwitchService.getSwitch(dpid);
+    private void installVerificationRule(final DatapathId dpid, final boolean isBroadcast)
+            throws SwitchOperationException {
+        IOFSwitch sw = lookupSwitch(dpid);
 
         Match match = matchVerification(sw, isBroadcast);
         ArrayList<OFAction> actionList = new ArrayList<>(2);
@@ -901,34 +898,53 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
                 cookie, FlowModUtils.PRIORITY_VERY_HIGH);
         String flowname = (isBroadcast) ? "Broadcast" : "Unicast";
         flowname += "--VerificationFlow--" + dpid.toString();
-        return pushFlow(flowname, dpid, flowMod);
+        pushFlow(sw, flowname, flowMod);
     }
 
     /**
      * Installs a last-resort rule to drop all packets that don't match any match.
      *
      * @param dpid datapathId of switch
-     * @return true if the command is accepted to be sent to switch, false otherwise - switch is disconnected or in
-     * SLAVE mode
+     * @throws SwitchOperationException
      */
-    private boolean installDropFlow(final DatapathId dpid) {
-        IOFSwitch sw = ofSwitchService.getSwitch(dpid);
+    private void installDropFlow(final DatapathId dpid) throws SwitchOperationException {
+        IOFSwitch sw = lookupSwitch(dpid);
         OFFlowMod flowMod = buildFlowMod(sw, null, null, null, DROP_COOKIE, 1);
-        String flowname = "--DropRule--" + dpid.toString();
-        return pushFlow(flowname, dpid, flowMod);
+        String flowName = "--DropRule--" + dpid.toString();
+        pushFlow(sw, flowName, flowMod);
     }
 
     /**
      * Pushes a single flow modification command to the switch with the given datapath ID.
      *
+     * @param sw      open flow switch descriptor
      * @param flowId  flow name, for logging
-     * @param dpid    switch datapath ID
      * @param flowMod command to send
-     * @return true if the command is accepted to be sent to switch, false otherwise - switch is disconnected or in
-     * SLAVE mode
+     * @return OF transaction Id (???)
+     * @throws OFInstallException
      */
-    private boolean pushFlow(final String flowId, final DatapathId dpid, final OFFlowMod flowMod) {
+    private long pushFlow(final IOFSwitch sw, final String flowId, final OFMessage flowMod) throws OFInstallException {
         logger.info("installing {} flow: {}", flowId, flowMod);
-        return ofSwitchService.getSwitch(dpid).write(flowMod);
+        if (! sw.write(flowMod)) {
+            throw new OFInstallException(sw.getId(), flowMod);
+        }
+
+        return flowMod.getXid();
+    }
+
+    /**
+     * Wrap IOFSwitchService.getSwitch call to check protect from null return value.
+     *
+     * @param  dpId switch identifier
+     * @return open flow switch descriptor
+     * @throws SwitchOperationException
+     */
+    private IOFSwitch lookupSwitch(DatapathId dpId) throws SwitchOperationException {
+        IOFSwitch swInfo = ofSwitchService.getSwitch(dpId);
+        if (swInfo == null) {
+            throw new SwitchOperationException(dpId);
+        }
+
+        return swInfo;
     }
 }

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchNotFoundException.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchNotFoundException.java
@@ -1,0 +1,9 @@
+package org.openkilda.floodlight.switchmanager;
+
+import org.projectfloodlight.openflow.types.DatapathId;
+
+public class SwitchNotFoundException extends SwitchOperationException {
+    public SwitchNotFoundException(DatapathId dpId) {
+        super(dpId, String.format("Switch \"%s\" is not connected", dpId));
+    }
+}

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchOperationException.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchOperationException.java
@@ -1,0 +1,20 @@
+package org.openkilda.floodlight.switchmanager;
+
+import org.projectfloodlight.openflow.types.DatapathId;
+
+public class SwitchOperationException extends Exception {
+    private final DatapathId dpId;
+
+    public SwitchOperationException(DatapathId dpId) {
+        this(dpId, "Switch manipulation has failed");
+    }
+
+    public SwitchOperationException(DatapathId dpId, String s) {
+        super(s);
+        this.dpId = dpId;
+    }
+
+    public DatapathId getDpId() {
+        return dpId;
+    }
+}

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/web/MetersResource.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/web/MetersResource.java
@@ -19,6 +19,7 @@ import static org.openkilda.messaging.Utils.DEFAULT_CORRELATION_ID;
 import static org.openkilda.messaging.Utils.MAPPER;
 
 import org.openkilda.floodlight.switchmanager.ISwitchManager;
+import org.openkilda.floodlight.switchmanager.SwitchOperationException;
 import org.openkilda.messaging.error.ErrorType;
 import org.openkilda.messaging.error.MessageError;
 
@@ -36,6 +37,7 @@ import java.util.Map;
 public class MetersResource extends ServerResource {
     private static final Logger logger = LoggerFactory.getLogger(MetersResource.class);
 
+    // FIXME(surabujin): is it used anywhere?
     @Get("json")
     @SuppressWarnings("unchecked")
     public Map<Long, Object> getMeters() {
@@ -54,7 +56,7 @@ public class MetersResource extends ServerResource {
                     response.put(entry.getMeterId(), entry);
                 }
             }
-        } catch (IllegalArgumentException exception) {
+        } catch (IllegalArgumentException|SwitchOperationException exception) {
             String messageString = "No such switch";
             logger.error("{}: {}", messageString, switchId, exception);
             MessageError responseMessage = new MessageError(DEFAULT_CORRELATION_ID, System.currentTimeMillis(),

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerTest.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerTest.java
@@ -274,7 +274,7 @@ public class SwitchManagerTest {
     }
 
     @Test
-    public void deleteMeter() {
+    public void deleteMeter() throws SwitchOperationException {
         final Capture<OFMeterMod> capture = prepareForMeterTest();
         switchManager.deleteMeter(dpid, meterId);
         final OFMeterMod meterMod = capture.getValue();


### PR DESCRIPTION
NPE arrives because of use result of IOFSwitchService.getSwitch call
without check for null value. This method return null values if there is
no switch with requested dpId.

There is a lot of calls to this method without check for null response
into org.openkilda.floodlight.switchmanager.SwitchManager. And there was
no simple way to fix them all.