### PR TITLE
Change default value for FEATURE_SYNC_OFRULES to False

### DIFF
--- a/services/topology-engine/queue-engine/topologylistener/messageclasses.py
+++ b/services/topology-engine/queue-engine/topologylistener/messageclasses.py
@@ -55,7 +55,7 @@ FEATURE_SYNC_OFRULES = 'sync_rules_on_activation'
 FEATURE_REROUTE_ON_ISL_DISCOVERY = 'flows_reroute_on_isl_discovery'
 
 features_status = {
-    FEATURE_SYNC_OFRULES: True,
+    FEATURE_SYNC_OFRULES: False,
     FEATURE_REROUTE_ON_ISL_DISCOVERY: True
 }
 


### PR DESCRIPTION
It was True. But we'd like deeper testing before we allow this to
be the default behavior.