### PR TITLE
Reimplement flowCache using direct read from neo4j

### DIFF
--- a/services/src/messaging/src/main/java/org/openkilda/messaging/payload/flow/FlowState.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/payload/flow/FlowState.java
@@ -43,7 +43,7 @@ public enum FlowState {
     DOWN("Down"),
 
     /**
-     * Flow is cached.
+     * Flow is cached. It means this flow is read from db and cached.
      */
     CACHED("Cached");
 
@@ -82,6 +82,10 @@ public enum FlowState {
 
     public boolean isActive() {
         return this == UP;
+    }
+
+    public boolean isActiveOrCached() {
+        return this == UP || this == CACHED;
     }
 }
 

--- a/services/src/pce/src/main/java/org/openkilda/pce/api/FlowAdapter.java
+++ b/services/src/pce/src/main/java/org/openkilda/pce/api/FlowAdapter.java
@@ -1,6 +1,5 @@
 package org.openkilda.pce.api;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.neo4j.driver.v1.Record;
 import org.openkilda.messaging.Utils;
 import org.openkilda.messaging.info.event.PathInfoData;
@@ -22,16 +21,6 @@ public class FlowAdapter {
                     "Can\'t deserialize flow path: json=%s", pathJson), e);
         }
 
-        String stateString = dbRecord.get("state").asString();
-        FlowState state;
-        try {
-            state = FlowState.valueOf(stateString);
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException(String.format(
-                    "Invalid value in \"state\" field: %s", stateString));
-        }
-
-
         flow = new Flow(
                 dbRecord.get(Utils.FLOW_ID).asString(),
                 dbRecord.get("bandwidth").asInt(),
@@ -47,7 +36,7 @@ public class FlowAdapter {
                 dbRecord.get("dst_vlan").asInt(),
                 dbRecord.get("meter_id").asInt(),
                 dbRecord.get("transit_vlan").asInt(),
-                path, state
+                path, FlowState.CACHED
         );
     }
 

--- a/services/src/pce/src/main/java/org/openkilda/pce/api/FlowAdapter.java
+++ b/services/src/pce/src/main/java/org/openkilda/pce/api/FlowAdapter.java
@@ -1,0 +1,57 @@
+package org.openkilda.pce.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.neo4j.driver.v1.Record;
+import org.openkilda.messaging.Utils;
+import org.openkilda.messaging.info.event.PathInfoData;
+import org.openkilda.messaging.model.Flow;
+import org.openkilda.messaging.payload.flow.FlowState;
+
+import java.io.IOException;
+
+public class FlowAdapter {
+    private final Flow flow;
+
+    public FlowAdapter(Record dbRecord) {
+        String pathJson = dbRecord.get("path").asString();
+        PathInfoData path;
+        try {
+            path = Utils.MAPPER.readValue(pathJson, PathInfoData.class);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(String.format(
+                    "Can\'t deserialize flow path: json=%s", pathJson), e);
+        }
+
+        String stateString = dbRecord.get("state").asString();
+        FlowState state;
+        try {
+            state = FlowState.valueOf(stateString);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(String.format(
+                    "Invalid value in \"state\" field: %s", stateString));
+        }
+
+
+        flow = new Flow(
+                dbRecord.get(Utils.FLOW_ID).asString(),
+                dbRecord.get("bandwidth").asInt(),
+                dbRecord.get("ignore_bandwidth").asBoolean(),
+                dbRecord.get("cookie").asLong(),
+                dbRecord.get("description").asString(),
+                dbRecord.get("last_updated").asString(),
+                dbRecord.get("src_switch").asString(),
+                dbRecord.get("dst_switch").asString(),
+                dbRecord.get("src_port").asInt(),
+                dbRecord.get("dst_port").asInt(),
+                dbRecord.get("src_vlan").asInt(),
+                dbRecord.get("dst_vlan").asInt(),
+                dbRecord.get("meter_id").asInt(),
+                dbRecord.get("transit_vlan").asInt(),
+                path, state
+        );
+    }
+
+    public Flow getFlow() {
+        return flow;
+    }
+}

