### PR TITLE
Restore neo4j host value in TE config

### DIFF
--- a/services/topology-engine/queue-engine/topology_engine.properties
+++ b/services/topology-engine/queue-engine/topology_engine.properties
@@ -14,7 +14,7 @@ worker.pool.size=512
 hosts=zookeeper.pendev:2181
 
 [neo4j]
-host=localhost
+host=neo4j
 user=neo4j
 pass=temppass
 socket.timeout=30


### PR DESCRIPTION
Fix corrupted neo4j.host option value in TE config.

PS Corruption affect only development environment, because all other
environment will overwrite config during deployment.