### PR TITLE
Allow no javadoc for junit, Cucumber step and Spring configuration methods

### DIFF
--- a/services/src/checkstyle/README.md
+++ b/services/src/checkstyle/README.md
@@ -1,0 +1,9 @@
+# Coding style guide
+
+## Installing the OpenKilda coding style settings in IntelliJ IDEA
+
+Download the intellij-java-openkilda-style.xml file from the [https://github.com/telstra/open-kilda/tree/master/services/src/checkstyle](https://github.com/telstra/open-kilda/tree/master/services/src/checkstyle) repo.
+
+Go into Settings -> Editor -> Code Style. Click on Import Scheme and choose the downloaded style file. 
+
+Select OpenKildaStyle as actual coding style.

--- a/services/src/checkstyle/checkstyle.xml
+++ b/services/src/checkstyle/checkstyle.xml
@@ -231,7 +231,8 @@
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="minLineCount" value="2"/>
-            <property name="allowedAnnotations" value="Override, Test"/>
+            <property name="allowedAnnotations"
+                      value="Override, Bean, Test, Given, When, Then, And, Before, After, BeforeClass, AfterClass"/>
             <property name="allowThrowsTagsForSubclasses" value="true"/>
             <property name="tokens" value="METHOD_DEF,ANNOTATION_FIELD_DEF"/>
         </module>

--- a/services/src/checkstyle/intellij-java-openkilda-style.xml
+++ b/services/src/checkstyle/intellij-java-openkilda-style.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<code_scheme name="OpenKildaStyle">
+    <option name="OTHER_INDENT_OPTIONS">
+        <value>
+            <option name="INDENT_SIZE" value="4"/>
+            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+            <option name="TAB_SIZE" value="4"/>
+            <option name="USE_TAB_CHARACTER" value="false"/>
+            <option name="SMART_TABS" value="false"/>
+            <option name="LABEL_INDENT_SIZE" value="0"/>
+            <option name="LABEL_INDENT_ABSOLUTE" value="false"/>
+            <option name="USE_RELATIVE_INDENTS" value="false"/>
+        </value>
+    </option>
+    <option name="INSERT_INNER_CLASS_IMPORTS" value="true"/>
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999"/>
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999"/>
+    <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+        <value/>
+    </option>
+    <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+            <package name="" withSubpackages="true" static="true"/>
+            <emptyLine/>
+            <package name="org.openkilda" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="java" withSubpackages="true" static="false"/>
+            <package name="javax" withSubpackages="true" static="false"/>
+        </value>
+    </option>
+    <option name="RIGHT_MARGIN" value="120"/>
+    <option name="JD_ALIGN_PARAM_COMMENTS" value="false"/>
+    <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false"/>
+    <option name="JD_P_AT_EMPTY_LINES" value="false"/>
+    <option name="JD_KEEP_EMPTY_PARAMETER" value="false"/>
+    <option name="JD_KEEP_EMPTY_EXCEPTION" value="false"/>
+    <option name="JD_KEEP_EMPTY_RETURN" value="false"/>
+
+    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0"/>
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+    <option name="ALIGN_MULTILINE_RESOURCES" value="false"/>
+    <option name="ALIGN_MULTILINE_FOR" value="false"/>
+    <option name="CALL_PARAMETERS_WRAP" value="1"/>
+    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+    <option name="EXTENDS_LIST_WRAP" value="1"/>
+    <option name="THROWS_KEYWORD_WRAP" value="1"/>
+    <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+    <option name="TERNARY_OPERATION_WRAP" value="1"/>
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+    <option name="FOR_STATEMENT_WRAP" value="1"/>
+    <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+    <option name="WRAP_COMMENTS" value="true"/>
+    <option name="IF_BRACE_FORCE" value="3"/>
+    <option name="DOWHILE_BRACE_FORCE" value="3"/>
+    <option name="WHILE_BRACE_FORCE" value="3"/>
+    <option name="FOR_BRACE_FORCE" value="3"/>
+    <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true"/>
+</code_scheme>

--- a/services/src/pom.xml
+++ b/services/src/pom.xml
@@ -31,7 +31,7 @@
         <jersey.version>2.25.1</jersey.version>
         <junit.version>4.12</junit.version>
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
-        <puppycrawl-tools-checkstyle.version>8.8</puppycrawl-tools-checkstyle.version>
+        <puppycrawl-tools-checkstyle.version>8.10</puppycrawl-tools-checkstyle.version>
         <maven.compiler.version>3.6.1</maven.compiler.version>
         <maven.jacoco.version>0.7.9</maven.jacoco.version>
         <maven.jar.version>3.0.2</maven.jar.version>

--- a/services/wfm/pom.xml
+++ b/services/wfm/pom.xml
@@ -31,7 +31,7 @@
 
         <aspectj-maven-plugin.version>1.11</aspectj-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
-        <puppycrawl-tools-checkstyle.version>8.8</puppycrawl-tools-checkstyle.version>
+        <puppycrawl-tools-checkstyle.version>8.10</puppycrawl-tools-checkstyle.version>
     </properties>
 
     <profiles>

--- a/services/wfm/src/checkstyle/checkstyle.xml
+++ b/services/wfm/src/checkstyle/checkstyle.xml
@@ -231,7 +231,8 @@
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="minLineCount" value="2"/>
-            <property name="allowedAnnotations" value="Override, Test, Given, When, Then, And"/>
+            <property name="allowedAnnotations"
+                      value="Override, Bean, Test, Given, When, Then, And, Before, After, BeforeClass, AfterClass"/>
             <property name="allowThrowsTagsForSubclasses" value="true"/>
             <property name="tokens" value="METHOD_DEF,ANNOTATION_FIELD_DEF"/>
         </module>


### PR DESCRIPTION
Update checkstyle rules: allow no javadoc for Spring bean factory methods, junit methods and Cucumber step definitions.