### PR TITLE
Introduce DELETE SWITCH RULES method in Northbound.

### DIFF
--- a/services/src/atdd/src/test/java/org/openkilda/SwitchesUtils.java
+++ b/services/src/atdd/src/test/java/org/openkilda/SwitchesUtils.java
@@ -3,6 +3,7 @@ package org.openkilda;
 import static java.lang.String.format;
 import static java.util.Base64.getEncoder;
 import static org.openkilda.DefaultParameters.mininetEndpoint;
+import static org.openkilda.DefaultParameters.northboundEndpoint;
 import static org.openkilda.DefaultParameters.topologyEndpoint;
 import static org.openkilda.DefaultParameters.topologyPassword;
 import static org.openkilda.DefaultParameters.topologyUsername;
@@ -11,6 +12,9 @@ import static org.openkilda.DefaultParameters.trafficEndpoint;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.glassfish.jersey.client.ClientConfig;
+import org.openkilda.messaging.Utils;
+import org.openkilda.messaging.command.switches.DefaultRulesAction;
+import org.openkilda.messaging.error.MessageError;
 import org.openkilda.messaging.info.event.SwitchInfoData;
 import org.openkilda.topo.exceptions.TopologyProcessingException;
 
@@ -19,6 +23,7 @@ import java.util.List;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -128,4 +133,39 @@ public final class SwitchesUtils {
     }
 
 
+    /**
+     * Delete switch rules through Northbound service.
+     */
+    public static List<Long> deleteSwitchRules(String switchId, DefaultRulesAction defaultRules) {
+        System.out.println("\n==> Northbound Delete Switch Rules");
+
+        Client client = ClientBuilder.newClient(new ClientConfig());
+
+        Response response = client
+                .target(northboundEndpoint)
+                .path("/api/v1/switches/")
+                .path("{switch-id}")
+                .path("rules")
+                .queryParam("defaultRules", defaultRules)
+                .resolveTemplate("switch-id", switchId)
+
+                .request(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, authHeaderValue)
+                .header(Utils.CORRELATION_ID, String.valueOf(System.currentTimeMillis()))
+                .header(Utils.EXTRA_AUTH, String.valueOf(System.currentTimeMillis()))
+                .delete();
+
+        System.out.println(format("===> Response = %s", response.toString()));
+
+        int responseCode = response.getStatus();
+        if (responseCode == 200) {
+            List<Long> cookies = response.readEntity(new GenericType<List<Long>>() {});
+            System.out.println(format("====> Northbound Delete Switch Rules = %d", cookies.size()));
+            return cookies;
+        } else {
+            System.out.println(format("====> Error: Northbound Delete Switch Rules = %s",
+                    response.readEntity(MessageError.class)));
+            return null;
+        }
+    }
 }

--- a/services/src/atdd/src/test/java/org/openkilda/atdd/NorthboundRunTest.java
+++ b/services/src/atdd/src/test/java/org/openkilda/atdd/NorthboundRunTest.java
@@ -20,16 +20,17 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.openkilda.flow.FlowUtils.getHealthCheck;
 
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import org.openkilda.SwitchesUtils;
 import org.openkilda.flow.FlowUtils;
+import org.openkilda.messaging.command.switches.DefaultRulesAction;
 import org.openkilda.messaging.info.event.PathInfoData;
 import org.openkilda.messaging.info.event.PathNode;
 import org.openkilda.messaging.payload.flow.FlowIdStatusPayload;
 import org.openkilda.messaging.payload.flow.FlowPathPayload;
 import org.openkilda.messaging.payload.flow.FlowPayload;
 import org.openkilda.messaging.payload.flow.FlowState;
-
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
 
 import java.util.Arrays;
 import java.util.List;
@@ -85,5 +86,19 @@ public class NorthboundRunTest {
         assertNotNull(payload);
         assertEquals(flowName, payload.getId());
         assertEquals(flowState, payload.getStatus());
+    }
+
+    @Then("^delete all non-default rules on (.*) switch$")
+    public void deleteAllNonDefaultRules(String switchId) {
+        List<Long> cookies = SwitchesUtils.deleteSwitchRules(switchId, DefaultRulesAction.IGNORE);
+        assertNotNull(cookies);
+        cookies.forEach(cookie -> System.out.println(cookie));
+    }
+
+    @Then("^delete all rules on (.*) switch$")
+    public void deleteAllDefaultRules(String switchId) {
+        List<Long> cookies = SwitchesUtils.deleteSwitchRules(switchId, DefaultRulesAction.DROP);
+        assertNotNull(cookies);
+        cookies.forEach(cookie -> System.out.println(cookie));
     }
 }

--- a/services/src/atdd/src/test/resources/features/mvp.1/NorthboundRun.feature
+++ b/services/src/atdd/src/test/resources/features/mvp.1/NorthboundRun.feature
@@ -64,3 +64,27 @@ Feature: Northbound tests
   This scenario setups flows across the entire set of switches and checks that these flows could be read from database
 
     Then flows dump contains 5 flows
