### PR TITLE
Increase ISL's cost on port down event only once

### DIFF
--- a/services/topology-engine/queue-engine/topologylistener/db.py
+++ b/services/topology-engine/queue-engine/topologylistener/db.py
@@ -36,6 +36,7 @@ def create_p2n_driver():
 
 
 def log_query(marker, q, p):
+    q = q.strip()
     log.debug('NEO4J QUERY %s:\n%s\nparams:\n%s', marker, q, pprint.pformat(p))
 
 

--- a/services/topology-engine/queue-engine/topologylistener/messageclasses.py
+++ b/services/topology-engine/queue-engine/topologylistener/messageclasses.py
@@ -308,9 +308,13 @@ class MessageItem(object):
                         tx, model.NetworkEndpoint(switch_id, port_id)):
                     # TODO(crimi): should be policy / toggle based
                     isl_utils.increase_cost(
-                        tx, isl, config.ISL_COST_WHEN_PORT_DOWN)
+                        tx, isl,
+                        config.ISL_COST_WHEN_PORT_DOWN,
+                        config.ISL_COST_WHEN_PORT_DOWN)
                     isl_utils.increase_cost(
-                        tx, isl.reversed(), config.ISL_COST_WHEN_PORT_DOWN)
+                        tx, isl.reversed(),
+                        config.ISL_COST_WHEN_PORT_DOWN,
+                        config.ISL_COST_WHEN_PORT_DOWN)
         except exc.DBRecordNotFound:
             logger.info("There is no ISL on %s_%s", switch_id, port_id)
 

--- a/services/topology-engine/queue-engine/topologylistener/model.py
+++ b/services/topology-engine/queue-engine/topologylistener/model.py
@@ -21,6 +21,12 @@ import json
 import pytz
 
 
+def convert_integer(raw):
+    if isinstance(raw, (int, long)):
+        return raw
+    return int(raw, 0)
+
+
 class NetworkEndpoint(
         collections.namedtuple('NetworkEndpoint', ('dpid', 'port'))):
 


### PR DESCRIPTION
Do not increase ISL cost on repeating `port down` events. First `port down`
event will trigger cost increse, but consequitive `port down` events do not
trigger cost increase.

Only if ISL's cost will be reset to `normal` value, `port down` event can
trigger cost increase again.

Closes #875