### PR TITLE
Fix switch rules validation and synchronization for non-standard cookies.

### DIFF
--- a/services/src/api/src/main/java/org/openkilda/northbound/dto/BatchResults.java
+++ b/services/src/api/src/main/java/org/openkilda/northbound/dto/BatchResults.java
@@ -1,4 +1,4 @@
-package org.openkilda.northbound.service;
+package org.openkilda.northbound.dto;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 

--- a/services/src/api/src/main/java/org/openkilda/northbound/dto/switches/RulesSyncResult.java
+++ b/services/src/api/src/main/java/org/openkilda/northbound/dto/switches/RulesSyncResult.java
@@ -25,14 +25,14 @@ import java.util.List;
 public class RulesSyncResult extends RulesValidationResult {
 
     @JsonProperty("installed_rules")
-    private List<String> installedRules;
+    private List<Long> installedRules;
 
     @JsonCreator
     public RulesSyncResult(
-            @JsonProperty("missing_rules") List<String> missingRules,
-            @JsonProperty("proper_rules") List<String> properRules,
-            @JsonProperty("excess_rules") List<String> excessRules,
-            @JsonProperty("installed_rules") List<String> installedRules) {
+            @JsonProperty("missing_rules") List<Long> missingRules,
+            @JsonProperty("proper_rules") List<Long> properRules,
+            @JsonProperty("excess_rules") List<Long> excessRules,
+            @JsonProperty("installed_rules") List<Long> installedRules) {
         super(missingRules, properRules, excessRules);
 
         this.installedRules = installedRules;

--- a/services/src/api/src/main/java/org/openkilda/northbound/dto/switches/RulesValidationResult.java
+++ b/services/src/api/src/main/java/org/openkilda/northbound/dto/switches/RulesValidationResult.java
@@ -27,19 +27,19 @@ import java.util.List;
 public class RulesValidationResult {
 
     @JsonProperty("missing_rules")
-    private List<String> missingRules;
+    private List<Long> missingRules;
 
     @JsonProperty("proper_rules")
-    private List<String> properRules;
+    private List<Long> properRules;
 
     @JsonProperty("excess_rules")
-    private List<String> excessRules;
+    private List<Long> excessRules;
 
     @JsonCreator
     public RulesValidationResult(
-            @JsonProperty("missing_rules") List<String> missingRules,
-            @JsonProperty("proper_rules") List<String> properRules,
-            @JsonProperty("excess_rules") List<String> excessRules) {
+            @JsonProperty("missing_rules") List<Long> missingRules,
+            @JsonProperty("proper_rules") List<Long> properRules,
+            @JsonProperty("excess_rules") List<Long> excessRules) {
         this.missingRules = missingRules;
         this.properRules = properRules;
         this.excessRules = excessRules;

--- a/services/src/atdd/src/test/java/org/openkilda/atdd/NorthboundRunTest.java
+++ b/services/src/atdd/src/test/java/org/openkilda/atdd/NorthboundRunTest.java
@@ -172,6 +172,7 @@ public class NorthboundRunTest {
     public void validateSwitchRules(String switchId) {
         RulesValidationResult validateResult = SwitchesUtils.validateSwitchRules(switchId);
 
+        assertNotNull(validateResult);
         assertThat("The switch has excessive rules.", validateResult.getExcessRules(), empty());
         assertThat("The switch has missing rules.", validateResult.getMissingRules(), empty());
     }
@@ -180,6 +181,7 @@ public class NorthboundRunTest {
     public void validateSwitchWithMissingRules(String switchId, int missingRulesCount) {
         RulesValidationResult validateResult = SwitchesUtils.validateSwitchRules(switchId);
 
+        assertNotNull(validateResult);
         assertEquals("Switch doesn't have expected missing rules.", missingRulesCount,
                 validateResult.getMissingRules().size());
         assertThat("The switch has excessive rules.", validateResult.getExcessRules(), empty());
@@ -189,6 +191,7 @@ public class NorthboundRunTest {
     public void validateSwitchWithExcessiveRules(String switchId, int excessiveRulesCount) {
         RulesValidationResult validateResult = SwitchesUtils.validateSwitchRules(switchId);
 
+        assertNotNull(validateResult);
         assertEquals("Switch doesn't have expected excessive rules.", excessiveRulesCount,
                 validateResult.getExcessRules().size());
         assertThat("The switch has missing rules.", validateResult.getMissingRules(), empty());
@@ -198,6 +201,7 @@ public class NorthboundRunTest {
     public void synchronizeSwitchWithInstalledRules(String switchId, int installedRulesCount) {
         RulesSyncResult validateResult = SwitchesUtils.synchronizeSwitchRules(switchId);
 
+        assertNotNull(validateResult);
         assertEquals("Switch doesn't have expected installed rules.", installedRulesCount,
                 validateResult.getInstalledRules().size());
     }
@@ -216,6 +220,7 @@ public class NorthboundRunTest {
     @Then("No rules installed on ([\\w:]+) switch$")
     public void checkThatNoRulesAreInstalled(String switchId) {
         List<FlowEntry> actualRules = SwitchesUtils.dumpSwitchRules(switchId);
+
         assertNotNull(actualRules);
         assertTrue("Switch contains rules, but expect to have none.", actualRules.isEmpty());
     }

--- a/services/src/atdd/src/test/resources/features/mvp.1/NorthboundRun.feature
+++ b/services/src/atdd/src/test/resources/features/mvp.1/NorthboundRun.feature
@@ -204,7 +204,7 @@ Feature: Northbound tests
   @MVP1
   Scenario: Invalidate Flow Cache
 
-  This scenario setups flows through NB, then delete a flow from DB and perform invalidation of the flow cache
+  This scenario setups flows through NB, then deletes a flow from DB and performs invalidation of the flow cache
 
     Given a clean flow topology
     And flow ifc1 creation request with de:ad:be:ef:00:00:00:03 1 109 and de:ad:be:ef:00:00:00:05 2 109 and 10000 is successful
@@ -221,7 +221,7 @@ Feature: Northbound tests
   @MVP1
   Scenario: Validate flow rules
 
-  This scenario setups a flow through NB, then delete rules from an intermediate switch and perform flow validation check
+  This scenario setups a flow through NB, then deletes rules from an intermediate switch and performs flow validation check
 
     Given a clean flow topology
     And flow vfr creation request with de:ad:be:ef:00:00:00:01 1 110 and de:ad:be:ef:00:00:00:04 2 110 and 1000 is successful
@@ -233,13 +233,83 @@ Feature: Northbound tests
     Then validation of flow vfr has passed and discrepancies are found
 
   @MVP1
-  Scenario: Validate switch with missing rules
+  Scenario: Validate intermediate switch with missing rules
 
-  This scenario setups a flow through NB, then delete rules from an intermediate switch and perform switch validation check
+  This scenario setups a flow through NB, then deletes rules from an intermediate switch and performs switch validation check
 
     Given a clean flow topology
-    And flow vsmr creation request with de:ad:be:ef:00:00:00:01 1 111 and de:ad:be:ef:00:00:00:04 2 111 and 1000 is successful
-    And flow vsmr in UP state
+    And flow vismr creation request with de:ad:be:ef:00:00:00:01 1 111 and de:ad:be:ef:00:00:00:04 2 111 and 1000 is successful
+    And flow vismr in UP state
+    And validation of rules on de:ad:be:ef:00:00:00:03 switch is successful with no discrepancies
+
+    When delete all non-default rules request on de:ad:be:ef:00:00:00:03 switch is successful with 2 rules deleted
+
+    Then validation of rules on de:ad:be:ef:00:00:00:03 switch has passed and 2 rules are missing
+
+  @MVP1
+  Scenario: Validate ingress switch with missing rules
+
+  This scenario setups a flow through NB, then deletes rules from an ingress switch and performs switch validation check
+
+    Given a clean flow topology
+    And flow vinsmr creation request with de:ad:be:ef:00:00:00:01 1 123 and de:ad:be:ef:00:00:00:04 2 123 and 1000 is successful
+    And flow vinsmr in UP state
+    And validation of rules on de:ad:be:ef:00:00:00:01 switch is successful with no discrepancies
+
+    When delete all non-default rules request on de:ad:be:ef:00:00:00:01 switch is successful with 2 rules deleted
+
+    Then validation of rules on de:ad:be:ef:00:00:00:01 switch has passed and 2 rules are missing
+
+  @MVP1
+  Scenario: Validate egress switch with missing rules
+
+  This scenario setups a flow through NB, then deletes rules from an egress switch and performs switch validation check
+
+    Given a clean flow topology
+    And flow vesmr creation request with de:ad:be:ef:00:00:00:01 1 124 and de:ad:be:ef:00:00:00:04 2 124 and 1000 is successful
+    And flow vesmr in UP state
+    And validation of rules on de:ad:be:ef:00:00:00:04 switch is successful with no discrepancies
+
+    When delete all non-default rules request on de:ad:be:ef:00:00:00:04 switch is successful with 2 rules deleted
+
+    Then validation of rules on de:ad:be:ef:00:00:00:04 switch has passed and 2 rules are missing
+
+  @MVP1
+  Scenario: Validate intermediate switch with non-standard cookies
+
+  This scenario pushes a flow with non-standard cookies through NB, then deletes rules from an intermediate switch and performs switch validation check
+
+    Given a clean flow topology
+    And flow visnsc push request for /flows/non-standard-cookies-flow.json is successful
+    And flow visnsc in UP state
+    And validation of rules on de:ad:be:ef:00:00:00:02 switch is successful with no discrepancies
+
+    When delete all non-default rules request on de:ad:be:ef:00:00:00:02 switch is successful with 2 rules deleted
+
+    Then validation of rules on de:ad:be:ef:00:00:00:02 switch has passed and 2 rules are missing
+
+  @MVP1
+  Scenario: Validate ingress switch with non-standard cookies
+
+  This scenario pushes a flow with non-standard cookies through NB, then deletes rules from an ingress switch and performs switch validation check
+
+    Given a clean flow topology
+    And flow vinsnsc push request for /flows/non-standard-cookies-flow.json is successful
+    And flow vinsnsc in UP state
+    And validation of rules on de:ad:be:ef:00:00:00:01 switch is successful with no discrepancies
+
+    When delete all non-default rules request on de:ad:be:ef:00:00:00:01 switch is successful with 2 rules deleted
+
+    Then validation of rules on de:ad:be:ef:00:00:00:01 switch has passed and 2 rules are missing
+
+  @MVP1
+  Scenario: Validate egress switch with non-standard cookies
+
+  This scenario pushes a flow with non-standard cookies through NB, then deletes rules from an egress switch and performs switch validation check
+
+    Given a clean flow topology
+    And flow vesnsc push request for /flows/non-standard-cookies-flow.json is successful
+    And flow vesnsc in UP state
     And validation of rules on de:ad:be:ef:00:00:00:03 switch is successful with no discrepancies
 
     When delete all non-default rules request on de:ad:be:ef:00:00:00:03 switch is successful with 2 rules deleted
@@ -249,11 +319,27 @@ Feature: Northbound tests
   @MVP1
   Scenario: Synchronize switch rules
 
-  This scenario setups a flow through NB, then delete rules from an intermediate switch and perform switch synchronization
+  This scenario setups a flow through NB, then deletes rules from an intermediate switch and performs switch synchronization
 
     Given a clean flow topology
     And flow ssr creation request with de:ad:be:ef:00:00:00:01 1 113 and de:ad:be:ef:00:00:00:04 2 113 and 1000 is successful
     And flow ssr in UP state
+    And validation of rules on de:ad:be:ef:00:00:00:03 switch is successful with no discrepancies
+
+    When delete all non-default rules request on de:ad:be:ef:00:00:00:03 switch is successful with 2 rules deleted
+
+    Then synchronization of rules on de:ad:be:ef:00:00:00:03 switch is successful with 2 rules installed
+    And validation of rules on de:ad:be:ef:00:00:00:03 switch is successful with no discrepancies
+
+  @MVP1
+  Scenario: Synchronize switch rules with non-standard cookies
+
+  This scenario pushes a flow with non-standard cookies through NB, then deletes rules from an intermediate switch aand performs switch synchronization
+
+    Given a clean flow topology
+
+    And flow ssnsc push request for /flows/non-standard-cookies-flow.json is successful
+    And flow ssnsc in UP state
     And validation of rules on de:ad:be:ef:00:00:00:03 switch is successful with no discrepancies
 
     When delete all non-default rules request on de:ad:be:ef:00:00:00:03 switch is successful with 2 rules deleted

--- a/services/src/atdd/src/test/resources/flows/non-standard-cookies-flow.json
+++ b/services/src/atdd/src/test/resources/flows/non-standard-cookies-flow.json
@@ -1,0 +1,97 @@
+{
+    "flowid": "vsnsc",
+    "payload": {
+        "forward": {
+            "last_updated": "0",
+            "description": "PUSHED FLOW",
+            "state": "UP",
+            "flowid": "vsnsc",
+            "bandwidth": 1000,
+            "ignore_bandwidth": false,
+            "transit_vlan": 300,
+            "cookie": 73183493944770561,
+            "meter_id": 1,
+            "src_switch": "de:ad:be:ef:00:00:00:01",
+            "src_port": 1,
+            "src_vlan": 200,
+            "dst_switch": "de:ad:be:ef:00:00:00:03",
+            "dst_port": 2,
+            "dst_vlan": 201,
+            "flowpath": {
+                "path": [
+                    {
+                        "seq_id": 1,
+                        "switch_id": "de:ad:be:ef:00:00:00:01",
+                        "port_no": 2
+                    },
+                    {
+                        "seq_id": 2,
+                        "switch_id": "de:ad:be:ef:00:00:00:02",
+                        "port_no": 1,
+                        "cookie": 145241087982698497
+                    },
+                    {
+                        "seq_id": 3,
+                        "switch_id": "de:ad:be:ef:00:00:00:02",
+                        "port_no": 2
+                    },
+                    {
+                        "seq_id": 4,
+                        "switch_id": "de:ad:be:ef:00:00:00:03",
+                        "port_no": 1,
+                        "cookie": 217298682020626433
+                    }
+                ],
+                "clazz": "org.openkilda.messaging.info.event.PathInfoData"
+            }
+        },
+        "reverse": {
+            "last_updated": "0",
+            "description": "PUSHED FLOW",
+            "state": "UP",
+            "flowid": "vsnsc",
+            "bandwidth": 1000,
+            "ignore_bandwidth": false,
+            "transit_vlan": 301,
+            "cookie": 109212290963734529,
+            "meter_id": 2,
+            "src_switch": "de:ad:be:ef:00:00:00:03",
+            "src_port": 2,
+            "src_vlan": 201,
+            "dst_switch": "de:ad:be:ef:00:00:00:01",
+            "dst_port": 1,
+            "dst_vlan": 200,
+            "flowpath": {
+                "path": [
+                    {
+                        "seq_id": 1,
+                        "switch_id": "de:ad:be:ef:00:00:00:03",
+                        "port_no": 1
+                    },
+                    {
+                        "seq_id": 2,
+                        "switch_id": "de:ad:be:ef:00:00:00:02",
+                        "port_no": 2,
+                        "cookie": 181269885001662465
+                    },
+                    {
+                        "seq_id": 3,
+                        "switch_id": "de:ad:be:ef:00:00:00:02",
+                        "port_no": 1
+                    },
+                    {
+                        "seq_id": 4,
+                        "switch_id": "de:ad:be:ef:00:00:00:01",
+                        "port_no": 2,
+                        "cookie": 253327479039590401
+                    }
+                ],
+                "clazz": "org.openkilda.messaging.info.event.PathInfoData"
+            }
+        }
+    },
+    "correlation_id": "None",
+    "timestamp": 0,
+    "operation": "PUSH",
+    "clazz": "org.openkilda.messaging.info.flow.FlowInfoData"
+}

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/command/switches/SwitchRulesSyncRequest.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/command/switches/SwitchRulesSyncRequest.java
@@ -28,11 +28,11 @@ public class SwitchRulesSyncRequest extends CommandData {
     private String switchId;
 
     @JsonProperty("rules")
-    private List<String> rules;
+    private List<Long> rules;
 
     public SwitchRulesSyncRequest(
         @JsonProperty("switch_id") String switchId,
-        @JsonProperty("rules") List<String> rules) {
+        @JsonProperty("rules") List<Long> rules) {
        this.switchId = switchId;
        this.rules = rules;
     }

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/switches/SyncRulesResponse.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/switches/SyncRulesResponse.java
@@ -17,7 +17,6 @@ package org.openkilda.messaging.info.switches;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
 import lombok.Value;
 import org.openkilda.messaging.info.InfoData;
 
@@ -27,23 +26,23 @@ import java.util.List;
 public class SyncRulesResponse extends InfoData {
 
     @JsonProperty("missing_rules")
-    private List<String> missingRules;
+    private List<Long> missingRules;
 
     @JsonProperty("proper_rules")
-    private List<String> properRules;
+    private List<Long> properRules;
 
     @JsonProperty("excess_rules")
-    private List<String> excessRules;
+    private List<Long> excessRules;
 
     @JsonProperty("installed_rules")
-    private List<String> installedRules;
+    private List<Long> installedRules;
 
     @JsonCreator
     public SyncRulesResponse(
-            @JsonProperty("missing_rules") List<String> missingRules,
-            @JsonProperty("proper_rules") List<String> properRules,
-            @JsonProperty("excess_rules") List<String> excessRules,
-            @JsonProperty("installed_rules") List<String> installedRules) {
+            @JsonProperty("missing_rules") List<Long> missingRules,
+            @JsonProperty("proper_rules") List<Long> properRules,
+            @JsonProperty("excess_rules") List<Long> excessRules,
+            @JsonProperty("installed_rules") List<Long> installedRules) {
         this.missingRules = missingRules;
         this.properRules = properRules;
         this.excessRules = excessRules;

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/controller/FlowController.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/controller/FlowController.java
@@ -32,7 +32,7 @@ import org.openkilda.messaging.payload.flow.FlowPathPayload;
 import org.openkilda.messaging.payload.flow.FlowPayload;
 import org.openkilda.messaging.payload.flow.FlowReroutePayload;
 import org.openkilda.northbound.dto.flows.FlowValidationDto;
-import org.openkilda.northbound.service.BatchResults;
+import org.openkilda.northbound.dto.BatchResults;
 import org.openkilda.northbound.service.FlowService;
 import org.openkilda.northbound.utils.ExtraAuthRequired;
 import org.slf4j.Logger;

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/converter/SwitchMapper.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/converter/SwitchMapper.java
@@ -19,7 +19,7 @@ public interface SwitchMapper {
                 response.getExcessRules(), response.getInstalledRules());
     }
 
-    default RulesSyncResult toRulesSyncResult(RulesValidationResult validationResult, List<String> installedRules) {
+    default RulesSyncResult toRulesSyncResult(RulesValidationResult validationResult, List<Long> installedRules) {
         return new RulesSyncResult(validationResult.getMissingRules(), validationResult.getProperRules(),
                 validationResult.getExcessRules(), installedRules);
     }

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/service/FlowService.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/service/FlowService.java
@@ -22,6 +22,7 @@ import org.openkilda.messaging.payload.flow.FlowIdStatusPayload;
 import org.openkilda.messaging.payload.flow.FlowPathPayload;
 import org.openkilda.messaging.payload.flow.FlowPayload;
 import org.openkilda.messaging.payload.flow.FlowReroutePayload;
+import org.openkilda.northbound.dto.BatchResults;
 import org.openkilda.northbound.dto.flows.FlowValidationDto;
 
 import java.util.List;

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/service/impl/FlowServiceImpl.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/service/impl/FlowServiceImpl.java
@@ -53,7 +53,7 @@ import org.openkilda.northbound.dto.flows.FlowValidationDto;
 import org.openkilda.northbound.dto.flows.PathDiscrepancyDto;
 import org.openkilda.northbound.messaging.MessageConsumer;
 import org.openkilda.northbound.messaging.MessageProducer;
-import org.openkilda.northbound.service.BatchResults;
+import org.openkilda.northbound.dto.BatchResults;
 import org.openkilda.northbound.service.FlowService;
 import org.openkilda.northbound.service.SwitchService;
 import org.openkilda.northbound.utils.Converter;

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/service/impl/SwitchServiceImpl.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/service/impl/SwitchServiceImpl.java
@@ -250,7 +250,7 @@ public class SwitchServiceImpl implements SwitchService {
     @Override
     public RulesSyncResult syncRules(String switchId) {
         RulesValidationResult validationResult = validateRules(switchId);
-        List<String> missingRules = validationResult.getMissingRules();
+        List<Long> missingRules = validationResult.getMissingRules();
 
         if (CollectionUtils.isEmpty(missingRules)) {
             return switchMapper.toRulesSyncResult(validationResult, emptyList());

--- a/services/topology-engine/queue-engine/topologylistener/message_utils.py
+++ b/services/topology-engine/queue-engine/topologylistener/message_utils.py
@@ -55,8 +55,8 @@ def build_ingress_flow(path_nodes, src_switch, src_port, src_vlan,
         raise ValueError('Output port was not found for ingress flow rule',
                          "path={}".format(path_nodes))
 
-    logger.debug('build_ingress_flow: flow_id=%s, cookie=%s, src_switch=%s, src_port=%s, src_vlan=%s, transit_vlan=%s, output_port=%s, output_action=%s',
-                flow_id, cookie, src_switch, src_port, src_vlan, transit_vlan, output_port, output_action)
+    logger.debug('build_ingress_flow: flow_id=%s, cookie=%s, src_switch=%s, src_port=%s, src_vlan=%s, transit_vlan=%s, output_port=%s, output_action=%s, bandwidth=%s, meter_id=%s',
+                flow_id, cookie, src_switch, src_port, src_vlan, transit_vlan, output_port, output_action, bandwidth, meter_id)
 
     flow = Flow()
     flow.clazz = "org.openkilda.messaging.command.flow.InstallIngressFlow"
@@ -115,14 +115,14 @@ def build_egress_flow(path_nodes, dst_switch, dst_port, dst_vlan,
     return flow
 
 
-def build_egress_flow_from_db(stored_flow, output_action):
+def build_egress_flow_from_db(stored_flow, output_action, cookie):
     print stored_flow
     return build_egress_flow(stored_flow['flowpath']['path'],
                              stored_flow['dst_switch'], stored_flow['dst_port'],
                              stored_flow['dst_vlan'],
                              stored_flow['transit_vlan'],
                              stored_flow['flowid'], output_action,
-                             stored_flow['cookie'])
+                             cookie)
 
 
 def build_intermediate_flows(switch, match, action, vlan, flow_id, cookie):
@@ -147,6 +147,10 @@ def build_intermediate_flows(switch, match, action, vlan, flow_id, cookie):
 def build_one_switch_flow(switch, src_port, src_vlan, dst_port, dst_vlan,
                           bandwidth, flow_id, output_action, cookie,
                           meter_id):
+    logger.debug('build_one_switch_flow: flow_id=%s, cookie=%s, switch=%s, input_port=%s, output_port=%s, input_vlan_id=%s, output_vlan_id=%s, output_vlan_type=%s, bandwidth=%s, meter_id=%s',
+        flow_id, cookie, switch, src_port, dst_port, src_vlan, dst_vlan,
+        output_action, bandwidth, meter_id)
+
     flow = Flow()
     flow.clazz = "org.openkilda.messaging.command.flow.InstallOneSwitchFlow"
     flow.transaction_id = 0

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/SplitterBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/SplitterBolt.java
@@ -48,7 +48,6 @@ import org.apache.storm.topology.base.BaseRichBolt;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 
-import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -113,9 +112,11 @@ public class SplitterBolt extends BaseRichBolt {
 
                     values = new Values(message, flowId);
                     logger.info("Flow {} message: operation={} values={}", flowId, fid.getOperation(), values);
-                    if (fid.getOperation() == FlowOperation.PUSH) {
+                    if (fid.getOperation() == FlowOperation.PUSH
+                            || fid.getOperation() == FlowOperation.PUSH_PROPAGATE) {
                         outputCollector.emit(StreamType.PUSH.toString(), tuple, values);
-                    } else if (fid.getOperation() == FlowOperation.UNPUSH) {
+                    } else if (fid.getOperation() == FlowOperation.UNPUSH
+                            || fid.getOperation() == FlowOperation.UNPUSH_PROPAGATE) {
                         outputCollector.emit(StreamType.UNPUSH.toString(), tuple, values);
                     } else {
                         logger.warn("Skip undefined FlowInfoData Operation {}: {}={}",


### PR DESCRIPTION
The changes:
- Proper fetching of cookies for switch rules validation and sync.
- ATDD tests for switch validation with non-standard cookies.
- Fix PUSH_PROPAGATE processing in SplitterBolt & flow_utils.py. This is required by ATDD to push a flow with non-standard cookies.

Fixes #559