### PR TITLE
Add validation of flow ports against conflicts with ISL ports.

### DIFF
--- a/services/src/atdd/src/checkstyle/checkstyle-suppress-known-issues.xml
+++ b/services/src/atdd/src/checkstyle/checkstyle-suppress-known-issues.xml
@@ -822,59 +822,10 @@
     <suppress files="src/test/java/org/openkilda/atdd/floodlight/HeartBeatTest.java" lines="41" checks="JavadocMethod"/>
     <suppress files="src/test/java/org/openkilda/atdd/floodlight/AvailabilityCtrl.java" lines="1" checks="RegexpHeader"/>
     <suppress files="src/test/java/org/openkilda/atdd/floodlight/KafkaBreakException.java" lines="1" checks="RegexpHeader"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="23" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="26" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="27" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="28" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="29" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="30" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="31" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="33" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="34" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="35" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="36" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="66" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="67" checks="MethodName"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="76" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="92" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="106" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="119" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="139" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="155" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="156" checks="LineLength"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="160" checks="VariableDeclarationUsageDistance"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="180" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="202" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="242" checks="LineLength"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="259" checks="WhitespaceAround"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="259" checks="ParenPad"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="260" checks="WhitespaceAround"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="260" checks="ParenPad"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="266" checks="WhitespaceAfter"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="266" checks="WhitespaceAfter"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="266" checks="WhitespaceAfter"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="267" checks="WhitespaceAfter"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="267" checks="WhitespaceAfter"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="267" checks="WhitespaceAfter"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="310" checks="WhitespaceAround"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="310" checks="ParenPad"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="311" checks="WhitespaceAround"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="311" checks="ParenPad"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="317" checks="WhitespaceAfter"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="317" checks="WhitespaceAfter"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="317" checks="WhitespaceAfter"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="318" checks="WhitespaceAfter"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="318" checks="WhitespaceAfter"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="318" checks="WhitespaceAfter"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="338" checks="NeedBraces"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="340" checks="NeedBraces"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="353" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="362" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="374" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="383" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="398" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="435" checks="SummaryJavadoc"/>
-    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="438" checks="NonEmptyAtclauseDescription"/>
+    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="59" checks="MethodName"/>
+    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="148" checks="LineLength"/>
+    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="152" checks="VariableDeclarationUsageDistance"/>
+    <suppress files="src/test/java/org/openkilda/atdd/FlowCrudBasicRunTest.java" lines="234" checks="LineLength"/>
     <suppress files="src/test/java/org/openkilda/atdd/utils/RestQueryException.java" lines="1" checks="RegexpHeader"/>
     <suppress files="src/test/java/org/openkilda/atdd/utils/controller/ControllerUtils.java" lines="1" checks="RegexpHeader"/>
     <suppress files="src/test/java/org/openkilda/atdd/utils/controller/ControllerUtils.java" lines="40" checks="JavadocMethod"/>

--- a/services/src/atdd/src/test/resources/features/mvp.1/FlowCrudBasicRun.feature
+++ b/services/src/atdd/src/test/resources/features/mvp.1/FlowCrudBasicRun.feature
@@ -36,11 +36,11 @@ Feature: Basic Flow CRUD
     Examples:
       | flow_id |      source_switch      | source_port | source_vlan |   destination_switch    | destination_port | destination_vlan | bandwidth |
       # flows with transit vlans and intermediate switches
-      | c3none  | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:05 |         2        |        0         |   10000   |
+      | c3none  | de:ad:be:ef:00:00:00:03 |      11      |      0      | de:ad:be:ef:00:00:00:05 |         12        |        0         |   10000   |
       # flows with transit vlans and without intermediate switches
-      | c2none  | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:04 |         2        |        0         |   10000   |
+      | c2none  | de:ad:be:ef:00:00:00:03 |      11      |      0      | de:ad:be:ef:00:00:00:04 |         12        |        0         |   10000   |
       # flows without transit vlans and intermediate switches
-      | c1none  | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:03 |         2        |        0         |   10000   |
+      | c1none  | de:ad:be:ef:00:00:00:03 |      11      |      0      | de:ad:be:ef:00:00:00:03 |         12        |        0         |   10000   |
 
 
 
@@ -76,10 +76,10 @@ Feature: Basic Flow CRUD
     Examples:
       | flow_id |      source_switch      | source_port | source_vlan |   destination_switch    | destination_port | destination_vlan | bandwidth |
       # flows with transit vlans and intermediate switches
-      | c3none  | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:05 |         2        |        0         |   10000   |
-      | c3push  | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:05 |         2        |       100        |   10000   |
-      | c3pop   | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:05 |         2        |        0         |   10000   |
-      | c3swap  | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:05 |         2        |       200        |   10000   |
+      | c3none  | de:ad:be:ef:00:00:00:03 |      11      |      0      | de:ad:be:ef:00:00:00:05 |         12        |        0         |   10000   |
+      | c3push  | de:ad:be:ef:00:00:00:03 |      11      |      0      | de:ad:be:ef:00:00:00:05 |         12        |       100        |   10000   |
+      | c3pop   | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:05 |         12        |        0         |   10000   |
+      | c3swap  | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:05 |         12        |       200        |   10000   |
 
   @MVP1 @CRUD_CREATE
   Scenario Outline: Flow Creation - flows with transit vlans and without intermediate switches
@@ -110,10 +110,10 @@ Feature: Basic Flow CRUD
     Examples:
       | flow_id |      source_switch      | source_port | source_vlan |   destination_switch    | destination_port | destination_vlan | bandwidth |
       # flows with transit vlans and without intermediate switches
-      | c2none  | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:04 |         2        |        0         |   10000   |
-      | c2push  | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:04 |         2        |       100        |   10000   |
-      | c2pop   | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:04 |         2        |        0         |   10000   |
-      | c2swap  | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:04 |         2        |       200        |   10000   |
+      | c2none  | de:ad:be:ef:00:00:00:03 |      11      |      0      | de:ad:be:ef:00:00:00:04 |         12        |        0         |   10000   |
+      | c2push  | de:ad:be:ef:00:00:00:03 |      11      |      0      | de:ad:be:ef:00:00:00:04 |         12        |       100        |   10000   |
+      | c2pop   | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:04 |         12        |        0         |   10000   |
+      | c2swap  | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:04 |         12        |       200        |   10000   |
 
   @MVP1 @CRUD_CREATE
   Scenario Outline: Flow Creation - flows without transit vlans and intermediate switches
@@ -144,10 +144,10 @@ Feature: Basic Flow CRUD
     Examples:
       | flow_id |      source_switch      | source_port | source_vlan |   destination_switch    | destination_port | destination_vlan | bandwidth |
       # flows without transit vlans and intermediate switches
-      | c1none  | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:03 |         2        |        0         |   10000   |
-      | c1push  | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:03 |         2        |       100        |   10000   |
-      | c1pop   | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:03 |         2        |        0         |   10000   |
-      | c1swap  | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:03 |         2        |       200        |   10000   |
+      | c1none  | de:ad:be:ef:00:00:00:03 |      11      |      0      | de:ad:be:ef:00:00:00:03 |         12        |        0         |   10000   |
+      | c1push  | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:03 |         12        |       100        |   10000   |
+      | c1pop   | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:03 |         12        |        0         |   10000   |
+      | c1swap  | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:03 |         12        |       200        |   10000   |
 
 
   @MVP1 @CRUD_UPDATE
@@ -172,23 +172,23 @@ Feature: Basic Flow CRUD
     Examples:
       | flow_id  |      source_switch      | source_port | source_vlan |   destination_switch    | destination_port | destination_vlan | bandwidth  | new_bandwidth |
       # flows with transit vlans and intermediate switches
-      | u3none   | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:05 |         2        |        0         |   10000    |     20000     |
-      | u3push   | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:05 |         2        |       100        |   10000    |     20000     |
-      | u3pop    | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:05 |         2        |        0         |   10000    |     20000     |
-      | u3swap   | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:05 |         2        |       200        |   10000    |     20000     |
-      | u3bwdown | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:05 |         2        |       200        |   10000000 |    1000000    |
+      | u3none   | de:ad:be:ef:00:00:00:03 |      11      |      0      | de:ad:be:ef:00:00:00:05 |         12        |        0         |   10000    |     20000     |
+      | u3push   | de:ad:be:ef:00:00:00:03 |      11      |      0      | de:ad:be:ef:00:00:00:05 |         12        |       100        |   10000    |     20000     |
+      | u3pop    | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:05 |         12        |        0         |   10000    |     20000     |
+      | u3swap   | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:05 |         12        |       200        |   10000    |     20000     |
+      | u3bwdown | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:05 |         12        |       200        |   10000000 |    1000000    |
       # flows with transit vlans and without intermediate switches
-      | u2none   | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:04 |         2        |        0         |   10000    |     20000     |
-      | u2push   | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:04 |         2        |       100        |   10000    |     20000     |
-      | u2pop    | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:04 |         2        |        0         |   10000    |     20000     |
-      | u2swap   | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:04 |         2        |       200        |   10000    |     20000     |
-      | u2bwdown | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:04 |         2        |       200        |   10000000 |    1000000    |
+      | u2none   | de:ad:be:ef:00:00:00:03 |      11      |      0      | de:ad:be:ef:00:00:00:04 |         12        |        0         |   10000    |     20000     |
+      | u2push   | de:ad:be:ef:00:00:00:03 |      11      |      0      | de:ad:be:ef:00:00:00:04 |         12        |       100        |   10000    |     20000     |
+      | u2pop    | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:04 |         12        |        0         |   10000    |     20000     |
+      | u2swap   | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:04 |         12        |       200        |   10000    |     20000     |
+      | u2bwdown | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:04 |         12        |       200        |   10000000 |    1000000    |
       # flows without transit vlans and intermediate switches
