### PR TITLE
ISL status is set to Moved on physically re-plugging of ISL

### DIFF
--- a/services/src/atdd-staging/src/main/resources/features/failsafe_behaviour.feature
+++ b/services/src/atdd-staging/src/main/resources/features/failsafe_behaviour.feature
@@ -56,3 +56,18 @@ Feature: Failsafe Suite
     And property 'cost' of aswitchIslReverse ISL equals to '11000'
 
     And delete all link properties
+
+  Scenario: Replugging cable to some other switch/port should cause old ISL status to be changed to MOVED
+    Given select a random ISL with A-Switch and alias it as 'aswitchIsl'
+    And select a reverse path ISL for 'aswitchIsl' and alias it as 'aswitchIslReverse'
+    And select a random not connected A-Switch link and alias it as 'notConnectedLink'
+    And a potential ISL from 'aswitchIsl' source to 'notConnectedLink' source aliased as 'expectedNewIsl'
+    And a potential ISL from 'notConnectedLink' source to 'aswitchIsl' source aliased as 'expectedNewIslReverse'
+
+    When replug 'aswitchIsl' destination to 'notConnectedLink' source
+    Then ISL status changes to MOVED for ISLs: aswitchIsl, aswitchIslReverse
+    And ISL status changes to DISCOVERED for ISLs: expectedNewIsl, expectedNewIslReverse
+
+    When replug 'expectedNewIsl' source to 'aswitchIsl' destination
+    Then ISL status changes to MOVED for ISLs: expectedNewIsl, expectedNewIslReverse
+    And ISL status changes to DISCOVERED for ISLs: aswitchIsl, aswitchIslReverse

--- a/services/src/atdd/src/checkstyle/checkstyle-suppress-known-issues.xml
+++ b/services/src/atdd/src/checkstyle/checkstyle-suppress-known-issues.xml
@@ -479,36 +479,26 @@
     <suppress files="src/test/java/org/openkilda/topo/TopologyPrinter.java" lines="112" checks="ParenPad"/>
     <suppress files="src/test/java/org/openkilda/topo/TopologyPrinter.java" lines="112" checks="OperatorWrap"/>
     <suppress files="src/test/java/org/openkilda/topo/TopologyPrinter.java" lines="120" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="22" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="23" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="24" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="25" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="27" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="29" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="30" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="31" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="32" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="33" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="38" checks="HideUtilityClassConstructor"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="40" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="47" checks="SeparatorWrap"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="50" checks="SeparatorWrap"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="51" checks="SeparatorWrap"/>
+    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="40" checks="HideUtilityClassConstructor"/>
+    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="42" checks="JavadocMethod"/>
+    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="49" checks="SeparatorWrap"/>
+    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="52" checks="SeparatorWrap"/>
     <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="53" checks="SeparatorWrap"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="79" checks="SummaryJavadoc"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="89" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="102" checks="SummaryJavadoc"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="106" checks="LocalVariableName"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="125" checks="NonEmptyAtclauseDescription"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="126" checks="NonEmptyAtclauseDescription"/>
+    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="55" checks="SeparatorWrap"/>
+    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="81" checks="SummaryJavadoc"/>
+    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="91" checks="JavadocMethod"/>
+    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="104" checks="SummaryJavadoc"/>
+    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="108" checks="LocalVariableName"/>
+    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="127" checks="NonEmptyAtclauseDescription"/>
     <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="128" checks="NonEmptyAtclauseDescription"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="132" checks="AbbreviationAsWordInName"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="132" checks="LocalVariableName"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="136" checks="MultipleVariableDeclarations"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="140" checks="AbbreviationAsWordInName"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="173" checks="SummaryJavadoc"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="180" checks="SummaryJavadoc"/>
