### PR TITLE
Remove noisy ISL discovery logging

### DIFF
--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
@@ -173,8 +173,6 @@ class RecordHandler implements Runnable {
     }
 
     private void doDiscoverIslCommand(DiscoverIslCommandData command) {
-        logger.debug("Processing send ISL discovery command {}", command);
-
         String switchId = command.getSwitchId();
         context.getPathVerificationService().sendDiscoveryMessage(
                 DatapathId.of(switchId), OFPort.of(command.getPortNo()));

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/pathverification/PathVerificationService.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/pathverification/PathVerificationService.java
@@ -267,7 +267,7 @@ public class PathVerificationService implements IFloodlightModule, IOFMessageLis
                 }
             }
         } catch (Exception exception) {
-            logger.error("Error trying to sendDiscoveryMessage: {}", exception);
+            logger.error(String.format("Unhandled exception in %s", getClass().getName()), exception);
         }
 
         return result;


### PR DESCRIPTION
Remove all logging related to ISL discovery from RecordHandler level.
Same logging is done on PathVerificationService level (into dedicated
logger for ISL)

Close #873 