### PR TITLE
Bump JDK version to 8u181

### DIFF
--- a/base/kilda-base-ubuntu/Dockerfile
+++ b/base/kilda-base-ubuntu/Dockerfile
@@ -47,7 +47,15 @@ ADD config/hosts /etc/ansible/hosts
 RUN add-apt-repository ppa:webupd8team/java \
     && apt-get update
 RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-get install -y oracle-java8-installer
+RUN apt-get install -y oracle-java8-installer || ( \
+    sed -i \
+        -e 's|JAVA_VERSION=8u171|JAVA_VERSION=8u181|' \
+        -e 's|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u171-b11/512cd62ec5174c3487ac17c61aaa89e8/|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/|' \
+        -e 's|SHA256SUM_TGZ="b6dd2837efaaec4109b36cfbb94a774db100029f98b0d78be68c27bec0275982"|SHA256SUM_TGZ="1845567095bfbfebd42ed0d09397939796d05456290fb20a83c476ba09f991d3"|' \
+        -e 's|J_DIR=jdk1.8.0_171|J_DIR=jdk1.8.0_181|' \
+        /var/lib/dpkg/info/oracle-java8-installer.config /var/lib/dpkg/info/oracle-java8-installer.postinst; \
+    apt-get install -y)
+
 ENV JAVA_VER 8
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 RUN echo "export JAVA_HOME=/usr/lib/jvm/java-8-oracle" >> ~/.bashrc


### PR DESCRIPTION
Due to upstream update (removing version 8u171 from download servers),
oracle-java8-installer become corrupted.

Hack download link and version number inside it, to point it to version
8u181.