### PR TITLE
#1038: Add cleanup step to 'Remove meter on switch' scenario

### DIFF
--- a/services/src/atdd-staging/src/main/resources/features/northbound.feature
+++ b/services/src/atdd-staging/src/main/resources/features/northbound.feature
@@ -31,6 +31,7 @@ Feature: Northbound endpoints
 
     When request all switch meters for switch 'srcSwitch' and alias results as 'srcSwitchMeters'
     Then meters 'srcSwitchMeters' does not have 'meterToDelete'
+    And delete flow flow1
 
 
   @Links


### PR DESCRIPTION
"Remove meter on switch" scenario doesn't have a cleanup step to remove
the flow after test execution. This patch adds the missing step.

Closes: #1038