### PR TITLE
Add details into ISL discovery log messages

### DIFF
--- a/services/topology-engine/queue-engine/topologylistener/isl_utils.py
+++ b/services/topology-engine/queue-engine/topologylistener/isl_utils.py
@@ -46,7 +46,7 @@ def create_if_missing(tx, *links):
             match = _make_match(target)
             match['status'] = 'inactive'
 
-            logger.info('Ensure ISL exist: %s', target)
+            logger.info('Ensure ISL %s exists', target)
             tx.run(q, match)
 
 
@@ -100,7 +100,7 @@ def fetch_by_datapath(tx, dpid):
 
 
 def resolve_conflicts(tx, isl):
-    logger.info('Check for ISL conflicts with %s', isl)
+    logger.info('Check ISL %s for conflicts', isl)
 
     involved = [
         fetch(tx, isl), fetch(tx, isl.reversed())]

--- a/services/topology-engine/queue-engine/topologylistener/messageclasses.py
+++ b/services/topology-engine/queue-engine/topologylistener/messageclasses.py
@@ -314,83 +314,75 @@ class MessageItem(object):
         speed = int(self.payload['speed'])
         available_bandwidth = int(self.payload['available_bandwidth'])
 
-        try:
-            logger.info('ISL %s_%d create or update request: timestamp=%s',
-                        a_switch, a_port, self.timestamp)
+        isl = model.InterSwitchLink.new_from_isl_data(self.payload)
+        isl.ensure_path_complete()
 
-            with graph.begin() as tx:
-                isl = model.InterSwitchLink.new_from_isl_data(self.payload)
-                isl.ensure_path_complete()
-
-                flow_utils.precreate_switches(
-                        tx, isl.source.dpid, isl.dest.dpid)
-                isl_utils.create_if_missing(tx, isl)
-
-                #
-                # Given that we know the the src and dst exist, the following query will either
-                # create the relationship if it doesn't exist, or update it if it does
-                #
-                isl_create_or_update = (
-                    "MERGE "
-                    "(src:switch {{name:'{}'}}) "
-                    "ON CREATE SET src.state = 'inactive' "
-                    "MERGE "
-                    "(dst:switch {{name:'{}'}}) "
-                    "ON CREATE SET dst.state = 'inactive' "
-                    "MERGE "
-                    "(src)-[i:isl {{"
-                    "src_switch: '{}', src_port: {}, "
-                    "dst_switch: '{}', dst_port: {} "
-                    "}}]->(dst) "
-                    "SET "
-                    "i.latency = {}, "
-                    "i.speed = {}, "
-                    "i.max_bandwidth = {}, "
-                    "i.actual = 'active', "
-                    "i.status = 'inactive'"
-                ).format(
-                    a_switch,
-                    b_switch,
-                    a_switch, a_port,
-                    b_switch, b_port,
-                    latency,
-                    speed,
-                    available_bandwidth
-                )
-                tx.run(isl_create_or_update)
-
-                isl_utils.update_status(tx, isl)
-                isl_utils.resolve_conflicts(tx, isl)
+        logger.info('ISL %s create request', isl)
+        with graph.begin() as tx:
+            flow_utils.precreate_switches(
+                tx, isl.source.dpid, isl.dest.dpid)
+            isl_utils.create_if_missing(tx, isl)
 
             #
-            # Now handle the second part .. pull properties from link_props if they exist
+            # Given that we know the the src and dst exist, the following query will either
+            # create the relationship if it doesn't exist, or update it if it does
             #