+
+  @MVP1
+  Scenario: Delete non-default rules from a switch
+
+  This scenario setups a flow through a switch, deletes non-default rules from the switch and checks that the traffic is not pingable
+
+    Then flow nbdnr creation request with de:ad:be:ef:00:00:00:02 1 0 and de:ad:be:ef:00:00:00:03 2 0 and 1000 is successful
+    And flow nbdnr in UP state
+    And traffic through de:ad:be:ef:00:00:00:02 1 0 and de:ad:be:ef:00:00:00:03 2 0 and 1000 is pingable
+
+    Then delete all non-default rules on de:ad:be:ef:00:00:00:03 switch
+    And traffic through de:ad:be:ef:00:00:00:02 1 0 and de:ad:be:ef:00:00:00:03 2 0 and 1000 is not pingable
+
+  @MVP1
+  Scenario: Delete all rules from a switch
+
+  This scenario setups a flow through a switch, deletes all rules from the switch and checks that the traffic is not pingable
+
+    Then flow nbdar creation request with de:ad:be:ef:00:00:00:02 1 0 and de:ad:be:ef:00:00:00:03 2 0 and 1000 is successful
+    And flow nbdar in UP state
+    And traffic through de:ad:be:ef:00:00:00:02 1 0 and de:ad:be:ef:00:00:00:03 2 0 and 1000 is pingable
+
+    Then delete all rules on de:ad:be:ef:00:00:00:03 switch
+    And traffic through de:ad:be:ef:00:00:00:02 1 0 and de:ad:be:ef:00:00:00:03 2 0 and 1000 is not pingable

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/ISwitchManager.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/ISwitchManager.java
@@ -15,14 +15,14 @@
 
 package org.openkilda.floodlight.switchmanager;
 
-import org.openkilda.messaging.payload.flow.OutputVlanType;
-
 import net.floodlightcontroller.core.IOFSwitch;
 import net.floodlightcontroller.core.module.IFloodlightService;
+import org.openkilda.messaging.payload.flow.OutputVlanType;
 import org.projectfloodlight.openflow.protocol.OFFlowStatsReply;
 import org.projectfloodlight.openflow.protocol.OFMeterConfigStatsReply;
 import org.projectfloodlight.openflow.types.DatapathId;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -154,4 +154,20 @@ public interface ISwitchManager extends IFloodlightService {
 
 
     Map<DatapathId, IOFSwitch> getAllSwitchMap();
+
+    /**
+     * Deletes all non-default rules from the switch
+     *
+     * @param dpid datapath ID of the switch
+     * @return the list of cookies for removed rules
+     */
+    List<Long> deleteAllNonDefaultRules(final DatapathId dpid) throws SwitchOperationException;
+
+    /**
+     * Deletes the default rules (drop + verification) from the switch
+     *
+     * @param dpid datapath ID of the switch
+     * @return the list of cookies for removed rules
+     */
+    List<Long> deleteDefaultRules(final DatapathId dpid) throws SwitchOperationException;
 }

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerTest.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerTest.java
@@ -15,6 +15,21 @@
 
 package org.openkilda.floodlight.switchmanager;
 
+import static java.util.Collections.singletonList;
+import static org.easymock.EasyMock.anyLong;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
+import static org.hamcrest.core.Every.everyItem;
+import static org.junit.Assert.assertEquals;
 import static org.openkilda.floodlight.Constants.bandwidth;
 import static org.openkilda.floodlight.Constants.burstSize;
 import static org.openkilda.floodlight.Constants.inputPort;
@@ -24,16 +39,11 @@ import static org.openkilda.floodlight.Constants.outputPort;
 import static org.openkilda.floodlight.Constants.outputVlanId;
 import static org.openkilda.floodlight.Constants.transitVlanId;
 import static org.openkilda.floodlight.message.command.encapsulation.PushSchemeOutputCommands.ofFactory;
-import static org.easymock.EasyMock.capture;
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertEquals;
+import static org.openkilda.floodlight.switchmanager.SwitchManager.DROP_RULE_COOKIE;
+import static org.openkilda.floodlight.switchmanager.SwitchManager.VERIFICATION_RULE_COOKIE_2;
+import static org.openkilda.floodlight.switchmanager.SwitchManager.VERIFICATION_RULE_COOKIE_3;
 
-import org.openkilda.floodlight.message.command.encapsulation.OutputCommands;
-import org.openkilda.floodlight.message.command.encapsulation.ReplaceSchemeOutputCommands;
-import org.openkilda.messaging.payload.flow.OutputVlanType;
-
+import com.google.common.util.concurrent.ListenableFuture;
 import net.floodlightcontroller.core.IOFSwitch;
 import net.floodlightcontroller.core.SwitchDescription;
 import net.floodlightcontroller.core.internal.IOFSwitchService;
