### PR TITLE
ATDD-Staging FlowCRUD - Check no meters after delete flow.

### DIFF
--- a/services/src/atdd-staging/src/main/resources/features/flow_crud.feature
+++ b/services/src/atdd-staging/src/main/resources/features/flow_crud.feature
@@ -34,4 +34,5 @@ Feature: Flow CRUD
     And each flow can not be read from Northbound
     And each flow can not be read from TopologyEngine
     And each flow has no rules installed
+    And all active switches have no excessive meters installed
     And each flow has no traffic


### PR DESCRIPTION
The changes:
- Introduce "all active switches have no excessive meters installed" step.

Fixes #712