### PR TITLE
Enable remote debugging for neo4j

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     ports:
       - "7474:7474"
       - "7687:7687"
+      - "16010:16010"
+      - "16011:16011"
     healthcheck:
       test: ["CMD-SHELL", "curl --fail http://localhost:7474/"]
       interval: 30s

--- a/services/neo4j/Dockerfile
+++ b/services/neo4j/Dockerfile
@@ -14,13 +14,9 @@
 #
 
 FROM kilda/base-ubuntu
+
 ADD ansible /ansible
 RUN ansible-playbook -s /ansible/deploy.yml
-ADD neo4j-config/neo4j.conf /etc/neo4j/neo4j.conf
-ADD neo4j-config/auth /var/lib/neo4j/data/dbms/auth
-ADD init/neo4j-queries.cql /app/neo4j-queries.cql
-ADD init/init.sh /app/init.sh
-RUN pip install cycli
 
 #
 # https://github.com/neo4j-contrib/neo4j-apoc-procedures#version-compatibility-matrix
@@ -34,5 +30,11 @@ RUN pip install cycli
 RUN wget \
   https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/3.3.0.1/apoc-3.3.0.1-all.jar \
    -O /var/lib/neo4j/plugins/apoc-3.3.0.1-all.jar
+
+ADD neo4j-config/neo4j.conf /etc/neo4j/neo4j.conf
+ADD neo4j-config/auth /var/lib/neo4j/data/dbms/auth
+ADD init/neo4j-queries.cql /app/neo4j-queries.cql
+ADD init/init.sh /app/init.sh
+RUN pip install cycli
 
 CMD /app/init.sh

--- a/services/neo4j/init/init.sh
+++ b/services/neo4j/init/init.sh
@@ -1,3 +1,19 @@
+#!/bin/sh
+
+if [ -n "${OK_TESTS}" ]; then
+    # enable debug for neo4j in case future lock issues (only on local/devel environment)
+
+    dbms_jvm_additional=""
+    dbms_jvm_additional="${dbms_jvm_additional} -Dcom.sun.management.jmxremote"
+    dbms_jvm_additional="${dbms_jvm_additional} -Dcom.sun.management.jmxremote.port=16010"
+    dbms_jvm_additional="${dbms_jvm_additional} -Dcom.sun.management.jmxremote.local.only=false"
+    dbms_jvm_additional="${dbms_jvm_additional} -Dcom.sun.management.jmxremote.authenticate=false"
+    dbms_jvm_additional="${dbms_jvm_additional} -Dcom.sun.management.jmxremote.ssl=false"
+    dbms_jvm_additional="${dbms_jvm_additional} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=16011"
+
+    export dbms_jvm_additional
+fi
+
 neo4j console &
 # Wait for neo4j to be and execute queries.
 /app/wait-for-it.sh -t 120 -h localhost -p 7473 -- cycli -f /app/neo4j-queries.cql


### PR DESCRIPTION
Enable remove debugging in neo4j on case of neo4j locking issues. It is
enabled only if OK_TESTS environment variable is set i.e. in our devel
environment.