@@ -41,14 +51,24 @@ import net.floodlightcontroller.core.module.FloodlightModuleContext;
 import net.floodlightcontroller.core.module.FloodlightModuleException;
 import net.floodlightcontroller.restserver.IRestApiService;
 import org.easymock.Capture;
+import org.easymock.CaptureType;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
+import org.openkilda.floodlight.message.command.encapsulation.OutputCommands;
+import org.openkilda.floodlight.message.command.encapsulation.ReplaceSchemeOutputCommands;
+import org.openkilda.messaging.payload.flow.OutputVlanType;
 import org.projectfloodlight.openflow.protocol.OFFlowMod;
 import org.projectfloodlight.openflow.protocol.OFFlowModCommand;
+import org.projectfloodlight.openflow.protocol.OFFlowStatsEntry;
+import org.projectfloodlight.openflow.protocol.OFFlowStatsReply;
+import org.projectfloodlight.openflow.protocol.OFFlowStatsRequest;
 import org.projectfloodlight.openflow.protocol.OFMeterMod;
 import org.projectfloodlight.openflow.protocol.OFMeterModCommand;
 import org.projectfloodlight.openflow.types.DatapathId;
+import org.projectfloodlight.openflow.types.U64;
+
+import java.util.List;
 
 public class SwitchManagerTest {
     private static final OutputCommands scheme = new ReplaceSchemeOutputCommands();
@@ -282,6 +302,63 @@ public class SwitchManagerTest {
         assertEquals(meterMod.getMeterId(), meterId);
     }
 
+    @Test
+    public void shouldDeleteAllNonDefaultRules() throws Exception {
+        // given
+        expect(ofSwitchService.getSwitch(dpid)).andStubReturn(iofSwitch);
+        expect(iofSwitch.getOFFactory()).andStubReturn(ofFactory);
+
+        OFFlowStatsEntry ofFlowStatsEntry = mock(OFFlowStatsEntry.class);
+        expect(ofFlowStatsEntry.getCookie()).andReturn(U64.of(cookie));
+
+        OFFlowStatsReply ofFlowStatsReply = mock(OFFlowStatsReply.class);
+        expect(ofFlowStatsReply.getEntries()).andReturn(singletonList(ofFlowStatsEntry));
+
+        ListenableFuture<OFFlowStatsReply> ofStatsFuture = mock(ListenableFuture.class);
+        expect(ofStatsFuture.get(anyLong(), anyObject())).andReturn(ofFlowStatsReply);
+
+        expect(iofSwitch.writeRequest(anyObject(OFFlowStatsRequest.class))).andReturn(ofStatsFuture);
+
+        Capture<OFFlowMod> capture = EasyMock.newCapture();
+        expect(iofSwitch.write(capture(capture))).andReturn(true);
+        expectLastCall();
+
+        replay(ofSwitchService, iofSwitch, ofFlowStatsEntry, ofFlowStatsReply, ofStatsFuture);
+
+        // when
+        switchManager.deleteAllNonDefaultRules(dpid);
+
+        // then
+        final OFFlowMod actual = capture.getValue();
+        assertEquals(OFFlowModCommand.DELETE, actual.getCommand());
+        assertEquals(cookie, actual.getCookie().getValue());
+        assertEquals(SwitchManager.NON_SYSTEM_MASK, actual.getCookieMask());
+    }
+
+    @Test
+    public void shouldDeleteDefaultRules() throws Exception {
+        // given
+        expect(ofSwitchService.getSwitch(dpid)).andStubReturn(iofSwitch);
+        expect(iofSwitch.getOFFactory()).andStubReturn(ofFactory);
+
+        Capture<OFFlowMod> capture = EasyMock.newCapture(CaptureType.ALL);
+        expect(iofSwitch.write(capture(capture))).andReturn(true).times(3);
+        expectLastCall();
+
+        replay(ofSwitchService, iofSwitch);
+
+        // when
+        switchManager.deleteDefaultRules(dpid);
+
+        // then
+        final List<OFFlowMod> actual = capture.getValues();
+        assertEquals(3, actual.size());
+        assertThat(actual, everyItem(hasProperty("command", equalTo(OFFlowModCommand.DELETE))));
+        assertThat(actual, hasItem(hasProperty("cookie", equalTo(U64.of(DROP_RULE_COOKIE)))));
+        assertThat(actual, hasItem(hasProperty("cookie", equalTo(U64.of(VERIFICATION_RULE_COOKIE_2)))));
+        assertThat(actual, hasItem(hasProperty("cookie", equalTo(U64.of(VERIFICATION_RULE_COOKIE_3)))));
+    }
+
     private Capture<OFFlowMod> prepareForInstallTest() {
         Capture<OFFlowMod> capture = EasyMock.newCapture();
 
@@ -290,7 +367,7 @@ public class SwitchManagerTest {
         expect(iofSwitch.getSwitchDescription()).andStubReturn(switchDescription);
         expect(switchDescription.getManufacturerDescription()).andStubReturn("");
         expect(iofSwitch.write(capture(capture))).andReturn(true);
-        EasyMock.expectLastCall();
+        expectLastCall();
 
         replay(ofSwitchService);
         replay(iofSwitch);
@@ -307,7 +384,7 @@ public class SwitchManagerTest {
         expect(iofSwitch.getSwitchDescription()).andStubReturn(switchDescription);
         expect(switchDescription.getManufacturerDescription()).andStubReturn("");
         expect(iofSwitch.write(capture(capture))).andReturn(true);
-        EasyMock.expectLastCall();
+        expectLastCall();
 
         replay(ofSwitchService);
         replay(iofSwitch);

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/command/CommandMessage.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/command/CommandMessage.java
@@ -50,7 +50,7 @@ public class CommandMessage extends Message {
      * Data of the command message.
      */
     @JsonProperty(PAYLOAD)
-    private CommandData data;
+    protected CommandData data;
 
     /**
      * Instance constructor.

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/command/CommandWithReplyToMessage.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/command/CommandWithReplyToMessage.java
@@ -1,0 +1,73 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.messaging.command;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static org.openkilda.messaging.Utils.CORRELATION_ID;
+import static org.openkilda.messaging.Utils.DESTINATION;
+import static org.openkilda.messaging.Utils.PAYLOAD;
+import static org.openkilda.messaging.Utils.TIMESTAMP;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.openkilda.messaging.Destination;
+
+import java.util.Objects;
+
+/**
+ * Class represents command message with reply-to topic.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CommandWithReplyToMessage extends CommandMessage {
+
+    @JsonProperty("reply_to")
+    protected String replyTo;
+
+    /**
+     * Instance constructor.
+     *
+     * @param data command message payload
+     * @param timestamp timestamp value
+     * @param correlationId message correlation id
+     * @param destination message destination
+     * @param replyTo topic for message reply to
+     */
+    @JsonCreator
+    public CommandWithReplyToMessage(@JsonProperty(PAYLOAD) final CommandData data,
+            @JsonProperty(TIMESTAMP) final long timestamp,
+            @JsonProperty(CORRELATION_ID) final String correlationId,
+            @JsonProperty(DESTINATION) final Destination destination,
+            @JsonProperty("reply_to") final String replyTo) {
+        super(data, timestamp, correlationId, destination);
+        this.replyTo = Objects.requireNonNull(replyTo, "reply_to must not be null");
+    }
+
+    public String getReplyTo() {
+        return replyTo;
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this)
+                .add(TIMESTAMP, timestamp)
+                .add(CORRELATION_ID, correlationId)
+                .add(DESTINATION, destination)
+                .add("replyTo", replyTo)
+                .add(PAYLOAD, data)
+                .toString();
+    }
+}

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/command/switches/DefaultRulesAction.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/command/switches/DefaultRulesAction.java
@@ -1,0 +1,34 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.messaging.command.switches;
+
+/**
+ * Describes what to do about the switch default rules.
+ */
+public enum DefaultRulesAction {
+    // Drop base rules.
+    DROP,
+
+    // Drop base rules, then add them back.
+    DROP_ADD,
+
+    // Don't drop the base rules - i.e. ignore them.
+    IGNORE,
+
+    // The same as IGNORE and ADD - i.e. re-install the base rules again.
+    OVERWRITE
+}
+

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/command/switches/SwitchRulesDeleteRequest.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/command/switches/SwitchRulesDeleteRequest.java
@@ -1,0 +1,72 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.messaging.command.switches;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static org.openkilda.messaging.Utils.TIMESTAMP;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.openkilda.messaging.Utils;
+import org.openkilda.messaging.command.CommandData;
+
+import java.util.Objects;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SwitchRulesDeleteRequest extends CommandData {
+
+    @JsonProperty("switch_id")
+    private String switchId;
+
+    @JsonProperty("default_rules")
+    private DefaultRulesAction defaultRulesAction;
+
+    /**
+     * Constructs a delete switch rules request.
+     *
+     * @param switchId switch id to delete rules from.
+     * @param defaultRulesAction defines what to do about the default rules
+     */
+    @JsonCreator
+    public SwitchRulesDeleteRequest(
+            @JsonProperty("switch_id") String switchId,
+            @JsonProperty("default_rules") DefaultRulesAction defaultRulesAction) {
+        this.switchId = Objects.requireNonNull(switchId, "switch_id must not be null");
+        if (!Utils.validateSwitchId(switchId)) {
+            throw new IllegalArgumentException("switch_id has invalid value");
+        }
+
+        this.defaultRulesAction = Objects.requireNonNull(defaultRulesAction);
+    }
+
+    public String getSwitchId() {
+        return switchId;
+    }
+
+    public DefaultRulesAction getDefaultRulesAction() {
+        return defaultRulesAction;
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this)
+                .add(TIMESTAMP, timestamp)
+                .add("switch_id", switchId)
+                .add("default_rules", defaultRulesAction)
+                .toString();
+    }
+}

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/switches/SwitchRulesResponse.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/switches/SwitchRulesResponse.java
@@ -1,0 +1,57 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.messaging.info.switches;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Collections.unmodifiableList;
+import static org.openkilda.messaging.Utils.TIMESTAMP;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.openkilda.messaging.info.InfoData;
+
+import java.util.List;
+import java.util.Objects;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SwitchRulesResponse extends InfoData {
+
+    @JsonProperty("rule_ids")
+    protected List<Long> ruleIds;
+
+    /**
+     * Instance constructor.
+     *
+     * @param ruleIds the list of affected rules
+     */
+    @JsonCreator
+    public SwitchRulesResponse(@JsonProperty("rule_ids") List<Long> ruleIds) {
+        this.ruleIds = unmodifiableList(Objects.requireNonNull(ruleIds, "rule_ids must not be null"));
+    }
+
+    public List<Long> getRuleIds() {
+        return ruleIds;
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this)
+                .add(TIMESTAMP, timestamp)
+                .add("rule_ids", ruleIds)
+                .toString();
+    }
+}

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/config/WebConfig.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/config/WebConfig.java
@@ -19,6 +19,7 @@ import static org.openkilda.messaging.Utils.CORRELATION_ID;
 import static org.openkilda.messaging.Utils.DEFAULT_CORRELATION_ID;
 
 import org.openkilda.northbound.utils.ExecutionTimeInterceptor;
+import org.openkilda.northbound.utils.ExtraAuthInterceptor;
 import org.slf4j.MDC;
 import org.slf4j.MDC.MDCCloseable;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -55,6 +56,7 @@ public class WebConfig extends WebMvcConfigurerAdapter {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(timeExecutionInterceptor());
+        registry.addInterceptor(extraAuthInterceptor());
     }
 
     /**
@@ -65,6 +67,11 @@ public class WebConfig extends WebMvcConfigurerAdapter {
     @Bean
     public ExecutionTimeInterceptor timeExecutionInterceptor() {
         return new ExecutionTimeInterceptor();
+    }
+
+    @Bean
+    public ExtraAuthInterceptor extraAuthInterceptor() {
+        return new ExtraAuthInterceptor();
     }
 
     /**

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/controller/FlowController.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/controller/FlowController.java
@@ -17,7 +17,6 @@ package org.openkilda.northbound.controller;
 
 import static org.openkilda.messaging.Utils.CORRELATION_ID;
 import static org.openkilda.messaging.Utils.DEFAULT_CORRELATION_ID;
-import static org.openkilda.messaging.Utils.EXTRA_AUTH;
 import static org.openkilda.messaging.Utils.FLOW_ID;
 
 import org.openkilda.messaging.error.MessageError;
@@ -32,6 +31,7 @@ import org.openkilda.northbound.service.FlowService;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import org.openkilda.northbound.utils.ExtraAuthRequired;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -223,20 +223,11 @@ public class FlowController {
             value = "/flows",
             method = RequestMethod.DELETE,
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @ExtraAuthRequired
     @SuppressWarnings("unchecked") // the error is unchecked
     public ResponseEntity<List<FlowPayload>> deleteFlows(
-            @RequestHeader(value = CORRELATION_ID, defaultValue = DEFAULT_CORRELATION_ID) String correlationId,
-            @RequestHeader(value = EXTRA_AUTH, defaultValue = "0") long extra_auth
-            ) {
-        logger.debug("Delete flows: {}={}, {}={}", CORRELATION_ID, correlationId, EXTRA_AUTH, extra_auth);
-
-        long current_auth = System.currentTimeMillis();
-        if (Math.abs(current_auth-extra_auth) > 120*1000) {
-            /*
-             * The request needs to be within 120 seconds of the system clock.
-             */
-            return new ResponseEntity("Invalid Auth: " + current_auth, new HttpHeaders(), HttpStatus.UNAUTHORIZED);
-        }
+            @RequestHeader(value = CORRELATION_ID, defaultValue = DEFAULT_CORRELATION_ID) String correlationId) {
+        logger.debug("Delete flows: {}={}", CORRELATION_ID);
 
         List<FlowPayload> response = flowService.deleteFlows(correlationId);
         return new ResponseEntity<>(response, new HttpHeaders(), HttpStatus.OK);

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/controller/SwitchController.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/controller/SwitchController.java
@@ -1,27 +1,53 @@
 package org.openkilda.northbound.controller;
 
+import static org.openkilda.messaging.Utils.CORRELATION_ID;
+import static org.openkilda.messaging.Utils.DEFAULT_CORRELATION_ID;
+
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import org.openkilda.messaging.command.switches.DefaultRulesAction;
 import org.openkilda.messaging.error.MessageError;
 import org.openkilda.messaging.payload.flow.FlowPayload;
 import org.openkilda.northbound.dto.SwitchDto;
 import org.openkilda.northbound.service.SwitchService;
+import org.openkilda.northbound.utils.ExtraAuthRequired;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * REST Controller for switches.
  */
 @RestController
 @PropertySource("classpath:northbound.properties")
+@Api(value = "switches")
+@ApiResponses(value = {
+        @ApiResponse(code = 200, response = FlowPayload.class, message = "Operation is successful"),
+        @ApiResponse(code = 400, response = MessageError.class, message = "Invalid input data"),
+        @ApiResponse(code = 401, response = MessageError.class, message = "Unauthorized"),
+        @ApiResponse(code = 403, response = MessageError.class, message = "Forbidden"),
+        @ApiResponse(code = 404, response = MessageError.class, message = "Not found"),
+        @ApiResponse(code = 500, response = MessageError.class, message = "General error"),
+        @ApiResponse(code = 503, response = MessageError.class, message = "Service unavailable")})
 public class SwitchController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SwitchController.class);
 
     @Autowired
     private SwitchService switchService;
