### PR TITLE
Raise ISL cost on ISL down

### DIFF
--- a/services/topology-engine/queue-engine/topology_engine.properties
+++ b/services/topology-engine/queue-engine/topology_engine.properties
@@ -23,3 +23,6 @@ socket.timeout=30
 # effective_policy determines what to do with a failed link.
 # Available options are delete and deactivate.
 effective_policy=deactivate
+
+[isl]
+cost_when_down=10000

--- a/services/topology-engine/queue-engine/topologylistener/__init__.py
+++ b/services/topology-engine/queue-engine/topologylistener/__init__.py
@@ -12,6 +12,3 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-
-import eventhandler, db, kafkareader
-

--- a/services/topology-engine/queue-engine/topologylistener/config.py
+++ b/services/topology-engine/queue-engine/topologylistener/config.py
@@ -14,9 +14,30 @@
 #
 
 import ConfigParser
+import os
+
+
+_root = os.path.dirname(__file__)
 
 config = ConfigParser.RawConfigParser()
-config.read('topology_engine.properties')
+path = os.path.join(_root, os.pardir, 'topology_engine.properties')
+config.read(path)
+
+_dummy = object()
+
+
+def read_option(section, name, conv=None, default=_dummy):
+    try:
+        value = config.get(section, name)
+    except ConfigParser.NoOptionError:
+        if default is _dummy:
+            raise ValueError('Option [{}]{} - not found'.format(section, name))
+        value = default
+
+    if conv is not None:
+        value = conv(value)
+
+    return value
 
 
 def get(section, option):
@@ -45,11 +66,8 @@ KAFKA_NORTHBOUND_TOPIC = config.get('kafka', 'northbound.topic')
 
 ZOOKEEPER_HOSTS = config.get('zookeeper', 'hosts')
 
-try:
-    value = config.getfloat('neo4j', 'socket.timeout')
-except ConfigParser.NoOptionError:
-    value = 30.0
+NEO4J_SOCKET_TIMEOUT = read_option(
+        'neo4j', 'socket.timeout', conv=float, default=30.0)
 
-NEO4J_SOCKET_TIMEOUT = value
-
-del value
+ISL_COST_WHEN_DOWN = read_option(
+        'isl', 'cost_when_down', conv=int, default=10000)

--- a/services/topology-engine/queue-engine/topologylistener/db.py
+++ b/services/topology-engine/queue-engine/topologylistener/db.py
@@ -29,6 +29,25 @@ def create_p2n_driver():
     return graph
 
 
+# FIXME(surabujin): use custom exception types
+def fetch_scalar(cursor):
+    extra = result_set = None
+    try:
+        result_set = next(cursor)
+        extra = next(cursor)
+    except StopIteration:
+        if result_set is None:
+            raise ValueError('There is no data in cursor')
+
+    if extra is not None:
+        raise ValueError('Cursor contain more than 1 result set')
+
+    if len(result_set) != 1:
+        raise ValueError(
+                'Invalid size of result set ({})'.format(len(result_set)))
+    return result_set.values()[0]
+
+
 # neo4j monkey patching staff
 
 dummy = object()

