### PR TITLE
Cleanup handling of correlationId in Northbound

### DIFF
--- a/services/src/northbound/src/main/java/org/openkilda/northbound/messaging/kafka/KafkaHealthCheckMessageConsumer.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/messaging/kafka/KafkaHealthCheckMessageConsumer.java
@@ -29,6 +29,8 @@ import org.openkilda.northbound.messaging.HealthCheckMessageConsumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.slf4j.MDC.MDCCloseable;
 import org.springframework.kafka.annotation.KafkaListener;
 
 import java.io.IOException;
@@ -62,9 +64,17 @@ public class KafkaHealthCheckMessageConsumer implements HealthCheckMessageConsum
      */
     @KafkaListener(id = "northbound-listener-health-check", topics = Topic.HEALTH_CHECK)
     public void receive(final String record) {
+        Message message;
+
         try {
             logger.trace("message received");
-            Message message = MAPPER.readValue(record, Message.class);
+            message = MAPPER.readValue(record, Message.class);
+        } catch (IOException exception) {
+            logger.error("Could not deserialize message: {}", record, exception);
+            return;
+        }
+
+        try (MDCCloseable closable = MDC.putCloseable(CORRELATION_ID, message.getCorrelationId())) {
             if (Destination.NORTHBOUND.equals(message.getDestination())) {
                 logger.debug("message received: {}", record);
                 InfoMessage info = (InfoMessage) message;
@@ -73,8 +83,6 @@ public class KafkaHealthCheckMessageConsumer implements HealthCheckMessageConsum
             } else {
                 logger.trace("Skip message: {}", message);
             }
-        } catch (IOException exception) {
-            logger.error("Could not deserialize message: {}", record, exception);
         }
     }
 

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/service/impl/FeatureTogglesServiceImpl.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/service/impl/FeatureTogglesServiceImpl.java
@@ -70,7 +70,7 @@ public class FeatureTogglesServiceImpl implements FeatureTogglesService {
                 correlationId, Destination.TOPOLOGY_ENGINE);
         messageProducer.send(topoEngTopic, requestMessage);
 
-        Message result = messageConsumer.poll(requestMessage.getCorrelationId());
+        Message result = messageConsumer.poll(correlationId);
         FeatureTogglesResponse response =
                 (FeatureTogglesResponse) validateInfoMessage(requestMessage, result, correlationId);
 

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/service/impl/LinkServiceImpl.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/service/impl/LinkServiceImpl.java
@@ -16,6 +16,7 @@
 package org.openkilda.northbound.service.impl;
 
 import static java.util.Base64.getEncoder;
+import static org.openkilda.messaging.Utils.CORRELATION_ID;
 
 import org.openkilda.messaging.info.event.IslInfoData;
 import org.openkilda.northbound.converter.LinkMapper;
@@ -23,6 +24,7 @@ import org.openkilda.northbound.dto.LinkPropsDto;
 import org.openkilda.northbound.dto.LinksDto;
 import org.openkilda.northbound.service.LinkPropsResult;
 import org.openkilda.northbound.service.LinkService;
