### PR TITLE
Treat the discovery timeout property as a number of ticks

### DIFF
--- a/services/src/api/pom.xml
+++ b/services/src/api/pom.xml
@@ -36,8 +36,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/services/src/atdd-staging/pom.xml
+++ b/services/src/atdd-staging/pom.xml
@@ -31,14 +31,10 @@
         <spring.version>5.0.4.RELEASE</spring.version>
 
         <cucumber.version>2.3.1</cucumber.version>
-        <junit.version>4.12</junit.version>
-        <mockito-core.version>2.8.47</mockito-core.version>
         <nitorcreations-matchers.version>1.3</nitorcreations-matchers.version>
 
         <log4j-slf4j.version>2.10.0</log4j-slf4j.version>
 
-        <commons-collections.version>4.1</commons-collections.version>
-        <commons-lang3.version>3.7</commons-lang3.version>
         <jackson.version>2.9.4</jackson.version>
     </properties>
 
@@ -128,14 +124,12 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <!-- Needed for Cucumber execution -->
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito-core.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -150,7 +144,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>${commons-collections.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -159,7 +152,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -181,8 +173,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/services/src/atdd-staging/pom.xml
+++ b/services/src/atdd-staging/pom.xml
@@ -40,7 +40,6 @@
         <commons-collections.version>4.1</commons-collections.version>
         <commons-lang3.version>3.7</commons-lang3.version>
         <jackson.version>2.9.4</jackson.version>
-        <failsafe.version>1.0.5</failsafe.version>
     </properties>
 
     <!-- Dependencies -->
@@ -177,7 +176,6 @@
         <dependency>
             <groupId>net.jodah</groupId>
             <artifactId>failsafe</artifactId>
-            <version>${failsafe.version}</version>
         </dependency>
 
         <dependency>

--- a/services/src/atdd/pom.xml
+++ b/services/src/atdd/pom.xml
@@ -109,6 +109,11 @@
             <artifactId>commons-collections4</artifactId>
             <version>4.0</version>
         </dependency>
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>failsafe</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/services/src/atdd/pom.xml
+++ b/services/src/atdd/pom.xml
@@ -107,7 +107,10 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>failsafe</artifactId>
         </dependency>
         <dependency>
             <groupId>net.jodah</groupId>
@@ -118,8 +121,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/services/src/atdd/src/checkstyle/checkstyle-suppress-known-issues.xml
+++ b/services/src/atdd/src/checkstyle/checkstyle-suppress-known-issues.xml
@@ -927,19 +927,7 @@
     <suppress files="src/test/java/org/openkilda/flow/FlowUtils.java" lines="705" checks="AbbreviationAsWordInName"/>
     <suppress files="src/test/java/org/openkilda/flow/FlowUtils.java" lines="752" checks="LineLength"/>
     <suppress files="src/test/java/org/openkilda/LinksUtils.java" lines="1" checks="RegexpHeader"/>
-    <suppress files="src/test/java/org/openkilda/LinksUtils.java" lines="12" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/LinksUtils.java" lines="13" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/LinksUtils.java" lines="14" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/LinksUtils.java" lines="15" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/LinksUtils.java" lines="18" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/LinksUtils.java" lines="19" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/LinksUtils.java" lines="20" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/LinksUtils.java" lines="21" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/LinksUtils.java" lines="22" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/LinksUtils.java" lines="23" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/LinksUtils.java" lines="24" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/LinksUtils.java" lines="25" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/LinksUtils.java" lines="68" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/LinksUtils.java" lines="87" checks="JavadocMethod"/>
+    <suppress files="src/test/java/org/openkilda/LinksUtils.java" lines="69" checks="JavadocMethod"/>
+    <suppress files="src/test/java/org/openkilda/LinksUtils.java" lines="88" checks="JavadocMethod"/>
     <suppress files="src/test/resources/atdd.properties" lines="0" checks="NewlineAtEndOfFile"/>
 </suppressions>

--- a/services/src/atdd/src/test/java/org/openkilda/atdd/TopologyEventsBasicTest.java
+++ b/services/src/atdd/src/test/java/org/openkilda/atdd/TopologyEventsBasicTest.java
@@ -15,6 +15,9 @@
 
 package org.openkilda.atdd;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -23,8 +26,8 @@ import static org.junit.Assert.assertTrue;
 import org.openkilda.LinksUtils;
 import org.openkilda.SwitchesUtils;
 import org.openkilda.messaging.info.event.SwitchState;
-import org.openkilda.northbound.dto.links.LinkStatus;
 import org.openkilda.northbound.dto.links.LinkDto;
+import org.openkilda.northbound.dto.links.LinkStatus;
 import org.openkilda.northbound.dto.links.PathDto;
 import org.openkilda.northbound.dto.switches.SwitchDto;
 import org.openkilda.topo.builders.TestTopologyBuilder;
@@ -32,8 +35,11 @@ import org.openkilda.topo.builders.TestTopologyBuilder;
 import cucumber.api.PendingException;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
+import org.junit.Before;
 
 import java.util.Comparator;
 import java.util.List;
@@ -47,8 +53,15 @@ import java.util.stream.IntStream;
  */
 public class TopologyEventsBasicTest {
 
+    private LinkDto manipulatedLink;
+
+    @Before
+    public void setUp() {
+        manipulatedLink = null;
+    }
+
     @When("^multiple links exist between all switches$")
-    public void multiple_links_exist_between_all_switches() throws Exception {
+    public void multipleLinksExistBetweenAllSwitches() throws Exception {
         List<String> switchIds = IntStream.range(1, 6)
                 .mapToObj(TestTopologyBuilder::intToSwitchId)
                 .collect(Collectors.toList());
@@ -65,11 +78,11 @@ public class TopologyEventsBasicTest {
     }
 
     @When("^a link is dropped in the middle$")
-    public void a_link_is_dropped_in_the_middle() throws Exception {
+    public void linkIsDroppedInTheMiddle() throws Exception {
         List<LinkDto> links = LinksUtils.dumpLinks();
-        LinkDto middleLink = getMiddleLink(links);
+        manipulatedLink = getMiddleLink(links);
 
-        PathDto node = middleLink.getPath().get(0);
+        PathDto node = manipulatedLink.getPath().get(0);
         assertTrue(LinksUtils.islFail(getSwitchName(node.getSwitchId()), String.valueOf(node.getPortNo())));
     }
 
@@ -84,14 +97,24 @@ public class TopologyEventsBasicTest {
         assertThat("Only one link should be cut", cutLinks.size(), is(1));
     }
 
-    @Then("^the link disappears from the topology engine\\.$")
-    public void the_link_disappears_from_the_topology_engine() throws Exception {
-        List<LinkDto> links = LinksUtils.dumpLinks();
+    @Then("^the link disappears from the topology engine in (\\d+) seconds\\.$")
+    public void theLinkDisappearsFromTheTopologyEngine(int timeout) throws Exception {
+        List<LinkDto> cutLinks = Failsafe.with(new RetryPolicy()
+                .withDelay(2, TimeUnit.SECONDS)
+                .withMaxDuration(timeout, TimeUnit.SECONDS)
+                .retryIf(links -> links instanceof List && ((List) links).isEmpty()))
+                .get(() -> LinksUtils.dumpLinks().stream()
+                        .filter(isl -> isl.getState() != LinkStatus.DISCOVERED)
+                        .collect(Collectors.toList())
+                );
 
+        assertFalse("Link should be cut", cutLinks.isEmpty());
+        assertThat("Only one link should be cut", cutLinks,
+                hasItems(hasProperty("path", equalTo(manipulatedLink.getPath()))));
     }
 
     @When("^a link is added in the middle$")
-    public void a_link_is_added_in_the_middle() throws Exception {
+    public void linkIsAddedInTheMiddle() throws Exception {
         List<LinkDto> links = LinksUtils.dumpLinks();
         LinkDto middleLink = getMiddleLink(links);
 
@@ -108,13 +131,13 @@ public class TopologyEventsBasicTest {
     }
 
     @Then("^the link appears in the topology engine\\.$")
-    public void the_link_appears_in_the_topology_engine() throws Exception {
+    public void theLinkAppearsInTheTopologyEngine() throws Exception {
         List<LinkDto> links = LinksUtils.dumpLinks();
         assertThat("Amount of links should be 18 (initial 16 and 2 newly created)", links.size(), is(18));
     }
 
     @When("^a switch is dropped in the middle$")
-    public void a_switch_is_dropped_in_the_middle() throws Exception {
+    public void switchIsDroppedInTheMiddle() throws Exception {
         List<SwitchDto> switches = SwitchesUtils.dumpSwitches();
         SwitchDto middleSwitch = getMiddleSwitch(switches);
         assertTrue("Should successfully knockout switch",
@@ -129,14 +152,15 @@ public class TopologyEventsBasicTest {
     }
 
     @Then("^all links through the dropped switch will have no health checks$")
-    public void all_links_through_the_dropped_switch_will_have_no_health_checks() throws Exception {
+    public void allLinksThroughTheDroppedSwitchWillHaveNoHealthChecks() throws Exception {
         // Write code here that turns the phrase above into concrete actions
         throw new PendingException();
     }
 
     @Then("^the links disappear from the topology engine\\.$")
-    public void the_links_disappear_from_the_topology_engine() throws Exception {
-        //todo check whether we need to wait until links will disappear or we might delete them instantly when switch goes down
+    public void theLinksDisappearFromTheTopologyEngine() throws Exception {
+        //todo check whether we need to wait until links will disappear or
+        // we might delete them instantly when switch goes down
         TimeUnit.SECONDS.sleep(15);
         final SwitchDto middleSwitch = getMiddleSwitch(SwitchesUtils.dumpSwitches());
         final List<LinkDto> links = LinksUtils.dumpLinks();
@@ -149,7 +173,7 @@ public class TopologyEventsBasicTest {
     }
 
     @Then("^the switch disappears from the topology engine\\.$")
-    public void the_switch_disappears_from_the_topology_engine() throws Exception {
+    public void theSwitchDisappearsFromTheTopologyEngine() throws Exception {
         List<SwitchDto> switches = SwitchesUtils.dumpSwitches();
         SwitchDto middleSwitch = getMiddleSwitch(switches);
 
@@ -158,14 +182,14 @@ public class TopologyEventsBasicTest {
     }
 
     @When("^a switch is added at the edge$")
-    public void a_switch_is_added_at_the_edge() throws Exception {
+    public void switchIsAddedAtTheEdge() throws Exception {
         assertTrue("Should add switch to mininet topology",
                 SwitchesUtils.addSwitch("01010001", "DEADBEEF01010001"));
         TimeUnit.SECONDS.sleep(1);
     }
 
     @When("^links are added between the new switch and its neighbor$")
-    public void links_are_added_between_the_new_switch_and_its_neighbor() throws Exception {
+    public void linksAreAddedBetweenTheNewSwitchAndItsNeighbor() throws Exception {
         List<LinkDto> links = LinksUtils.dumpLinks();
         List<SwitchDto> switches = SwitchesUtils.dumpSwitches();
 
@@ -187,13 +211,13 @@ public class TopologyEventsBasicTest {
     }
 
     @Then("^all links through the added switch will have health checks$")
-    public void all_links_through_the_added_switch_will_have_health_checks() throws Exception {
+    public void allLinksThroughTheAddedSwitchWillHaveHealthChecks() throws Exception {
         // Write code here that turns the phrase above into concrete actions
         throw new PendingException();
     }
 
     @Then("^now amount of switches is (\\d+)\\.$")
-    public void the_switch_appears_in_the_topology_engine(int switches) throws Exception {
+    public void theSwitchAppearsInTheTopologyEngine(int switches) throws Exception {
         List<SwitchDto> switchList = SwitchesUtils.dumpSwitches();
         List<SwitchDto> activeSwitches = switchList.stream()
                 .filter(sw -> SwitchState.ACTIVATED.getType().equals(sw.getState()))

--- a/services/src/atdd/src/test/resources/features/mvp.1/TopologyEventsBasic.feature
+++ b/services/src/atdd/src/test/resources/features/mvp.1/TopologyEventsBasic.feature
@@ -11,7 +11,7 @@ Feature: Basic Topology Events
   these types of tests - ie ensure we are honoring the policies, and have the ability to overwrite
   the policies.
 
-  @MVP1.1
+  @MVP1
   Scenario: Link is Dropped
 
     Given a clean controller
@@ -19,7 +19,7 @@ Feature: Basic Topology Events
     When the controller learns the topology
     And multiple links exist between all switches
     And a link is dropped in the middle
-    Then the link disappears from the topology engine.
+    Then the link disappears from the topology engine in 60 seconds.
 
   @MVP1.1
   Scenario: Link is Added

--- a/services/src/floodlight-modules/pom.xml
+++ b/services/src/floodlight-modules/pom.xml
@@ -78,17 +78,14 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/services/src/messaging/pom.xml
+++ b/services/src/messaging/pom.xml
@@ -16,10 +16,6 @@
     <name>Messaging</name>
     <description>Common messaging data structures</description>
 
-    <properties>
-        <commons-lang3.version>3.7</commons-lang3.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -40,8 +36,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -66,7 +60,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
         </dependency>
     </dependencies>
 

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/model/DiscoveryLink.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/model/DiscoveryLink.java
@@ -185,7 +185,7 @@ public class DiscoveryLink implements Serializable {
      * Check if we should stop to verify ISL.
      * @return true if attempts is greater than attemptLimit.
      */
-    public boolean isAttemptsLimitExceeded(Integer attemptsLimit) {
+    public boolean isAttemptsLimitExceeded(int attemptsLimit) {
         return attempts > attemptsLimit;
     }
 

--- a/services/src/northbound/pom.xml
+++ b/services/src/northbound/pom.xml
@@ -139,7 +139,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.7</version>
         </dependency>
 
         <!-- Swagger dependencies -->
@@ -174,7 +173,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.3</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -184,7 +182,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>4.1</version>
         </dependency>
 
     </dependencies>

--- a/services/src/pom.xml
+++ b/services/src/pom.xml
@@ -19,6 +19,8 @@
         <apache.kafka.version>0.10.2.1</apache.kafka.version>
         <commons.cli.version>1.4</commons.cli.version>
         <commons.codec.version>1.10</commons.codec.version>
+        <commons-collections.version>4.1</commons-collections.version>
+        <commons-lang3.version>3.7</commons-lang3.version>
         <cucumber.version>1.2.5</cucumber.version>
         <easymock.version>3.4</easymock.version>
         <enunciate.version>2.9.1</enunciate.version>
@@ -49,6 +51,7 @@
         <commons.io.version>1.3.2</commons.io.version>
         <aspectj.version>1.8.13</aspectj.version>
         <aspectj-maven-plugin.version>1.11</aspectj-maven-plugin.version>
+        <failsafe.version>1.0.5</failsafe.version>
     </properties>
 
     <modules>
@@ -128,6 +131,16 @@
                 <groupId>commons-httpclient</groupId>
                 <artifactId>commons-httpclient</artifactId>
                 <version>${httpclient.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-collections4</artifactId>
+                <version>${commons-collections.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
@@ -213,6 +226,13 @@
                 <artifactId>easymock</artifactId>
                 <version>${easymock.version}</version>
                 <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+                <scope>provided</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/services/src/pom.xml
+++ b/services/src/pom.xml
@@ -45,6 +45,7 @@
         <slf4j.version>1.7.25</slf4j.version>
         <snakeyaml.version>1.18</snakeyaml.version>
         <lombok.version>1.16.20</lombok.version>
+        <failsafe.version>1.0.5</failsafe.version>
         <commons.io.version>1.3.2</commons.io.version>
         <aspectj.version>1.8.13</aspectj.version>
         <aspectj-maven-plugin.version>1.11</aspectj-maven-plugin.version>
@@ -170,6 +171,11 @@
                 <groupId>org.aspectj</groupId>
                 <artifactId>aspectjrt</artifactId>
                 <version>${aspectj.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.jodah</groupId>
+                <artifactId>failsafe</artifactId>
+                <version>${failsafe.version}</version>
             </dependency>
 
             <dependency>

--- a/services/wfm/src/main/java/org/openkilda/wfm/isl/DiscoveryManager.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/isl/DiscoveryManager.java
@@ -41,9 +41,9 @@ public class DiscoveryManager {
     /**
      * The frequency with which we should check if the ISL is healthy or existant.
      */
-    private final Integer islHealthCheckInterval;
-    private final Integer islConsecutiveFailureLimit;
-    private final Integer maxAttempts;
+    private final int islHealthCheckInterval;
+    private final int islConsecutiveFailureLimit;
+    private final int maxAttempts;
     private final LinkedList<DiscoveryLink> pollQueue;
     private final Map<NetworkEndpoint, DiscoveryLink> removedFromDiscovery;
 
@@ -56,8 +56,8 @@ public class DiscoveryManager {
      * @param maxAttempts - the limit for stopping all checks.
      */
     public DiscoveryManager(IIslFilter filter, LinkedList<DiscoveryLink> persistentQueue,
-                            Integer islHealthCheckInterval, Integer islConsecutiveFailureLimit,
-                            Integer maxAttempts, Integer minutesKeepRemovedIsl) {
+                            int islHealthCheckInterval, int islConsecutiveFailureLimit,
+                            int maxAttempts, Integer minutesKeepRemovedIsl) {
         this.filter = filter;
         this.islHealthCheckInterval = islHealthCheckInterval;
         this.islConsecutiveFailureLimit = islConsecutiveFailureLimit;


### PR DESCRIPTION
The changes:
- Make OFELinkBolt treating the discovery timeout property as a number of ticks, not as attempts.
- Cleanup in POMs.

Affected components:
- wfm/kilda-wfm

Fixes #807