@@ -32,18 +58,31 @@ public class SwitchController {
      * @return list of links.
      */
     @ApiOperation(value = "Get all available switches", response = SwitchDto.class)
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, response = FlowPayload.class, message = "Operation is successful"),
-            @ApiResponse(code = 400, response = MessageError.class, message = "Invalid input data"),
-            @ApiResponse(code = 401, response = MessageError.class, message = "Unauthorized"),
-            @ApiResponse(code = 403, response = MessageError.class, message = "Forbidden"),
-            @ApiResponse(code = 404, response = MessageError.class, message = "Not found"),
-            @ApiResponse(code = 500, response = MessageError.class, message = "General error"),
-            @ApiResponse(code = 503, response = MessageError.class, message = "Service unavailable")})
     @GetMapping(path = "/switches")
     @ResponseStatus(HttpStatus.OK)
     public List<SwitchDto> getSwitches() {
         return switchService.getSwitches();
     }
 
+    /**
+     * Delete switch rules.
+     *
+     * @param switchId switch id to delete rules from
+     * @param defaultRules defines what to do about the default rules
+     * @param correlationId correlation ID header value
+     * @return list of rules that have been deleted
+     */
+    @ApiOperation(value = "Delete switch rules. Requires special authorization",
+            response = String.class, responseContainer = "List")
+    @DeleteMapping(value = "/switches/{switch-id}/rules",
+            produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @ExtraAuthRequired
+    public ResponseEntity deleteSwitchRules(
+            @PathVariable("switch-id") String switchId,
+            @RequestParam("defaultRules") Optional<DefaultRulesAction> defaultRules,
+            @RequestHeader(value = CORRELATION_ID, defaultValue = DEFAULT_CORRELATION_ID) String correlationId) {
+        List<Long> response = switchService
+                .deleteRules(switchId, defaultRules.orElse(DefaultRulesAction.IGNORE), correlationId);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/service/SwitchService.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/service/SwitchService.java
@@ -1,5 +1,6 @@
 package org.openkilda.northbound.service;
 
+import org.openkilda.messaging.command.switches.DefaultRulesAction;
 import org.openkilda.northbound.dto.SwitchDto;
 
 import java.util.List;
@@ -8,4 +9,13 @@ public interface SwitchService extends BasicService {
 
     List<SwitchDto> getSwitches();
 
+    /**
+     * Deletes all rules from the switch. The flag (@code defaultRules) defines what to do about the default rules.
+     *
+     * @param switchId switch id
+     * @param defaultRules defines what to do about the default rules
+     * @param correlationId request correlation Id
+     * @return the list of cookies for removed rules
+     */
+    List<Long> deleteRules(String switchId, DefaultRulesAction defaultRules, String correlationId);
 }

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/utils/ExtraAuthInterceptor.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/utils/ExtraAuthInterceptor.java
@@ -1,0 +1,83 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.northbound.utils;
+
+import static org.openkilda.messaging.Utils.EXTRA_AUTH;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+import java.util.concurrent.TimeUnit;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Interceptor which enforces extra authentication for methods annotated with {@link ExtraAuthRequired}.
+ */
+public class ExtraAuthInterceptor extends HandlerInterceptorAdapter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExtraAuthInterceptor.class);
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+        if (!supports(handler)) {
+            return true;
+        }
+
+        HandlerMethod handlerMethod = (HandlerMethod) handler;
+        ExtraAuthRequired annotation = handlerMethod.getMethodAnnotation(ExtraAuthRequired.class);
+        if (annotation == null) {
+            Class<?> handlerClass = handlerMethod.getMethod().getDeclaringClass();
+            annotation = AnnotationUtils.findAnnotation(handlerClass, ExtraAuthRequired.class);
+            if (annotation == null) {
+                return true;
+            }
+        }
+
+        long currentAuth = System.currentTimeMillis();
+
+        final String extraAuthHeader = request.getHeader(EXTRA_AUTH);
+        long extraAuth;
+        try {
+            extraAuth = Long.parseLong(extraAuthHeader);
+        } catch (NumberFormatException ex) {
+            LOGGER.warn("Invalid {} header: {}", EXTRA_AUTH, extraAuthHeader);
+
+            response.getWriter().write("Invalid Auth: " + currentAuth);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
+        }
+
+        if (Math.abs(currentAuth - extraAuth) > TimeUnit.SECONDS.toMillis(120)) {
+            /*
+             * The request needs to be within 120 seconds of the system clock.
+             */
+            response.getWriter().write("Invalid Auth: " + currentAuth);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean supports(Object handler) {
+        return handler instanceof HandlerMethod;
+    }
+}

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/utils/ExtraAuthRequired.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/utils/ExtraAuthRequired.java
@@ -1,0 +1,31 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.northbound.utils;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+public @interface ExtraAuthRequired {
+
+}

--- a/services/src/northbound/src/main/resources/northbound.properties
+++ b/services/src/northbound/src/main/resources/northbound.properties
@@ -13,4 +13,5 @@ kafka.flow.topic=kilda.flow
 kafka.topo.eng.topic=kilda.topo.eng
 kafka.health.topic=kilda.health.check
 kafka.northbound.topic=kilda.northbound
+kafka.speaker.topic=kilda.speaker
 topology.engine.rest.endpoint=http://topology-engine-rest.pendev:80

--- a/services/src/northbound/src/test/java/org/openkilda/northbound/controller/SwitchControllerTest.java
+++ b/services/src/northbound/src/test/java/org/openkilda/northbound/controller/SwitchControllerTest.java
@@ -1,0 +1,98 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.northbound.controller;
+
+import static org.junit.Assert.assertEquals;
+import static org.openkilda.messaging.Utils.CORRELATION_ID;
+import static org.openkilda.messaging.Utils.EXTRA_AUTH;
+import static org.openkilda.messaging.Utils.MAPPER;
+import static org.openkilda.northbound.controller.TestMessageMock.TEST_SWITCH_ID;
+import static org.openkilda.northbound.controller.TestMessageMock.TEST_SWITCH_RULE_COOKIE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(classes = TestConfig.class)
+public class SwitchControllerTest {
+
+    private static final String USERNAME = "kilda";
+    private static final String PASSWORD = "kilda";
+    private static final String ROLE = "ADMIN";
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Before
+    public void setUp() throws Exception {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).apply(springSecurity()).build();
+    }
+
+    @Test
+    @WithMockUser(username = USERNAME, password = PASSWORD, roles = ROLE)
+    public void shouldDeleteSwitchRules() throws Exception {
+        // given TestMessageMock as kafka topic mocks
+        // when
+        MvcResult result = mockMvc.perform(delete("/switches/{switch-id}/rules", TEST_SWITCH_ID)
+                .header(CORRELATION_ID, testCorrelationId())
+                .header(EXTRA_AUTH, System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(119))
+                .contentType(APPLICATION_JSON_VALUE))
+                // then
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(APPLICATION_JSON_UTF8_VALUE))
+                .andReturn();
+        Long[] response = MAPPER.readValue(result.getResponse().getContentAsString(), Long[].class);
+        assertEquals(TEST_SWITCH_RULE_COOKIE, (long) response[0]);
+    }
+
+    @Test
+    @WithMockUser(username = USERNAME, password = PASSWORD, roles = ROLE)
+    public void shouldFailDeleteSwitchRulesWithoutExtraAuth() throws Exception {
+        // given TestMessageMock as kafka topic mocks
+        // when
+        mockMvc.perform(delete("/switches/{switch-id}/rules", TEST_SWITCH_ID)
+                .header(CORRELATION_ID, testCorrelationId())
+                .contentType(APPLICATION_JSON_VALUE))
+                // then
+                .andExpect(status().isUnauthorized());
+    }
+
+    private static String testCorrelationId() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/services/src/northbound/src/test/java/org/openkilda/northbound/controller/TestMessageMock.java
+++ b/services/src/northbound/src/test/java/org/openkilda/northbound/controller/TestMessageMock.java
@@ -15,6 +15,7 @@
 
 package org.openkilda.northbound.controller;
 