+import org.openkilda.northbound.utils.RequestCorrelationId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,7 +56,6 @@ public class LinkServiceImpl implements LinkService {
     /** The URL to hit the Links Properties table .. ie :link_props in Neo4J */
     private String linkPropsUrlBase;
     private UriComponentsBuilder linkPropsBuilder;
-    private HttpHeaders headers;
 
     @Value("${topology.engine.rest.endpoint}")
     private String topologyEngineRest;
@@ -73,14 +74,12 @@ public class LinkServiceImpl implements LinkService {
                 .pathSegment("api", "v1", "topology", "link", "props");
         linkPropsUrlBase = UriComponentsBuilder.fromHttpUrl(topologyEngineRest)
                 .pathSegment("api", "v1", "topology", "link", "props").build().toUriString();
-        headers = new HttpHeaders();
-        headers.add(HttpHeaders.AUTHORIZATION, authHeaderValue);
     }
 
     @Override
     public List<LinksDto> getLinks() {
         LOGGER.debug("Get links request received");
-        IslInfoData[] links = restTemplate.exchange(linksUrl, HttpMethod.GET, new HttpEntity<>(headers),
+        IslInfoData[] links = restTemplate.exchange(linksUrl, HttpMethod.GET, new HttpEntity<>(buildHttpHeaders()),
                 IslInfoData[].class).getBody();
         LOGGER.debug("Returned {} links", links.length);
         return Stream.of(links)
@@ -106,7 +105,7 @@ public class LinkServiceImpl implements LinkService {
         String fullUri = builder.build().toUriString();
 
         ResponseEntity<LinkPropsDto[]> response = restTemplate.exchange(fullUri,
-                HttpMethod.GET, new HttpEntity<>(headers), LinkPropsDto[].class);
+                HttpMethod.GET, new HttpEntity<>(buildHttpHeaders()), LinkPropsDto[].class);
         LinkPropsDto[] linkProps = response.getBody();
         LOGGER.debug("Returned {} links (with properties)", linkProps.length);
         return Arrays.asList(linkProps);
@@ -125,11 +124,18 @@ public class LinkServiceImpl implements LinkService {
     protected LinkPropsResult doLinkProps(HttpMethod verb, List<LinkPropsDto> linkPropsList) {
         LOGGER.debug("{} link properties request received", verb);
         LOGGER.debug("Size of list: {}", linkPropsList.size());
-        HttpEntity<List<LinkPropsDto>> entity = new HttpEntity<>(linkPropsList,headers);
+        HttpEntity<List<LinkPropsDto>> entity = new HttpEntity<>(linkPropsList, buildHttpHeaders());
         ResponseEntity<LinkPropsResult> response = restTemplate.exchange(linkPropsUrlBase,
                 verb, entity, LinkPropsResult.class);
         LinkPropsResult result = response.getBody();
         LOGGER.debug("Returned: ", result);
         return result;
+    }
+
+    private HttpHeaders buildHttpHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.AUTHORIZATION, authHeaderValue);
+        headers.add(CORRELATION_ID, RequestCorrelationId.getId());
+        return headers;
     }
 }

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/utils/NorthboundBasicAuthenticationEntryPoint.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/utils/NorthboundBasicAuthenticationEntryPoint.java
@@ -16,6 +16,7 @@
 package org.openkilda.northbound.utils;
 
 import static org.openkilda.messaging.Utils.CORRELATION_ID;
+import static org.openkilda.messaging.Utils.DEFAULT_CORRELATION_ID;
 import static org.openkilda.messaging.Utils.MAPPER;
 
 import org.openkilda.messaging.error.ErrorType;
@@ -28,6 +29,7 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationEn
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.Optional;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -59,7 +61,9 @@ public class NorthboundBasicAuthenticationEntryPoint extends BasicAuthentication
         response.addHeader(HttpHeaders.WWW_AUTHENTICATE, realm);
         response.setContentType(MediaType.APPLICATION_JSON_UTF8_VALUE);
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        MessageError error = new MessageError(request.getHeader(CORRELATION_ID), System.currentTimeMillis(),
+
+        String correlationId = Optional.ofNullable(request.getHeader(CORRELATION_ID)).orElse(DEFAULT_CORRELATION_ID);
+        MessageError error = new MessageError(correlationId, System.currentTimeMillis(),
                 ErrorType.AUTH_FAILED.toString(), DEFAULT_REALM, exception.getClass().getSimpleName());
         response.getWriter().print(MAPPER.writeValueAsString(error));
     }

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/utils/NorthboundExceptionHandler.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/utils/NorthboundExceptionHandler.java
@@ -17,6 +17,7 @@ package org.openkilda.northbound.utils;
 
 import static java.lang.String.format;
 import static org.openkilda.messaging.Utils.CORRELATION_ID;
+import static org.openkilda.messaging.Utils.DEFAULT_CORRELATION_ID;
 
 import org.openkilda.messaging.error.ErrorType;
 import org.openkilda.messaging.error.MessageError;
@@ -29,6 +30,8 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.Optional;
 
 /**
  * Common exception handler for controllers.
@@ -81,7 +84,8 @@ public class NorthboundExceptionHandler extends ResponseEntityExceptionHandler {
     @Override
     protected ResponseEntity<Object> handleExceptionInternal(Exception exception, Object body, HttpHeaders headers,
                                                              HttpStatus status, WebRequest request) {
-        MessageError error = new MessageError(request.getHeader(CORRELATION_ID), System.currentTimeMillis(),
+        String correlationId = Optional.ofNullable(request.getHeader(CORRELATION_ID)).orElse(DEFAULT_CORRELATION_ID);
+        MessageError error = new MessageError(correlationId, System.currentTimeMillis(),
                 ErrorType.REQUEST_INVALID.toString(), exception.getMessage(), exception.getClass().getSimpleName());
 
         logger.error(format("Unknown error %s caught.", error), exception);

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/utils/RequestCorrelationId.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/utils/RequestCorrelationId.java
@@ -1,4 +1,4 @@
-/* Copyright 2017 Telstra Open Source
+/* Copyright 2018 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -15,17 +15,32 @@
 
 package org.openkilda.northbound.utils;
 
+import static org.openkilda.messaging.Utils.DEFAULT_CORRELATION_ID;
+
+import java.io.Closeable;
+import java.util.Optional;
+
 /**
- * Correlation id for every single request request.
+ * Associates a given correlationId with the current execution thread.
  */
 public final class RequestCorrelationId {
 
-    public static final String CORRELATION_ID = "correlation_id";
-
     private static final InheritableThreadLocal<String> ID = new InheritableThreadLocal<>();
 
-    public static String getId() { return ID.get(); }
+    public static String getId() {
+        return Optional.ofNullable(ID.get()).orElse(DEFAULT_CORRELATION_ID);
+    }
 
-    public static void setId(String correlationId) { ID.set(correlationId); }
+    public static RequestCorrelationClosable create(String correlationId) {
+        ID.set(correlationId);
 
+        return new RequestCorrelationClosable();
+    }
+
+    public static class RequestCorrelationClosable implements Closeable {
+
+        public void close() {
+            ID.remove();
+        }
+    }
 }

--- a/services/src/northbound/src/main/resources/log4j2.xml
+++ b/services/src/northbound/src/main/resources/log4j2.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration monitorInterval="30">
+<Configuration status="WARN" monitorInterval="30">
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} | %-5.5p | %-32.32t | %-32.32c{1} | @project.name@ - @project.version@ | [%X] %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} %-5p [%t] %c{1.} - [%X] %m%n"/>
         </Console>
         <Socket name="LOGSTASH" host="logstash.pendev" port="5005">
