### PR TITLE
Avoid usage of in memory storage meter-id in FL

### DIFF
--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
@@ -335,7 +335,8 @@ class RecordHandler implements Runnable {
         try {
             switchManager.deleteFlow(dpid, command.getId(), command.getCookie());
 
-            Integer meterId = meterPool.deallocate(command.getSwitchId(), command.getId());
+            // FIXME(surabujin): QUICK FIX - try to drop meterPool completely
+            Long meterId = command.getMeterId();
             if (meterId != null) {
                 switchManager.deleteMeter(dpid, meterId);
             }

--- a/services/topology-engine/queue-engine/topologylistener/message_utils.py
+++ b/services/topology-engine/queue-engine/topologylistener/message_utils.py
@@ -178,7 +178,7 @@ def build_one_switch_flow_from_db(switch, stored_flow, output_action):
     return flow
 
 
-def build_delete_flow(switch, flow_id, cookie, meter_id=0):
+def build_delete_flow(switch, flow_id, cookie, meter_id):
     flow = Flow()
     flow.clazz = "org.openkilda.messaging.command.flow.RemoveFlow"
     flow.transaction_id = 0
@@ -306,7 +306,7 @@ def send_delete_commands(nodes, correlation_id):
 
     logger.debug('Send Delete Commands: node count=%d', len(nodes))
     for node in nodes:
-        data = build_delete_flow(str(node['switch_id']), str(node['flow_id']), node['cookie'])
+        data = build_delete_flow(str(node['switch_id']), str(node['flow_id']), node['cookie'], node['meter_id'])
         # TODO: Whereas this is part of the current workflow .. feels like we should have the workflow manager work
         #       as a hub and spoke ... ie: send delete to FL, get confirmation. Then send delete to DB, get confirmation.
         #       Then send a message to a FLOW_EVENT topic that says "FLOW DELETED"


### PR DESCRIPTION
FL stores installed meter-id in in-memory storage. The problem appers when FL
become reboote. It lost stored meter-ids and will be unable to remove them on
flow remove request.