-    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="220" checks="JavadocMethod"/>
+    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="130" checks="NonEmptyAtclauseDescription"/>
+    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="134" checks="AbbreviationAsWordInName"/>
+    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="134" checks="LocalVariableName"/>
+    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="138" checks="MultipleVariableDeclarations"/>
+    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="142" checks="AbbreviationAsWordInName"/>
+    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="175" checks="SummaryJavadoc"/>
+    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="182" checks="SummaryJavadoc"/>
+    <suppress files="src/test/java/org/openkilda/topo/TestUtils.java" lines="227" checks="JavadocMethod"/>
     <suppress files="src/test/java/org/openkilda/smoke/MininetSmokeTest.java" lines="20" checks="CustomImportOrder"/>
     <suppress files="src/test/java/org/openkilda/smoke/MininetSmokeTest.java" lines="20" checks="AvoidStarImport"/>
     <suppress files="src/test/java/org/openkilda/smoke/MininetSmokeTest.java" lines="23" checks="UnusedImports"/>
@@ -895,12 +885,13 @@
     <suppress files="src/test/java/org/openkilda/atdd/utils/controller/DpIdNotFoundException.java" lines="1" checks="RegexpHeader"/>
     <suppress files="src/test/java/org/openkilda/KafkaUtils.java" lines="19" checks="CustomImportOrder"/>
     <suppress files="src/test/java/org/openkilda/KafkaUtils.java" lines="54" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/KafkaUtils.java" lines="62" checks="JavadocMethod"/>
+    <suppress files="src/test/java/org/openkilda/KafkaUtils.java" lines="63" checks="JavadocMethod"/>
     <suppress files="src/test/java/org/openkilda/KafkaUtils.java" lines="82" checks="JavadocMethod"/>
     <suppress files="src/test/java/org/openkilda/KafkaUtils.java" lines="88" checks="JavadocMethod"/>
     <suppress files="src/test/java/org/openkilda/KafkaUtils.java" lines="102" checks="JavadocMethod"/>
     <suppress files="src/test/java/org/openkilda/KafkaUtils.java" lines="125" checks="AbbreviationAsWordInName"/>
     <suppress files="src/test/java/org/openkilda/KafkaUtils.java" lines="126" checks="AbbreviationAsWordInName"/>
+    <suppress files="src/test/java/org/openkilda/KafkaUtils.java" lines="175" checks="AbbreviationAsWordInName"/>
     <suppress files="src/test/java/org/openkilda/perf/TopologyEnginePerfTest.java" lines="19" checks="CustomImportOrder"/>
     <suppress files="src/test/java/org/openkilda/perf/TopologyEnginePerfTest.java" lines="32" checks="WhitespaceAround"/>
     <suppress files="src/test/java/org/openkilda/perf/MininetPerfTest.java" lines="20" checks="CustomImportOrder"/>

