### PR TITLE
Ansible neo4j tempfix

### DIFF
--- a/services/neo4j/ansible/deploy.yml
+++ b/services/neo4j/ansible/deploy.yml
@@ -4,12 +4,11 @@
   - name: add neo4j apt repo
     shell: "{{ item }}"
     with_items:
-    - wget -O - https://debian.neo4j.org/neotechnology.gpg.key | apt-key add -
+    - wget --no-check-certificate -O - https://debian.neo4j.org/neotechnology.gpg.key | apt-key add -
     - echo 'deb http://debian.neo4j.org/repo stable/' | tee /etc/apt/sources.list.d/neo4j.list
     - apt-get clean
     - apt-get -o Acquire::CompressionTypes::Order=bz2 update
 
-    
   - name: install apt packages
     apt:
       name: "{{ item }}"


### PR DESCRIPTION
As NEO4J maintainers forgot to renew they SSL cert, we have to add the temporary fix, for disabling ssl check. Must be removed as soon, as NEO4 fix this issue