### PR TITLE
Increase switch validation verbosity

### DIFF
--- a/services/topology-engine/queue-engine/topologylistener/flow_utils.py
+++ b/services/topology-engine/queue-engine/topologylistener/flow_utils.py
@@ -517,8 +517,20 @@ def validate_switch_rules(switch_id, switch_rules):
             logger.warn('Rule %s is excessive on the switch %s', cookie, switch_id)
             excess_rules.add(cookie)
 
-    return {"missing_rules": missing_rules, "excess_rules": excess_rules,
-            "proper_rules": proper_rules}
+    level = logging.INFO
+    if missing_rules:
+        level = logging.ERROR
+    elif excess_rules:
+        level = logging.WARN
+
+    diff = {
+        "missing_rules": missing_rules,
+        "excess_rules": excess_rules,
+        "proper_rules": proper_rules}
+
+    logger.log(level, 'Switch %s rules validation result: %s', switch_id, diff)
+
+    return diff
 
 
 def build_commands_to_sync_rules(switch_id, switch_rules):

--- a/services/topology-engine/queue-engine/topologylistener/messageclasses.py
+++ b/services/topology-engine/queue-engine/topologylistener/messageclasses.py
@@ -759,8 +759,6 @@ class MessageItem(model.JsonSerializable):
     def validate_switch_rules(self):
         diff = flow_utils.validate_switch_rules(self.payload['switch_id'],
                                                 self.payload['flows'])
-        logger.debug('Switch rules validation result: %s', diff)
-
         message_utils.send_validation_rules_response(diff["missing_rules"],
                                                      diff["excess_rules"],
                                                      diff["proper_rules"],
@@ -772,8 +770,6 @@ class MessageItem(model.JsonSerializable):
 
         diff = flow_utils.validate_switch_rules(switch_id,
                                                 self.payload['flows'])
-        logger.debug('Switch rules validation result: %s', diff)
-
         sync_actions = flow_utils.build_commands_to_sync_rules(switch_id,
                                                                diff["missing_rules"])
         commands = sync_actions["commands"]


### PR DESCRIPTION
Log switch id with list of missing/extra rules, also use level error if
there is missing rules, level warn if there is excess rules and level
info if there is valid rules only.