### PR TITLE
Alter ISL cost on port down event

### DIFF
--- a/services/topology-engine/queue-engine/topology_engine.properties
+++ b/services/topology-engine/queue-engine/topology_engine.properties
@@ -25,4 +25,4 @@ socket.timeout=30
 effective_policy=deactivate
 
 [isl]
-cost_when_down=10000
+cost_when_port_down=10000

--- a/services/topology-engine/queue-engine/topologylistener/config.py
+++ b/services/topology-engine/queue-engine/topologylistener/config.py
@@ -69,5 +69,5 @@ ZOOKEEPER_HOSTS = config.get('zookeeper', 'hosts')
 NEO4J_SOCKET_TIMEOUT = read_option(
         'neo4j', 'socket.timeout', conv=float, default=30.0)
 
-ISL_COST_WHEN_DOWN = read_option(
-        'isl', 'cost_when_down', conv=int, default=10000)
+ISL_COST_WHEN_PORT_DOWN = read_option(
+        'isl', 'cost_when_port_down', conv=int, default=10000)

--- a/services/topology-engine/queue-engine/topologylistener/db.py
+++ b/services/topology-engine/queue-engine/topologylistener/db.py
@@ -18,7 +18,8 @@ import socket
 
 import py2neo
 
-import config
+from topologylistener import config
+from topologylistener import exc
 
 
 def create_p2n_driver():
@@ -52,23 +53,19 @@ def escape_fields(payload, raw_values=False):
     return result
 
 
-# FIXME(surabujin): use custom exception types
-def fetch_scalar(cursor):
+def fetch_one(cursor):
     extra = result_set = None
     try:
         result_set = next(cursor)
         extra = next(cursor)
     except StopIteration:
         if result_set is None:
-            raise ValueError('There is no data in cursor')
+            raise exc.DBEmptyResponse
 
     if extra is not None:
-        raise ValueError('Cursor contain more than 1 result set')
+        raise exc.DBMultipleResponse
 
-    if len(result_set) != 1:
-        raise ValueError(
-                'Invalid size of result set ({})'.format(len(result_set)))
-    return result_set.values()[0]
+    return result_set
 
 
 # neo4j monkey patching staff

--- a/services/topology-engine/queue-engine/topologylistener/exc.py
+++ b/services/topology-engine/queue-engine/topologylistener/exc.py
@@ -20,6 +20,20 @@ class Error(Exception):
     pass
 
 
+class DBInvalidResponse(Error):
+    pass
+
+
+class DBEmptyResponse(DBInvalidResponse):
+    def __str__(self):
+        return 'There is no record fetched from DB cursor'
+
+
+class DBMultipleResponse(DBInvalidResponse):
+    def __str__(self):
+        return 'DB cursor contain too many result records'
+
+
 class DBRecordNotFound(Error):
     @property
     def query(self):

--- a/templates/templates/topology-engine/topology_engine.properties.j2
+++ b/templates/templates/topology-engine/topology_engine.properties.j2
@@ -25,4 +25,4 @@ socket.timeout=30
 effective_policy=deactivate
 
 [isl]
-cost_when_down=10000
+cost_when_port_down=10000


### PR DESCRIPTION
On port down event both ISL(foward and reverse) receive significant
cost penalty.

There is no automatic rollback for this action. Manual update must be
done to recover normal ISL cost.