### PR TITLE
Send a barrier after each meter install command in FL

### DIFF
--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/kafka/ReplaceInstallFlowTest.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/kafka/ReplaceInstallFlowTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.openkilda.floodlight.message.command.encapsulation.PushSchemeOutputCommands.ofFactory;
 import static org.openkilda.messaging.Utils.MAPPER;
 
+import com.google.common.util.concurrent.Futures;
 import org.openkilda.floodlight.message.command.encapsulation.OutputCommands;
 import org.openkilda.floodlight.message.command.encapsulation.ReplaceSchemeOutputCommands;
 import org.openkilda.floodlight.pathverification.IPathVerificationService;
@@ -54,6 +55,8 @@ import org.easymock.Capture;
 import org.easymock.CaptureType;
 import org.junit.Before;
 import org.junit.Test;
+import org.projectfloodlight.openflow.protocol.OFBarrierReply;
+import org.projectfloodlight.openflow.protocol.OFBarrierRequest;
 import org.projectfloodlight.openflow.protocol.OFFlowAdd;
 import org.projectfloodlight.openflow.protocol.OFMeterMod;
 import org.projectfloodlight.openflow.types.DatapathId;
@@ -295,6 +298,8 @@ public class ReplaceInstallFlowTest {
 
         if (meterAddCapture != null) {
             expect(iofSwitch.write(capture(meterAddCapture))).andReturn(true);
+            expect(iofSwitch.writeRequest(anyObject(OFBarrierRequest.class)))
+                    .andReturn(Futures.immediateFuture(createMock(OFBarrierReply.class)));
             if (flowAddCapture != null) {
                 expect(iofSwitch.write(capture(flowAddCapture))).andReturn(true);
             }

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerTest.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerTest.java
@@ -46,6 +46,7 @@ import static org.openkilda.floodlight.switchmanager.ISwitchManager.DROP_RULE_CO
 import static org.openkilda.floodlight.switchmanager.ISwitchManager.VERIFICATION_BROADCAST_RULE_COOKIE;
 import static org.openkilda.floodlight.switchmanager.ISwitchManager.VERIFICATION_UNICAST_RULE_COOKIE;
 
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import net.floodlightcontroller.core.IOFSwitch;
 import net.floodlightcontroller.core.SwitchDescription;
@@ -286,6 +287,8 @@ public class SwitchManagerTest {
         expect(switchDescription.getManufacturerDescription()).andStubReturn("");
 
         expect(iofSwitch.write(scheme.installMeter(bandwidth, burstSize, meterId))).andReturn(true);
+        expect(iofSwitch.writeRequest(anyObject(OFBarrierRequest.class)))
+                .andReturn(Futures.immediateFuture(createMock(OFBarrierReply.class)));
 
         replay(ofSwitchService);
         replay(iofSwitch);


### PR DESCRIPTION
This ensures that a meter is installed before a flow install request sent.

Fixes #592