### PR TITLE
Docker raise warning for empty line joined via '\'

### DIFF
--- a/base/kilda-base-ubuntu/Dockerfile
+++ b/base/kilda-base-ubuntu/Dockerfile
@@ -54,7 +54,6 @@ RUN apt-get update \
                -e 's|J_DIR=jdk1.8.0_171|J_DIR=jdk1.8.0_181|' \
                /var/lib/dpkg/info/oracle-java8-installer.config /var/lib/dpkg/info/oracle-java8-installer.postinst; \
            apt-get install -y) \
-
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN chmod +x /usr/local/bin/ansible*


### PR DESCRIPTION
It threaten to treat such empty lines as error in next release.