### PR TITLE
Split network dump respose

### DIFF
--- a/services/src/Makefile
+++ b/services/src/Makefile
@@ -7,7 +7,7 @@ projectfloodlight:
 	$(MAKE) -C projectfloodlight
 
 build: projectfloodlight
-	mvn -B clean install
+	mvn -B -DskipTests clean install
 
 build-pce:
 	mvn install -pl pce -am -DskipTests

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
@@ -381,7 +381,8 @@ class RecordHandler implements Runnable {
                 switchesInfoData,
                 portsInfoData,
                 Collections.emptySet(),
-                Collections.emptySet());
+                Collections.emptySet(),
+                null);
 
         InfoMessage infoMessage = new InfoMessage(dump, System.currentTimeMillis(),
                 message.getCorrelationId());

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/discovery/ChunkDescriptor.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/discovery/ChunkDescriptor.java
@@ -1,0 +1,28 @@
+package org.openkilda.messaging.info.discovery;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+
+public class ChunkDescriptor implements Serializable {
+    @JsonProperty("current")
+    private int current;
+
+    @JsonProperty("total")
+    private int total;
+
+    public ChunkDescriptor(
+            @JsonProperty("current") int current,
+            @JsonProperty("total") int total) {
+        this.current = current;
+        this.total = total;
+    }
+
+    public int getCurrent() {
+        return current;
+    }
+
+    public int getTotal() {
+        return total;
+    }
+}

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/discovery/NetworkInfoData.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/discovery/NetworkInfoData.java
@@ -80,6 +80,9 @@ public class NetworkInfoData extends InfoData {
     @JsonProperty("flows")
     private Set<ImmutablePair<Flow, Flow>> flows;
 
+    @JsonProperty("chunk")
+    private ChunkDescriptor chunk;
+
     /**
      * Default constructor.
      */
@@ -99,12 +102,14 @@ public class NetworkInfoData extends InfoData {
                            @JsonProperty("switches") Set<SwitchInfoData> switches,
                            @JsonProperty("ports") Set<PortInfoData> ports,
                            @JsonProperty("isls") Set<IslInfoData> isls,
-                           @JsonProperty("flows") Set<ImmutablePair<Flow, Flow>> flows) {
+                           @JsonProperty("flows") Set<ImmutablePair<Flow, Flow>> flows,
+                           @JsonProperty("chunk") ChunkDescriptor chunk) {
         this.requester = requester;
         this.switches = switches;
         this.ports = ports;
         this.isls = isls;
         this.flows = flows;
+        this.chunk = chunk;
     }
 
     /**
@@ -196,6 +201,10 @@ public class NetworkInfoData extends InfoData {
      */
     public void setFlows(Set<ImmutablePair<Flow, Flow>> flows) {
         this.flows = flows;
+    }
+
+    public ChunkDescriptor getChunk() {
+        return chunk;
     }
 
     /**

--- a/services/src/messaging/src/test/java/org/openkilda/messaging/command/flow/AbstractSerializerTest.java
+++ b/services/src/messaging/src/test/java/org/openkilda/messaging/command/flow/AbstractSerializerTest.java
@@ -586,7 +586,8 @@ public abstract class AbstractSerializerTest implements AbstractSerializer {
                 new HashSet<>(Arrays.asList(sw1, sw2)),
                 new HashSet<>(),
                 Collections.singleton(isl),
-                Collections.singleton(new ImmutablePair<>(flowModel, flowModel)));
+                Collections.singleton(new ImmutablePair<>(flowModel, flowModel)),
+                null);
         System.out.println(data);
 
         InfoMessage info = new InfoMessage(data, System.currentTimeMillis(), CORRELATION_ID, DESTINATION);

--- a/services/topology-engine/queue-engine/test.py
+++ b/services/topology-engine/queue-engine/test.py
@@ -1,0 +1,56 @@
+# -*- coding:utf-8 -*-
+
+import pprint
+import random
+import json
+
+from topologylistener import message_utils
+
+
+send_idx = 0
+
+
+def mock_send(payload, correlation_id):
+    global send_idx
+
+    print('Send request #{}'.format(send_idx))
+    print('Send correlation id: {}'.format(correlation_id))
+
+    send_idx += 1
+    encoded = json.dumps(payload, indent=4)
+    print(encoded)
+    print('\n')
+
+
+message_utils.send_cache_message = mock_send
+
+
+def main():
+    switch_set = []
+    isl_set = []
+    flow_set = []
+
+    payload_dummy = []
+    for dummy_size in (20, 32, 64, 128, 512, 1024):
+        desc = ' {} '.format(dummy_size)
+        dummy = '*' * dummy_size
+        dummy = dummy[:2] + desc + dummy[2 + len(desc):]
+        dummy = dummy[:dummy_size]
+        payload_dummy.append(dummy)
+
+    for kind, dest in (
+            ('switch', switch_set),
+            ('isl', isl_set),
+            ('flow', flow_set)):
+
+        available_chunks = payload_dummy[:]
+        random.shuffle(available_chunks)
+        for payload in available_chunks:
+            dest.append({'kind': kind, 'payload': payload})
+
+    message_utils.send_network_dump(
+        'correlation', switch_set, isl_set, flow_set, size_limit=10000)
+
+
+if __name__ == '__main__':
+    main()

--- a/services/topology-engine/queue-engine/topologylistener/messageclasses.py
+++ b/services/topology-engine/queue-engine/topologylistener/messageclasses.py
@@ -39,7 +39,6 @@ MT_ISL = "org.openkilda.messaging.info.event.IslInfoData"
 MT_PORT = "org.openkilda.messaging.info.event.PortInfoData"
 MT_FLOW_INFODATA = "org.openkilda.messaging.info.flow.FlowInfoData"
 MT_FLOW_RESPONSE = "org.openkilda.messaging.info.flow.FlowResponse"
-MT_NETWORK = "org.openkilda.messaging.info.discovery.NetworkInfoData"
 MT_SYNC_REQUEST = "org.openkilda.messaging.command.switches.SyncRulesRequest"
 MT_SWITCH_RULES = "org.openkilda.messaging.info.rule.SwitchFlowEntries"
 #feature toggle is the functionality to turn off/on specific features
@@ -756,12 +755,8 @@ class MessageItem(object):
             logger.debug("%s: %s", step, flows)
 
             step = "Send"
-            payload = {
-                'switches': switches,
-                'isls': isls,
-                'flows': flows,
-                'clazz': MT_NETWORK}
-            message_utils.send_cache_message(payload, correlation_id)
+            message_utils.send_network_dump(
+                correlation_id, switches, isls, flows)
 
         except Exception as e:
             logger.exception('Can not dump network: %s', e.message)
@@ -777,7 +772,7 @@ class MessageItem(object):
             'switches': [],
             'isls': [],
             'flows': flow_utils.get_flows(),
-            'clazz': MT_NETWORK}
+            'clazz': message_utils.MT_NETWORK}
         message_utils.send_to_topic(
             payload, self.correlation_id, message_utils.MT_INFO,
             destination="WFM_FLOW_LCM", topic=config.KAFKA_FLOW_TOPIC)

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/cache/CacheTopologyTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/cache/CacheTopologyTest.java
@@ -85,7 +85,7 @@ public class CacheTopologyTest extends AbstractStormTest {
             new Flow(thirdFlowId, 10000, false, "", "test-switch", 1, 2, "test-switch", 1, 2));
     private static final Set<ImmutablePair<Flow, Flow>> flows = new HashSet<>();
     private static final NetworkInfoData dump = new NetworkInfoData(
-            "test", Collections.singleton(sw), Collections.emptySet(), Collections.emptySet(), flows);
+            "test", Collections.singleton(sw), Collections.emptySet(), Collections.emptySet(), flows, null);
 
     private static TestKafkaConsumer teConsumer;
     private static TestKafkaConsumer flowConsumer;

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/event/OFELinkBoltFloodTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/event/OFELinkBoltFloodTest.java
@@ -86,7 +86,8 @@ public class OFELinkBoltFloodTest extends AbstractStormTest {
                 "test", Collections.emptySet(),
                 Collections.emptySet(),
                 Collections.emptySet(),
-                Collections.emptySet());
+                Collections.emptySet(),
+                null);
 
         InfoMessage info = new InfoMessage(dump, 0, DEFAULT_CORRELATION_ID, Destination.WFM);
 

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/event/OFELinkBoltTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/event/OFELinkBoltTest.java
@@ -164,7 +164,8 @@ public class OFELinkBoltTest extends AbstractStormTest {
                 new HashSet<>(Arrays.asList(sw1, sw2)),
                 new HashSet<>(Arrays.asList(sw1Port1, sw2Port1)),
                 Collections.emptySet(),
-                Collections.emptySet());
+                Collections.emptySet(),
+                null);
 
         InfoMessage info = new InfoMessage(dump, 0, DEFAULT_CORRELATION_ID, Destination.WFM);
         String request = objectMapper.writeValueAsString(info);
@@ -190,7 +191,8 @@ public class OFELinkBoltTest extends AbstractStormTest {
                 "test", Collections.emptySet(),
                 Collections.emptySet(),
                 Collections.emptySet(),
-                Collections.emptySet());
+                Collections.emptySet(),
+                null);
 
         InfoMessage info = new InfoMessage(dump, 0, DEFAULT_CORRELATION_ID, Destination.WFM);
         String request = objectMapper.writeValueAsString(info);


### PR DESCRIPTION
Kafka limit it's payload to 2Mb. And our dump have overcome this limit. (It is
not matter the exact value of this limit, there is always chance to overcome
it).

Topology engine split this dump on several messages. This messages will be
assembled on CacheBolt side.