### PR TITLE
Chunkded event topology sync

### DIFF
--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/KafkaTopicOrderDescriptor.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/KafkaTopicOrderDescriptor.java
@@ -1,0 +1,61 @@
+package org.openkilda.floodlight.kafka;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.common.PartitionInfo;
+
+public class KafkaTopicOrderDescriptor {
+    private int deep = 0;
+    private long expireAt = 0;
+    private final String topic;
+    private final int partition;
+
+    public KafkaTopicOrderDescriptor(KafkaProducer<?, ?> producer, String topic) {
+        this.topic = topic;
+        partition = producer.partitionsFor(topic)
+                .stream()
+                .map(PartitionInfo::partition)
+                .sorted()
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        String.format("There is no any partition for topic %s", topic)));
+    }
+
+    public void enable() {
+        deep += 1;
+    }
+
+    public void disable() {
+        disable(1000);
+    }
+
+    public void disable(long transitionPeriod) {
+        if (deep == 0) {
+            throw new IllegalStateException("Number of .diable() calls have overcome number of .enable() calls");
+        }
+
+        deep -= 1;
+        if (deep == 0) {
+            expireAt = System.currentTimeMillis() + transitionPeriod;
+        }
+    }
+
+    public boolean isEnabled() {
+        if (0 < deep) {
+            return true;
+        }
+        return expireAt < System.currentTimeMillis();
+    }
+
+    public int getPartition() {
+        return partition;
+    }
+
+    @Override
+    public String toString() {
+        return "KafkaTopicOrderDescriptor{" +
+                "topic='" + topic + '\'' +
+                ", deep=" + deep +
+                ", partition=" + partition +
+                '}';
+    }
+}

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/Producer.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/Producer.java
@@ -10,13 +10,27 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class Producer {
     private static final Logger logger = LoggerFactory.getLogger(Producer.class);
 
     private final KafkaProducer<String, String> producer;
+    private Map<String, KafkaTopicOrderDescriptor> guaranteedOrder = new HashMap<>();
 
     public Producer(Context context) {
         producer = new KafkaProducer<>(context.getKafkaConfig());
+    }
+
+    public void enableGuaranteedOrder(String topic) {
+        logger.debug("Enable predictable order for topic {}", topic);
+        getOrderDescriptor(topic).enable();
+    }
+
+    public void disableGuaranteedOrder(String topic) {
+        logger.debug("Disable predictable order for topic {} (due to fanout period some future messages will be forced to have predictable order)", topic);
+        getOrderDescriptor(topic).disable();
     }
 
     public void handle(String topic, Message payload) {
@@ -31,6 +45,21 @@ public class Producer {
     protected void send(String topic, String jsonPayload) {
         // (crimi) - uncomment for development only .. some messages (stats) fill up the log too quickly
         logger.debug("Posting: topic={}, message={}", topic, jsonPayload);
-        producer.send(new ProducerRecord<>(topic, jsonPayload));
+        ProducerRecord<String, String> record;
+
+        KafkaTopicOrderDescriptor orderDescriptor = getOrderDescriptor(topic);
+        if (orderDescriptor.isEnabled()) {
+            logger.debug("Topic %s forces predictable message ordering", topic);
+            record = new ProducerRecord<>(topic, orderDescriptor.getPartition(), null, jsonPayload);
+        } else {
+            record = new ProducerRecord<>(topic, jsonPayload);
+        }
+
+        producer.send(record);
+    }
+
+    private KafkaTopicOrderDescriptor getOrderDescriptor(String topic) {
+        return guaranteedOrder.computeIfAbsent(
+                topic, t ->  new KafkaTopicOrderDescriptor(producer, t));
     }
 }

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
@@ -34,7 +34,8 @@ import org.openkilda.messaging.error.ErrorData;
 import org.openkilda.messaging.error.ErrorMessage;
 import org.openkilda.messaging.error.ErrorType;
 import org.openkilda.messaging.info.InfoMessage;
-import org.openkilda.messaging.info.discovery.NetworkInfoData;
+import org.openkilda.messaging.info.discovery.NetworkSyncBeginMarker;
+import org.openkilda.messaging.info.discovery.NetworkSyncEndMarker;
 import org.openkilda.messaging.info.event.PortChangeType;
 import org.openkilda.messaging.info.event.PortInfoData;
 import org.openkilda.messaging.info.event.SwitchInfoData;
@@ -48,6 +49,7 @@ import org.openkilda.messaging.payload.flow.OutputVlanType;
 import net.floodlightcontroller.core.IOFSwitch;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.projectfloodlight.openflow.protocol.OFFlowStatsReply;
+import org.projectfloodlight.openflow.protocol.OFPortDesc;
 import org.projectfloodlight.openflow.types.DatapathId;
 import org.projectfloodlight.openflow.types.OFPort;
 import org.slf4j.Logger;
@@ -354,35 +356,38 @@ class RecordHandler implements Runnable {
      * @param message NetworkCommandData
      */
     private void doNetworkDump(final CommandMessage message) {
-        logger.info("Create network dump");
-        NetworkCommandData command = (NetworkCommandData) message.getData();
+        String correlationId = message.getCorrelationId();
+        KafkaMessageProducer kafkaProducer = context.getKafkaProducer();
+
+        logger.debug("Processing request from WFM to dump switches. {}", correlationId);
+
+        kafkaProducer.postMessage(OUTPUT_DISCO_TOPIC,
+                new InfoMessage(new NetworkSyncBeginMarker(), System.currentTimeMillis(), correlationId));
 
         Map<DatapathId, IOFSwitch> allSwitchMap = context.getSwitchManager().getAllSwitchMap();
 
-        Set<SwitchInfoData> switchesInfoData = allSwitchMap.values().stream().map(
-                this::buildSwitchInfoData).collect(Collectors.toSet());
+        allSwitchMap.values().stream()
+                .map(this::buildSwitchInfoData)
+                .forEach(sw ->
+                        kafkaProducer.postMessage(OUTPUT_DISCO_TOPIC,
+                                new InfoMessage(sw, System.currentTimeMillis(), correlationId)));
 
-        Set<PortInfoData> portsInfoData = allSwitchMap.values().stream().flatMap(sw ->
-                sw.getEnabledPorts().stream().map( port ->
-                        new PortInfoData(sw.getId().toString(), port.getPortNo().getPortNumber(), null,
-                        PortChangeType.UP)
-                    ).collect(Collectors.toSet()).stream())
-                .collect(Collectors.toSet());
+        allSwitchMap.values().stream()
+                .flatMap(sw ->
+                        sw.getEnabledPorts().stream()
+                                .map(port -> buildPort(sw, port))
+                                .collect(Collectors.toSet())
+                                .stream())
+                .forEach(port ->
+                        kafkaProducer.postMessage(OUTPUT_DISCO_TOPIC,
+                                new InfoMessage(port, System.currentTimeMillis(), correlationId)));
 
-        NetworkInfoData dump = new NetworkInfoData(
-                command.getRequester(),
-                switchesInfoData,
-                portsInfoData,
-                Collections.emptySet(),
-                Collections.emptySet(),
-                null);
-
-        InfoMessage infoMessage = new InfoMessage(dump, System.currentTimeMillis(),
-                message.getCorrelationId());
-
-        context.getKafkaProducer().postMessage(OUTPUT_DISCO_TOPIC, infoMessage);
+        kafkaProducer.postMessage(
+                OUTPUT_DISCO_TOPIC,
+                new InfoMessage(
+                        new NetworkSyncEndMarker(), System.currentTimeMillis(),
+                        correlationId));
     }
-
 
     private void doInstallSwitchRules(final CommandMessage message, String replyToTopic, Destination replyDestination) {
         SwitchRulesInstallRequest request = (SwitchRulesInstallRequest) message.getData();
@@ -591,6 +596,11 @@ class RecordHandler implements Runnable {
         // I don't know is that correct
         SwitchState state = sw.isActive() ? SwitchState.ACTIVATED : SwitchState.ADDED;
         return IOFSwitchConverter.buildSwitchInfoData(sw, state);
+    }
+
+    private PortInfoData buildPort(IOFSwitch sw, OFPortDesc port) {
+        return new PortInfoData(sw.getId().toString(), port.getPortNo().getPortNumber(), null,
+                PortChangeType.UP);
     }
 
     public static class Factory {

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/discovery/NetworkSyncBeginMarker.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/discovery/NetworkSyncBeginMarker.java
@@ -1,0 +1,22 @@
+/* Copyright 2017 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.messaging.info.discovery;
+
+import org.openkilda.messaging.info.InfoData;
+
+public class NetworkSyncBeginMarker extends InfoData {
+
+}

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/discovery/NetworkSyncEndMarker.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/discovery/NetworkSyncEndMarker.java
@@ -1,0 +1,21 @@
+/* Copyright 2017 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.messaging.info.discovery;
+
+import org.openkilda.messaging.info.InfoData;
+
+public class NetworkSyncEndMarker extends InfoData {
+}

--- a/services/wfm/Dockerfile
+++ b/services/wfm/Dockerfile
@@ -21,15 +21,13 @@ RUN apt-get update
 RUN pip install kafka
 RUN echo "PATH=$PATH:/opt/storm/bin" >> ~/.bashrc
 
-
+WORKDIR /app
 ADD app/deploy_topos_and_monitor.sh /app/
 RUN chmod 777 /app/deploy_topos_and_monitor.sh
 ADD Makefile /app/
 ADD src/main/resources/topology.properties /app/
-ADD target/WorkflowManager-1.0-SNAPSHOT-jar-with-dependencies.jar /app/target/
-RUN TZ=Australia/Melbourne date >> /container_baked_on.txt
-
-WORKDIR /app
-
-# Default command.
 CMD ["/app/deploy_topos_and_monitor.sh", "topology.properties"]
+
+ADD target/WorkflowManager-1.0-SNAPSHOT-jar-with-dependencies.jar /app/target/
+
+RUN TZ=Australia/Melbourne date >> /container_baked_on.txt

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/TopologyConfig.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/TopologyConfig.java
@@ -17,7 +17,8 @@ public class TopologyConfig {
     private Integer discoveryInterval;
     private Integer discoveryTimeout;
     private Integer discoveryLimit;
-    private float discoverySpeakerFailureTimeout;
+    private final float discoverySpeakerFailureTimeout;
+    private final float discoveryDumpRequestTimeout;
     private String filterDirectory;
     private Level loggerLevel;
     private String loggerWatermark;
@@ -78,6 +79,7 @@ public class TopologyConfig {
         filterDirectory = config.getString("filter.directory");
         loggerLevel = Level.valueOf(config.getString("logger.level"));
         loggerWatermark = config.getString("logger.watermark");
+        discoveryDumpRequestTimeout = config.getFloat("discovery.dump-request-timeout-seconds");
 
         zookeeperHosts = config.getString("zookeeper.hosts");
         zookeeperSessionTimeout = (int)(config.getFloat("zookeeper.session.timeout") * 1000);
@@ -160,6 +162,10 @@ public class TopologyConfig {
 
     public String getFilterDirectory() {
         return filterDirectory;
+    }
+
+    public float getDiscoveryDumpRequestTimeout() {
+        return discoveryDumpRequestTimeout;
     }
 
     public Level getLoggerLevel() {

--- a/services/wfm/src/main/resources/topology.properties
+++ b/services/wfm/src/main/resources/topology.properties
@@ -58,6 +58,7 @@ discovery.interval = 2
 discovery.timeout = 9
 discovery.limit = -1
 discovery.speaker-failure-timeout = 5
+discovery.dump-request-timeout-seconds=60
 
 local = no
 local.execution.time = 300

--- a/services/wfm/src/test/resources/topology.properties
+++ b/services/wfm/src/test/resources/topology.properties
@@ -63,6 +63,7 @@ discovery.interval = 2
 discovery.timeout = 9
 discovery.limit = -1
 discovery.speaker-failure-timeout = 5
+discovery.dump-request-timeout-seconds=60
 
 local = no
 local.execution.time = 10

--- a/templates/templates/wfm/topology.properties.j2
+++ b/templates/templates/wfm/topology.properties.j2
@@ -58,6 +58,7 @@ discovery.interval = {{ discovery_interval }}
 discovery.timeout = {{ discovery_timeout }}
 discovery.limit = {{ discovery_limit }}
 discovery.speaker-failure-timeout = 5
+discovery.dump-request-timeout-seconds=60
 
 local = no
 local.execution.time = 10


### PR DESCRIPTION
Use "regual" network envent to "fill" event topology network representation after restart.

PS It also fixes state sync after FL disconnects.