### PR TITLE
Add original PathNode constructor (4 args)

### DIFF
--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/event/PathNode.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/event/PathNode.java
@@ -106,6 +106,14 @@ public class PathNode implements Serializable {
         this.seqId = seqId;
     }
 
+    public PathNode(final String switchId, final int portNo, final int seqId, final Long segmentLatency) {
+        this.switchId = switchId;
+        this.portNo = portNo;
+        this.seqId = seqId;
+        this.segmentLatency = segmentLatency;
+        this.cookie = null;
+    }
+
     /**
      * Instance creator.
      *

--- a/services/src/pce/src/test/java/org/openkilda/pce/NetworkTopologyConstants.java
+++ b/services/src/pce/src/test/java/org/openkilda/pce/NetworkTopologyConstants.java
@@ -31,59 +31,59 @@ public final class NetworkTopologyConstants {
     public static final SwitchInfoData sw5 = new SwitchInfoData("sw5", SwitchState.REMOVED, "", "", "", "remote");
 
     public static final IslInfoData isl12 = new IslInfoData(3L, Arrays.asList(
-            new PathNode(sw1.getSwitchId(), 1, 0, 3L),
-            new PathNode(sw2.getSwitchId(), 2, 1, 0L)),
+            new PathNode(sw1.getSwitchId(), 1, 0, 0L, 3L),
+            new PathNode(sw2.getSwitchId(), 2, 1, 0L, 0L)),
             10L, IslChangeType.DISCOVERED, 10L);
     public static final IslInfoData isl21 = new IslInfoData(3L, Arrays.asList(
-            new PathNode(sw2.getSwitchId(), 2, 0, 3L),
-            new PathNode(sw1.getSwitchId(), 1, 1, 0L)),
+            new PathNode(sw2.getSwitchId(), 2, 0, 0L, 3L),
+            new PathNode(sw1.getSwitchId(), 1, 1, 0L, 0L)),
             10L, IslChangeType.DISCOVERED, 10L);
     public static final IslInfoData isl23 = new IslInfoData(5L, Arrays.asList(
-            new PathNode(sw2.getSwitchId(), 1, 0, 5L),
-            new PathNode(sw3.getSwitchId(), 2, 1, 0L)),
+            new PathNode(sw2.getSwitchId(), 1, 0, 0L, 5L),
+            new PathNode(sw3.getSwitchId(), 2, 1, 0L, 0L)),
             10L, IslChangeType.DISCOVERED, 10L);
     public static final IslInfoData isl32 = new IslInfoData(5L, Arrays.asList(
-            new PathNode(sw3.getSwitchId(), 2, 0, 5L),
-            new PathNode(sw2.getSwitchId(), 1, 1, 0L)),
+            new PathNode(sw3.getSwitchId(), 2, 0, 0L, 5L),
+            new PathNode(sw2.getSwitchId(), 1, 1, 0L, 0L)),
             10L, IslChangeType.DISCOVERED, 10L);
     public static final IslInfoData isl14 = new IslInfoData(5L, Arrays.asList(
-            new PathNode(sw1.getSwitchId(), 2, 0, 5L),
-            new PathNode(sw4.getSwitchId(), 1, 1, 0L)),
+            new PathNode(sw1.getSwitchId(), 2, 0, 0L, 5L),
+            new PathNode(sw4.getSwitchId(), 1, 1, 0L, 0L)),
             10L, IslChangeType.DISCOVERED, 10L);
     public static final IslInfoData isl41 = new IslInfoData(5L, Arrays.asList(
-            new PathNode(sw4.getSwitchId(), 1, 0, 5L),
-            new PathNode(sw1.getSwitchId(), 2, 1, 0L)),
+            new PathNode(sw4.getSwitchId(), 1, 0, 0L, 5L),
+            new PathNode(sw1.getSwitchId(), 2, 1, 0L, 0L)),
             10L, IslChangeType.DISCOVERED, 10L);
     public static final IslInfoData isl24 = new IslInfoData(6L, Arrays.asList(
-            new PathNode(sw2.getSwitchId(), 3, 0, 6L),
-            new PathNode(sw4.getSwitchId(), 2, 1, 0L)),
+            new PathNode(sw2.getSwitchId(), 3, 0, 0L, 6L),
+            new PathNode(sw4.getSwitchId(), 2, 1, 0L, 0L)),
             10L, IslChangeType.DISCOVERED, 10L);
     public static final IslInfoData isl42 = new IslInfoData(6L, Arrays.asList(
-            new PathNode(sw4.getSwitchId(), 2, 0, 6L),
-            new PathNode(sw2.getSwitchId(), 3, 1, 0L)),
+            new PathNode(sw4.getSwitchId(), 2, 0, 0L, 6L),
+            new PathNode(sw2.getSwitchId(), 3, 1, 0L, 0L)),
             10L, IslChangeType.DISCOVERED, 10L);
     public static final IslInfoData isl54 = new IslInfoData(9L, Arrays.asList(
-            new PathNode(sw5.getSwitchId(), 1, 0, 9L),
-            new PathNode(sw4.getSwitchId(), 3, 1, 0L)),
+            new PathNode(sw5.getSwitchId(), 1, 0, 0L, 9L),
+            new PathNode(sw4.getSwitchId(), 3, 1, 0L, 0L)),
             10L, IslChangeType.DISCOVERED, 10L);
     public static final IslInfoData isl45 = new IslInfoData(9L, Arrays.asList(
-            new PathNode(sw4.getSwitchId(), 3, 0, 9L),
-            new PathNode(sw5.getSwitchId(), 1, 1, 0L)),
+            new PathNode(sw4.getSwitchId(), 3, 0, 0L, 9L),
+            new PathNode(sw5.getSwitchId(), 1, 1, 0L, 0L)),
             10L, IslChangeType.DISCOVERED, 10L);
     public static final IslInfoData isl52 = new IslInfoData(7L, Arrays.asList(
-            new PathNode(sw5.getSwitchId(), 2, 0, 7L),
-            new PathNode(sw2.getSwitchId(), 4, 1, 0L)),
+            new PathNode(sw5.getSwitchId(), 2, 0, 0L, 7L),
+            new PathNode(sw2.getSwitchId(), 4, 1, 0L, 0L)),
             10L, IslChangeType.DISCOVERED, 10L);
     public static final IslInfoData isl25 = new IslInfoData(7L, Arrays.asList(
-            new PathNode(sw2.getSwitchId(), 4, 0, 7L),
-            new PathNode(sw5.getSwitchId(), 2, 1, 0L)),
+            new PathNode(sw2.getSwitchId(), 4, 0, 0L, 7L),
+            new PathNode(sw5.getSwitchId(), 2, 1, 0L, 0L)),
             10L, IslChangeType.DISCOVERED, 10L);
     public static final IslInfoData isl53 = new IslInfoData(8L, Arrays.asList(
-            new PathNode(sw5.getSwitchId(), 3, 0, 8L),
-            new PathNode(sw3.getSwitchId(), 1, 1, 0L)),
+            new PathNode(sw5.getSwitchId(), 3, 0, 0L, 8L),
+            new PathNode(sw3.getSwitchId(), 1, 1, 0L, 0L)),
             10L, IslChangeType.DISCOVERED, 10L);
     public static final IslInfoData isl35 = new IslInfoData(8L, Arrays.asList(
-            new PathNode(sw3.getSwitchId(), 1, 0, 8L),
-            new PathNode(sw5.getSwitchId(), 3, 1, 0L)),
+            new PathNode(sw3.getSwitchId(), 1, 0, 0L, 8L),
+            new PathNode(sw5.getSwitchId(), 3, 1, 0L, 0L)),
             10L, IslChangeType.DISCOVERED, 10L);
 }


### PR DESCRIPTION
The cookie field was added, but several areas of code rely
on the original 4 constructor mechanism.