-      | u1none   | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:03 |         2        |        0         |   10000    |     20000     |
-      | u1push   | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:03 |         2        |       100        |   10000    |     20000     |
-      | u1pop    | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:03 |         2        |        0         |   10000    |     20000     |
-      | u1swap   | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:03 |         2        |       200        |   10000    |     20000     |
-      | u1bwdown | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:03 |         2        |       200        |   10000000 |    1000000    |
+      | u1none   | de:ad:be:ef:00:00:00:03 |      11      |      0      | de:ad:be:ef:00:00:00:03 |         12        |        0         |   10000    |     20000     |
+      | u1push   | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:03 |         12        |       100        |   10000    |     20000     |
+      | u1pop    | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:03 |         12        |        0         |   10000    |     20000     |
+      | u1swap   | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:03 |         12        |       200        |   10000    |     20000     |
+      | u1bwdown | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:03 |         12        |       200        |   10000000 |    1000000    |
 
 
   @MVP1.1 @CRUD_NEGATIVE
@@ -206,14 +206,36 @@ Feature: Basic Flow CRUD
 
     Examples:
       | flow_id  |      source_switch      | source_port | source_vlan |   destination_switch    | destination_port | destination_vlan | bandwidth |
-      | vc2none  | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:04 |         2        |        0         |   10000   |
-      | vc2push1 | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:04 |         2        |       100        |   10000   |
-      | vc2push2 | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:04 |         2        |       200        |   10000   |
-      | vc2pop1  | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:04 |         2        |        0         |   10000   |
-      | vc2pop2  | de:ad:be:ef:00:00:00:03 |      1      |     200     | de:ad:be:ef:00:00:00:04 |         2        |        0         |   10000   |
-      | vs2swap1 | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:04 |         2        |       200        |   10000   |
-      | vs2swap2 | de:ad:be:ef:00:00:00:03 |      1      |     200     | de:ad:be:ef:00:00:00:04 |         2        |       100        |   10000   |
-      | vs2swap3 | de:ad:be:ef:00:00:00:03 |      1      |     200     | de:ad:be:ef:00:00:00:04 |         2        |       200        |   10000   |
+      | vc2none  | de:ad:be:ef:00:00:00:03 |      11      |      0      | de:ad:be:ef:00:00:00:04 |         12        |        0         |   10000   |
+      | vc2push1 | de:ad:be:ef:00:00:00:03 |      11      |      0      | de:ad:be:ef:00:00:00:04 |         12        |       100        |   10000   |
+      | vc2push2 | de:ad:be:ef:00:00:00:03 |      11      |      0      | de:ad:be:ef:00:00:00:04 |         12        |       200        |   10000   |
+      | vc2pop1  | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:04 |         12        |        0         |   10000   |
+      | vc2pop2  | de:ad:be:ef:00:00:00:03 |      11      |     200     | de:ad:be:ef:00:00:00:04 |         12        |        0         |   10000   |
+      | vs2swap1 | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:04 |         12        |       200        |   10000   |
+      | vs2swap2 | de:ad:be:ef:00:00:00:03 |      11      |     200     | de:ad:be:ef:00:00:00:04 |         12        |       100        |   10000   |
+      | vs2swap3 | de:ad:be:ef:00:00:00:03 |      11      |     200     | de:ad:be:ef:00:00:00:04 |         12        |       200        |   10000   |
+
+  @MVP1.1 @CRUD_NEGATIVE
+  Scenario Outline: Flow Creation Negative Scenario for ISL Port Conflicts
+
+  This scenario checks that no new flow with ports conflicting with ISL ports could be installed
+
+    Given a clean controller
+    And a nonrandom linear topology of 7 switches
+    And topology contains 12 links
+    And a clean flow topology
+    Then flow <flow_id>_conflict creation request with <source_switch> <source_port> <source_vlan> and <destination_switch> <destination_port> <destination_vlan> and <bandwidth> is failed
+
+    Examples:
+      | flow_id  |      source_switch      | source_port | source_vlan |   destination_switch    | destination_port | destination_vlan | bandwidth |
+      | ic2none  | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:04 |         12       |        0         |   10000   |
+      | ic2push1 | de:ad:be:ef:00:00:00:03 |      11     |      0      | de:ad:be:ef:00:00:00:04 |         2        |       100        |   10000   |
+      | ic2push2 | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:04 |         2        |       200        |   10000   |
+      | ic2pop1  | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:04 |         12       |        0         |   10000   |
+      | ic2pop2  | de:ad:be:ef:00:00:00:03 |      11     |     200     | de:ad:be:ef:00:00:00:04 |         2        |        0         |   10000   |
+      | is2swap1 | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:04 |         12       |       200        |   10000   |
+      | is2swap2 | de:ad:be:ef:00:00:00:03 |      11     |     200     | de:ad:be:ef:00:00:00:04 |         2        |       100        |   10000   |
+      | is2swap3 | de:ad:be:ef:00:00:00:03 |      1      |     200     | de:ad:be:ef:00:00:00:04 |         2        |       200        |   10000   |
 
   @MVP1 @CRUD_CREATE
   Scenario Outline: Flow Creation - unmetered flows with transit vlans and intermediate switches
@@ -240,7 +262,7 @@ Feature: Basic Flow CRUD
 
     Examples:
       | flow_id |      source_switch      | source_port | source_vlan |   destination_switch    | destination_port | destination_vlan | bandwidth |
-      | uf3none | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:05 |         2        |        0         |     0     |
-      | uf3push | de:ad:be:ef:00:00:00:03 |      1      |      0      | de:ad:be:ef:00:00:00:05 |         2        |       100        |     0     |
-      | uf3pop  | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:05 |         2        |        0         |     0     |
-      | uf3swap | de:ad:be:ef:00:00:00:03 |      1      |     100     | de:ad:be:ef:00:00:00:05 |         2        |       200        |     0     |
+      | uf3none | de:ad:be:ef:00:00:00:03 |      11      |      0      | de:ad:be:ef:00:00:00:05 |         12        |        0         |     0     |
+      | uf3push | de:ad:be:ef:00:00:00:03 |      11      |      0      | de:ad:be:ef:00:00:00:05 |         12        |       100        |     0     |
+      | uf3pop  | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:05 |         12        |        0         |     0     |
+      | uf3swap | de:ad:be:ef:00:00:00:03 |      11      |     100     | de:ad:be:ef:00:00:00:05 |         12        |       200        |     0     |

--- a/services/src/atdd/src/test/resources/features/mvp.1/FlowFFR.feature
+++ b/services/src/atdd/src/test/resources/features/mvp.1/FlowFFR.feature
@@ -149,8 +149,8 @@ Feature: Flow failover, failure and recovery
   Examples:
     | flow_id |      source_switch      | source_port | source_vlan |   destination_switch    | destination_port | destination_vlan | bandwidth | split_state |
       # flow with transit vlans and intermediate switches
-    | c3swap  | 00:00:00:00:00:00:00:02 |      1      |     103     | 00:00:00:00:00:00:00:07 |         2        |       203        |   10000   |    DOWN     |
+    | c3swap  | 00:00:00:00:00:00:00:02 |      11      |     103     | 00:00:00:00:00:00:00:07 |         12        |       203        |   10000   |    DOWN     |
       # flow with transit vlans and without intermediate switches
-    | c2swap  | 00:00:00:00:00:00:00:05 |      1      |     102     | 00:00:00:00:00:00:00:06 |         2        |       202        |   10000   |    DOWN     |
+    | c2swap  | 00:00:00:00:00:00:00:05 |      11      |     102     | 00:00:00:00:00:00:00:06 |         12        |       202        |   10000   |    DOWN     |
       # flow without transit vlans and intermediate switches
-    | c1swap  | 00:00:00:00:00:00:00:04 |      1      |     101     | 00:00:00:00:00:00:00:04 |         2        |       201        |   10000   |     UP      |
+    | c1swap  | 00:00:00:00:00:00:00:04 |      11      |     101     | 00:00:00:00:00:00:00:04 |         12        |       201        |   10000   |     UP      |

--- a/services/src/atdd/src/test/resources/features/mvp.1/FlowPath.feature
+++ b/services/src/atdd/src/test/resources/features/mvp.1/FlowPath.feature
@@ -14,12 +14,12 @@ Feature: Flow path computation tests
     And a multi-path topology
     And topology contains 16 links
     Then all links have available bandwidth 9000000
-    When flow pcet creation request with 00:00:00:00:00:00:00:02 1 0 and 00:00:00:00:00:00:00:07 2 0 and 1000000 is successful
-    And flow pcet with 00:00:00:00:00:00:00:02 1 0 and 00:00:00:00:00:00:00:07 2 0 and 1000000 could be created
+    When flow pcet creation request with 00:00:00:00:00:00:00:02 11 0 and 00:00:00:00:00:00:00:07 12 0 and 1000000 is successful
+    And flow pcet with 00:00:00:00:00:00:00:02 11 0 and 00:00:00:00:00:00:00:07 12 0 and 1000000 could be created
     Then shortest path links available bandwidth have available bandwidth 8000000
