### PR TITLE
Remove upper py2neo version limit

### DIFF
--- a/services/topology-engine-rest/Dockerfile
+++ b/services/topology-engine-rest/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update \
         uwsgi \
         pyotp \
         jsonschema \
-        'py2neo<4.0.0' \
+        'py2neo>=4.0.0' \
         requests \
         python-logstash \
         pytz \

--- a/services/topology-engine/Dockerfile
+++ b/services/topology-engine/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
     && pip install --upgrade pip \
     && pip install \
         kafka \
-        'py2neo<4.0.0' \
+        'py2neo>=4.0.0' \
         'gevent<=1.3.1' \
         python-logstash \
         pytz \

--- a/services/topology-engine/queue-engine/topologylistener/isl_utils.py
+++ b/services/topology-engine/queue-engine/topologylistener/isl_utils.py
@@ -229,6 +229,7 @@ def update_status(tx, isl, mtime=True):
 
     db.log_query('ISL update status', q, p)
     cursor = tx.run(q, p)
+    cursor.evaluate()  # to fetch first record
 
     stats = cursor.stats()
     if stats['properties_set'] != expected_update_properties_count:


### PR DESCRIPTION
Newer py2neo version doen't have a problem with neo4j error response
handling. It allow us to remove some set of crutches added in TE to
overcome this problem.