### PR TITLE
Avoid force rediscovery during FL - Event/WFM synchronization process.

### DIFF
--- a/services/src/floodlight-modules/src/checkstyle/checkstyle-suppress-known-issues.xml
+++ b/services/src/floodlight-modules/src/checkstyle/checkstyle-suppress-known-issues.xml
@@ -5,11 +5,7 @@
 
 <suppressions>
     <suppress files="src/main/java/org/openkilda/floodlight/converter/IOFSwitchConverter.java" lines="1" checks="RegexpHeader"/>
-    <suppress files="src/main/java/org/openkilda/floodlight/converter/IOFSwitchConverter.java" lines="5" checks="CustomImportOrder"/>
-    <suppress files="src/main/java/org/openkilda/floodlight/converter/IOFSwitchConverter.java" lines="6" checks="CustomImportOrder"/>
-    <suppress files="src/main/java/org/openkilda/floodlight/converter/IOFSwitchConverter.java" lines="7" checks="CustomImportOrder"/>
-    <suppress files="src/main/java/org/openkilda/floodlight/converter/IOFSwitchConverter.java" lines="8" checks="CustomImportOrder"/>
-    <suppress files="src/main/java/org/openkilda/floodlight/converter/IOFSwitchConverter.java" lines="18" checks="AbbreviationAsWordInName"/>
+    <suppress files="src/main/java/org/openkilda/floodlight/converter/IOFSwitchConverter.java" lines="35" checks="AbbreviationAsWordInName"/>
     <suppress files="src/main/java/org/openkilda/floodlight/converter/IOFSwitchConverter.java" lines="29" checks="WhitespaceAround"/>
     <suppress files="src/main/java/org/openkilda/floodlight/converter/OFFlowStatsConverter.java" lines="23" checks="CustomImportOrder"/>
     <suppress files="src/main/java/org/openkilda/floodlight/converter/OFFlowStatsConverter.java" lines="48" checks="AbbreviationAsWordInName"/>

--- a/services/src/floodlight-modules/src/checkstyle/checkstyle-suppress-known-issues.xml
+++ b/services/src/floodlight-modules/src/checkstyle/checkstyle-suppress-known-issues.xml
@@ -5,7 +5,11 @@
 
 <suppressions>
     <suppress files="src/main/java/org/openkilda/floodlight/converter/IOFSwitchConverter.java" lines="1" checks="RegexpHeader"/>
-    <suppress files="src/main/java/org/openkilda/floodlight/converter/IOFSwitchConverter.java" lines="35" checks="AbbreviationAsWordInName"/>
+    <suppress files="src/main/java/org/openkilda/floodlight/converter/IOFSwitchConverter.java" lines="5" checks="CustomImportOrder"/>
+    <suppress files="src/main/java/org/openkilda/floodlight/converter/IOFSwitchConverter.java" lines="6" checks="CustomImportOrder"/>
+    <suppress files="src/main/java/org/openkilda/floodlight/converter/IOFSwitchConverter.java" lines="7" checks="CustomImportOrder"/>
+    <suppress files="src/main/java/org/openkilda/floodlight/converter/IOFSwitchConverter.java" lines="8" checks="CustomImportOrder"/>
+    <suppress files="src/main/java/org/openkilda/floodlight/converter/IOFSwitchConverter.java" lines="18" checks="AbbreviationAsWordInName"/>
     <suppress files="src/main/java/org/openkilda/floodlight/converter/IOFSwitchConverter.java" lines="29" checks="WhitespaceAround"/>
     <suppress files="src/main/java/org/openkilda/floodlight/converter/OFFlowStatsConverter.java" lines="23" checks="CustomImportOrder"/>
     <suppress files="src/main/java/org/openkilda/floodlight/converter/OFFlowStatsConverter.java" lines="48" checks="AbbreviationAsWordInName"/>

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/kafka/RecordHandlerMock.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/kafka/RecordHandlerMock.java
@@ -17,7 +17,7 @@ package org.openkilda.floodlight.kafka;
 
 import org.openkilda.floodlight.switchmanager.MeterPool;
 import org.openkilda.messaging.command.CommandMessage;