-            <JsonLayout compact="true" eventEol="true" />
+            <JsonLayout compact="true" eventEol="true" properties="true"/>
         </Socket>
         <RollingFile name="ROLLINGFILE" fileName="/var/logs/northbound/app.log"
                 filePattern="/var/logs/northbound/app-%d{MM-dd-yyyy}-%i.log.gz">
-            <PatternLayout pattern="%d{ISO8601} | %-5.5p | %-32.32t | %-32.32c{1} | @project.name@ - @project.version@ | [%X] %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} %-5p [%t] %c{1} - [%X] %m%n"/>
             <Policies>
-                <TimeBasedTriggeringPolicy />
+                <TimeBasedTriggeringPolicy/>
                 <SizeBasedTriggeringPolicy size="250 MB"/>
             </Policies>
         </RollingFile>
     </Appenders>
     <Loggers>
-        <Logger name="org.openkilda" level="DEBUG" />
+        <Logger name="org.openkilda" level="DEBUG"/>
         <Root level="INFO">
             <AppenderRef ref="STDOUT"/>
             <AppenderRef ref="LOGSTASH"/>

--- a/services/src/northbound/src/test/java/org/openkilda/northbound/controller/FlowControllerTest.java
+++ b/services/src/northbound/src/test/java/org/openkilda/northbound/controller/FlowControllerTest.java
@@ -79,7 +79,7 @@ public class FlowControllerTest extends NorthboundBaseTest {
     @Before
     public void setUp() throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).apply(springSecurity()).build();
-        RequestCorrelationId.setId(DEFAULT_CORRELATION_ID);
+        RequestCorrelationId.create(DEFAULT_CORRELATION_ID);
     }
 
     @Test

