### PR TITLE
Fix ISL check interval

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java
@@ -86,6 +86,7 @@ public class OFELinkBolt
         extends AbstractTickStatefulBolt<KeyValueState<String, Object>>
         implements ICtrlBolt {
     private static final Logger logger = LoggerFactory.getLogger(OFELinkBolt.class);
+    private static final int BOLT_TICK_INTERVAL = 1;
 
     private final String STREAM_ID_CTRL = "ctrl";
     private final String STATE_ID_DISCOVERY = "discovery-manager";
@@ -119,7 +120,7 @@ public class OFELinkBolt
      * Default constructor .. default health check frequency
      */
     public OFELinkBolt(TopologyConfig config) {
-        super(config.getDiscoveryInterval());
+        super(BOLT_TICK_INTERVAL);
 
         this.islHealthCheckInterval = config.getDiscoveryInterval();
         this.islHealthCheckTimeout = config.getDiscoveryTimeout();

--- a/services/wfm/src/main/resources/topology.properties
+++ b/services/wfm/src/main/resources/topology.properties
@@ -43,13 +43,13 @@ logger.watermark =
 
 #######
 # Discovery
-# - discovery.interval = how many bolt ticks between ISL discovery / health checks
+# - discovery.interval = how many bolt ticks(1 tick per second) between ISL discovery / health checks, starts from 0
 # - discovery.timeout = at which point do we send an ISL Failure (if it is an ISL)
 #       - NB: the number is in "ticks", not "attempts" .. attempts = timeout/interval
 # - discovery.limit = at what point do we stop sending? -1 means never ..
 # - discovery.speaker-failure-timeout - after this amount of seconds without a
 #   message from speaker it will be marked as unavailable
-discovery.interval = 3
+discovery.interval = 2
 discovery.timeout = 9
 discovery.limit = -1
 discovery.speaker-failure-timeout = 5

--- a/services/wfm/src/test/resources/topology.properties
+++ b/services/wfm/src/test/resources/topology.properties
@@ -51,13 +51,13 @@ logger.watermark =
 
 #######
 # Discovery
-# - discovery.interval = how many bolt ticks between ISL discovery / health checks
+# - discovery.interval = how many bolt ticks(1 tick per second) between ISL discovery / health checks, starts from 0
 # - discovery.timeout = at which point do we send an ISL Failure (if it is an ISL)
 #       - NB: the number is in "ticks", not "attempts" .. attempts = timeout/interval
 # - discovery.limit = at what point do we stop sending? -1 means never ..
 # - discovery.speaker-failure-timeout - after this amount of seconds without a
 #   message from speaker it will be marked as unavailable
-discovery.interval = 3
+discovery.interval = 2
 discovery.timeout = 9
 discovery.limit = -1
 discovery.speaker-failure-timeout = 5

--- a/templates/defaults/main.yaml
+++ b/templates/defaults/main.yaml
@@ -31,7 +31,7 @@ kafka_topic_stats: "kilda.stats"
 kafka_topic_topo_cache: "kilda.topo.cache"
 kafka_topic_topo_disco: "kilda.topo.disco"
 kafka_topic_topo_eng: "kilda.topo.eng"
-discovery_interval: "3"
+discovery_interval: 2
 discovery_timeout: "9"
 # discovery_limit of -1 is forever
 # 28000 is about a day (test every 3 seconds, 20 failures per minute, 1200 per hour ..

--- a/templates/templates/wfm/topology.properties.j2
+++ b/templates/templates/wfm/topology.properties.j2
@@ -41,7 +41,7 @@ logger.watermark =
 
 #######
 # Discovery
-# - discovery.interval = how many bolt ticks between ISL discovery / health checks
+# - discovery.interval = how many bolt ticks(1 tick per second) between ISL discovery / health checks, starts from 0
 # - discovery.timeout = at which point do we send an ISL Failure (if it is an ISL)
 #       - NB: the number is in "ticks", not "attempts" .. attempts = timeout/interval
 # - discovery.limit = at what point do we stop sending? -1 means never ..


### PR DESCRIPTION
Due to incorrect usage of OFELinkBolt's tick interval and discovery
interval used in DiscoveryManager kilda sends ISL with interval 12
seconds (4 ticks * 3 seconds).

Change OFELinkBolt's tick interval to 1 second. It simplifies math and
make system more crear. And it should be more "handy" when we will add
more logic into discovery process.

Close #313