-    When flow pcet with 00:00:00:00:00:00:00:02 1 0 and 00:00:00:00:00:00:00:07 2 0 and 1000000 could be updated with 2000000
+    When flow pcet with 00:00:00:00:00:00:00:02 11 0 and 00:00:00:00:00:00:00:07 12 0 and 1000000 could be updated with 2000000
     Then shortest path links available bandwidth have available bandwidth 7000000
-    When flow pcet with 00:00:00:00:00:00:00:02 1 0 and 00:00:00:00:00:00:00:07 2 0 and 2000000 could be deleted
+    When flow pcet with 00:00:00:00:00:00:00:02 11 0 and 00:00:00:00:00:00:00:07 12 0 and 2000000 could be deleted
     Then all links have available bandwidth 9000000
 
 
@@ -36,11 +36,11 @@ Feature: Flow path computation tests
     And a multi-path topology
     And topology contains 16 links
     Then all links have available bandwidth 9000000
-    When flow pcel1 creation request with 00:00:00:00:00:00:00:02 1 0 and 00:00:00:00:00:00:00:07 2 0 and 5000000 is successful
-    And flow pcel1 with 00:00:00:00:00:00:00:02 1 0 and 00:00:00:00:00:00:00:07 2 0 and 5000000 could be created
+    When flow pcel1 creation request with 00:00:00:00:00:00:00:02 11 0 and 00:00:00:00:00:00:00:07 12 0 and 5000000 is successful
+    And flow pcel1 with 00:00:00:00:00:00:00:02 11 0 and 00:00:00:00:00:00:00:07 12 0 and 5000000 could be created
     Then shortest path links available bandwidth have available bandwidth 4000000
-    When flow pcel2 creation request with 00:00:00:00:00:00:00:02 1 0 and 00:00:00:00:00:00:00:07 2 0 and 5000000 is successful
-    And flow pcel2 with 00:00:00:00:00:00:00:02 1 0 and 00:00:00:00:00:00:00:07 2 0 and 5000000 could be created
+    When flow pcel2 creation request with 00:00:00:00:00:00:00:02 11 0 and 00:00:00:00:00:00:00:07 12 0 and 5000000 is successful
+    And flow pcel2 with 00:00:00:00:00:00:00:02 11 0 and 00:00:00:00:00:00:00:07 12 0 and 5000000 could be created
     Then alternative path links available bandwidth have available bandwidth 4000000
 
 
@@ -57,11 +57,11 @@ Feature: Flow path computation tests
     And a multi-path topology
     And topology contains 16 links
     Then all links have available bandwidth 9000000
-    When flow pceb1 creation request with 00:00:00:00:00:00:00:02 1 0 and 00:00:00:00:00:00:00:07 2 0 and 9000000 is successful
-    And flow pceb1 with 00:00:00:00:00:00:00:02 1 0 and 00:00:00:00:00:00:00:07 2 0 and 9000000 could be created
-    When flow pceb2 creation request with 00:00:00:00:00:00:00:02 1 0 and 00:00:00:00:00:00:00:07 2 0 and 9000000 is successful
-    And flow pceb2 with 00:00:00:00:00:00:00:02 1 0 and 00:00:00:00:00:00:00:07 2 0 and 9000000 could be created
-    When flow pceb3_failed creation request with 00:00:00:00:00:00:00:02 1 0 and 00:00:00:00:00:00:00:07 2 0 and 1 is failed
+    When flow pceb1 creation request with 00:00:00:00:00:00:00:02 11 0 and 00:00:00:00:00:00:00:07 12 0 and 9000000 is successful
+    And flow pceb1 with 00:00:00:00:00:00:00:02 11 0 and 00:00:00:00:00:00:00:07 2 0 and 9000000 could be created
+    When flow pceb2 creation request with 00:00:00:00:00:00:00:02 11 0 and 00:00:00:00:00:00:00:07 12 0 and 9000000 is successful
+    And flow pceb2 with 00:00:00:00:00:00:00:02 11 0 and 00:00:00:00:00:00:00:07 12 0 and 9000000 could be created
+    When flow pceb3_failed creation request with 00:00:00:00:00:00:00:02 11 0 and 00:00:00:00:00:00:00:07 12 0 and 1 is failed
     Then flows count is 2
 
   @MVP1
@@ -76,6 +76,6 @@ Feature: Flow path computation tests
     And a multi-path topology
     And topology contains 16 links
     Then all links have available bandwidth 9000000
-    And flow pceb1 with 00:00:00:00:00:00:00:02 1 0 and 00:00:00:00:00:00:00:07 2 0 and 9000000 path correct
-    When flow pceb1 creation request with 00:00:00:00:00:00:00:02 1 0 and 00:00:00:00:00:00:00:07 2 0 and 9000000 is successful
-    And flow pceb1 with 00:00:00:00:00:00:00:02 1 0 and 00:00:00:00:00:00:00:07 2 0 and 9000000 could be created
+    And flow pceb1 with 00:00:00:00:00:00:00:02 11 0 and 00:00:00:00:00:00:00:07 12 0 and 9000000 path correct
+    When flow pceb1 creation request with 00:00:00:00:00:00:00:02 11 0 and 00:00:00:00:00:00:00:07 12 0 and 9000000 is successful
+    And flow pceb1 with 00:00:00:00:00:00:00:02 11 0 and 00:00:00:00:00:00:00:07 12 0 and 9000000 could be created

--- a/services/src/atdd/src/test/resources/features/mvp.1/FlowReinstall.feature
+++ b/services/src/atdd/src/test/resources/features/mvp.1/FlowReinstall.feature
@@ -11,7 +11,7 @@ Feature: Flow re-reinstalling after switch comes back up.
     And a clean controller
     And created simple topology from two switches
     And topology contains 2 links
-    And flow pcet creation request with 00:01:00:00:00:00:00:01 1 0 and 00:01:00:00:00:00:00:02 2 0 and 1000000 is successful
+    And flow pcet creation request with 00:01:00:00:00:00:00:01 11 0 and 00:01:00:00:00:00:00:02 12 0 and 1000000 is successful
     And flow pcet in UP state
 
     When switch switch1 is turned off
@@ -31,7 +31,7 @@ Feature: Flow re-reinstalling after switch comes back up.
     And a clean controller
     And a random linear topology of 3 switches
     And topology contains 8 links
-    When flow pcet creation request with de:ad:be:ef:00:00:00:01 2 0 and de:ad:be:ef:00:00:00:03 2 0 and 100 is successful
+    When flow pcet creation request with de:ad:be:ef:00:00:00:01 12 0 and de:ad:be:ef:00:00:00:03 12 0 and 100 is successful
     And flow pcet in UP state
 
     When switch 00000002 is turned off
@@ -52,7 +52,7 @@ Feature: Flow re-reinstalling after switch comes back up.
     And a clean controller
     And a random linear topology of 3 switches
     And topology contains 8 links
-    When flow disableReflowTest creation request with de:ad:be:ef:00:00:00:01 2 0 and de:ad:be:ef:00:00:00:03 2 0 and 100 is successful
+    When flow disableReflowTest creation request with de:ad:be:ef:00:00:00:01 12 0 and de:ad:be:ef:00:00:00:03 12 0 and 100 is successful
     And flow disableReflowTest in UP state
 
     And flow reroute feature is off
@@ -73,7 +73,7 @@ Feature: Flow re-reinstalling after switch comes back up.
     And a clean controller
     And a multi-path topology
     And topology contains 16 links
-    And flow fr_multipath creation request with 00:00:00:00:00:00:00:01 1 0 and 00:00:00:00:00:00:00:08 1 0 and 100 is successful
+    And flow fr_multipath creation request with 00:00:00:00:00:00:00:01 11 0 and 00:00:00:00:00:00:00:08 11 0 and 100 is successful
     And flow fr_multipath is built through 00:00:00:00:00:00:00:03 switch
 
     When switch s3 is turned off

--- a/services/src/atdd/src/test/resources/features/mvp.1/FlowVerification.feature
+++ b/services/src/atdd/src/test/resources/features/mvp.1/FlowVerification.feature
@@ -5,7 +5,7 @@ Feature: Test flow integrity by sending special discovery packet by flow's path
     And a nonrandom linear topology of 7 switches
     And a clean flow topology
     And topology contains 12 links
-    And flow de:ad:be:ef:00:00:00:01(4) and de:ad:be:ef:00:00:00:07(4) with id="positive-flow-verify" is created
+    And flow de:ad:be:ef:00:00:00:01(14) and de:ad:be:ef:00:00:00:07(14) with id="positive-flow-verify" is created
 
     Then use flow verification for flow id="positive-flow-verify"
     And flow verification for flow id="positive-flow-verify" is ok ok
@@ -15,7 +15,7 @@ Feature: Test flow integrity by sending special discovery packet by flow's path
     And a nonrandom linear topology of 7 switches
     And a clean flow topology
     And topology contains 12 links
-    And flow de:ad:be:ef:00:00:00:01(4) and de:ad:be:ef:00:00:00:07(4) with id="half-fail-flow-verify" is created
+    And flow de:ad:be:ef:00:00:00:01(14) and de:ad:be:ef:00:00:00:07(14) with id="half-fail-flow-verify" is created
     And forward flow path is broken
 
     Then use flow verification for flow id="half-fail-flow-verify"

--- a/services/src/atdd/src/test/resources/features/mvp.1/NorthboundRun.feature
+++ b/services/src/atdd/src/test/resources/features/mvp.1/NorthboundRun.feature
@@ -15,39 +15,39 @@ Feature: Northbound tests
 
   This scenario setups flows across the entire set of switches and checks that response was successful
 
