### PR TITLE
Workaround for TE hangs due to neo4j disconnects

### DIFF
--- a/services/topology-engine/queue-engine/topology_engine.properties
+++ b/services/topology-engine/queue-engine/topology_engine.properties
@@ -17,6 +17,7 @@ hosts=zookeeper.pendev:2181
 host=neo4j
 user=neo4j
 pass=temppass
+socket.timeout=30
 
 [isl_failover_policy]
 # effective_policy determines what to do with a failed link.

--- a/services/topology-engine/queue-engine/topologylistener/config.py
+++ b/services/topology-engine/queue-engine/topologylistener/config.py
@@ -44,3 +44,12 @@ KAFKA_TOPO_ENG_TOPIC = config.get('kafka', 'topo.eng.topic')
 KAFKA_NORTHBOUND_TOPIC = config.get('kafka', 'northbound.topic')
 
 ZOOKEEPER_HOSTS = config.get('zookeeper', 'hosts')
+
+try:
+    value = config.getfloat('neo4j', 'socket.timeout')
+except ConfigParser.NoOptionError:
+    value = 30.0
+
+NEO4J_SOCKET_TIMEOUT = value
+
+del value

--- a/services/topology-engine/queue-engine/topologylistener/db.py
+++ b/services/topology-engine/queue-engine/topologylistener/db.py
@@ -14,6 +14,8 @@
 #
 
 import os
+import socket
+
 from py2neo import Graph
 
 import config
@@ -25,3 +27,20 @@ def create_p2n_driver():
         os.environ.get('neo4jpass') or config.get('neo4j', 'pass'),
         os.environ.get('neo4jhost') or config.get('neo4j', 'host')))
     return graph
+
+
+# neo4j monkey patching staff
+
+dummy = object()
+
+
+def create_connection(address, timeout=dummy, source_address=None):
+    if timeout is dummy:
+        timeout = config.NEO4J_SOCKET_TIMEOUT
+    return socket.create_connection(
+        address, timeout, source_address=source_address)
+
+
+# Remove endless hang after Neo4j disconnect
+import py2neo.packages.neo4j.v1.bolt
+py2neo.packages.neo4j.v1.bolt.create_connection = create_connection

--- a/templates/templates/topology-engine/topology_engine.properties.j2
+++ b/templates/templates/topology-engine/topology_engine.properties.j2
@@ -17,6 +17,7 @@ hosts={{ zookeeper_hosts }}
 host={{ neo4j_host }}
 user={{ neo4j_user }}
 pass={{ neo4j_password }}
+socket.timeout=30
 
 [isl_failover_policy]
 # effective_policy determines what to do with a failed link.


### PR DESCRIPTION
If there is open connect (usually they are, because py2neo keep pools of
recently used connections), proess hangs forever in socket.sendall() call.

If timeout is set via socket.setdefaulttimeout(), it affect not only py2neo,
but kafka too. To avoid influence on other components, py2neo code is
monkeypatched on verstion that set timeout on newly created socket objects.