+import static java.util.Collections.singletonList;
 import static org.openkilda.messaging.Utils.SYSTEM_CORRELATION_ID;
 import static org.openkilda.messaging.error.ErrorType.OPERATION_TIMED_OUT;
 
@@ -29,6 +30,7 @@ import org.openkilda.messaging.command.flow.FlowPathRequest;
 import org.openkilda.messaging.command.flow.FlowStatusRequest;
 import org.openkilda.messaging.command.flow.FlowUpdateRequest;
 import org.openkilda.messaging.command.flow.FlowsGetRequest;
+import org.openkilda.messaging.command.switches.SwitchRulesDeleteRequest;
 import org.openkilda.messaging.error.ErrorData;
 import org.openkilda.messaging.error.ErrorMessage;
 import org.openkilda.messaging.error.ErrorType;
@@ -39,6 +41,7 @@ import org.openkilda.messaging.info.flow.FlowPathResponse;
 import org.openkilda.messaging.info.flow.FlowResponse;
 import org.openkilda.messaging.info.flow.FlowStatusResponse;
 import org.openkilda.messaging.info.flow.FlowsResponse;
+import org.openkilda.messaging.info.switches.SwitchRulesResponse;
 import org.openkilda.messaging.model.Flow;
 import org.openkilda.messaging.payload.flow.FlowEndpointPayload;
 import org.openkilda.messaging.payload.flow.FlowIdStatusPayload;