-    Then flow nbc creation request with de:ad:be:ef:00:00:00:03 1 100 and de:ad:be:ef:00:00:00:05 2 100 and 10000 is successful
+    Then flow nbc creation request with de:ad:be:ef:00:00:00:03 11 100 and de:ad:be:ef:00:00:00:05 12 100 and 10000 is successful
 
   @MVP1
   Scenario: Flow Reading
 
   This scenario setups flows across the entire set of switches and checks that response was successful
 
-    When flow nbr creation request with de:ad:be:ef:00:00:00:03 1 101 and de:ad:be:ef:00:00:00:05 2 101 and 10000 is successful
-    Then flow nbr with de:ad:be:ef:00:00:00:03 1 101 and de:ad:be:ef:00:00:00:05 2 101 and 10000 could be read
+    When flow nbr creation request with de:ad:be:ef:00:00:00:03 11 101 and de:ad:be:ef:00:00:00:05 12 101 and 10000 is successful
+    Then flow nbr with de:ad:be:ef:00:00:00:03 11 101 and de:ad:be:ef:00:00:00:05 12 101 and 10000 could be read
 
   @MVP1
   Scenario: Flow Updating
 
   This scenario setups flows across the entire set of switches, then updates them and checks that response was successful
 
-    When flow nbu creation request with de:ad:be:ef:00:00:00:03 1 102 and de:ad:be:ef:00:00:00:05 2 102 and 10000 is successful
-    Then flow nbu with de:ad:be:ef:00:00:00:03 1 102 and de:ad:be:ef:00:00:00:05 2 102 and 10000 could be updated with 20000
+    When flow nbu creation request with de:ad:be:ef:00:00:00:03 11 102 and de:ad:be:ef:00:00:00:05 12 102 and 10000 is successful
+    Then flow nbu with de:ad:be:ef:00:00:00:03 11 102 and de:ad:be:ef:00:00:00:05 12 102 and 10000 could be updated with 20000
 
   @MVP1
   Scenario: Flow Deletion
 
   This scenario setups flows across the entire set of switches, then deletes them and checks that response was successful
 
-    When flow nbd creation request with de:ad:be:ef:00:00:00:03 1 103 and de:ad:be:ef:00:00:00:05 2 103 and 10000 is successful
-    Then flow nbd with de:ad:be:ef:00:00:00:03 1 103 and de:ad:be:ef:00:00:00:05 2 103 and 10000 could be created
-    Then flow nbd with de:ad:be:ef:00:00:00:03 1 103 and de:ad:be:ef:00:00:00:05 2 103 and 10000 could be deleted
+    When flow nbd creation request with de:ad:be:ef:00:00:00:03 11 103 and de:ad:be:ef:00:00:00:05 12 103 and 10000 is successful
+    Then flow nbd with de:ad:be:ef:00:00:00:03 11 103 and de:ad:be:ef:00:00:00:05 12 103 and 10000 could be created
+    Then flow nbd with de:ad:be:ef:00:00:00:03 11 103 and de:ad:be:ef:00:00:00:05 12 103 and 10000 could be deleted
 
   @MVP1
   Scenario: Flow Path
 
   This scenario setups flows across the entire set of switches and checks that these flows could be read from database
 
-    When flow nbp creation request with de:ad:be:ef:00:00:00:03 1 104 and de:ad:be:ef:00:00:00:05 2 104 and 10000 is successful
+    When flow nbp creation request with de:ad:be:ef:00:00:00:03 11 104 and de:ad:be:ef:00:00:00:05 12 104 and 10000 is successful
     Then path of flow nbp could be read
 
   @MVP1
@@ -55,7 +55,7 @@ Feature: Northbound tests
 
   This scenario setups flows across the entire set of switches and checks that these flows could be read from database
 
-    When flow nbs creation request with de:ad:be:ef:00:00:00:03 1 105 and de:ad:be:ef:00:00:00:05 2 105 and 10000 is successful
+    When flow nbs creation request with de:ad:be:ef:00:00:00:03 11 105 and de:ad:be:ef:00:00:00:05 12 105 and 10000 is successful
     Then status of flow nbs could be read
 
   @MVP1
@@ -72,12 +72,12 @@ Feature: Northbound tests
 
     Given 8000000000000001,8000000000000002,8000000000000003 rules are installed on de:ad:be:ef:00:00:00:03 switch
 
-    When flow nbdnr creation request with de:ad:be:ef:00:00:00:02 1 106 and de:ad:be:ef:00:00:00:03 2 106 and 1000 is successful
+    When flow nbdnr creation request with de:ad:be:ef:00:00:00:02 11 106 and de:ad:be:ef:00:00:00:03 12 106 and 1000 is successful
     And flow nbdnr in UP state
-    And traffic through de:ad:be:ef:00:00:00:02 1 106 and de:ad:be:ef:00:00:00:03 2 106 and 1000 is pingable
+    And traffic through de:ad:be:ef:00:00:00:02 11 106 and de:ad:be:ef:00:00:00:03 12 106 and 1000 is pingable
 
     Then delete all non-default rules request on de:ad:be:ef:00:00:00:03 switch is successful with 2 rules deleted
-    And traffic through de:ad:be:ef:00:00:00:02 1 106 and de:ad:be:ef:00:00:00:03 2 106 and 1000 is not pingable
+    And traffic through de:ad:be:ef:00:00:00:02 11 106 and de:ad:be:ef:00:00:00:03 12 106 and 1000 is not pingable
     And 8000000000000001,8000000000000002,8000000000000003 rules are installed on de:ad:be:ef:00:00:00:03 switch
 
   @MVP1
@@ -87,12 +87,12 @@ Feature: Northbound tests
 
     Given 8000000000000001,8000000000000002,8000000000000003 rules are installed on de:ad:be:ef:00:00:00:03 switch
 
-    When flow nbdar creation request with de:ad:be:ef:00:00:00:02 1 107 and de:ad:be:ef:00:00:00:03 2 107 and 1000 is successful
+    When flow nbdar creation request with de:ad:be:ef:00:00:00:02 11 107 and de:ad:be:ef:00:00:00:03 12 107 and 1000 is successful
     And flow nbdar in UP state
-    And traffic through de:ad:be:ef:00:00:00:02 1 107 and de:ad:be:ef:00:00:00:03 2 107 and 1000 is pingable
+    And traffic through de:ad:be:ef:00:00:00:02 11 107 and de:ad:be:ef:00:00:00:03 12 107 and 1000 is pingable
 
     Then delete all rules request on de:ad:be:ef:00:00:00:03 switch is successful with 5 rules deleted
-    And traffic through de:ad:be:ef:00:00:00:02 1 107 and de:ad:be:ef:00:00:00:03 2 107 and 1000 is not pingable
+    And traffic through de:ad:be:ef:00:00:00:02 11 107 and de:ad:be:ef:00:00:00:03 12 107 and 1000 is not pingable
     And No rules installed on de:ad:be:ef:00:00:00:03 switch
 
   @MVP1
@@ -102,12 +102,12 @@ Feature: Northbound tests
 
     Given 8000000000000001,8000000000000002,8000000000000003 rules are installed on de:ad:be:ef:00:00:00:02 switch
 
-    When flow nbdrip creation request with de:ad:be:ef:00:00:00:02 1 116 and de:ad:be:ef:00:00:00:03 2 116 and 1000 is successful
+    When flow nbdrip creation request with de:ad:be:ef:00:00:00:02 11 116 and de:ad:be:ef:00:00:00:03 12 116 and 1000 is successful
     And flow nbdrip in UP state
-    And traffic through de:ad:be:ef:00:00:00:02 1 116 and de:ad:be:ef:00:00:00:03 2 116 and 1000 is pingable
+    And traffic through de:ad:be:ef:00:00:00:02 11 116 and de:ad:be:ef:00:00:00:03 12 116 and 1000 is pingable
 
     Then delete rules request by 1 in-port on de:ad:be:ef:00:00:00:02 switch is successful with 1 rules deleted
-    And traffic through de:ad:be:ef:00:00:00:02 1 116 and de:ad:be:ef:00:00:00:03 2 116 and 1000 is not pingable
+    And traffic through de:ad:be:ef:00:00:00:02 11 116 and de:ad:be:ef:00:00:00:03 12 116 and 1000 is not pingable
     And 8000000000000001,8000000000000002,8000000000000003 rules are installed on de:ad:be:ef:00:00:00:02 switch
 
   @MVP1
@@ -117,12 +117,12 @@ Feature: Northbound tests
 
     Given 8000000000000001,8000000000000002,8000000000000003 rules are installed on de:ad:be:ef:00:00:00:02 switch
 
-    When flow nbdripn creation request with de:ad:be:ef:00:00:00:02 1 121 and de:ad:be:ef:00:00:00:03 2 121 and 1000 is successful
+    When flow nbdripn creation request with de:ad:be:ef:00:00:00:02 11 121 and de:ad:be:ef:00:00:00:03 12 121 and 1000 is successful
     And flow nbdripn in UP state
-    And traffic through de:ad:be:ef:00:00:00:02 1 121 and de:ad:be:ef:00:00:00:03 2 121 and 1000 is pingable
+    And traffic through de:ad:be:ef:00:00:00:02 11 121 and de:ad:be:ef:00:00:00:03 12 121 and 1000 is pingable
 
     Then delete rules request by 10 in-port on de:ad:be:ef:00:00:00:02 switch is successful with 0 rules deleted