--- a/services/src/northbound/src/test/java/org/openkilda/northbound/utils/RequestCorrelationIdTest.java
+++ b/services/src/northbound/src/test/java/org/openkilda/northbound/utils/RequestCorrelationIdTest.java
@@ -1,0 +1,46 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.northbound.utils;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertThat;
+import static org.openkilda.messaging.Utils.DEFAULT_CORRELATION_ID;
+
+import org.junit.Test;
+import org.openkilda.northbound.utils.RequestCorrelationId.RequestCorrelationClosable;
+
+import java.util.UUID;
+
+public class RequestCorrelationIdTest {
+
+    @Test
+    public void shouldResetCorrelationIdOnClose() {
+        // given
+        RequestCorrelationId.create(String.format("test-%s", UUID.randomUUID()));
+        String before = RequestCorrelationId.getId();
+
+        // when
+        try (RequestCorrelationClosable closable = RequestCorrelationId
+                .create(String.format("test-%s", UUID.randomUUID()))) {
+
+            //then
+            assertThat(RequestCorrelationId.getId(), not(equalTo(before)));
+        }
+
+        assertThat(RequestCorrelationId.getId(), equalTo(DEFAULT_CORRELATION_ID));
+    }
+}

--- a/services/src/northbound/src/test/resources/log4j2.xml
+++ b/services/src/northbound/src/test/resources/log4j2.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration monitorInterval="30">
+<Configuration status="WARN" monitorInterval="30">
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} | %-5.5p | %-32.32t | %-32.32c{1} | @project.name@ - @project.version@ | %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} %-5p %c{1.}:%L - [%X] %m%n"/>
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="org.openkilda.northbound" level="DEBUG" />
-        <Root level="DEBUG">
+        <Logger name="org.openkilda" level="DEBUG"/>
+        <Root level="INFO">
             <AppenderRef ref="STDOUT"/>
-            <AppenderRef ref="LOGSTASH"/>
-            <AppenderRef ref="ROLLINGFILE"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/templates/templates/northbound/log4j2.xml.j2
+++ b/templates/templates/northbound/log4j2.xml.j2
@@ -2,13 +2,13 @@
 <Configuration monitorInterval="30">
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{ISO8601} | %-5.5p | %-32.32t | %-32.32c{1} | @project.name@ - @project.version@ | %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} %-5p [%t] %c{1.} - [%X] %m%n"/>
         </Console>
 {% if logging.json_file %}
         <RollingFile name="J1" immediateFlush="false"
                  fileName="{{ logging.logfile_path }}/northbound.log.json"
                  filePattern="{{ logging.logfile_path }}/northbound.log.json.%i.gz">
-           <JSONLayout compact="true" eventEol="true"/>
+           <JSONLayout compact="true" eventEol="true" properties="true"/>
            <Policies>
             <SizeBasedTriggeringPolicy size="100 MB"/> <!-- Or every 100 MB -->
           </Policies>
@@ -17,12 +17,12 @@
 {% endif %}
 {% if logging.logstash %}
         <Socket name="LOGSTASH" host="{{ logging.logstash_host }}" port="{{ logging.port.northbound }}">
-            <JsonLayout compact="true" eventEol="true" />
+            <JsonLayout compact="true" eventEol="true" properties="true" />
         </Socket>
 {% endif %}
         <RollingFile name="ROLLINGFILE" fileName="/var/logs/northbound/app.log"
                 filePattern="/var/logs/northbound/app-%d{MM-dd-yyyy}-%i.log.gz">
-            <PatternLayout pattern="%d{ISO8601} | %-5.5p | %-32.32t | %-32.32c{1} | @project.name@ - @project.version@ | %m%n"/>
+            <PatternLayout pattern="%d{ISO8601} %-5p [%t] %c{1} - [%X] %m%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy />
                 <SizeBasedTriggeringPolicy size="250 MB"/>
@@ -30,7 +30,7 @@
         </RollingFile>
     </Appenders>
     <Loggers>
-        <Logger name="org.openkilda.northbound" level="DEBUG" />
+        <Logger name="org.openkilda" level="DEBUG" />
         <Root level="INFO">
             <AppenderRef ref="STDOUT"/>
 {% if logging.json_file %}


### PR DESCRIPTION
The changes:
- Set correlationId from an incoming Kafka message into Northbound logger context in order to have it logged along with each message.
- Minor cleanup for correlationId handling code.