--- a/services/src/pce/src/main/java/org/openkilda/pce/cache/FlowCache.java
+++ b/services/src/pce/src/main/java/org/openkilda/pce/cache/FlowCache.java
@@ -17,7 +17,6 @@ package org.openkilda.pce.cache;
 
 import org.openkilda.messaging.error.CacheException;
 import org.openkilda.messaging.error.ErrorType;
-import org.openkilda.messaging.info.event.NetworkTopologyChange;
 import org.openkilda.messaging.info.event.IslInfoData;
 import org.openkilda.messaging.info.event.PathInfoData;
 import org.openkilda.messaging.info.event.PathNode;
@@ -136,7 +135,7 @@ public class FlowCache extends Cache {
     }
 
     /**
-     * Gets active flows with specified switch in the path.
+     * Gets active or cached flows with specified switch in the path.
      *
      * @param switchId switch id
      * @return set of flows
@@ -148,7 +147,7 @@ public class FlowCache extends Cache {
                         || flow.getRight().getFlowPath().getPath().stream()
                         .anyMatch(node -> node.getSwitchId().equals(switchId))
                         || isOneSwitchFlow(flow) && flow.getLeft().getSourceSwitch().equals(switchId))
-                .filter(flow -> FlowState.UP == flow.getLeft().getState())
+                .filter(flow -> flow.getLeft().getState().isActiveOrCached())
                 .collect(Collectors.toSet());
     }
 
@@ -175,7 +174,7 @@ public class FlowCache extends Cache {
         return flowPool.values().stream()
                 .filter(flow -> flow.getLeft().getFlowPath().getPath().contains(islData.getPath().get(0))
                         || flow.getRight().getFlowPath().getPath().contains(islData.getPath().get(0)))
-                .filter(flow -> FlowState.UP == flow.getLeft().getState())
+                .filter(flow -> flow.getLeft().getState().isActiveOrCached())
                 .collect(Collectors.toSet());
     }
 
@@ -204,7 +203,7 @@ public class FlowCache extends Cache {
         return flowPool.values().stream()
                 .filter(flow -> flow.getLeft().getFlowPath().getPath().contains(node)
                         || flow.getRight().getFlowPath().getPath().contains(node))
-                .filter(flow -> flow.getLeft().getState().isActive())
+                .filter(flow -> flow.getLeft().getState().isActiveOrCached())
                 .collect(Collectors.toSet());
     }
 

--- a/services/src/pce/src/main/java/org/openkilda/pce/provider/NeoDriver.java
+++ b/services/src/pce/src/main/java/org/openkilda/pce/provider/NeoDriver.java
@@ -29,6 +29,7 @@ import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.Values;
 import org.neo4j.driver.v1.exceptions.NoSuchRecordException;
 import org.neo4j.driver.v1.types.Relationship;
+import org.openkilda.pce.api.FlowAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -138,6 +139,23 @@ public class NeoDriver implements PathComputer {
             );
         }
         return flows;
+    }
+
+    @Override
+    public List<Flow> getAllFlows() {
+        String q =
+                "MATCH (:switch)-[f:flow]->(:switch)\n" +
+                "RETURN f";
+
+        Session session = driver.session();
+        StatementResult queryResults = session.run(q);
+        List<Flow> results = new LinkedList<>();
+        for (Record record : queryResults.list()) {
+            FlowAdapter adapter = new FlowAdapter(record);
+            results.add(adapter.getFlow());
+        }
+
+        return results;
     }
 
     /**

--- a/services/src/pce/src/main/java/org/openkilda/pce/provider/NeoDriver.java
+++ b/services/src/pce/src/main/java/org/openkilda/pce/provider/NeoDriver.java
@@ -144,8 +144,21 @@ public class NeoDriver implements PathComputer {
     @Override
     public List<Flow> getAllFlows() {
         String q =
-                "MATCH (:switch)-[f:flow]->(:switch)\n" +
-                "RETURN f";
+                "MATCH (:switch)-[f:flow]->(:switch) " +
+                "RETURN f.flowid as flowid, " +
+                "f.bandwidth as bandwidth, " +
+                "f.ignore_bandwidth as ignore_bandwidth, " +
+                "f.cookie as cookie, " +
+                "f.description as description, " +
+                "f.last_updated as last_updated, " +
+                "f.src_switch as src_switch, " +
+                "f.dst_switch as dst_switch, " +
+                "f.src_port as src_port, " +
+                "f.dst_port as dst_port, " +
+                "f.src_vlan as src_vlan, " +
+                "f.dst_vlan as dst_vlan, " +
+                "f.meter_id as meter_id, " +
+                "f.transit_vlan as transit_vlan";
 
         Session session = driver.session();
         StatementResult queryResults = session.run(q);

--- a/services/src/pce/src/main/java/org/openkilda/pce/provider/PathComputer.java
+++ b/services/src/pce/src/main/java/org/openkilda/pce/provider/PathComputer.java
@@ -22,6 +22,7 @@ import org.openkilda.messaging.model.ImmutablePair;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -61,6 +62,16 @@ public interface PathComputer extends Serializable {
      * @return a list containing the "key" flow info for all flows.
      */
     default List<FlowInfo> getFlowInfo() {
+        return new ArrayList<>();
+    }
+
+    /**
+     * Read flows from Neo4j and covert them in our common representation
+     * org.openkilda.messaging.model.Flow
+     *
+     * @return all flow objects stored in neo4j
+     */
+    default List<Flow> getAllFlows() {
         return new ArrayList<>();
     }
 }