-import org.openkilda.messaging.info.event.SwitchInfoData;
+import org.openkilda.messaging.info.discovery.NetworkDumpSwitchData;
 
 import net.floodlightcontroller.core.IOFSwitch;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 class RecordHandlerMock extends RecordHandler {
-    Map<DatapathId, SwitchInfoData> switchInfoDataOverride;
+    Map<DatapathId, NetworkDumpSwitchData> switchInfoDataOverride;
 
     RecordHandlerMock(ConsumerContext context) {
         super(context, EasyMock.mock(ConsumerRecord.class), new MeterPool());
@@ -39,15 +39,15 @@ class RecordHandlerMock extends RecordHandler {
         doControllerMsg(message);
     }
 
-    public void overrideSwitchInfoData(DatapathId swId, SwitchInfoData infoData) {
+    public void overrideNetworkDumpSwitchData(DatapathId swId, NetworkDumpSwitchData infoData) {
         switchInfoDataOverride.put(swId, infoData);
     }
 
     @Override
-    protected SwitchInfoData buildSwitchInfoData(IOFSwitch sw) {
+    protected NetworkDumpSwitchData buildNetworkDumpSwitchData(IOFSwitch sw) {
         if (switchInfoDataOverride.containsKey(sw.getId())) {
             return switchInfoDataOverride.get(sw.getId());
         }
-        return super.buildSwitchInfoData(sw);
+        return super.buildNetworkDumpSwitchData(sw);
     }
 }

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/kafka/RecordHandlerTest.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/kafka/RecordHandlerTest.java
@@ -32,8 +32,7 @@ import org.openkilda.messaging.Utils;
 import org.openkilda.messaging.command.CommandMessage;
 import org.openkilda.messaging.command.discovery.NetworkCommandData;
 import org.openkilda.messaging.info.InfoMessage;
-import org.openkilda.messaging.info.event.SwitchInfoData;
-import org.openkilda.messaging.info.event.SwitchState;
+import org.openkilda.messaging.info.discovery.NetworkDumpSwitchData;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -133,12 +132,12 @@ public class RecordHandlerTest extends EasyMockSupport {
 
         // Logic in SwitchEventCollector.buildSwitchInfoData is too complicated and requires a lot
         // of mocking code so I replaced it with mock on kafkaMessageCollector.buildSwitchInfoData
-        handler.overrideSwitchInfoData(
+        handler.overrideNetworkDumpSwitchData(
                 DatapathId.of(1),
-                new SwitchInfoData("sw1", SwitchState.ADDED, "127.0.0.1", "localhost", "test switch", "kilda"));
-        handler.overrideSwitchInfoData(
+                new NetworkDumpSwitchData("sw1"));
+        handler.overrideNetworkDumpSwitchData(
                 DatapathId.of(2),
-                new SwitchInfoData("sw2", SwitchState.ADDED, "127.0.0.1", "localhost", "test switch", "kilda"));
+                new NetworkDumpSwitchData("sw2"));
 
         // setup hook for verify that we create new message for producer
         producer.postMessage(eq(consumerContext.getKafkaTopoDiscoTopic()), anyObject(InfoMessage.class));

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/discovery/NetworkDumpBeginMarker.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/discovery/NetworkDumpBeginMarker.java
@@ -17,6 +17,5 @@ package org.openkilda.messaging.info.discovery;
 
 import org.openkilda.messaging.info.InfoData;
 
-public class NetworkSyncBeginMarker extends InfoData {
-
+public class NetworkDumpBeginMarker extends InfoData {
 }

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/discovery/NetworkDumpEndMarker.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/discovery/NetworkDumpEndMarker.java
@@ -17,5 +17,5 @@ package org.openkilda.messaging.info.discovery;
 
 import org.openkilda.messaging.info.InfoData;
 
-public class NetworkSyncEndMarker extends InfoData {
+public class NetworkDumpEndMarker extends InfoData {
 }

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/discovery/NetworkDumpPortData.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/discovery/NetworkDumpPortData.java
@@ -1,0 +1,47 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.messaging.info.discovery;
+
+import static java.util.Objects.requireNonNull;
+
+import org.openkilda.messaging.info.InfoData;
+import org.openkilda.messaging.info.InfoMessage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Value;
+
+/**
+ * Defines the {@link InfoMessage} payload representing a switch port for network sync process.
+ */
+@Value
+@JsonNaming(SnakeCaseStrategy.class)
+public class NetworkDumpPortData extends InfoData {
+    private static final long serialVersionUID = 1L;
+
+    private String switchId;
+
+    private int portNo;
+
+    @JsonCreator
+    public NetworkDumpPortData(@JsonProperty("switch_id") String switchId,
+                               @JsonProperty("port_no") int portNo) {
+        this.switchId = requireNonNull(switchId);
+        this.portNo = portNo;
+    }
+}

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/discovery/NetworkDumpSwitchData.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/discovery/NetworkDumpSwitchData.java
@@ -1,0 +1,45 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.messaging.info.discovery;
+
+import static java.util.Objects.requireNonNull;
+
+import org.openkilda.messaging.info.InfoData;
+import org.openkilda.messaging.info.InfoMessage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Defines the {@link InfoMessage} payload representing a switch for network sync process.
+ */
+@Value
+@Builder
+@JsonNaming(SnakeCaseStrategy.class)
+public class NetworkDumpSwitchData extends InfoData {
+    private static final long serialVersionUID = 1L;
+
+    private String switchId;
+
+    @JsonCreator
+    public NetworkDumpSwitchData(@JsonProperty("switch_id") String switchId) {
+        this.switchId = requireNonNull(switchId);
+    }
+}

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/event/SwitchInfoData.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/event/SwitchInfoData.java
@@ -17,18 +17,22 @@ package org.openkilda.messaging.info.event;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
+import org.openkilda.messaging.info.CacheTimeTag;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.openkilda.messaging.info.CacheTimeTag;
 
 import java.util.Map;
 import java.util.Objects;
 
 /**
  * Defines the payload payload of a Message representing a switch info.
+ * <p/>
+ * TODO: it doesn't look correct that we utilize SwitchInfo DTO class as cache entiries
+ * and also injected cache related fields there.
  */
 @JsonSerialize
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/event/SwitchInfoData.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/event/SwitchInfoData.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Defines the payload payload of a Message representing a switch info.
+ * Defines the payload of a Message representing a switch info.
  * <p/>
  * TODO: it doesn't look correct that we utilize SwitchInfo DTO class as cache entiries
  * and also injected cache related fields there.

--- a/services/wfm/pom.xml
+++ b/services/wfm/pom.xml
@@ -275,6 +275,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>

--- a/services/wfm/src/checkstyle/checkstyle-suppress-known-issues.xml
+++ b/services/wfm/src/checkstyle/checkstyle-suppress-known-issues.xml
@@ -376,7 +376,7 @@
     <suppress files="src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java" lines="93" checks="AbbreviationAsWordInName"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java" lines="93" checks="MemberName"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java" lines="94" checks="MemberName"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java" lines="96" checks="AbbreviationAsWordInName"/>
+    <suppress files="src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java" lines="98" checks="AbbreviationAsWordInName"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java" lines="160" checks="SummaryJavadoc"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java" lines="173" checks="MissingSwitchDefault"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java" lines="205" checks="Indentation"/>
@@ -911,7 +911,7 @@
     <suppress files="src/test/java/org/openkilda/wfm/topology/event/OFELinkBoltFloodTest.java" lines="100" checks="LeftCurly"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/event/OFELinkBoltFloodTest.java" lines="101" checks="NeedBraces"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/event/OFELinkBoltTest.java" lines="1" checks="RegexpHeader"/>
-    <suppress files="src/test/java/org/openkilda/wfm/topology/event/OFELinkBoltTest.java" lines="20" checks="AbbreviationAsWordInName"/>
+    <suppress files="src/test/java/org/openkilda/wfm/topology/event/OFELinkBoltTest.java" lines="54" checks="AbbreviationAsWordInName"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/event/OFELinkBoltTest.java" lines="31" checks="JavadocMethod"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/flow/FlowTopologyTest.java" lines="95" checks="JavadocMethod"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/flow/FlowTopologyTest.java" lines="121" checks="CommentsIndentation"/>

--- a/services/wfm/src/main/java/org/openkilda/wfm/isl/DiscoveryManager.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/isl/DiscoveryManager.java
@@ -240,24 +240,37 @@ public class DiscoveryManager {
      * Handle port up event.
      */
     public void handlePortUp(String switchId, int portId) {
-        DiscoveryLink link;
-        NetworkEndpoint node = new NetworkEndpoint(switchId, portId);
-        List<DiscoveryLink> subjectList = findBySourceSwitch(node);
-
-        if (subjectList.size() != 0) {
+        DiscoveryLink link = registerPort(switchId, portId);
+        if (link.isActive() || link.isDiscoverySuspended()) {
             // Similar to SwitchUp, if we have a PortUp on an existing port, either we are receiving
             // a duplicate, or we missed the port down, or a new discovery has occurred.
             // NB: this should cause an ISL discovery packet to be sent.
             // TODO: we should probably separate "port up" from "do discovery". ATM, one would call
             //          this function just to get the "do discovery" functionality.
-            link = subjectList.get(0);
             logger.info("Port UP on existing node {};  clear failures and ISLFound", link);
             link.deactivate();
         } else {
-            link = new DiscoveryLink(node.getSwitchDpId(), node.getPortId(),
+            logger.info("Port UP on new node: {}", link);
+        }
+    }
+
+    /**
+     * Register a switch port for the discovery process.
+     *
+     * @param switchId the port's switch.
+     * @param portId   the port number.
+     * @return either a link of already registered port or a new one.
+     */
+    public DiscoveryLink registerPort(String switchId, int portId) {
+        NetworkEndpoint node = new NetworkEndpoint(switchId, portId);
+        List<DiscoveryLink> subjectList = findBySourceSwitch(node);
+        if (!subjectList.isEmpty()) {
+            return subjectList.get(0);
+        } else {
+            DiscoveryLink link = new DiscoveryLink(switchId, portId,
                     this.islHealthCheckInterval, this.maxAttempts);
             pollQueue.add(link);
-            logger.info("New {}", link);
+            return link;
         }
     }
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java
@@ -29,8 +29,10 @@ import org.openkilda.messaging.ctrl.AbstractDumpState;
 import org.openkilda.messaging.ctrl.state.OFELinkBoltState;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.InfoMessage;
-import org.openkilda.messaging.info.discovery.NetworkSyncBeginMarker;
-import org.openkilda.messaging.info.discovery.NetworkSyncEndMarker;
+import org.openkilda.messaging.info.discovery.NetworkDumpBeginMarker;
+import org.openkilda.messaging.info.discovery.NetworkDumpEndMarker;
+import org.openkilda.messaging.info.discovery.NetworkDumpPortData;
+import org.openkilda.messaging.info.discovery.NetworkDumpSwitchData;
 import org.openkilda.messaging.info.event.IslChangeType;
 import org.openkilda.messaging.info.event.IslInfoData;
 import org.openkilda.messaging.info.event.PathNode;
@@ -100,7 +102,8 @@ public class OFELinkBolt
     private static final int BOLT_TICK_INTERVAL = 1;
 
     private static final String STREAM_ID_CTRL = "ctrl";
-    private static final String STATE_ID_DISCOVERY = "discovery-manager";
+    @VisibleForTesting
+    static final String STATE_ID_DISCOVERY = "discovery-manager";
     static final String TOPO_ENG_STREAM = "topo.eng";
     static final String SPEAKER_STREAM = "speaker";
 
@@ -122,7 +125,8 @@ public class OFELinkBolt
     private String dumpRequestCorrelationId = null;
     private float dumpRequestTimeout;
     private Timer dumpRequestTimer;
-    private State state = State.NEED_SYNC;
+    @VisibleForTesting
+    State state = State.NEED_SYNC;
 
     /**
      * Default constructor .. default health check frequency
@@ -348,7 +352,7 @@ public class OFELinkBolt
 
     private void dispatchWaitSync(Tuple tuple, InfoMessage infoMessage) {
         InfoData data = infoMessage.getData();
-        if (data instanceof NetworkSyncBeginMarker) {
+        if (data instanceof NetworkDumpBeginMarker) {
             if (dumpRequestCorrelationId.equals(infoMessage.getCorrelationId())) {
                 logger.info("Got response on network sync request, start processing network events");
                 enableDumpRequestTimer();
@@ -366,11 +370,16 @@ public class OFELinkBolt
 
     private void dispatchSyncInProgress(Tuple tuple, InfoMessage infoMessage) {
         InfoData data = infoMessage.getData();
-        if (data instanceof SwitchInfoData) {
-            handleSwitchEvent(tuple, (SwitchInfoData) data);
-        } else if (data instanceof PortInfoData) {
-            handlePortEvent(tuple, (PortInfoData) data);
-        } else if (data instanceof NetworkSyncEndMarker) {
+        if (data instanceof NetworkDumpSwitchData) {
+            logger.info("DISCO Sync: switch {}", data);
+            // no sync actions required for switches.
+
+        } else if (data instanceof NetworkDumpPortData) {
+            logger.info("DISCO Sync: port {}", data);
+            NetworkDumpPortData portData = (NetworkDumpPortData) data;
+            discovery.registerPort(portData.getSwitchId(), portData.getPortNo());
+
+        } else if (data instanceof NetworkDumpEndMarker) {
             logger.info("End of network sync stream received");
             stateTransition(State.MAIN);
         } else {
@@ -623,7 +632,8 @@ public class OFELinkBolt
         return this.discoveryQueue;
     }
 
-    private enum State {
+    @VisibleForTesting
+    enum State {
         NEED_SYNC,
         WAIT_SYNC,
         SYNC_IN_PROGRESS,

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/event/OFELinkBolt.java
@@ -371,11 +371,11 @@ public class OFELinkBolt
     private void dispatchSyncInProgress(Tuple tuple, InfoMessage infoMessage) {
         InfoData data = infoMessage.getData();
         if (data instanceof NetworkDumpSwitchData) {
-            logger.info("DISCO Sync: switch {}", data);
+            logger.info("Event/WFM Sync: switch {}", data);
             // no sync actions required for switches.
 
         } else if (data instanceof NetworkDumpPortData) {
-            logger.info("DISCO Sync: port {}", data);
+            logger.info("Event/WFM Sync: port {}", data);
             NetworkDumpPortData portData = (NetworkDumpPortData) data;
             discovery.registerPort(portData.getSwitchId(), portData.getPortNo());
 

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/event/OFELinkBoltTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/event/OFELinkBoltTest.java
@@ -1,26 +1,63 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package org.openkilda.wfm.topology.event;
 
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.openkilda.messaging.Utils.DEFAULT_CORRELATION_ID;
+import static org.openkilda.wfm.topology.event.OFELinkBolt.STATE_ID_DISCOVERY;
+
+import org.openkilda.messaging.Destination;
+import org.openkilda.messaging.info.InfoMessage;
+import org.openkilda.messaging.info.event.PortChangeType;
+import org.openkilda.messaging.info.event.PortInfoData;
+import org.openkilda.messaging.model.DiscoveryLink;
 import org.openkilda.wfm.AbstractStormTest;
 import org.openkilda.wfm.error.ConfigurationException;
 import org.openkilda.wfm.protocol.KafkaMessage;
 import org.openkilda.wfm.topology.OutputCollectorMock;
+import org.openkilda.wfm.topology.event.OFELinkBolt.State;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.storm.state.InMemoryKeyValueState;
+import org.apache.storm.state.KeyValueState;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.TupleImpl;
 import org.apache.storm.tuple.Values;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.kohsuke.args4j.CmdLineException;
 import org.mockito.Mockito;
 
+import java.util.LinkedList;
+
 public class OFELinkBoltTest extends AbstractStormTest {
 
     private static final Integer TASK_ID_BOLT = 0;
     private static final String STREAM_ID_INPUT = "input";
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
     private TopologyContext context;
     private OFELinkBolt bolt;
     private OutputCollectorMock outputDelegate;
@@ -54,5 +91,33 @@ public class OFELinkBoltTest extends AbstractStormTest {
         bolt.doWork(tuple);
 
         Mockito.verify(outputDelegate).ack(tuple);
+    }
+
+    @Test
+    public void shouldNotResetDiscoveryStatusOnSync() throws JsonProcessingException {
+        // given
+        DiscoveryLink testLink = new DiscoveryLink("sw1", 2, "sw2", 2, 0, -1, true);
+
+        KeyValueState<String, Object> boltState = new InMemoryKeyValueState<>();
+        boltState.put(STATE_ID_DISCOVERY, new LinkedList<DiscoveryLink>(singletonList(testLink)));
+        bolt.initState(boltState);
+
+        // set the state to WAIT_SYNC
+        bolt.state = State.SYNC_IN_PROGRESS;
+
+        // when
+        PortInfoData dumpPortData = new PortInfoData("sw1", 2, PortChangeType.UP);
+        InfoMessage dumpBeginMessage = new InfoMessage(dumpPortData, 0, DEFAULT_CORRELATION_ID, Destination.WFM);
+        Tuple tuple = new TupleImpl(context, new Values(objectMapper.writeValueAsString(dumpBeginMessage)),
+                TASK_ID_BOLT, STREAM_ID_INPUT);
+        bolt.doWork(tuple);
+
+        // then
+        @SuppressWarnings("unchecked")
+        LinkedList<DiscoveryLink> stateAfterSync = (LinkedList<DiscoveryLink>) boltState.get(STATE_ID_DISCOVERY);
+        assertThat(stateAfterSync, Matchers.contains(
+                allOf(hasProperty("source", hasProperty("datapath", is("sw1"))),
+                        hasProperty("destination", hasProperty("datapath", is("sw2"))),
+                        hasProperty("active", is(true)))));
     }
 }

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/event/OFELinkBoltTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/event/OFELinkBoltTest.java
@@ -17,6 +17,7 @@ package org.openkilda.wfm.topology.event;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -43,7 +44,6 @@ import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.TupleImpl;
 import org.apache.storm.tuple.Values;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.kohsuke.args4j.CmdLineException;
@@ -115,7 +115,7 @@ public class OFELinkBoltTest extends AbstractStormTest {
         // then
         @SuppressWarnings("unchecked")
         LinkedList<DiscoveryLink> stateAfterSync = (LinkedList<DiscoveryLink>) boltState.get(STATE_ID_DISCOVERY);
-        assertThat(stateAfterSync, Matchers.contains(
+        assertThat(stateAfterSync, contains(
                 allOf(hasProperty("source", hasProperty("datapath", is("sw1"))),
                         hasProperty("destination", hasProperty("datapath", is("sw2"))),
                         hasProperty("active", is(true)))));


### PR DESCRIPTION
The changes:
- Introduce dedicated payload entities for messages used in FL - Event/WFM synchronization: NetworkDumpSwitchData, NetworkDumpPortData.
- Use NetworkDumpSwitchData, NetworkDumpPortData as the result of execution of NetworkCommandData in FL.
- Modify OFELinkBolt to do not deactivate ISLs on NetworkDumpPortData.

Fixes #784