-    And traffic through de:ad:be:ef:00:00:00:02 1 121 and de:ad:be:ef:00:00:00:03 2 121 and 1000 is pingable
+    And traffic through de:ad:be:ef:00:00:00:02 11 121 and de:ad:be:ef:00:00:00:03 12 121 and 1000 is pingable
     And 8000000000000001,8000000000000002,8000000000000003 rules are installed on de:ad:be:ef:00:00:00:02 switch
 
   @MVP1
@@ -132,12 +132,12 @@ Feature: Northbound tests
 
     Given 8000000000000001,8000000000000002,8000000000000003 rules are installed on de:ad:be:ef:00:00:00:02 switch
 
-    When flow nbdripv creation request with de:ad:be:ef:00:00:00:02 1 117 and de:ad:be:ef:00:00:00:03 2 117 and 1000 is successful
+    When flow nbdripv creation request with de:ad:be:ef:00:00:00:02 11 117 and de:ad:be:ef:00:00:00:03 12 117 and 1000 is successful
     And flow nbdripv in UP state
-    And traffic through de:ad:be:ef:00:00:00:02 1 117 and de:ad:be:ef:00:00:00:03 2 117 and 1000 is pingable
+    And traffic through de:ad:be:ef:00:00:00:02 11 117 and de:ad:be:ef:00:00:00:03 12 117 and 1000 is pingable
 
     Then delete rules request by 1 in-port and 117 in-vlan on de:ad:be:ef:00:00:00:02 switch is successful with 1 rules deleted
-    And traffic through de:ad:be:ef:00:00:00:02 1 117 and de:ad:be:ef:00:00:00:03 2 117 and 1000 is not pingable
+    And traffic through de:ad:be:ef:00:00:00:02 11 117 and de:ad:be:ef:00:00:00:03 12 117 and 1000 is not pingable
     And 8000000000000001,8000000000000002,8000000000000003 rules are installed on de:ad:be:ef:00:00:00:02 switch
 
   @MVP1
@@ -147,12 +147,12 @@ Feature: Northbound tests
 
     Given 8000000000000001,8000000000000002,8000000000000003 rules are installed on de:ad:be:ef:00:00:00:02 switch
 
-    When flow nbdripvn creation request with de:ad:be:ef:00:00:00:02 1 122 and de:ad:be:ef:00:00:00:03 2 122 and 1000 is successful
+    When flow nbdripvn creation request with de:ad:be:ef:00:00:00:02 11 122 and de:ad:be:ef:00:00:00:03 12 122 and 1000 is successful
     And flow nbdripvn in UP state
-    And traffic through de:ad:be:ef:00:00:00:02 1 122 and de:ad:be:ef:00:00:00:03 2 122 and 1000 is pingable
+    And traffic through de:ad:be:ef:00:00:00:02 11 122 and de:ad:be:ef:00:00:00:03 12 122 and 1000 is pingable
 
     Then delete rules request by 1 in-port and 200 in-vlan on de:ad:be:ef:00:00:00:02 switch is successful with 0 rules deleted
-    And traffic through de:ad:be:ef:00:00:00:02 1 122 and de:ad:be:ef:00:00:00:03 2 122 and 1000 is pingable
+    And traffic through de:ad:be:ef:00:00:00:02 11 122 and de:ad:be:ef:00:00:00:03 12 122 and 1000 is pingable
     And 8000000000000001,8000000000000002,8000000000000003 rules are installed on de:ad:be:ef:00:00:00:02 switch
 
   @MVP1
@@ -162,12 +162,12 @@ Feature: Northbound tests
 
     Given 8000000000000001,8000000000000002,8000000000000003 rules are installed on de:ad:be:ef:00:00:00:02 switch
 
-    When flow nbdriv creation request with de:ad:be:ef:00:00:00:02 1 119 and de:ad:be:ef:00:00:00:03 2 119 and 1000 is successful
+    When flow nbdriv creation request with de:ad:be:ef:00:00:00:02 11 119 and de:ad:be:ef:00:00:00:03 12 119 and 1000 is successful
     And flow nbdriv in UP state
-    And traffic through de:ad:be:ef:00:00:00:02 1 119 and de:ad:be:ef:00:00:00:03 2 119 and 1000 is pingable
+    And traffic through de:ad:be:ef:00:00:00:02 11 119 and de:ad:be:ef:00:00:00:03 12 119 and 1000 is pingable
 
     Then delete rules request by 119 in-vlan on de:ad:be:ef:00:00:00:02 switch is successful with 1 rules deleted
-    And traffic through de:ad:be:ef:00:00:00:02 1 119 and de:ad:be:ef:00:00:00:03 2 119 and 1000 is not pingable
+    And traffic through de:ad:be:ef:00:00:00:02 11 119 and de:ad:be:ef:00:00:00:03 12 119 and 1000 is not pingable
     And 8000000000000001,8000000000000002,8000000000000003 rules are installed on de:ad:be:ef:00:00:00:02 switch
 
   @MVP1
@@ -177,12 +177,12 @@ Feature: Northbound tests
 
     Given 8000000000000001,8000000000000002,8000000000000003 rules are installed on de:ad:be:ef:00:00:00:03 switch
 
-    When flow nbdrop creation request with de:ad:be:ef:00:00:00:02 1 118 and de:ad:be:ef:00:00:00:03 2 118 and 1000 is successful
+    When flow nbdrop creation request with de:ad:be:ef:00:00:00:02 11 118 and de:ad:be:ef:00:00:00:03 12 118 and 1000 is successful
     And flow nbdrop in UP state
-    And traffic through de:ad:be:ef:00:00:00:02 1 118 and de:ad:be:ef:00:00:00:03 2 118 and 1000 is pingable
+    And traffic through de:ad:be:ef:00:00:00:02 11 118 and de:ad:be:ef:00:00:00:03 12 118 and 1000 is pingable
 
     Then delete rules request by 2 out-port on de:ad:be:ef:00:00:00:03 switch is successful with 1 rules deleted
-    And traffic through de:ad:be:ef:00:00:00:02 1 118 and de:ad:be:ef:00:00:00:03 2 118 and 1000 is not pingable
+    And traffic through de:ad:be:ef:00:00:00:02 11 118 and de:ad:be:ef:00:00:00:03 12 118 and 1000 is not pingable
     And 8000000000000001,8000000000000002,8000000000000003 rules are installed on de:ad:be:ef:00:00:00:03 switch
 
   @MVP1
@@ -191,8 +191,8 @@ Feature: Northbound tests
   This scenario setups flows through NB, then deletes from DB and perform synchronization of the flow cache
 
     Given a clean flow topology
-    And flow sfc1 creation request with de:ad:be:ef:00:00:00:03 1 108 and de:ad:be:ef:00:00:00:05 2 108 and 10000 is successful
-    And flow sfc2 creation request with de:ad:be:ef:00:00:00:04 1 108 and de:ad:be:ef:00:00:00:06 2 108 and 10000 is successful
+    And flow sfc1 creation request with de:ad:be:ef:00:00:00:03 11 108 and de:ad:be:ef:00:00:00:05 12 108 and 10000 is successful
+    And flow sfc2 creation request with de:ad:be:ef:00:00:00:04 11 108 and de:ad:be:ef:00:00:00:06 12 108 and 10000 is successful
     And flows dump contains 2 flows
 
     When flow sfc1 could be deleted from DB
@@ -224,7 +224,7 @@ Feature: Northbound tests
   This scenario setups a flow through NB, then deletes rules from an intermediate switch and performs flow validation check
 
     Given a clean flow topology
-    And flow vfris creation request with de:ad:be:ef:00:00:00:01 1 110 and de:ad:be:ef:00:00:00:04 2 110 and 1000 is successful
+    And flow vfris creation request with de:ad:be:ef:00:00:00:01 11 110 and de:ad:be:ef:00:00:00:04 12 110 and 1000 is successful
     And flow vfris in UP state
     And validation of flow vfris is successful with no discrepancies
 
@@ -238,7 +238,7 @@ Feature: Northbound tests
   This scenario setups a flow through NB, then deletes rules from an ingress switch and performs flow validation check
 
     Given a clean flow topology
-    And flow vfrins creation request with de:ad:be:ef:00:00:00:01 1 110 and de:ad:be:ef:00:00:00:04 2 110 and 1000 is successful
+    And flow vfrins creation request with de:ad:be:ef:00:00:00:01 11 110 and de:ad:be:ef:00:00:00:04 12 110 and 1000 is successful
     And flow vfrins in UP state
     And validation of flow vfrins is successful with no discrepancies
 
@@ -252,7 +252,7 @@ Feature: Northbound tests
   This scenario setups a flow through NB, then deletes rules from an egress switch and performs flow validation check
 
     Given a clean flow topology
-    And flow vfres creation request with de:ad:be:ef:00:00:00:01 1 110 and de:ad:be:ef:00:00:00:04 2 110 and 1000 is successful
+    And flow vfres creation request with de:ad:be:ef:00:00:00:01 11 110 and de:ad:be:ef:00:00:00:04 12 110 and 1000 is successful
     And flow vfres in UP state
     And validation of flow vfres is successful with no discrepancies
 
@@ -322,7 +322,7 @@ Feature: Northbound tests
   This scenario setups a flow through NB, then deletes rules from an ingress switch and performs switch validation check
 
     Given a clean flow topology
