### PR TITLE
[ENH] ADD Delete Flow by Segment Cookie

### DIFF
--- a/services/topology-engine/queue-engine/tests/test_flow_segments.py
+++ b/services/topology-engine/queue-engine/tests/test_flow_segments.py
@@ -64,7 +64,7 @@ print('Hello World')
 print("TEST #1 & #2 - create flow, get segments, spot check some of the values.")
 flow_utils.store_flow(flow1)
 
-result = flow_utils.fetch_flow_segments(flow1)
+result = flow_utils.fetch_flow_segments(flow1['flowid'], flow1['cookie'])
 print("Validate #1 - Length of segments should be 2: %d" % len(result))
 for i,val in enumerate(result):
     print("Validate #3.* - seq_id should be %d: is: %d" % (flow1['flowpath']['path'][i*2]['seq_id'], val['seq_id']))
@@ -80,7 +80,7 @@ for i,isl in enumerate(messageclasses.MessageItem.fetch_isls()):
 print("TEST #4 - remove flow, validate bandwidth.")
 flow_utils.remove_flow(flow1)
 
-result = flow_utils.fetch_flow_segments(flow1)
+result = flow_utils.fetch_flow_segments(flow1['flowid'], flow1['cookie'])
 print("Validate #4.1 - should have no flow segments: %s " % result)
 
 for i,isl in enumerate(messageclasses.MessageItem.fetch_isls()):

--- a/services/topology-engine/queue-engine/topologylistener/message_utils.py
+++ b/services/topology-engine/queue-engine/topologylistener/message_utils.py
@@ -195,21 +195,17 @@ def send_install_commands(flow_rules, correlation_id):
                       destination="WFM", topic=config.KAFKA_FLOW_TOPIC)
 
 
-def send_delete_commands(nodes, flow_id, flow, correlation_id, cookie):
+def send_delete_commands(nodes, correlation_id):
+    """
+    Build the message for each switch node in the path and send the message to both the speaker and the flow topic
 
-    if flow['src_switch'] == flow['dst_switch']:
-        #
-        # This means the flow is a single switch. The code north of here doesn't currently handle
-        # this scenario (for flow creation, the flow_utils.build_rules does account for it, but
-        # there isn't a symmetrical call .. ie build_delete_rules.
-        #
-        # Given the above, there should be no nodes, Create a node now.
-        #
-        nodes = [ {'switch_id':flow['src_switch']} ]
+    :param nodes: array of dicts: switch_id; flow_id; cookie
+    :return:
+    """
 
     logger.debug('Send Delete Commands: node count=%d', len(nodes))
     for node in nodes:
-        data = build_delete_flow(str(node['switch_id']), str(flow_id), cookie)
+        data = build_delete_flow(str(node['switch_id']), str(node['flow_id']), node['cookie'])
         send_to_topic(data, correlation_id, MT_COMMAND,
                       destination="CONTROLLER", topic=config.KAFKA_SPEAKER_TOPIC)
         send_to_topic(data, correlation_id, MT_COMMAND,


### PR DESCRIPTION
Previously we assumed a global cookie for each flow - ie flow_id and
cookie was same for all segments in one direction.

Now, we use the flow_id (global) and a per segment cookie.

Closes issue #233 