### PR TITLE
Limit upper version of py2neo library

### DIFF
--- a/services/topology-engine-rest/Dockerfile
+++ b/services/topology-engine-rest/Dockerfile
@@ -33,7 +33,7 @@ RUN pip install \
     uwsgi \
     pyotp \
     jsonschema \
-    py2neo \
+    'py2neo<4.0.0' \
     requests \
     python-logstash \
     pytz

--- a/services/topology-engine/Dockerfile
+++ b/services/topology-engine/Dockerfile
@@ -17,7 +17,7 @@ FROM kilda/base-ubuntu
 RUN apt-get update && \
       apt-get install -y python-pip supervisor vim && \
       pip install --upgrade pip && \
-      pip install kafka py2neo 'gevent<=1.3.1' python-logstash pytz
+      pip install kafka 'py2neo<4.0.0' 'gevent<=1.3.1' python-logstash pytz
 
 ADD entrypoint.sh /entrypoint.sh
 ADD supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
There is new major release of py2neo-4.0.0. It have some difference in
internal structure (our import become corrupted).

Also we can't use it until it will be completelly tested on all our
usecases.