### PR TITLE
Fix bug with single switch flow cache update in stats topology

### DIFF
--- a/services/wfm/src/checkstyle/checkstyle-suppress-known-issues.xml
+++ b/services/wfm/src/checkstyle/checkstyle-suppress-known-issues.xml
@@ -1323,29 +1323,28 @@
     <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="40" checks="CustomImportOrder"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="41" checks="CustomImportOrder"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="42" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="60" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="61" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="62" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="63" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="64" checks="CustomImportOrder"/>
+    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="43" checks="CustomImportOrder"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="65" checks="CustomImportOrder"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="66" checks="CustomImportOrder"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="67" checks="CustomImportOrder"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="68" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="84" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="145" checks="LineLength"/>
-    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="186" checks="ParenPad"/>
-    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="186" checks="ParenPad"/>
-    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="190" checks="WhitespaceAfter"/>
-    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="196" checks="WhitespaceAfter"/>
-    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="197" checks="WhitespaceAfter"/>
-    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="198" checks="WhitespaceAfter"/>
+    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="69" checks="CustomImportOrder"/>
+    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="70" checks="CustomImportOrder"/>
+    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="71" checks="CustomImportOrder"/>
+    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="72" checks="CustomImportOrder"/>
+    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="73" checks="CustomImportOrder"/>
+    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="87" checks="JavadocMethod"/>
+    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="148" checks="LineLength"/>
+    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="189" checks="ParenPad"/>
+    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="193" checks="WhitespaceAfter"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="199" checks="WhitespaceAfter"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="200" checks="WhitespaceAfter"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="201" checks="WhitespaceAfter"/>
+    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="202" checks="WhitespaceAfter"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="203" checks="WhitespaceAfter"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="204" checks="WhitespaceAfter"/>
-    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="255" checks="SummaryJavadoc"/>
+    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="206" checks="WhitespaceAfter"/>
+    <suppress files="src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java" lines="207" checks="WhitespaceAfter"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/TestKafkaConsumer.java" lines="20" checks="CustomImportOrder"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/TestKafkaConsumer.java" lines="21" checks="CustomImportOrder"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/TestKafkaConsumer.java" lines="22" checks="CustomImportOrder"/>

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/bolts/CacheFilterBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/bolts/CacheFilterBolt.java
@@ -101,15 +101,12 @@ public class CacheFilterBolt extends BaseRichBolt {
                     InstallEgressFlow command = (InstallEgressFlow) data;
                     logMatchedRecord(command);
                     emit(tuple, Commands.UPDATE, command, MeasurePoint.EGRESS);
-                }
-                else if (data instanceof InstallOneSwitchFlow)
-                {
+                } else if (data instanceof InstallOneSwitchFlow) {
                     InstallOneSwitchFlow command = (InstallOneSwitchFlow) data;
                     logMatchedRecord(command);
-                    emit(tuple, Commands.UPDATE, command);
-                }
-                else if (data instanceof RemoveFlow)
-                {
+                    emit(tuple, Commands.UPDATE, command, MeasurePoint.INGRESS);
+                    emit(tuple, Commands.UPDATE, command, MeasurePoint.EGRESS);
+                } else if (data instanceof RemoveFlow) {
                     RemoveFlow command = (RemoveFlow) data;
                     logMatchedRecord(command);
                     emit(tuple, Commands.REMOVE, command);

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java
@@ -30,6 +30,7 @@ import org.apache.storm.testing.MockedSources;
 import org.apache.storm.topology.TopologyBuilder;
 import org.apache.storm.tuple.Values;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -41,6 +42,8 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.openkilda.messaging.Destination;
 import org.openkilda.messaging.Utils;
+import org.openkilda.messaging.command.CommandMessage;
+import org.openkilda.messaging.command.flow.InstallOneSwitchFlow;
 import org.openkilda.messaging.info.Datapoint;
 import org.openkilda.messaging.info.InfoMessage;
 import org.openkilda.messaging.info.stats.FlowStatsData;
@@ -51,17 +54,19 @@ import org.openkilda.messaging.info.stats.MeterConfigStatsData;
 import org.openkilda.messaging.info.stats.PortStatsData;
 import org.openkilda.messaging.info.stats.PortStatsEntry;
 import org.openkilda.messaging.info.stats.PortStatsReply;
+import org.openkilda.messaging.payload.flow.OutputVlanType;
 import org.openkilda.wfm.LaunchEnvironment;
 import org.openkilda.wfm.Neo4jFixture;
 import org.openkilda.wfm.StableAbstractStormTest;
 import org.openkilda.wfm.topology.TestingKafkaBolt;
+import org.openkilda.wfm.topology.stats.bolts.CacheFilterBolt;
 import org.openkilda.wfm.topology.utils.StatsUtil;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -70,8 +75,6 @@ import java.util.stream.IntStream;
 public class StatsTopologyTest extends StableAbstractStormTest {
 
     private static final long timestamp = System.currentTimeMillis();
-    private static GraphDatabaseService graphDb;
-    private static File dbFile;
 
     private final String switchId = "00:00:00:00:00:00:00:01";
     private final long cookie = 0x4000000000000001L;
@@ -243,6 +246,48 @@ public class StatsTopologyTest extends StableAbstractStormTest {
         });
     }
 
