### PR TITLE
Fix log message

### DIFF
--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/Producer.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/Producer.java
@@ -49,7 +49,7 @@ public class Producer {
 
         KafkaTopicOrderDescriptor orderDescriptor = getOrderDescriptor(topic);
         if (orderDescriptor.isEnabled()) {
-            logger.debug("Topic %s forces predictable message ordering", topic);
+            logger.debug("Topic {} forces predictable message ordering", topic);
             record = new ProducerRecord<>(topic, orderDescriptor.getPartition(), null, jsonPayload);
         } else {
             record = new ProducerRecord<>(topic, jsonPayload);


### PR DESCRIPTION
Replace invalid substitution marker "%s" with correct one "{}".

This commit is not enough reason to FL deployement. It can wait till FL will receive some real update.