### PR TITLE
Limit neo4j version

### DIFF
--- a/services/neo4j/ansible/deploy.yml
+++ b/services/neo4j/ansible/deploy.yml
@@ -14,7 +14,7 @@
     apt:
       name: "{{ item }}"
     with_items:
-    - neo4j
+    - neo4j=1:3.3.3
     - curl
     - vim
     become_method: sudo


### PR DESCRIPTION
To avoid issues due ancidental DB version change, install specific version into DB container.
