### PR TITLE
Update log4j configuration to expose correlation_id MDC field as a top level JSON value.

### DIFF
--- a/services/src/northbound/src/main/resources/log4j2.xml
+++ b/services/src/northbound/src/main/resources/log4j2.xml
@@ -5,7 +5,9 @@
             <PatternLayout pattern="%d{ISO8601} %-5p [%t] %c{1.} - [%X] %m%n"/>
         </Console>
         <Socket name="LOGSTASH" host="logstash.pendev" port="5005">
-            <JsonLayout compact="true" eventEol="true" properties="true"/>
+            <JsonLayout compact="true" eventEol="true">
+                <KeyValuePair key="correlation_id" value="${ctx:correlation_id}"/>
+            </JsonLayout>
         </Socket>
         <RollingFile name="ROLLINGFILE" fileName="/var/logs/northbound/app.log"
                 filePattern="/var/logs/northbound/app-%d{MM-dd-yyyy}-%i.log.gz">

--- a/services/src/pom.xml
+++ b/services/src/pom.xml
@@ -45,6 +45,7 @@
         <neo4j.java.driver.version>1.5.1</neo4j.java.driver.version>
         <openflowj.version>3.2.0-kilda-2</openflowj.version>
         <slf4j.version>1.7.25</slf4j.version>
+        <log4j.version>2.11.0</log4j.version>
         <snakeyaml.version>1.18</snakeyaml.version>
         <lombok.version>1.16.20</lombok.version>
         <failsafe.version>1.0.5</failsafe.version>
@@ -177,6 +178,21 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
                 <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${log4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.yaml</groupId>

--- a/services/storm/log4j2/cluster.xml
+++ b/services/storm/log4j2/cluster.xml
@@ -18,7 +18,7 @@
 
 <configuration monitorInterval="60" shutdownHook="disable">
 <properties>
-    <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1.} %t [%p] %msg%n</property>
+    <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1.} %t [%p] - [%X] %m%n</property>
 </properties>
 <appenders>
     <RollingFile name="A1" immediateFlush="false"
@@ -67,7 +67,9 @@
     </RollingFile>
 
     <Socket name="LOGSTASH" host="logstash.pendev" port="5001">
-        <JsonLayout compact="true" eventEol="true" />
+        <JsonLayout compact="true" eventEol="true" properties="true">
+            <KeyValuePair key="correlation_id" value="${ctx:correlation_id}"/>
+        </JsonLayout>
     </Socket>
 
     <Syslog name="syslog" format="RFC5424" charset="UTF-8" host="localhost" port="514"

--- a/services/storm/log4j2/worker.xml
+++ b/services/storm/log4j2/worker.xml
@@ -18,7 +18,7 @@
 
 <configuration monitorInterval="60" shutdownHook="disable">
 <properties>
-    <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1.} %t [%p] %msg%n</property>
+    <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1.} %t [%p] - [%X] %m%n</property>
     <property name="patternNoTime">%msg%n</property>
     <property name="patternMetrics">%d %-8r %m%n</property>
 </properties>
@@ -69,7 +69,9 @@
     </RollingFile>
 
     <Socket name="LOGSTASH" host="logstash.pendev" port="5001">
-        <JsonLayout compact="true" eventEol="true" />
+        <JsonLayout compact="true" eventEol="true" properties="true">
+            <KeyValuePair key="correlation_id" value="${ctx:correlation_id}"/>
+        </JsonLayout>
     </Socket>
 
     <Syslog name="syslog" format="RFC5424" charset="UTF-8" host="localhost" port="514"

--- a/services/wfm/src/main/resources/log4j2.xml
+++ b/services/wfm/src/main/resources/log4j2.xml
@@ -5,7 +5,9 @@
             <PatternLayout pattern="%d{ISO8601} %-5p [%t] %c{1.} - [%X] %m%n"/>
         </Console>
         <Socket name="LOGSTASH" host="logstash" port="5001">
-            <JsonLayout compact="true" eventEol="true" properties="true"/>
+            <JsonLayout compact="true" eventEol="true" properties="true">
+                <KeyValuePair key="correlation_id" value="${ctx:correlation_id}"/>
+            </JsonLayout>
         </Socket>
     </Appenders>
     <Loggers>

--- a/templates/templates/northbound/log4j2.xml.j2
+++ b/templates/templates/northbound/log4j2.xml.j2
@@ -8,7 +8,9 @@
         <RollingFile name="J1" immediateFlush="false"
                  fileName="{{ logging.logfile_path }}/northbound.log.json"
                  filePattern="{{ logging.logfile_path }}/northbound.log.json.%i.gz">
-           <JSONLayout compact="true" eventEol="true" properties="true"/>
+           <JsonLayout compact="true" eventEol="true" properties="true">
+                <KeyValuePair key="correlation_id" value="${ctx:correlation_id}"/>
+           </JsonLayout>
            <Policies>
             <SizeBasedTriggeringPolicy size="100 MB"/> <!-- Or every 100 MB -->
           </Policies>
@@ -17,7 +19,9 @@
 {% endif %}
 {% if logging.logstash %}
         <Socket name="LOGSTASH" host="{{ logging.logstash_host }}" port="{{ logging.port.northbound }}">
-            <JsonLayout compact="true" eventEol="true" properties="true" />
+           <JsonLayout compact="true" eventEol="true" properties="true">
+                <KeyValuePair key="correlation_id" value="${ctx:correlation_id}"/>
+           </JsonLayout>
         </Socket>
 {% endif %}
         <RollingFile name="ROLLINGFILE" fileName="/var/logs/northbound/app.log"

--- a/templates/templates/storm/log4j2/cluster.xml.j2
+++ b/templates/templates/storm/log4j2/cluster.xml.j2
@@ -67,7 +67,9 @@
     </RollingFile>
 
     <Socket name="LOGSTASH" host="{{ logging.logstash_host }}" port="{{ logging.port.storm }}">
-        <JsonLayout compact="true" eventEol="true" properties="true" />
+        <JsonLayout compact="true" eventEol="true" properties="true">
+            <KeyValuePair key="correlation_id" value="${ctx:correlation_id}"/>
+        </JsonLayout>
     </Socket>
 
     <Syslog name="syslog" format="RFC5424" charset="UTF-8" host="localhost" port="514"

--- a/templates/templates/storm/log4j2/worker.xml.j2
+++ b/templates/templates/storm/log4j2/worker.xml.j2
@@ -69,7 +69,9 @@
     </RollingFile>
 
     <Socket name="LOGSTASH" host="{{ logging.logstash_host }}" port="{{ logging.port.storm }}">
-        <JsonLayout compact="true" eventEol="true" properties="true" />
+        <JsonLayout compact="true" eventEol="true" properties="true">
+            <KeyValuePair key="correlation_id" value="${ctx:correlation_id}"/>
+        </JsonLayout>
     </Socket>
 
     <Syslog name="syslog" format="RFC5424" charset="UTF-8" host="localhost" port="514"


### PR DESCRIPTION
The changes:
- Modify log4j configuration in Northbound, WFM and Storm to expose correlation_id.
- Update log4j implementation version to 2.11.0, in order to support KeyValuePair in JsonLayout.