+    @Test
+    public void cacheSyncSingleSwitchFlowAdd() throws Exception {
+        final String switchId = "00:00:00:00:00:00:00:01";
+        final String flowId = "sync-test-add-ssf";
+        final InstallOneSwitchFlow payload = new InstallOneSwitchFlow(
+                0L, flowId, 0xFFFF000000000001L, switchId, 8, 9, 127, 127, OutputVlanType.PUSH, 1000L, 0L);
+        final CommandMessage message = new CommandMessage(payload, timestamp, flowId, Destination.WFM_STATS);
+        final String json = MAPPER.writeValueAsString(message);
+
+        MockedSources sources = new MockedSources();
+        sources.addMockData(StatsComponentType.STATS_OFS_KAFKA_SPOUT.name());
+        sources.addMockData(StatsComponentType.STATS_KILDA_SPEAKER_SPOUT.name(), new Values(json));
+        completeTopologyParam.setMockedSources(sources);
+
+        Testing.withTrackedCluster(clusterParam, (cluster) -> {
+            StatsTopology topologyManager = new TestingTargetTopology(launchEnvironment, new TestingKafkaBolt());
+            StormTopology topology = topologyManager.createTopology();
+
+            Map result = Testing.completeTopology(cluster, topology, completeTopologyParam);
+            List<FixedTuple> cacheSyncStream = (List<FixedTuple>) result.get(
+                    StatsComponentType.STATS_CACHE_FILTER_BOLT.name());
+
+            final HashSet<MeasurePoint> expectedEvents = new HashSet<>();
+            expectedEvents.add(MeasurePoint.INGRESS);
+            expectedEvents.add(MeasurePoint.EGRESS);
+
+            final HashSet<MeasurePoint> seenEvents = new HashSet<>();
+            cacheSyncStream.stream()
+                    .filter(item -> StatsStreamType.CACHE_UPDATE == StatsStreamType.valueOf(item.stream))
+                    .forEach(item -> {
+                        Assert.assertEquals(CacheFilterBolt.Commands.UPDATE, item.values.get(0));
+                        Assert.assertEquals(flowId, item.values.get(1));
+                        Assert.assertEquals(switchId, item.values.get(2));
+                        MeasurePoint affectedPoint = (MeasurePoint) item.values.get(4);
+
+                        seenEvents.add(affectedPoint);
+                    });
+
+            Assert.assertEquals(expectedEvents, seenEvents);
+        });
+    }
+
     private Datapoint readFromJson(FixedTuple tuple) {
         try {
             return Utils.MAPPER.readValue(tuple.values.get(0).toString(), Datapoint.class);
@@ -253,7 +298,7 @@ public class StatsTopologyTest extends StableAbstractStormTest {
     }
 
     /**
-     * We should create child with these overridden methods because we don't want to use real kafka instance,
+     * We should create child with these overridden methods because we don't want to use real kafka instance.
      */
     private class TestingTargetTopology extends StatsTopology {
 


### PR DESCRIPTION
Signle switch flow cache update command did not provide measurement point
info. And as result NPE in CacheBolt.

Closes #811