--- a/services/src/pce/src/test/java/org/openkilda/pce/provider/NeoDriverTest.java
+++ b/services/src/pce/src/test/java/org/openkilda/pce/provider/NeoDriverTest.java
@@ -1,5 +1,6 @@
 package org.openkilda.pce.provider;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -39,12 +40,13 @@ public class NeoDriverTest {
                 .setConfig( bolt.enabled, "true" )
                 .setConfig( bolt.listen_address, "localhost:7878" )
                 .newGraphDatabase();
+        }
 
-        // Shuts down nicely when the VM exits
-        Runtime.getRuntime().addShutdownHook( new Thread(() -> {
-            graphDb.shutdown();
-        }));
+    @AfterClass
+    public static void teatDownOnce() {
+        graphDb.shutdown();
     }
+
 
     @Test
     public void getAllFlows() {

--- a/services/src/pce/src/test/java/org/openkilda/pce/provider/NeoDriverTest.java
+++ b/services/src/pce/src/test/java/org/openkilda/pce/provider/NeoDriverTest.java
@@ -1,0 +1,82 @@
+package org.openkilda.pce.provider;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.driver.v1.AuthTokens;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.io.fs.FileUtils;
+import org.neo4j.kernel.configuration.BoltConnector;
+import org.openkilda.messaging.model.Flow;
+
+import java.io.File;
+import java.util.List;
+
+public class NeoDriverTest {
+
+    private NeoDriver target = new NeoDriver(GraphDatabase.driver("bolt://localhost:7878",
+            AuthTokens.basic("neo4j", "neo4j")));
+    private static GraphDatabaseService graphDb;
+
+    private static final File databaseDirectory = new File( "target/neo4j-test-db" );
+
+    @BeforeClass
+    public static void setUpOnce() throws Exception {
+        FileUtils.deleteRecursively( databaseDirectory );       // delete neo db file
+
+        // This next area enables Kilda to connect to the local db
+        BoltConnector bolt = new BoltConnector("0");
+        graphDb = new GraphDatabaseFactory()
+                .newEmbeddedDatabaseBuilder( databaseDirectory )
+                .setConfig( bolt.type, "BOLT" )
+                .setConfig( bolt.enabled, "true" )
+                .setConfig( bolt.listen_address, "localhost:7878" )
+                .newGraphDatabase();
+
+        // Shuts down nicely when the VM exits
+        Runtime.getRuntime().addShutdownHook( new Thread(() -> {
+            graphDb.shutdown();
+        }));
+    }
+
+    @Test
+    public void getAllFlows() {
+        try ( Transaction tx = graphDb.beginTx() ) {
+            Node node1, node2;
+            node1 = graphDb.createNode(Label.label("switch"));
+            node1.setProperty("name", "00:01");
+            node2 = graphDb.createNode(Label.label("switch"));
+            node2.setProperty("name", "00:02");
+            Relationship rel1 = node1.createRelationshipTo(node2, RelationshipType.withName("flow"));
+            rel1.setProperty("flowid","f1");
+            rel1.setProperty("cookie", 3);
+            rel1.setProperty("meter_id", 2);
+            rel1.setProperty("transit_vlan", 1);
+            rel1.setProperty("src_switch","00:01");
+            rel1.setProperty("dst_switch","00:02");
+            rel1.setProperty("src_port",1);
+            rel1.setProperty("dst_port",2);
+            rel1.setProperty("src_vlan",5);
+            rel1.setProperty("dst_vlan",5);
+            rel1.setProperty("bandwidth",200);
+            rel1.setProperty("ignore_bandwidth", true);
+            rel1.setProperty("description","description");
+            rel1.setProperty("last_updated","last_updated");
+            tx.success();
+        }
+
+        List<Flow> flows = target.getAllFlows();
+        Flow flow = flows.get(0);
+        Assert.assertEquals(3, flow.getCookie());
+        Assert.assertEquals("f1", flow.getFlowId());
+        Assert.assertEquals(true, flow.isIgnoreBandwidth());
+    }
+
+}

--- a/services/src/pce/src/test/java/org/openkilda/pce/provider/PathComputerTest.java
+++ b/services/src/pce/src/test/java/org/openkilda/pce/provider/PathComputerTest.java
@@ -1,6 +1,5 @@
 package org.openkilda.pce.provider;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.*;
@@ -50,16 +49,11 @@ public class PathComputerTest {
                 .setConfig( bolt.enabled, "true" )
                 .setConfig( bolt.listen_address, "localhost:7878" )
                 .newGraphDatabase();
-
-        // Shuts down nicely when the VM exits
-        Runtime.getRuntime().addShutdownHook( new Thread(() -> {
-            System.out.println("Killing Elephants \uD83D\uDC18");
-            graphDb.shutdown();
-        }));
     }
 
     @AfterClass
     public static void teatDownOnce() {
+        graphDb.shutdown();
     }
 
     @Before

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/cache/CacheBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/cache/CacheBolt.java
@@ -21,7 +21,6 @@ import org.openkilda.messaging.BaseMessage;
 import org.openkilda.messaging.Destination;
 import org.openkilda.messaging.Message;
 import org.openkilda.messaging.Utils;
-import org.openkilda.messaging.command.CommandData;
 import org.openkilda.messaging.command.CommandMessage;
 import org.openkilda.messaging.command.discovery.NetworkCommandData;
 import org.openkilda.messaging.command.flow.FlowRerouteRequest;
@@ -39,7 +38,6 @@ import org.openkilda.messaging.info.event.NetworkTopologyChange;
 import org.openkilda.messaging.info.event.PathNode;
 import org.openkilda.messaging.info.event.PortInfoData;
 import org.openkilda.messaging.info.event.SwitchInfoData;
-import org.openkilda.messaging.info.event.SwitchState;
 import org.openkilda.messaging.info.flow.FlowInfoData;
 import org.openkilda.messaging.info.flow.FlowOperation;
 import org.openkilda.messaging.model.Flow;
@@ -168,7 +166,6 @@ public class CacheBolt
             this.state.put(FLOW_CACHE, flowCache);
         }
 
