### PR TITLE
#1061: Extend atdd-staging scenario in failsafe suite

### DIFF
--- a/services/src/atdd-staging/src/main/java/org/openkilda/atdd/staging/service/flowmanager/FlowManagerImpl.java
+++ b/services/src/atdd-staging/src/main/java/org/openkilda/atdd/staging/service/flowmanager/FlowManagerImpl.java
@@ -128,7 +128,7 @@ public class FlowManagerImpl implements FlowManager {
         if (!foundEnoughFlows) {
             result.keySet().forEach(f -> northboundService.deleteFlow(f.getId()));
         }
-        Assume.assumeTrue("Didn't find enough of requested flows. This test cannot be run on given topology."
+        Assume.assumeTrue("Didn't find enough of requested flows. This test cannot be run on given topology. "
                 + "Do you have enough a-switch links in the topology?", foundEnoughFlows);
         return result;
     }

--- a/services/src/atdd-staging/src/main/java/org/openkilda/atdd/staging/steps/CommonSteps.java
+++ b/services/src/atdd-staging/src/main/java/org/openkilda/atdd/staging/steps/CommonSteps.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 
 public class CommonSteps {
 
-    @And("(?:Remains? in this state|Wait) for (\\d+) seconds")
+    @And("(?:remains? in this state|wait) for (\\d+) seconds")
     public void delay(int seconds) throws InterruptedException {
         TimeUnit.SECONDS.sleep(seconds);
     }

--- a/services/src/atdd-staging/src/main/resources/features/failsafe_behaviour.feature
+++ b/services/src/atdd-staging/src/main/resources/features/failsafe_behaviour.feature
@@ -5,15 +5,16 @@ Feature: Failsafe Suite
 
   Background:
     Given the reference topology
-
+    
   Scenario: ISL connectivity is lost, system is able to react in expected way and reroute after some timeout
     Given Create 1 flow with A Switch used and at least 1 alternate path between source and destination switch and 500 bandwidth
 
     When ISL between switches loses connectivity
-    And Remains in this state for 30 seconds
+    And remains in this state for 30 seconds
     Then ISL status is DISCOVERED
     And ISL status changes to FAILED
     And flow is in UP state
+    And flow path is changed
     And flow is valid per Northbound validation
     And all active switches have correct rules installed per Northbound validation
     And flow has traffic going with bandwidth not less than 450 and not greater than 550
@@ -21,6 +22,7 @@ Feature: Failsafe Suite
     When Changed ISL restores connectivity
     Then ISL status changes to DISCOVERED
     And flow is in UP state
+    And flow path is unchanged
     And flow is valid per Northbound validation
     And all active switches have correct rules installed per Northbound validation
     And flow has traffic going with bandwidth not less than 450 and not greater than 550


### PR DESCRIPTION
This patch is intended to extend "ISL connectivity is lost, system is able to react 
in expected way and reroute after some timeout" scenario by adding extra steps 
for checking flow paths. 

Current scenario:
Scenario: ISL connectivity is lost, system is able to react in expected way and reroute after some timeout

Given Create 1 flow with A Switch used and at least 1 alternate path between source and destination switch and 500 bandwidth

When ISL between switches loses connectivity
And remains in this state for 30 seconds
Then ISL status is DISCOVERED
And ISL status changes to FAILED
And flow is in UP state
And flow is valid per Northbound validation
And all active switches have correct rules installed per Northbound validation
And flow has traffic going with bandwidth not less than 450 and not greater than 550

When Changed ISL restores connectivity
Then ISL status changes to DISCOVERED
And flow is in UP state
And flow is valid per Northbound validation
And all active switches have correct rules installed per Northbound validation
And flow has traffic going with bandwidth not less than 450 and not greater than 550
And each flow can be deleted

It is needed to extend this scenario by adding extra steps for checking flow paths.

The extended scenario will look in such a way:
Scenario: ISL connectivity is lost, system is able to react in expected way and reroute after some timeout

Given Create 1 flow with A Switch used and at least 1 alternate path between source and destination switch and 500 bandwidth

When ISL between switches loses connectivity
And remains in this state for 30 seconds
Then ISL status is DISCOVERED
And ISL status changes to FAILED
And flow is in UP state
And flow path is changed <-------------------- This step is going to be added
And flow is valid per Northbound validation
And all active switches have correct rules installed per Northbound validation
And flow has traffic going with bandwidth not less than 450 and not greater than 550
When Changed ISL restores connectivity
Then ISL status changes to DISCOVERED
And flow is in UP state
And flow path is unchanged <-------------------- This step is going to be added
And flow is valid per Northbound validation
And all active switches have correct rules installed per Northbound validation
And flow has traffic going with bandwidth not less than 450 and not greater than 550
And each flow can be deleted

Closes #1061