### PR TITLE
Added ports for elasticsearch to docker-compose elasticsearch service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -394,6 +394,9 @@ services:
     container_name: elasticsearch
     image: elasticsearch:5.6.5
     hostname: elasticsearch.pendev
+    ports:
+      - "127.0.0.1:9200:9200"
+      - "127.0.0.1:9300:9300"
     networks:
       default:
         aliases:


### PR DESCRIPTION
Added ports for elasticsearch to docker-compose elasticsearch service, for creating index dumps after tests