-    And flow vinsmr creation request with de:ad:be:ef:00:00:00:01 1 123 and de:ad:be:ef:00:00:00:04 2 123 and 1000 is successful
+    And flow vinsmr creation request with de:ad:be:ef:00:00:00:01 11 123 and de:ad:be:ef:00:00:00:04 12 123 and 1000 is successful
     And flow vinsmr in UP state
     And validation of rules on de:ad:be:ef:00:00:00:01 switch is successful with no discrepancies
 
@@ -336,7 +336,7 @@ Feature: Northbound tests
   This scenario setups a flow through NB, then deletes rules from an egress switch and performs switch validation check
 
     Given a clean flow topology
-    And flow vesmr creation request with de:ad:be:ef:00:00:00:01 1 124 and de:ad:be:ef:00:00:00:04 2 124 and 1000 is successful
+    And flow vesmr creation request with de:ad:be:ef:00:00:00:01 11 124 and de:ad:be:ef:00:00:00:04 12 124 and 1000 is successful
     And flow vesmr in UP state
     And validation of rules on de:ad:be:ef:00:00:00:04 switch is successful with no discrepancies
 
@@ -392,7 +392,7 @@ Feature: Northbound tests
   This scenario setups a flow through NB, then deletes rules from an intermediate switch and performs switch synchronization
 
     Given a clean flow topology
-    And flow ssr creation request with de:ad:be:ef:00:00:00:01 1 113 and de:ad:be:ef:00:00:00:04 2 113 and 1000 is successful
+    And flow ssr creation request with de:ad:be:ef:00:00:00:01 11 113 and de:ad:be:ef:00:00:00:04 12 113 and 1000 is successful
     And flow ssr in UP state
     And validation of rules on de:ad:be:ef:00:00:00:03 switch is successful with no discrepancies
 

--- a/services/src/atdd/src/test/resources/flows/non-standard-cookies-flow.json
+++ b/services/src/atdd/src/test/resources/flows/non-standard-cookies-flow.json
@@ -12,10 +12,10 @@
             "cookie": 73183493944770561,
             "meter_id": 1,
             "src_switch": "de:ad:be:ef:00:00:00:01",
-            "src_port": 1,
+            "src_port": 11,
             "src_vlan": 200,
             "dst_switch": "de:ad:be:ef:00:00:00:03",
