### PR TITLE
Use last commited kafka offset for OpenTSDB topology spout

### DIFF
--- a/services/wfm/src/checkstyle/checkstyle-suppress-known-issues.xml
+++ b/services/wfm/src/checkstyle/checkstyle-suppress-known-issues.xml
@@ -654,23 +654,7 @@
     <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/bolts/OpenTSDBFilterBolt.java" lines="130" checks="Indentation"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/bolts/OpenTSDBFilterBolt.java" lines="132" checks="OperatorWrap"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/bolts/OpenTSDBFilterBolt.java" lines="142" checks="OperatorWrap"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java" lines="20" checks="CustomImportOrder"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java" lines="22" checks="CustomImportOrder"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java" lines="23" checks="CustomImportOrder"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java" lines="24" checks="CustomImportOrder"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java" lines="25" checks="CustomImportOrder"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java" lines="26" checks="CustomImportOrder"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java" lines="27" checks="CustomImportOrder"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java" lines="28" checks="CustomImportOrder"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java" lines="29" checks="CustomImportOrder"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java" lines="30" checks="CustomImportOrder"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java" lines="31" checks="CustomImportOrder"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java" lines="38" checks="AbbreviationAsWordInName"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java" lines="70" checks="CommentsIndentation"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java" lines="72" checks="WhitespaceAfter"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java" lines="72" checks="WhitespaceAround"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java" lines="79" checks="CommentsIndentation"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java" lines="87" checks="JavadocMethod"/>
+    <suppress files="src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java" lines="40" checks="AbbreviationAsWordInName"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/portstate/bolt/CacheBolt.java" lines="1" checks="RegexpHeader"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/portstate/bolt/ParsePortInfoBolt.java" lines="1" checks="RegexpHeader"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/portstate/bolt/ParsePortInfoBolt.java" lines="10" checks="CustomImportOrder"/>

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTSDBTopology.java
@@ -15,21 +15,22 @@
 
 package org.openkilda.wfm.topology.opentsdb;
 
+import org.openkilda.wfm.LaunchEnvironment;
+import org.openkilda.wfm.error.ConfigurationException;
+import org.openkilda.wfm.topology.AbstractTopology;
+import org.openkilda.wfm.topology.opentsdb.bolts.DatapointParseBolt;
+import org.openkilda.wfm.topology.opentsdb.bolts.OpenTSDBFilterBolt;
+
+import org.apache.storm.generated.StormTopology;
 import org.apache.storm.kafka.spout.KafkaSpout;
 import org.apache.storm.kafka.spout.KafkaSpoutConfig;
-import org.apache.storm.tuple.Fields;
-import org.openkilda.wfm.topology.opentsdb.bolts.DatapointParseBolt;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
-import org.apache.storm.generated.StormTopology;
 import org.apache.storm.opentsdb.bolt.OpenTsdbBolt;
 import org.apache.storm.opentsdb.bolt.TupleOpenTsdbDatapointMapper;
 import org.apache.storm.opentsdb.client.OpenTsdbClient;
 import org.apache.storm.topology.TopologyBuilder;
-import org.openkilda.wfm.error.ConfigurationException;
-import org.openkilda.wfm.LaunchEnvironment;
-import org.openkilda.wfm.topology.AbstractTopology;
-import org.openkilda.wfm.topology.opentsdb.bolts.OpenTSDBFilterBolt;
+import org.apache.storm.tuple.Fields;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 
@@ -65,16 +66,16 @@ public class OpenTSDBTopology extends AbstractTopology {
 
         OpenTsdbClient.Builder tsdbBuilder = OpenTsdbClient
                 .newBuilder(config.getOpenTsDBHosts())
-//                .sync(config.getOpenTsdbTimeout())
+                // .sync(config.getOpenTsdbTimeout())
                 .returnDetails();
-        if(config.isOpenTsdbClientChunkedRequestsEnabled()) {
+        if (config.isOpenTsdbClientChunkedRequestsEnabled()) {
             tsdbBuilder.enableChunkedEncoding();
         }
 
         OpenTsdbBolt openTsdbBolt = new OpenTsdbBolt(tsdbBuilder,
                 Collections.singletonList(TupleOpenTsdbDatapointMapper.DEFAULT_MAPPER));
         openTsdbBolt.withBatchSize(config.getOpenTsdbBatchSize()).withFlushInterval(config.getOpenTsdbFlushInterval());
-//                .failTupleForFailedMetrics();
+        //        .failTupleForFailedMetrics();
         tb.setBolt("opentsdb", openTsdbBolt, config.getOpenTsdbBoltExecutors())
                 .setNumTasks(config.getOpenTsdbBoltWorkers())
                 .shuffleGrouping(boltId);
@@ -92,6 +93,9 @@ public class OpenTSDBTopology extends AbstractTopology {
         topology.setSpout(spoutId, kafkaSpout, config.getOpenTsdbNumSpouts());
     }
 
+    /**
+     * main.
+     */
     public static void main(String[] args) {
         try {
             LaunchEnvironment env = new LaunchEnvironment(args);


### PR DESCRIPTION
To not loose stats data during topology restart or any other outages
switch it to use last commited offset (instead of LATEST offset).