### PR TITLE
Separate logger for ISL events in FL

### DIFF
--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
@@ -111,7 +111,7 @@ class RecordHandler implements Runnable {
     private void handleCommand(CommandMessage message, CommandData data, String replyToTopic,
             Destination replyDestination) throws FlowCommandException {
         if (data instanceof DiscoverIslCommandData) {
-            doDiscoverIslCommand(data);
+            doDiscoverIslCommand((DiscoverIslCommandData)data);
         } else if (data instanceof DiscoverPathCommandData) {
             doDiscoverPathCommand(data);
         } else if (data instanceof InstallIngressFlow) {
@@ -153,19 +153,12 @@ class RecordHandler implements Runnable {
         }
     }
 
-    private void doDiscoverIslCommand(CommandData data) {
-        DiscoverIslCommandData command = (DiscoverIslCommandData) data;
-        logger.debug("sending discover ISL to {}", command);
+    private void doDiscoverIslCommand(DiscoverIslCommandData command) {
+        logger.debug("Processing send ISL discovery command {}", command);
 
         String switchId = command.getSwitchId();
-        boolean result = context.getPathVerificationService().sendDiscoveryMessage(
+        context.getPathVerificationService().sendDiscoveryMessage(
                 DatapathId.of(switchId), OFPort.of(command.getPortNo()));
-
-        if (result) {
-            logger.debug("packet_out was sent to {}", switchId);
-        } else {
-            logger.warn("packet_out was not sent to {}-{}", switchId, command.getPortNo());
-        }
     }
 
     private void doDiscoverPathCommand(CommandData data) {

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/pathverification/PathVerificationService.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/pathverification/PathVerificationService.java
@@ -87,11 +87,14 @@ import java.util.Map;
 import java.util.Properties;
 
 public class PathVerificationService implements IFloodlightModule, IOFMessageListener, IPathVerificationService {
+    private static final Logger logger = LoggerFactory.getLogger(PathVerificationService.class);
+    private static final Logger logIsl = LoggerFactory.getLogger(
+            String.format("%s.ISL", PathVerificationService.class));
+
     public static final String VERIFICATION_BCAST_PACKET_DST = "08:ED:02:E3:FF:FF";
     public static final int VERIFICATION_PACKET_UDP_PORT = 61231;
     public static final String VERIFICATION_PACKET_IP_DST = "192.168.0.255";
     private static final String TOPIC = Topic.TOPO_DISCO;
-    private static final Logger logger = LoggerFactory.getLogger(PathVerificationService.class);
 
     private IFloodlightProviderService floodlightProvider;
     private IOFSwitchService switchService;
@@ -243,6 +246,7 @@ public class PathVerificationService implements IFloodlightModule, IOFMessageLis
             if (srcSwitch != null && srcSwitch.getPort(port) != null) {
                 IOFSwitch dstSwitch = (dstSwId == null) ? null : switchService.getSwitch(dstSwId);
                 OFPacketOut ofPacketOut = generateVerificationPacket(srcSwitch, port, dstSwitch, true);
+
                 if (ofPacketOut != null) {
                     logger.debug("==> Sending verification packet out {}/{}: {}", srcSwitch.getId().toString(), port.getPortNumber(),
                             Hex.encodeHexString(ofPacketOut.getData()));
@@ -250,6 +254,14 @@ public class PathVerificationService implements IFloodlightModule, IOFMessageLis
                 } else {
                     logger.error("<== Received null from generateVerificationPacket, inputs where: " +
                             "srcSwitch: {}, port: {}, dstSwitch: {}", srcSwitch, port, dstSwitch);
+                }
+
+                if (result) {
+                    logIsl.info("push discovery package via: {}-{}", srcSwitch.getId(), port.getPortNumber());
+                } else {
+                    logger.error(
+                            "Failed to send PACKET_OUT(ISL discovery packet) via {}-{}",
+                            srcSwitch.getId(), port.getPortNumber());
                 }
             }
         } catch (Exception exception) {
@@ -501,7 +513,7 @@ public class PathVerificationService implements IFloodlightModule, IOFMessageLis
 
             U64 latency = (timestamp != 0 && (time - timestamp) > 0) ? U64.of(time - timestamp) : U64.ZERO;
 
-            logger.debug("link discovered: {}-{} ===( {} ms )===> {}-{}",
+            logIsl.info("link discovered: {}-{} ===( {} ms )===> {}-{}",
                     remoteSwitch.getId(), remotePort, latency.getValue(), sw.getId(), inPort);
 
             // this verification packet was sent from remote switch/port to received switch/port

--- a/services/src/floodlight-modules/src/main/resources/logback.xml
+++ b/services/src/floodlight-modules/src/main/resources/logback.xml
@@ -20,6 +20,7 @@
   <logger name="LogService" level="ERROR"/> <!-- Restlet access logging -->
   <logger name="net.floodlightcontroller" level="INFO"/>
   <logger name="org.openkilda.floodlight.*" level="DEBUG"/>
+  <logger name="org.openkilda.floodlight.pathverification.PathVerificationService.ISL" level="INFO"/>
   <logger name="org.sdnplatform" level="ERROR"/>
   <logger name="org.openkilda" level="DEBUG"/>
   <logger name="ch.qos.logback" level="DEBUG"/>

--- a/services/src/floodlight-modules/src/test/resources/logback.xml
+++ b/services/src/floodlight-modules/src/test/resources/logback.xml
@@ -10,6 +10,7 @@
   <logger name="io" level="ERROR"></logger> <!-- Netty logging -->
   <logger name="LogService" level="ERROR"/> <!-- Restlet access logging -->
   <logger name="net.floodlightcontroller" level="INFO"/>
+  <logger name="org.openkilda.floodlight.pathverification.PathVerificationService.ISL" level="INFO"/>
   <logger name="org.sdnplatform" level="ERROR"/>
   <logger name="org.openkilda" level="DEBUG"/>
 </configuration>

--- a/templates/templates/floodlight/logback.xml.j2
+++ b/templates/templates/floodlight/logback.xml.j2
@@ -43,6 +43,7 @@
   <logger name="org.apache.kafka.clients" level="INFO"/>
   <logger name="org.openkilda.floodlight.kafka.RecordHandler" level="DEBUG"/>
   <logger name="org.openkilda.floodlight.switchmanager.SwitchManager" level="DEBUG"/>
+  <logger name="org.openkilda.floodlight.pathverification.PathVerificationService.ISL" level="INFO"/>
   <logger name="org.openkilda" level="INFO"/>
 
 </configuration>


### PR DESCRIPTION
To be able to see both (send and receive) events regarding ISL events,
move all related log calls into PathVerivicationService class and make
separate logger for them.

It allow us to enable this logger in prod evironment and do not overload
logs collecting and processing system.