-        cacheWarmingService = new CacheWarmingService(networkCache);
         reroutedFlows.clear();
     }
 
@@ -318,7 +315,7 @@ public class CacheBolt
 
             case ADDED:
             case ACTIVATED:
-                onSwitchUp(sw, tuple);
+                onSwitchUp(sw);
                 break;
 
             case REMOVED:
@@ -496,21 +493,10 @@ public class CacheBolt
         return values;
     }
 
-    private void onSwitchUp(SwitchInfoData sw, Tuple tuple) throws IOException {
+    private void onSwitchUp(SwitchInfoData sw) throws IOException {
         logger.info("Switch {} is {}", sw.getSwitchId(), sw.getState().getType());
         if (networkCache.cacheContainsSwitch(sw.getSwitchId())) {
-            SwitchState prevState = networkCache.getSwitch(sw.getSwitchId()).getState();
             networkCache.updateSwitch(sw);
-
-            if (prevState == SwitchState.CACHED) {
-                String switchId = sw.getSwitchId();
-                List<PortInfoData> ports = cacheWarmingService.getPortsForDiscovering(switchId);
-                logger.info("Found {} links for discovery", ports.size());
-                sendPortCachedEvent(ports);
-
-                List<? extends CommandData> commands = cacheWarmingService.getFlowCommands(switchId);
-                sendFlowCommands(commands);
-            }
         } else {
             networkCache.createSwitch(sw);
         }
@@ -570,31 +556,6 @@ public class CacheBolt
                 logger.warn("Skip undefined flow operation {}", flowData);
                 break;
         }
-    }
-
-    private void sendFlowCommands(List<? extends CommandData> commands) {
-        commands.forEach(command -> {
-            try {
-                outputCollector.emit(StreamType.WFM_DUMP.toString(), new Values(MAPPER.writeValueAsString(command)));
-                logger.debug("Flow command request sent from CacheBolt: {}", command);
-            } catch (JsonProcessingException e) {
-                logger.error("Error during serializing CommandData", e);
-            }
-        });
-    }
-
-    private void sendPortCachedEvent(List<PortInfoData> ports) {
-        ports.forEach(portInfoData -> {
-            String correlationId = UUID.randomUUID().toString();
-            InfoMessage message = new InfoMessage(portInfoData, System.currentTimeMillis(), correlationId,
-                    Destination.WFM);
-            try {
-                outputCollector.emit(StreamType.OFE.toString(), new Values(MAPPER.writeValueAsString(message)));
-                logger.info("Isl discovery request sent from CacheBolt with correlationId {}", correlationId);
-            } catch (JsonProcessingException e) {
-                logger.error("Error during serializing PortInfoData", e);
-            }
-        });
     }
 
     /**

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/CrudBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/CrudBolt.java
@@ -139,6 +139,7 @@ public class CrudBolt
             flowCache = new FlowCache();
             this.caches.put(FLOW_CACHE, flowCache);
         }
+        initFlowCache();
     }
 
     /**
@@ -165,8 +166,6 @@ public class CrudBolt
         this.outputCollector = outputCollector;
 
         pathComputer = pathComputerAuth.connect();
-
-        initFlowCache();
     }
 
     /**

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/CrudBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/CrudBolt.java
@@ -62,6 +62,7 @@ import org.openkilda.wfm.topology.AbstractTopology;
 import org.openkilda.wfm.topology.flow.ComponentType;
 import org.openkilda.wfm.topology.flow.FlowTopology;
 import org.openkilda.wfm.topology.flow.StreamType;
+import org.openkilda.wfm.topology.flow.utils.BidirectionalFlow;
 import org.openkilda.wfm.topology.flow.validation.FlowValidationException;
 import org.openkilda.wfm.topology.flow.validation.FlowValidator;
 
@@ -77,12 +78,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class CrudBolt
@@ -169,6 +165,8 @@ public class CrudBolt
         this.outputCollector = outputCollector;
 
         pathComputer = pathComputerAuth.connect();
+
+        initFlowCache();
     }
 
     /**
@@ -730,6 +728,22 @@ public class CrudBolt
 
     private boolean isFlowActive(ImmutablePair<Flow, Flow> flowPair) {
         return flowPair.getLeft().getState().isActive() && flowPair.getRight().getState().isActive();
+    }
+
+    private void initFlowCache() {
+        Map<String, BidirectionalFlow> flowPairsMap = new HashMap<>();
+        for (Flow flow : pathComputer.getAllFlows()) {
+            if (! flowPairsMap.containsKey(flow.getFlowId())) {
+                flowPairsMap.put(flow.getFlowId(), new BidirectionalFlow());
+            }
+
+            BidirectionalFlow pair = flowPairsMap.get(flow.getFlowId());
+            pair.add(flow);
+        }
+
+        for (BidirectionalFlow bidirectionalFlow : flowPairsMap.values()) {
+            flowCache.pushFlow(bidirectionalFlow.makeFlowPair());
+        }
     }
 
     @Override

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/CrudBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/CrudBolt.java
@@ -733,7 +733,7 @@ public class CrudBolt
     private void initFlowCache() {
         Map<String, BidirectionalFlow> flowPairsMap = new HashMap<>();
         for (Flow flow : pathComputer.getAllFlows()) {
-            if (! flowPairsMap.containsKey(flow.getFlowId())) {
+            if (!flowPairsMap.containsKey(flow.getFlowId())) {
                 flowPairsMap.put(flow.getFlowId(), new BidirectionalFlow());
             }
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/utils/BidirectionalFlow.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/utils/BidirectionalFlow.java
@@ -1,0 +1,57 @@
+package org.openkilda.wfm.topology.flow.utils;
+
+import org.openkilda.messaging.model.Flow;
+import org.openkilda.messaging.model.ImmutablePair;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BidirectionalFlow {
+    private String flowId;
+    private Flow forward = null;
+    private Flow reverse = null;
+
+    public void add(Flow flow) {
+        Flow current;
+
+        boolean isForward = flow.isForward();
+        if (isForward) {
+            current = this.forward;
+        } else {
+            current = reverse;
+        }
+
+        if (current != null) {
+            throw new IllegalArgumentException(
+                    String.format("The flow(%s) for %s is already set",
+                            flowId, isForward ? "forward" : "reverse"));
+        }
+
+        if (isForward) {
+            forward = flow;
+        } else {
+            reverse = flow;
+        }
+
+        flowId = flow.getFlowId();
+    }
+
+    public ImmutablePair<Flow, Flow> makeFlowPair() {
+        List<String> missing = new ArrayList<>(2);
+        if (forward == null) {
+            missing.add("forward is missing");
+        }
+        if (reverse == null) {
+            missing.add("reverse is missing");
+        }
+        if (0 < missing.size()) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Flow pair is incomplete: %s",
+                            String.join(" and ", missing))
+            );
+        }
+
+        return new ImmutablePair<>(forward, reverse);
+    }
+}


### PR DESCRIPTION
Dump all flows from neo4j during CrudBolt inirialization(prepare) phase and
"push" them into flowCache.
# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
# On branch master
# Your branch is ahead of 'surabujin/master' by 43 commits.
#   (use "git push" to publish your local commits)
#
# Changes to be committed:
#	modified:   services/src/messaging/src/main/java/org/openkilda/messaging/model/Flow.java
#	new file:   services/src/pce/src/main/java/org/openkilda/pce/api/FlowAdapter.java
#	modified:   services/src/pce/src/main/java/org/openkilda/pce/provider/NeoDriver.java
#	modified:   services/src/pce/src/main/java/org/openkilda/pce/provider/PathComputer.java
#	modified:   services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/CrudBolt.java
#	new file:   services/wfm/src/main/java/org/openkilda/wfm/topology/flow/utils/BidirectionalFlow.java
#