### PR TITLE
Fix HeartBeat scheduling

### DIFF
--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/HeartBeat.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/HeartBeat.java
@@ -27,7 +27,9 @@ public class HeartBeat {
         TimerTask replace = new HeartBeatAction(producer, topic);
         timer.scheduleAtFixedRate(replace, interval, interval);
 
-        task.cancel();
-        task = replace;
+        synchronized (this) {
+            task.cancel();
+            task = replace;
+        }
     }
 }


### PR DESCRIPTION
Due to missing lock in "rescheduling" process some timer event are leaks
and stays sheduled forever.

Close #420