### PR TITLE
Inject fake Neo4j DB into WFM integtational test

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/LaunchEnvironment.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/LaunchEnvironment.java
@@ -30,6 +30,14 @@ public class LaunchEnvironment {
         return new PropertiesReader(getProperties(), CLI_OVERLAY, ownSection, defaults, "");
     }
 
+    public void setupOverlay(Properties overlay) {
+        Properties newLayer = new Properties(getProperties());
+        for (String name : overlay.stringPropertyNames()) {
+            newLayer.setProperty(name, overlay.getProperty(name));
+        }
+        properties = newLayer;
+    }
+
     private Properties makeCliOverlay() {
         Properties overlay = new Properties(getProperties());
 

--- a/services/wfm/src/test/java/org/openkilda/wfm/AbstractStormTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/AbstractStormTest.java
@@ -15,6 +15,7 @@
 
 package org.openkilda.wfm;
 
+import com.google.common.io.Files;
 import org.apache.storm.testing.CompleteTopologyParam;
 import org.apache.storm.testing.MkClusterParam;
 import org.kohsuke.args4j.CmdLineException;
@@ -28,6 +29,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
+
 import org.openkilda.wfm.topology.TopologyConfig;
 
 import java.io.File;
@@ -40,12 +42,15 @@ import java.util.Properties;
  */
 public class AbstractStormTest {
     protected static String CONFIG_NAME = "class-level-overlay.properties";
+    protected static String NEO4J_LISTEN_ADDRESS = "localhost:27600";
 
     protected static TestKafkaProducer kProducer;
     protected static LocalCluster cluster;
     protected static MkClusterParam clusterParam;
     protected static CompleteTopologyParam completeTopologyParam;
     static TestUtils.KafkaTestFixture server;
+
+    protected static final File rootDir = Files.createTempDir();
 
     @ClassRule
     public static TemporaryFolder fsData = new TemporaryFolder();

--- a/services/wfm/src/test/java/org/openkilda/wfm/Neo4jFixture.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/Neo4jFixture.java
@@ -1,0 +1,45 @@
+package org.openkilda.wfm;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.kernel.configuration.BoltConnector;
+
+public class Neo4jFixture {
+    private final String DIRECTORY_NAME = "neo4j";
+
+    private final GraphDatabaseBuilder dbBuilder;
+    private GraphDatabaseService db = null;
+    private final String listenAddress;
+
+    public Neo4jFixture(Path rootDir, String listenAddress) {
+        this.listenAddress = listenAddress;
+
+        Path dbPath = rootDir.resolve(DIRECTORY_NAME);
+        File dbDir = dbPath.toFile();
+        dbDir.mkdir();
+
+        BoltConnector bolt = new BoltConnector("0");
+        dbBuilder = new GraphDatabaseFactory()
+                .newEmbeddedDatabaseBuilder(dbDir)
+                .setConfig(bolt.type, "BOLT")
+                .setConfig(bolt.enabled, "true")
+                .setConfig(bolt.listen_address, this.listenAddress);
+    }
+
+    public void start() {
+        db = dbBuilder.newGraphDatabase();
+    }
+
+    public void stop() {
+        db.shutdown();
+    }
+
+    public String getListenAddress() {
+        return listenAddress;
+    }
+}

--- a/services/wfm/src/test/resources/topology.properties
+++ b/services/wfm/src/test/resources/topology.properties
@@ -43,6 +43,7 @@ opentsdb.workers.datapointparserbolt = 2
 opentsdb.batch.size = 50
 opentsdb.flush.interval = 1
 
+# dynamically overridden during some tests
 neo4j.hosts = neo4j.pendev:7687
 neo4j.user = neo4j
 neo4j.pswd = temppass


### PR DESCRIPTION
Due to added feature to read initial state directly from neo4j, WFM
integrational(unit) tests become corrupted.

Tests are failed at storm topology start due to unability to connect to
neo4j.