### PR TITLE
Revert "As NEO4J maintainers forgot to renew they SSL cert, we have t…

### DIFF
--- a/services/neo4j/ansible/deploy.yml
+++ b/services/neo4j/ansible/deploy.yml
@@ -4,7 +4,7 @@
   - name: add neo4j apt repo
     shell: "{{ item }}"
     with_items:
-    - wget --no-check-certificate -O - https://debian.neo4j.org/neotechnology.gpg.key | apt-key add -
+    - wget -O - https://debian.neo4j.org/neotechnology.gpg.key | apt-key add -
     - echo 'deb http://debian.neo4j.org/repo stable/' | tee /etc/apt/sources.list.d/neo4j.list
     - apt-get clean
     - apt-get -o Acquire::CompressionTypes::Order=bz2 update


### PR DESCRIPTION
…o add temporary fix, for disabling ssl check. Must be removed as soon, as NEO4 fix this issue"

Certificate have been updated:
notBefore=May  9 00:00:00 2018 GMT
notAfter=Jun  9 12:00:00 2019 GMT

This reverts commit daa7205509b31be529a6b1db14629bb02e2d1c56.