### PR TITLE
Decrease parallelism of opentsdb topology on dev env

### DIFF
--- a/services/wfm/src/main/resources/topology.properties
+++ b/services/wfm/src/main/resources/topology.properties
@@ -1,4 +1,4 @@
-environment.naming.prefix =
+environment.naming.prefix = 
 
 parallelism = 1
 workers = 1
@@ -9,17 +9,16 @@ kafka.replication.default = 3
 
 opentsdb.hosts = http://opentsdb.pendev:4242
 opentsdb.timeout = 30
-opentsdb.client.chunked-requests.enabled=true
-
-opentsdb.num.spouts = 5
-opentsdb.num.opentsdbfilterbolt = 10
-opentsdb.num.opentsdbbolt = 10
-opentsdb.workers.opentsdbolt = 10
-opentsdb.num.datapointparserbolt = 5
-opentsdb.workers.datapointparserbolt = 5
+opentsdb.num.spouts = 1
+opentsdb.num.opentsdbfilterbolt = 1
+opentsdb.num.opentsdbbolt = 1
+opentsdb.workers.opentsdbolt = 1
+opentsdb.num.datapointparserbolt = 1
+opentsdb.workers.datapointparserbolt = 1
 opentsdb.batch.size = 50
 opentsdb.flush.interval = 1
-opentsdb.workers = 5
+opentsdb.workers = 1
+opentsdb.client.chunked-requests.enabled = true
 
 neo4j.hosts = neo4j.pendev:7687
 neo4j.user = neo4j
@@ -28,10 +27,6 @@ neo4j.pswd = temppass
 filter.directory =
 logger.level = INFO
 logger.watermark =
-
-topology.engine.rest.endpoint = http://topology-engine-rest.pendev:80
-topology.engine.rest.login =
-topology.engine.rest.password =
 
 #######
 # Discovery
@@ -48,8 +43,7 @@ discovery.timeout = 9
 discovery.limit = -1
 discovery.speaker-failure-timeout = 5
 discovery.dump-request-timeout-seconds=60
-discovery.keep.removed.isl=60
+discovery.keep.removed.isl = 60
 
 local = no
 local.execution.time = 300
-

--- a/templates/defaults/main.yaml
+++ b/templates/defaults/main.yaml
@@ -47,15 +47,15 @@ discovery_keep_removed_isl: 60
 worker_pool_size: 512
 production_fileserver: "http://127.0.0.1"
 opentsdb_timeout: 30
-opentsdb_num_spouts: 5
-opentsdb_num_opentsdbfilterbolt: 10
-opentsdb_num_opentsdbbolt: 10
-opentsdb_workers_opentsdbolt: 20
+opentsdb_num_spouts: 1
+opentsdb_num_opentsdbfilterbolt: 1
+opentsdb_num_opentsdbbolt: 1
+opentsdb_workers_opentsdbolt: 1
 opentsdb_num_datapointparserbolt: 1
-opentsdb_workers_datapointparserbolt: 2
+opentsdb_workers_datapointparserbolt: 1
 opentsdb_batch_size: 50
 opentsdb_flush_interval: 1
-opentsdb_workers: 10
+opentsdb_workers: 1
 
 logging:
   # method can be file of logstash

--- a/templates/templates/wfm/topology.properties.j2
+++ b/templates/templates/wfm/topology.properties.j2
@@ -8,7 +8,6 @@ kafka.partitions.default = 1
 kafka.replication.default = 3
 
 opentsdb.hosts = {{ opentsdb_hosts }}
-
 opentsdb.timeout = {{ opentsdb_timeout }}
 opentsdb.num.spouts = {{ opentsdb_num_spouts }}
 opentsdb.num.opentsdbfilterbolt = {{ opentsdb_num_opentsdbfilterbolt }}
@@ -19,7 +18,7 @@ opentsdb.workers.datapointparserbolt = {{ opentsdb_workers_datapointparserbolt }
 opentsdb.batch.size = {{ opentsdb_batch_size }}
 opentsdb.flush.interval = {{ opentsdb_flush_interval }}
 opentsdb.workers = {{ opentsdb_workers }}
-opentsdb.client.chunked-requests.enabled=true
+opentsdb.client.chunked-requests.enabled = true
 
 neo4j.hosts = {{ neo4j_hosts }}
 neo4j.user = {{ neo4j_user }}
@@ -47,4 +46,4 @@ discovery.dump-request-timeout-seconds=60
 discovery.keep.removed.isl = {{ discovery_keep_removed_isl }}
 
 local = no
-local.execution.time = 10
+local.execution.time = 300


### PR DESCRIPTION
To decrease RAM requirement for dev enviroment, decrease parallelism of
opentsdb topology. This is the only topology that start in paralle on
devel environment.