### PR TITLE
Deny adding address that collide exising addresses

### DIFF
--- a/services/traffexam/kilda/traffexam/__init__.py
+++ b/services/traffexam/kilda/traffexam/__init__.py
@@ -13,4 +13,4 @@
 #   limitations under the License.
 #
 
-__version__ = '0.1.dev2'
+__version__ = '0.1.dev12'

--- a/services/traffexam/kilda/traffexam/exc.py
+++ b/services/traffexam/kilda/traffexam/exc.py
@@ -118,6 +118,16 @@ class ServiceDeleteError(ServiceError):
             *self.args)
 
 
+class ServiceCreateCollisionError(ServiceCreateError):
+    def __init__(self, pool, subject, collision, *extra):
+        super().__init__(pool, subject, collision, *extra)
+
+    def __str__(self):
+        return (
+            'Can\'t add item {args[1]} into {args[0]!r} due to collision '
+            'with existing object {args[2]}').format(args=self.args)
+
+
 class RegistryLookupError(AbstractError):
     def __init__(self, context, klass, *extra):
         super().__init__(context, klass, *extra)

--- a/services/traffexam/kilda/traffexam/model.py
+++ b/services/traffexam/kilda/traffexam/model.py
@@ -15,7 +15,9 @@
 
 import collections
 import enum
+import ipaddress
 import itertools
+import json
 import socket
 import uuid
 import weakref
@@ -152,6 +154,11 @@ class Abstract(object):
             raise TypeError('{!r} got unknown arguments: "{}"'.format(
                 self, '", "'.join(sorted(extra))))
 
+    def __str__(self):
+        return '<{}:{}>'.format(
+                type(self).__name__,
+                json.dumps(self.pack(), sort_keys=True, cls=JSONEncoder))
+
     def pack(self):
         payload = vars(self).copy()
 
@@ -219,11 +226,13 @@ class IpAddress(IdMixin, Abstract):
             self.address, self.prefix = self.unpack_cidr(address)
         else:
             self.address = address
-
+        self.network = ipaddress.IPv4Network(
+                '{}/{}'.format(self.address, self.prefix), strict=False)
         self._ports = PortQueue(6000, 7000)
 
     def pack(self):
         payload = super().pack()
+        payload.pop('network')
         payload['vlan'] = self.iface.vlan_tag
         return payload
 
@@ -322,3 +331,14 @@ class PortQueue(collections.Iterator):
         if not self.lower <= item < self.upper:
             raise ValueError
         self.released.add(item)
+
+
+class JSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, Abstract):
+            value = o.pack()
+        elif isinstance(o, uuid.UUID):
+            value = str(o)
+        else:
+            value = super().default(o)
+        return value


### PR DESCRIPTION
To prevent misunderstanding of used routing in controlled by traffexam
environment, deny installation of overlapping ip networks.