+            isl_create_or_update = (
+                "MERGE "
+                "(src:switch {{name:'{}'}}) "
+                "ON CREATE SET src.state = 'inactive' "
+                "MERGE "
+                "(dst:switch {{name:'{}'}}) "
+                "ON CREATE SET dst.state = 'inactive' "
+                "MERGE "
+                "(src)-[i:isl {{"
+                "src_switch: '{}', src_port: {}, "
+                "dst_switch: '{}', dst_port: {} "
+                "}}]->(dst) "
+                "SET "
+                "i.latency = {}, "
+                "i.speed = {}, "
+                "i.max_bandwidth = {}, "
+                "i.actual = 'active', "
+                "i.status = 'inactive'"
+            ).format(
+                a_switch,
+                b_switch,
+                a_switch, a_port,
+                b_switch, b_port,
+                latency,
+                speed,
+                available_bandwidth
+            )
+            tx.run(isl_create_or_update)
 
-            src_sw, src_pt, dst_sw, dst_pt = a_switch, a_port, b_switch, b_port # use same names as TER code
-            query = 'MATCH (src:switch)-[i:isl]->(dst:switch) '
-            query += ' WHERE i.src_switch = "%s" ' \
-                     ' AND i.src_port = %s ' \
-                     ' AND i.dst_switch = "%s" ' \
-                     ' AND i.dst_port = %s ' % (src_sw, src_pt, dst_sw, dst_pt)
-            query += ' MATCH (lp:link_props) '
-            query += ' WHERE lp.src_switch = "%s" ' \
-                     ' AND lp.src_port = %s ' \
-                     ' AND lp.dst_switch = "%s" ' \
-                     ' AND lp.dst_port = %s ' % (src_sw, src_pt, dst_sw, dst_pt)
-            query += ' SET i += lp '
-            graph.run(query)
+            isl_utils.update_status(tx, isl)
+            isl_utils.resolve_conflicts(tx, isl)
 
-            #
-            # Finally, update the available_bandwidth..
-            #
-            flow_utils.update_isl_bandwidth(src_sw, src_pt, dst_sw, dst_pt)
+        #
+        # Now handle the second part .. pull properties from link_props if they exist
+        #
 
-            logger.info('ISL between %s and %s updated', a_switch, b_switch)
+        src_sw, src_pt, dst_sw, dst_pt = a_switch, a_port, b_switch, b_port  # use same names as TER code
+        query = 'MATCH (src:switch)-[i:isl]->(dst:switch) '
+        query += ' WHERE i.src_switch = "%s" ' \
+                 ' AND i.src_port = %s ' \
+                 ' AND i.dst_switch = "%s" ' \
+                 ' AND i.dst_port = %s ' % (src_sw, src_pt, dst_sw, dst_pt)
+        query += ' MATCH (lp:link_props) '
+        query += ' WHERE lp.src_switch = "%s" ' \
+                 ' AND lp.src_port = %s ' \
+                 ' AND lp.dst_switch = "%s" ' \
+                 ' AND lp.dst_port = %s ' % (src_sw, src_pt, dst_sw, dst_pt)
+        query += ' SET i += lp '
+        graph.run(query)
 
-        except Exception as e:
-            logger.exception('ISL between %s and %s creation error: %s',
-                             a_switch, b_switch, e.message)
-            return False
+        #
+        # Finally, update the available_bandwidth..
+        #
+        flow_utils.update_isl_bandwidth(src_sw, src_pt, dst_sw, dst_pt)
+
+        logger.info('ISL %s have been created/updated', isl)
 
         return True
 

--- a/services/topology-engine/queue-engine/topologylistener/model.py
+++ b/services/topology-engine/queue-engine/topologylistener/model.py
@@ -24,6 +24,9 @@ class NetworkEndpoint(
     def new_from_isl_data_path(cls, path_node):
         return cls(path_node['switch_id'], path_node['port_no'])
 
+    def __str__(self):
+        return '{}-{}'.format(*self)
+
 
 class InterSwitchLink(
         collections.namedtuple(
@@ -67,3 +70,6 @@ class InterSwitchLink(
     def reversed(self):
         cls = type(self)
         return cls(self.dest, self.source, self.state)
+
+    def __str__(self):
+        return '{} <===> {}'.format(self.source, self.dest)


### PR DESCRIPTION
Include dpid and port into ISL discovery log messages. Also log both
ends of ISL when we know them(i.e. almost always).