### PR TITLE
 Fix invalid call apt-get update in TPE Dockerfile

### DIFF
--- a/services/topology-engine-rest/Dockerfile
+++ b/services/topology-engine-rest/Dockerfile
@@ -17,8 +17,7 @@ FROM kilda/base-ubuntu
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
     python-pip \
     supervisor \
     nginx \


### PR DESCRIPTION
Always combine RUN apt-get update with apt-get install in the same RUN statement. 

from -> https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run