--- a/services/src/atdd/src/test/java/org/openkilda/KafkaParameters.java
+++ b/services/src/atdd/src/test/java/org/openkilda/KafkaParameters.java
@@ -31,7 +31,7 @@ import java.io.InputStream;
 import java.util.Properties;
 
 public class KafkaParameters {
-    private static final String CONFIG_FILE = "atdd.properties";
+    private static final String CONFIG_FILE = "/atdd.properties";
 
     private final KafkaConfig kafkaConfig;
     private final KafkaTopicsConfig kafkaTopicsConfig;

--- a/services/src/atdd/src/test/java/org/openkilda/TopologyCtrlProcessingException.java
+++ b/services/src/atdd/src/test/java/org/openkilda/TopologyCtrlProcessingException.java
@@ -1,0 +1,30 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda;
+
+/**
+ * {@code TopologyCtrlProcessingException} is thrown when a topology ctrl request/response fails to be processed.
+ */
+public class TopologyCtrlProcessingException extends RuntimeException {
+
+    public TopologyCtrlProcessingException(String message) {
+        super(message);
+    }
+
+    public TopologyCtrlProcessingException(String message, Exception cause) {
+        super(message, cause);
+    }
+}

--- a/services/src/atdd/src/test/java/org/openkilda/topo/TestUtils.java
+++ b/services/src/atdd/src/test/java/org/openkilda/topo/TestUtils.java
@@ -19,12 +19,14 @@ import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import org.openkilda.KafkaUtils;
+import org.openkilda.topo.builders.TeTopologyParser;
+import org.openkilda.topo.builders.TestTopologyBuilder;
+import org.openkilda.topo.exceptions.TopologyProcessingException;
+
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import com.google.common.util.concurrent.Uninterruptibles;
-import org.openkilda.topo.builders.TeTopologyParser;
-import org.openkilda.topo.exceptions.TopologyProcessingException;
-import org.openkilda.topo.builders.TestTopologyBuilder;
 
 import java.io.IOException;
 import java.net.URL;
@@ -173,14 +175,14 @@ public class TestUtils {
     /**
      * Default behavior - hit localhost
      */
-    public static void clearEverything() throws InterruptedException {
+    public static void clearEverything() throws InterruptedException, IOException {
         clearEverything("localhost");
     }
 
     /**
      * @param endpoint the kilda endpoint to clear
      */
-    public static void clearEverything(String endpoint) throws InterruptedException {
+    public static void clearEverything(String endpoint) throws InterruptedException, IOException {
         String expected = "{\"nodes\": []}";
         TopologyHelp.DeleteMininetTopology();
         // Give Mininet some time to clear things naturally
@@ -198,6 +200,11 @@ public class TestUtils {
                 break;
             }
         }
+
+        KafkaUtils kafkaUtils = new KafkaUtils();
+        // TODO: the topology name is environment dependent and may be changed during deployment,
+        // so the solution on how to send a Ctrl request should be reconsidered.
+        kafkaUtils.clearTopologyComponentState("wfm", "OFELinkBolt");
 
         Uninterruptibles.sleepUninterruptibly(3, TimeUnit.SECONDS);
     }

--- a/services/wfm/src/checkstyle/checkstyle-suppress-known-issues.xml
+++ b/services/wfm/src/checkstyle/checkstyle-suppress-known-issues.xml
@@ -376,7 +376,7 @@
     <suppress files="src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java" lines="93" checks="AbbreviationAsWordInName"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java" lines="93" checks="MemberName"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java" lines="94" checks="MemberName"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java" lines="95" checks="AbbreviationAsWordInName"/>
+    <suppress files="src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java" lines="96" checks="AbbreviationAsWordInName"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java" lines="160" checks="SummaryJavadoc"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java" lines="173" checks="MissingSwitchDefault"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java" lines="205" checks="Indentation"/>

--- a/services/wfm/src/main/java/org/openkilda/wfm/AbstractBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/AbstractBolt.java
@@ -17,7 +17,7 @@ package org.openkilda.wfm;
 
 import org.openkilda.wfm.error.AbstractException;
 
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.base.BaseRichBolt;
@@ -25,7 +25,7 @@ import org.apache.storm.tuple.Tuple;
 
 import java.util.Map;
 
-@Log4j2
+@Slf4j
 public abstract class AbstractBolt extends BaseRichBolt {
     private OutputCollector output;
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java
@@ -55,6 +55,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.storm.kafka.spout.internal.Timer;
+import org.apache.storm.state.InMemoryKeyValueState;
 import org.apache.storm.state.KeyValueState;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
@@ -584,6 +585,12 @@ public class OFELinkBolt
     @Override
     public String getCtrlStreamId() {
         return STREAM_ID_CTRL;
+    }
+
+    @Override
+    public void clearState() {
+        logger.info("ClearState request has been received.");
+        initState(new InMemoryKeyValueState<>());
     }
 
     @Override


### PR DESCRIPTION
The changes:
- Fix the ISL move detection logic: look for a moved ISL in the removedFromDiscovery list in the case when a non-active link is already created by a portUp event.
- Add support of the clearState control request by OFELinkBolt. And utilize it in ATDD tests to clean up the removedFromDiscovery list. 
- Add ATDD-Staging scenario to cover the case.

Fixes #815 