### PR TITLE
FIX FL module dependencides

### DIFF
--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/ConsumerContext.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/ConsumerContext.java
@@ -14,10 +14,9 @@ public class ConsumerContext extends Context {
     private final KafkaMessageProducer kafkaProducer;
     private final ISwitchManager switchManager;
 
-    public static void fillDedendencies(Collection<Class<? extends IFloodlightService>> dependencies) {
+    public static void fillDependencies(Collection<Class<? extends IFloodlightService>> dependencies) {
         Context.fillDependencies(dependencies);
 
-        dependencies.add(IPathVerificationService.class);
         dependencies.add(IPathVerificationService.class);
         dependencies.add(ISwitchManager.class);
     }


### PR DESCRIPTION
Due to typo in static method name it don't called during module initialisation.