--- a/services/topology-engine/queue-engine/topologylistener/model.py
+++ b/services/topology-engine/queue-engine/topologylistener/model.py
@@ -63,3 +63,7 @@ class InterSwitchLink(
         if ends_count != 2:
             raise ValueError(
                 'ISL path not define %s/2 ends'.format(ends_count))
+
+    def reversed(self):
+        cls = type(self)
+        return cls(self.dest, self.source, self.state)

--- a/services/topology-engine/queue-engine/topologylistener/tests/test_isl.py
+++ b/services/topology-engine/queue-engine/topologylistener/tests/test_isl.py
@@ -1,0 +1,181 @@
+# Copyright 2017 Telstra Open Source
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import logging
+import unittest
+import uuid
+
+import py2neo
+
+from topologylistener import flow_utils
+from topologylistener import messageclasses
+from topologylistener import message_utils
+from topologylistener import model
+
+dpid_test_marker = 0xfffe000000000000
+dpid_protected_bits = 0xffffff0000000000
+
+neo4j_connect = flow_utils.graph
+
+
+def clean_neo4j_test_data(tx):
+    drop_test_isls(tx)
+    drop_test_switches(tx)
+
+
+def drop_test_isls(tx):
+    q = 'MATCH (:switch)-[self:isl]->() RETURN self'
+    for data_set in tx.run(q):
+        isl = data_set['self']
+        if not is_test_dpid(isl['src_switch']):
+            continue
+        if not is_test_dpid(isl['dst_switch']):
+            continue
+
+        tx.separate(isl)
+
+
+def drop_test_switches(tx):
+    selector = py2neo.NodeSelector(tx)
+    for sw in selector.select('switch'):
+        if not is_test_dpid(sw['name']):
+            continue
+        tx.delete(sw)
+
+
+def make_isl_pair(tx, source, dest):
+    template = {
+        'clazz': messageclasses.MT_ISL,
+        'state': 'DISCOVERED',
+        'latency_ns': 20,
+        'speed': 1000,
+        'available_bandwidth': 1000,
+        'path': [
+            {
+                'switch_id': make_datapath_id(1),
+                'port_no': 2},
+            {
+                'switch_id': make_datapath_id(2),
+                'port_no': 4}]}
+
+    for nodes in (
+            (source, dest),
+            (dest, source)):
+        payload = template.copy()
+        payload['path'] = [
+            {'switch_id': x.dpid, 'port_no': x.port} for x in nodes]
+
+        command = make_command(payload)
+
+        messageclasses.MessageItem(**command).handle()
+
+
+def make_command(payload):
+    return {
+        'payload': payload,
+        'clazz': message_utils.MT_INFO,
+        'timestamp': 0,
+        'correlation_id': make_correlation_id('test-isl')}
+
+
+def make_correlation_id(prefix=''):
+    if prefix and prefix[-1] != '.':
+        prefix += '.'
+    return '{}{}'.format(prefix, uuid.uuid1())
+
+
+def make_datapath_id(number):
+    if number & dpid_protected_bits:
+        raise ValueError(
+                'Invalid switch id {}: use protected bits'.format(number))
+    return pack_dpid(number | dpid_test_marker)
+
+
+def is_test_dpid(dpid):
+    dpid = unpack_dpid(dpid)
+    return dpid & dpid_protected_bits == dpid_test_marker
+
+
+def pack_dpid(dpid):
+    value = hex(dpid)
+    i = iter(value)
+    chunked = [a + b for a, b in zip(i, i)]
+    chunked.pop(0)
+    return ':'.join(chunked)
+
+
+def unpack_dpid(dpid_str):
+    value = dpid_str.replace(':', '')
+    return int(value, 16)
+
+
+class TestIsl(unittest.TestCase):
+    switch_nodes = [
+        model.NetworkEndpoint(make_datapath_id(1), 2),
+        model.NetworkEndpoint(make_datapath_id(2), 4)]
+
+    def setUp(self):
+        logging.basicConfig(level=logging.INFO)
+        with neo4j_connect.begin() as tx:
+            clean_neo4j_test_data(tx)
+
+            make_isl_pair(tx, *self.switch_nodes[:2])
+
+    def tearDown(self):
+        with neo4j_connect.begin() as tx:
+            clean_neo4j_test_data(tx)
+
+    def test_isl_set_cost(self):
+        for isl in self.enumerate_isl(*self.switch_nodes[:2]):
+            self.assertFalse('cost' in isl)
+
+        sw = self.switch_nodes[0]
+        payload = {
+            'clazz': messageclasses.MT_PORT,
+            'state': 'DOWN',
+            'switch_id': sw.dpid,
+            'port_no': sw.port}
+        command = make_command(payload)
+
+        result = messageclasses.MessageItem(**command).handle()
+        self.assertTrue(result, 'Port DOWN command have failed')
+
+        for idx, isl in enumerate(self.enumerate_isl(*self.switch_nodes[:2])):
+            if not idx:
+                self.assertTrue(
+                        'cost' in isl,
+                        'There is no "cost" property in ISL {!r}'.format(isl))
+                self.assertEqual(
+                        isl['cost'], 10000,
+                        'Bad "cost" value {!r} in isl {!r}'.format(
+                                isl['cost'], isl))
+            else:
+                self.assertTrue(
+                        'cost' not in isl,
+                        'Extra/peer record receive "cost" update during port '
+                        'DOWN')
+
+    def enumerate_isl(self, *endpoints):
+        with neo4j_connect.begin() as tx:
+            for node in endpoints:
+                q = (
+                    'MATCH (a:switch)-[self:isl]->(:switch)\n'
+                    'WHERE a.name={dpid}\n'
+                    'RETURN self')
+
+                for data_set in tx.run(q, dpid=node.dpid):
+                    node = data_set['self']
+                    neo4j_connect.pull(node)
+                    yield node

--- a/templates/templates/topology-engine/topology_engine.properties.j2
+++ b/templates/templates/topology-engine/topology_engine.properties.j2
@@ -23,3 +23,6 @@ socket.timeout=30
 # effective_policy determines what to do with a failed link.
 # Available options are delete and deactivate.
 effective_policy=deactivate
+
+[isl]
+cost_when_down=10000


### PR DESCRIPTION
To prevent repeatable flows migration due port flapping substantially
increate ISL cost on ISL down event.

At this moment there is no automatic recover of ISL cost to
normal/previous value. ISL cost must be altered by operator after
solving issue with port flapping.