-            "dst_port": 2,
+            "dst_port": 12,
             "dst_vlan": 201,
             "flowpath": {
                 "path": [
@@ -56,10 +56,10 @@
             "cookie": 109212290963734529,
             "meter_id": 2,
             "src_switch": "de:ad:be:ef:00:00:00:03",
-            "src_port": 2,
+            "src_port": 12,
             "src_vlan": 201,
             "dst_switch": "de:ad:be:ef:00:00:00:01",
-            "dst_port": 1,
+            "dst_port": 11,
             "dst_vlan": 200,
             "flowpath": {
                 "path": [

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/service/impl/FlowServiceImpl.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/service/impl/FlowServiceImpl.java
@@ -711,8 +711,8 @@ public class FlowServiceImpl implements FlowService {
          * 3) Do the comparison
          */
 
-        List<Flow> flows = pathComputer.getFlow(flowId);
-        if (flows == null) {
+        List<Flow> flows = pathComputer.getFlows(flowId);
+        if (flows == null || flows.isEmpty()) {
             return null;
         }
 

--- a/services/src/pce/src/main/java/org/openkilda/pce/provider/NeoDriver.java
+++ b/services/src/pce/src/main/java/org/openkilda/pce/provider/NeoDriver.java
@@ -31,6 +31,7 @@ import org.openkilda.pce.api.FlowAdapter;
 import org.openkilda.pce.model.AvailableNetwork;
 import org.openkilda.pce.model.SimpleIsl;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.tuple.Pair;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Driver;
@@ -45,9 +46,9 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
-public class NeoDriver implements PathComputer {
-
+public class NeoDriver implements PathComputer, TopologyRepository {
     private static final Logger logger = LoggerFactory.getLogger(NeoDriver.class);
 
     private final Driver driver;
@@ -77,7 +78,7 @@ public class NeoDriver implements PathComputer {
         List<PathNode> forwardNodes = new LinkedList<>();
         List<PathNode> reverseNodes = new LinkedList<>();
 
-        if (! flow.isOneSwitchFlow()) {
+        if (!flow.isOneSwitchFlow()) {
             try {
                 Pair<LinkedList<SimpleIsl>, LinkedList<SimpleIsl>> biPath = getPathFromNetwork(flow, network, strategy);
                 if (biPath.getLeft().size() == 0 || biPath.getRight().size() == 0) {
@@ -100,7 +101,7 @@ public class NeoDriver implements PathComputer {
                             seqId++, (long) isl.getLatency()));
                     reverseNodes.add(new PathNode(isl.getDstDpid(), isl.getDstPort(), seqId++, 0L));
                 }
-            // FIXME(surabujin): Need to catch and trace exact exception thrown in recoverable places.
+                // FIXME(surabujin): Need to catch and trace exact exception thrown in recoverable places.
             } catch (TransientException e) {
                 throw new RecoverableException("TransientError from neo4j", e);
             } catch (ClientException e) {
@@ -156,22 +157,16 @@ public class NeoDriver implements PathComputer {
 
             for (Record record : result.list()) {
                 flows.add(new FlowInfo()
-                            .setFlowId(record.get("flow_id").asString())
-                            .setSrcSwitchId(record.get("src_switch").asString())
-                            .setCookie(record.get("cookie").asLong())
-                            .setMeterId(safeAsInt(record.get("meter_id")))
-                            .setTransitVlanId(safeAsInt(record.get("transit_vlan")))
+                        .setFlowId(record.get("flow_id").asString())
+                        .setSrcSwitchId(record.get("src_switch").asString())
+                        .setCookie(record.get("cookie").asLong())
+                        .setMeterId(safeAsInt(record.get("meter_id")))
+                        .setTransitVlanId(safeAsInt(record.get("transit_vlan")))
                 );
             }
 
         }
         return flows;
-    }
-
-    @Override
-    public List<Flow> getFlow(String flowId) {
-        List<Flow> found = getFlows(flowId);
-        return found.size() > 0 ? found : null;
     }
 
     @Override
@@ -221,7 +216,7 @@ public class NeoDriver implements PathComputer {
     }
 
     @Override
-    public  List<SwitchInfoData> getSwitches() {
+    public List<SwitchInfoData> getSwitches() {
         String q =
                 "MATCH (sw:switch) "
                         + "RETURN "
@@ -314,5 +309,24 @@ public class NeoDriver implements PathComputer {
     @Override
     public AvailableNetwork getAvailableNetwork(boolean ignoreBandwidth, int requestedBandwidth) {
         return new AvailableNetwork(driver, ignoreBandwidth, requestedBandwidth);
+    }
+
+    @Override
+    public long getWeight(IslInfoData isl) {
+        return 1L;
+    }
+
+    @Override
+    public boolean isIslPort(String switchId, int port) {
+        String queryForIsl = "MATCH ()-[isl:isl]->() "
+                + "WHERE isl.src_switch = {switch} AND isl.src_port = {port} "
+                + "OR isl.dst_switch = {switch} AND isl.dst_port = {port} "
+                + "RETURN isl";
+        Map<String, Object> queryParams = ImmutableMap.of("switch", switchId, "port", port);
+
+        try (Session session = driver.session()) {
+            StatementResult queryResults = session.run(queryForIsl, queryParams);
+            return queryResults.hasNext();
+        }
     }
 }

--- a/services/src/pce/src/main/java/org/openkilda/pce/provider/PathComputer.java
+++ b/services/src/pce/src/main/java/org/openkilda/pce/provider/PathComputer.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.pce.provider;
 
-import org.openkilda.messaging.info.event.SwitchInfoData;
-import org.openkilda.messaging.info.event.IslInfoData;
 import org.openkilda.messaging.info.event.PathInfoData;
 import org.openkilda.messaging.model.Flow;
 import org.openkilda.messaging.model.ImmutablePair;
@@ -24,13 +22,11 @@ import org.openkilda.pce.RecoverableException;
 import org.openkilda.pce.model.AvailableNetwork;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * PathComputation interface represent operations on flow path.
  */
-public interface PathComputer extends Serializable {
+public interface PathComputer extends TopologyRepository, Serializable {
 
     /**
      * The Strategy is used for getting a Path - ie what filters to apply.
@@ -38,16 +34,6 @@ public interface PathComputer extends Serializable {
      */
     enum Strategy {
         HOPS, COST, LATENCY, EXTERNAL
-    }
-
-    /**
-     * Gets isl weight.
-     *
-     * @param isl isl instance
-     * @return isl weight
-     */
-    default Long getWeight(IslInfoData isl) {
-        return 1L;
     }
 
     /**
@@ -68,50 +54,6 @@ public interface PathComputer extends Serializable {
      */
     ImmutablePair<PathInfoData, PathInfoData> getPath(Flow flow, Strategy strategy)
             throws UnroutablePathException, RecoverableException;
-
-    /**
-     * Interact with the PathComputer to get the FlowInfo for all flows.
-     *
-     * @return a list containing the "key" flow info for all flows.
-     */
-    default List<FlowInfo> getFlowInfo() {
-        return new ArrayList<>();
-    }
-
-    /**
-     * Read flows from Neo4j and covert them in our common representation
-     * org.openkilda.messaging.model.Flow
-     *
-     * @return all flow objects stored in neo4j
-     */
-    default List<Flow> getAllFlows() {
-        return new ArrayList<>();
-    }
-
-    /**
-     * Read a single flow from Neo4j and convert to our common representation {@link Flow}.
-     * In reality, a single flow will typically be bi-directional, so just represent as a list.
-     *
-     * @return the Flow if it exists, null otherwise.
-     */
-    default List<Flow> getFlow(String flowId) {
-        return null;
-    }
-
-    /*
-     * @return all flows (forward and reverse) by id, if exist.
-     */
-    default List<Flow> getFlows(String flowId) {
-        return null;
-    }
-
-    default List<SwitchInfoData> getSwitches() {
-        return null;
-    }
-
-    default List<IslInfoData> getIsls() {
-        return null;
-    }
 
     /**
      * Loads network and ignores all ISLs with not enough available bandwidth if ignoreBandwidth is false.

--- a/services/src/pce/src/main/java/org/openkilda/pce/provider/TopologyRepository.java
+++ b/services/src/pce/src/main/java/org/openkilda/pce/provider/TopologyRepository.java
@@ -1,0 +1,82 @@
+/* Copyright 2017 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.pce.provider;
+
+import org.openkilda.messaging.info.event.IslInfoData;
+import org.openkilda.messaging.info.event.SwitchInfoData;
+import org.openkilda.messaging.model.Flow;
+
+import java.util.List;
+
+/**
+ * {@link TopologyRepository} declares operations on Topology entities in a storage.
+ */
+public interface TopologyRepository {
+
+    /**
+     * Gets ISL weight.
+     *
+     * @param isl an ISL instance.
+     * @return the weight of requested ISL.
+     */
+    long getWeight(IslInfoData isl);
+
+    /**
+     * Gets all flows.
+     *
+     * @return a list of {@link FlowInfo} for all flows.
+     */
+    List<FlowInfo> getFlowInfo();
+
+    /**
+     * Gets all flows.
+     *
+     * @return a list of {@link Flow} for all flows.
+     */
+    List<Flow> getAllFlows();
+
+    /**
+     * Gets a single flow.
+     * <p/>
+     * In reality, a single flow will typically be bi-directional, so just represent as a list.
+     *
+     * @return the flows (forward and reverse) by id, if exist.
+     */
+    List<Flow> getFlows(String flowId);
+
+    /**
+     * Gets all switches.
+     *
+     * @return a list of {@link SwitchInfoData} for all switches.
+     */
+    List<SwitchInfoData> getSwitches();
+
+    /**
+     * Gets all ISLs.
+     *
+     * @return a list of {@link IslInfoData} for all ISLs.
+     */
+    List<IslInfoData> getIsls();
+
+    /**
+     * Checks whether the port belongs to any ISL (regardless the source or destination end).
+     *
+     * @param switchId the switch to check
+     * @param port     the port to check
+     * @return true if the port is ISL, or false otherwise.
+     */
+    boolean isIslPort(String switchId, int port);
+}

--- a/services/src/pce/src/test/java/org/openkilda/pce/provider/PathComputerMock.java
+++ b/services/src/pce/src/test/java/org/openkilda/pce/provider/PathComputerMock.java
@@ -15,6 +15,8 @@
 
 package org.openkilda.pce.provider;
 
+import static java.util.Collections.emptyList;
+
 import org.openkilda.messaging.error.CacheException;
 import org.openkilda.messaging.error.ErrorType;
 import org.openkilda.messaging.info.event.IslInfoData;
@@ -42,7 +44,7 @@ public class PathComputerMock implements PathComputer {
     private MutableNetwork<SwitchInfoData, IslInfoData> network;
 
     @Override
-    public Long getWeight(IslInfoData isl) {
+    public long getWeight(IslInfoData isl) {
         return 1L;
     }
 
@@ -179,5 +181,30 @@ public class PathComputerMock implements PathComputer {
         path.getPath().add(destination);
 
         path.setLatency(path.getLatency() + isl.getLatency());
+    }
+
+    @Override
+    public List<Flow> getAllFlows() {
+        return emptyList();
+    }
+
+    @Override
+    public List<Flow> getFlows(String flowId) {
+        return emptyList();
+    }
+
+    @Override
+    public List<SwitchInfoData> getSwitches() {
+        return emptyList();
+    }
+
+    @Override
+    public List<IslInfoData> getIsls() {
+        return emptyList();
+    }
+
+    @Override
+    public boolean isIslPort(String switchId, int port) {
+        return false;
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/CrudBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/CrudBolt.java
@@ -171,7 +171,7 @@ public class CrudBolt
         }
         initFlowCache();
 
-        flowValidator = new FlowValidator(flowCache);
+        flowValidator = new FlowValidator(flowCache, pathComputer);
     }
 
     /**

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/validation/FlowValidator.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/validation/FlowValidator.java
@@ -16,9 +16,11 @@
 package org.openkilda.wfm.topology.flow.validation;
 
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 import org.openkilda.messaging.model.Flow;
 import org.openkilda.pce.cache.FlowCache;
+import org.openkilda.pce.provider.TopologyRepository;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -31,9 +33,11 @@ import java.util.Set;
 public class FlowValidator {
 
     private final FlowCache flowCache;
+    private final TopologyRepository topologyRepository;
 
-    public FlowValidator(FlowCache flowCache) {
-        this.flowCache = flowCache;
+    public FlowValidator(FlowCache flowCache, TopologyRepository topologyRepository) {
+        this.flowCache = requireNonNull(flowCache, "flowCache cannot be null");
+        this.topologyRepository = requireNonNull(topologyRepository, "topologyRepository cannot be null");
     }
 
     /**
@@ -45,6 +49,7 @@ public class FlowValidator {
     public void validate(Flow flow) throws FlowValidationException {
         checkBandwidth(flow);
         checkFlowForEndpointConflicts(flow);
+        checkFlowForIslConflicts(flow);
     }
 
     @VisibleForTesting
@@ -111,6 +116,29 @@ public class FlowValidator {
                             requestedFlow.getDestinationPort(),
                             requestedFlow.getDestinationSwitch(),
                             conflictedFlow.get().getFlowId()));
+        }
+    }
+
+    /**
+     * Checks a flow for conflicts with ISL ports.
+     *
+     * @param flow a flow to be validated.
+     * @throws FlowValidationException is thrown in a case when flow endpoints conflict with existing ISL ports.
+     */
+    @VisibleForTesting
+    void checkFlowForIslConflicts(Flow flow) throws FlowValidationException {
+        // Check the source
+        if (topologyRepository.isIslPort(flow.getSourceSwitch(), flow.getSourcePort())) {
+            throw new FlowValidationException(
+                    format("The port %d on the switch '%s' is occupied by an ISL.",
+                            flow.getSourcePort(), flow.getSourceSwitch()));
+        }
+
+        // Check the destination
+        if (topologyRepository.isIslPort(flow.getDestinationSwitch(), flow.getDestinationPort())) {
+            throw new FlowValidationException(
+                    format("The port %d on the switch '%s' is occupied by an ISL.",
+                            flow.getDestinationPort(), flow.getDestinationSwitch()));
         }
     }
 }

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flow/PathComputerMock.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flow/PathComputerMock.java
@@ -15,13 +15,18 @@
 
 package org.openkilda.wfm.topology.flow;
 
+import static java.util.Collections.emptyList;
+
+import org.openkilda.messaging.info.event.IslInfoData;
 import org.openkilda.messaging.info.event.PathInfoData;
+import org.openkilda.messaging.info.event.SwitchInfoData;
 import org.openkilda.messaging.model.Flow;
 import org.openkilda.messaging.model.ImmutablePair;
 import org.openkilda.pce.model.AvailableNetwork;
+import org.openkilda.pce.provider.FlowInfo;
 import org.openkilda.pce.provider.PathComputer;
 
-import java.util.Collections;
+import java.util.List;
 
 public class PathComputerMock implements PathComputer {
     @Override
@@ -41,8 +46,43 @@ public class PathComputerMock implements PathComputer {
 
     private static ImmutablePair<PathInfoData, PathInfoData> emptyPath() {
         return new ImmutablePair<>(
-                new PathInfoData(0L, Collections.emptyList()),
-                new PathInfoData(0L, Collections.emptyList()));
+                new PathInfoData(0L, emptyList()),
+                new PathInfoData(0L, emptyList()));
+    }
+
+    @Override
+    public long getWeight(IslInfoData isl) {
+        return 1L;
+    }
+
+    @Override
+    public List<FlowInfo> getFlowInfo() {
+        return emptyList();
+    }
+
+    @Override
+    public List<Flow> getAllFlows() {
+        return emptyList();
+    }
+
+    @Override
+    public List<Flow> getFlows(String flowId) {
+        return emptyList();
+    }
+
+    @Override
+    public List<SwitchInfoData> getSwitches() {
+        return emptyList();
+    }
+
+    @Override
+    public List<IslInfoData> getIsls() {
+        return emptyList();
+    }
+
+    @Override
+    public boolean isIslPort(String switchId, int port) {
+        return false;
     }
 
     private class MockedAvailableNetwork extends AvailableNetwork {

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flow/validation/FlowValidatorTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flow/validation/FlowValidatorTest.java
@@ -1,21 +1,42 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 package org.openkilda.wfm.topology.flow.validation;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
 import org.openkilda.messaging.model.Flow;
 import org.openkilda.messaging.model.ImmutablePair;
 import org.openkilda.pce.cache.FlowCache;
+import org.openkilda.pce.provider.TopologyRepository;
+import org.openkilda.wfm.topology.flow.PathComputerMock;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class FlowValidatorTest {
-    private FlowValidator target = new FlowValidator(flowCache);
+    private FlowValidator target = new FlowValidator(flowCache, new PathComputerMock());
 
     private static final FlowCache flowCache = new FlowCache();
     private static final String SRC_SWITCH = "00:00:00:00:00:00:00:01";
     private static final int SRC_PORT = 1;
     private static final int SRC_VLAN = 1;
+    private static final int SRC_VLAN_OF_EXISTING_FLOW = 2;
     private static final String DST_SWITCH = "00:00:00:00:00:00:00:02";
     private static final int DST_PORT = 5;
     private static final int DST_VLAN = 5;
+    private static final int DST_VLAN_OF_EXISTING_FLOW = 6;
+    private static final int ISL_PORT = 10;
 
     @BeforeClass
     public static void initCache() {
@@ -23,88 +44,194 @@ public class FlowValidatorTest {
         flow.setFlowId("1");
         flow.setSourceSwitch(SRC_SWITCH);
         flow.setSourcePort(SRC_PORT);
-        flow.setSourceVlan(SRC_VLAN);
+        flow.setSourceVlan(SRC_VLAN_OF_EXISTING_FLOW);
 
         flow.setDestinationSwitch(DST_SWITCH);
         flow.setDestinationPort(DST_PORT);
-        flow.setDestinationVlan(DST_VLAN);
+        flow.setDestinationVlan(DST_VLAN_OF_EXISTING_FLOW);
         flowCache.pushFlow(new ImmutablePair<>(flow, flow));
     }
 
     @Test(expected = FlowValidationException.class)
     public void shouldFailIfSourceVlanIsZeroAndPortIsOccupied() throws FlowValidationException {
+        // given
         Flow flow = new Flow();
         flow.setSourceSwitch(SRC_SWITCH);
         flow.setSourcePort(SRC_PORT);
         flow.setSourceVlan(0);
 
+        // when
         target.checkFlowForEndpointConflicts(flow);
+
+        // then a FlowValidationException is thrown
     }
 
     @Test(expected = FlowValidationException.class)
     public void shouldFailIfSourceVlanIsAlreadyOccupied() throws FlowValidationException {
+        // given
+        Flow flow = new Flow();
+        flow.setSourceSwitch(SRC_SWITCH);
+        flow.setSourcePort(SRC_PORT);
+        flow.setSourceVlan(SRC_VLAN_OF_EXISTING_FLOW);
+
+        // when
+        target.checkFlowForEndpointConflicts(flow);
+
+        // then a FlowValidationException is thrown
+    }
+
+    @Test
+    public void shouldNotFailIfSourceVlanIsNotOccupied() throws FlowValidationException {
+        // given
         Flow flow = new Flow();
         flow.setSourceSwitch(SRC_SWITCH);
         flow.setSourcePort(SRC_PORT);
         flow.setSourceVlan(SRC_VLAN);
 
+        // when
         target.checkFlowForEndpointConflicts(flow);
-    }
 
-    @Test
-    public void shouldNotFailIfSourceVlanIsNotOccupied() throws FlowValidationException {
-        Flow flow = new Flow();
-        flow.setSourceSwitch(SRC_SWITCH);
-        flow.setSourcePort(SRC_PORT);
-        flow.setSourceVlan(SRC_VLAN + 1);
-
-        target.checkFlowForEndpointConflicts(flow);
+        // then pass with no exceptions
     }
 
     @Test(expected = FlowValidationException.class)
     public void shouldFailIfDestinationVlanIsZeroAndPortIsOccupied() throws FlowValidationException {
+        // given
         Flow flow = new Flow();
         flow.setSourceSwitch(SRC_SWITCH);
         flow.setSourcePort(SRC_PORT);
-        flow.setSourceVlan(SRC_VLAN + 1);
+        flow.setSourceVlan(SRC_VLAN);
         flow.setDestinationSwitch(DST_SWITCH);
         flow.setDestinationPort(DST_PORT);
         flow.setDestinationVlan(0);
 
+        // when
         target.checkFlowForEndpointConflicts(flow);
+
+        // then a FlowValidationException is thrown
     }
 
     @Test(expected = FlowValidationException.class)
     public void shouldFailIfDestinationVlanIsAlreadyOccupied() throws FlowValidationException {
+        // given
         Flow flow = new Flow();
         flow.setSourceSwitch(SRC_SWITCH);
         flow.setSourcePort(SRC_PORT);
-        flow.setSourceVlan(SRC_VLAN + 1);
+        flow.setSourceVlan(SRC_VLAN);
         flow.setDestinationSwitch(DST_SWITCH);
         flow.setDestinationPort(DST_PORT);
-        flow.setDestinationVlan(DST_VLAN);
+        flow.setDestinationVlan(DST_VLAN_OF_EXISTING_FLOW);
 
+        // when
         target.checkFlowForEndpointConflicts(flow);
+
+        // then a FlowValidationException is thrown
     }
 
     @Test
     public void shouldNotFailIfDestinationVlanIsNotOccupied() throws FlowValidationException {
+        // given
         Flow flow = new Flow();
         flow.setSourceSwitch(SRC_SWITCH);
         flow.setSourcePort(SRC_PORT);
-        flow.setSourceVlan(SRC_VLAN + 1);
+        flow.setSourceVlan(SRC_VLAN);
         flow.setDestinationSwitch(DST_SWITCH);
         flow.setDestinationPort(DST_PORT);
-        flow.setDestinationVlan(DST_VLAN + 1);
+        flow.setDestinationVlan(DST_VLAN);
 
+        // when
         target.checkFlowForEndpointConflicts(flow);
+
+        // then pass with no exceptions
     }
 
     @Test(expected = FlowValidationException.class)
     public void shouldFailForNegativeBandwidth() throws FlowValidationException {
+        // given
         Flow flow = new Flow();
         flow.setBandwidth(-1);
 
+        // when
         target.checkBandwidth(flow);
+
+        // then a FlowValidationException is thrown
+    }
+
+    @Test(expected = FlowValidationException.class)
+    public void shouldFailIfSourcePortIsIslPort() throws FlowValidationException {
+        // given
+        Flow flow = new Flow();
+        flow.setSourceSwitch(SRC_SWITCH);
+        flow.setSourcePort(ISL_PORT);
+        flow.setSourceVlan(SRC_VLAN);
+
+        // when
+        FlowValidator target = new FlowValidator(new FlowCache(), buildTopologyRepository(SRC_SWITCH));
+        target.checkFlowForIslConflicts(flow);
+
+        // then a FlowValidationException is thrown
+    }
+
+    @Test(expected = FlowValidationException.class)
+    public void shouldFailIfDestinationPortIsIslPort() throws FlowValidationException {
+        // given
+        Flow flow = new Flow();
+        flow.setSourceSwitch(SRC_SWITCH);
+        flow.setSourcePort(SRC_PORT);
+        flow.setSourceVlan(SRC_VLAN);
+        flow.setDestinationSwitch(DST_SWITCH);
+        flow.setDestinationPort(ISL_PORT);
+        flow.setDestinationVlan(DST_VLAN);
+
+        // when
+        FlowValidator target = new FlowValidator(new FlowCache(), buildTopologyRepository(DST_SWITCH));
+        target.checkFlowForIslConflicts(flow);
+
+        // then a FlowValidationException is thrown
+    }
+
+    @Test(expected = FlowValidationException.class)
+    public void shouldFailIfSourceVlanIsZeroAndPortIsIslPort() throws FlowValidationException {
+        // given
+        Flow flow = new Flow();
+        flow.setSourceSwitch(SRC_SWITCH);
+        flow.setSourcePort(ISL_PORT);
+        flow.setSourceVlan(0);
+        flow.setDestinationSwitch(DST_SWITCH);
+        flow.setDestinationPort(DST_PORT);
+        flow.setDestinationVlan(DST_VLAN);
+
+        // when
+        FlowValidator target = new FlowValidator(new FlowCache(), buildTopologyRepository(SRC_SWITCH));
+        target.checkFlowForIslConflicts(flow);
+
+        // then a FlowValidationException is thrown
+    }
+
+    @Test(expected = FlowValidationException.class)
+    public void shouldFailIfVlanIsZeroAndPortIsIslPort() throws FlowValidationException {
+        // given
+        Flow flow = new Flow();
+        flow.setSourceSwitch(SRC_SWITCH);
+        flow.setSourcePort(SRC_PORT);
+        flow.setSourceVlan(SRC_VLAN);
+        flow.setDestinationSwitch(DST_SWITCH);
+        flow.setDestinationPort(ISL_PORT);
+        flow.setDestinationVlan(0);
+
+        // when
+        FlowValidator target = new FlowValidator(new FlowCache(), buildTopologyRepository(DST_SWITCH));
+        target.checkFlowForIslConflicts(flow);
+
+        // then a FlowValidationException is thrown
+    }
+
+    private TopologyRepository buildTopologyRepository(String switchId) {
+        return new PathComputerMock() {
+            @Override
+            public boolean isIslPort(String swId, int port) {
+                return swId.equals(switchId) && ISL_PORT == port;
+            }
+        };
     }
 }


### PR DESCRIPTION
The changes:
- Add check for conflicts with ISL ports in FlowValidator.
- Introduce TopologyRepository interface (NeoDriver implements it) which declares operations on Topology entities in a storage.
- Update ATDD tests to have flows not using ISL ports.

Resolves #183