@@ -63,6 +66,8 @@ import java.util.concurrent.ConcurrentHashMap;
 public class TestMessageMock implements MessageProducer, MessageConsumer<Object> {
     static final String FLOW_ID = "test-flow";
     static final String ERROR_FLOW_ID = "error-flow";
+    static final String TEST_SWITCH_ID = "test-switch";
+    static final long TEST_SWITCH_RULE_COOKIE = 1L;
     static final FlowEndpointPayload flowEndpoint = new FlowEndpointPayload(FLOW_ID, 1, 1);
     static final FlowPayload flow = new FlowPayload(FLOW_ID, flowEndpoint, flowEndpoint, 10000, false, FLOW_ID, null);
     static final FlowIdStatusPayload flowStatus = new FlowIdStatusPayload(FLOW_ID, FlowState.IN_PROGRESS);
@@ -70,9 +75,10 @@ public class TestMessageMock implements MessageProducer, MessageConsumer<Object>
     static final FlowPathPayload flowPath = new FlowPathPayload(FLOW_ID, path);
     static final Flow flowModel = new Flow(FLOW_ID, 10000, false, FLOW_ID, FLOW_ID, 1, 1, FLOW_ID, 1, 1);
     private static final FlowResponse flowResponse = new FlowResponse(flowModel);
-    private static final FlowsResponse flowsResponse = new FlowsResponse(Collections.singletonList(flowModel));
+    private static final FlowsResponse flowsResponse = new FlowsResponse(singletonList(flowModel));
     private static final FlowPathResponse flowPathResponse = new FlowPathResponse(path);
     private static final FlowStatusResponse flowStatusResponse = new FlowStatusResponse(flowStatus);
+    private static final SwitchRulesResponse switchRulesResponse = new SwitchRulesResponse(singletonList(TEST_SWITCH_RULE_COOKIE));
     private static final Map<String, CommandData> messages = new ConcurrentHashMap<>();
 
     /**
@@ -101,6 +107,8 @@ public class TestMessageMock implements MessageProducer, MessageConsumer<Object>
             return new InfoMessage(flowStatusResponse, 0, correlationId, Destination.NORTHBOUND);
         } else if (data instanceof FlowPathRequest) {
             return new InfoMessage(flowPathResponse, 0, correlationId, Destination.NORTHBOUND);
+        } else if (data instanceof SwitchRulesDeleteRequest) {
+            return new InfoMessage(switchRulesResponse, 0, correlationId, Destination.NORTHBOUND);
         } else {
             return null;
         }

--- a/templates/templates/northbound/northbound.properties.j2
+++ b/templates/templates/northbound/northbound.properties.j2
@@ -13,4 +13,5 @@ kafka.flow.topic={{ kafka_topic_flow }}
 kafka.topo.eng.topic={{ kafka_topic_topo_eng }}
 kafka.health.topic={{ kafka_topic_health_check }}
 kafka.northbound.topic={{ kafka_topic_northbound }}
+kafka.speaker.topic={{ kafka_topic_speaker }}
 topology.engine.rest.endpoint={{ topology_engine_rest_endpoint }}:{{ topology_engine_rest_port }}


### PR DESCRIPTION
The changes:
- Intro DELETE method for "/api/v1/switches/{switch-id}/rules" resource in Northbound.
- Send the command message from NB to FL with Reply-To topic passed.
- New "deleteAllNonDefaultRules" and "deleteDefaultRules" methods in FL SwitchManager.
- New ATDD tests for the "delete switch rules" command.

Fixes #376.