### PR TITLE
#950 delete rules for invalid switch.

### DIFF
--- a/services/src/floodlight-modules/src/checkstyle/checkstyle-suppress-known-issues.xml
+++ b/services/src/floodlight-modules/src/checkstyle/checkstyle-suppress-known-issues.xml
@@ -87,11 +87,6 @@
     <suppress files="src/main/java/org/openkilda/floodlight/switchmanager/SwitchNotFoundException.java" lines="1" checks="RegexpHeader"/>
     <suppress files="src/main/java/org/openkilda/floodlight/switchmanager/SwitchOperationException.java" lines="1" checks="RegexpHeader"/>
     <suppress files="src/main/java/org/openkilda/floodlight/switchmanager/web/FlowResource.java" lines="44" checks="JavadocMethod"/>
-    <suppress files="src/main/java/org/openkilda/floodlight/switchmanager/web/FlowsResource.java" lines="20" checks="CustomImportOrder"/>
-    <suppress files="src/main/java/org/openkilda/floodlight/switchmanager/web/FlowsResource.java" lines="21" checks="CustomImportOrder"/>
-    <suppress files="src/main/java/org/openkilda/floodlight/switchmanager/web/FlowsResource.java" lines="25" checks="CustomImportOrder"/>
-    <suppress files="src/main/java/org/openkilda/floodlight/switchmanager/web/FlowsResource.java" lines="75" checks="LocalVariableName"/>
-    <suppress files="src/main/java/org/openkilda/floodlight/switchmanager/web/FlowsResource.java" lines="138" checks="JavadocMethod"/>
     <suppress files="src/main/java/org/openkilda/floodlight/switchmanager/web/MetersResource.java" lines="23" checks="CustomImportOrder"/>
     <suppress files="src/main/java/org/openkilda/floodlight/switchmanager/web/MetersResource.java" lines="43" checks="JavadocMethod"/>
     <suppress files="src/main/java/org/openkilda/floodlight/switchmanager/web/MetersResource.java" lines="70" checks="WhitespaceAround"/>

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
@@ -24,6 +24,7 @@ import org.openkilda.floodlight.converter.OFFlowStatsConverter;
 import org.openkilda.floodlight.switchmanager.ISwitchManager;
 import org.openkilda.floodlight.switchmanager.MeterPool;
 import org.openkilda.floodlight.switchmanager.SwitchEventCollector;
+import org.openkilda.floodlight.switchmanager.SwitchNotFoundException;
 import org.openkilda.floodlight.switchmanager.SwitchOperationException;
 import org.openkilda.floodlight.utils.CorrelationContext;
 import org.openkilda.floodlight.utils.CorrelationContext.CorrelationContextClosable;
@@ -154,7 +155,7 @@ class RecordHandler implements Runnable {
         } else if (data instanceof ConnectModeRequest) {
             doConnectMode(message, replyToTopic, replyDestination);
         } else if (data instanceof DumpRulesRequest) {
-            doDumpRulesRequest(message, replyToTopic);
+            doDumpRulesRequest(message, replyToTopic, replyDestination);
         } else if (data instanceof BatchInstallRequest) {
             doBatchInstall(message);
         } else if (data instanceof PortsCommandData) {
@@ -563,6 +564,13 @@ class RecordHandler implements Runnable {
                     System.currentTimeMillis(), message.getCorrelationId(), replyDestination);
             context.getKafkaProducer().postMessage(replyToTopic, infoMessage);
 
+        } catch (SwitchNotFoundException e) {
+            logger.info("Deleting switch rules is unsuccessful. Switch {} not found", request.getSwitchId());
+            ErrorData errorData = new ErrorData(ErrorType.NOT_FOUND, e.getMessage(),
+                    request.getSwitchId().toString());
+            ErrorMessage error = new ErrorMessage(errorData,
+                    System.currentTimeMillis(), message.getCorrelationId(), replyDestination);
+            context.getKafkaProducer().postMessage(replyToTopic, error);
         } catch (SwitchOperationException e) {
             ErrorData errorData = new ErrorData(ErrorType.DELETION_FAILURE, e.getMessage(),
                     request.getSwitchId().toString());
@@ -591,24 +599,33 @@ class RecordHandler implements Runnable {
 
     }
 
-    private void doDumpRulesRequest(final CommandMessage message, String replyToTopic) {
+    private void doDumpRulesRequest(final CommandMessage message,  String replyToTopic, Destination replyDestination) {
         DumpRulesRequest request = (DumpRulesRequest) message.getData();
-        SwitchId switchId = request.getSwitchId();
-        logger.debug("Loading installed rules for switch {}", switchId);
+        try {
+            SwitchId switchId = request.getSwitchId();
+            logger.debug("Loading installed rules for switch {}", switchId);
 
-        List<OFFlowStatsEntry> flowEntries =
-                context.getSwitchManager().dumpFlowTable(DatapathId.of(switchId.toLong()));
-        List<FlowEntry> flows = flowEntries.stream()
-                .map(OFFlowStatsConverter::toFlowEntry)
-                .collect(Collectors.toList());
+            List<OFFlowStatsEntry> flowEntries =
+                    context.getSwitchManager().dumpFlowTable(DatapathId.of(switchId.toLong()));
+            List<FlowEntry> flows = flowEntries.stream()
+                    .map(OFFlowStatsConverter::toFlowEntry)
+                    .collect(Collectors.toList());
 
-        SwitchFlowEntries response = SwitchFlowEntries.builder()
-                .switchId(switchId)
-                .flowEntries(flows)
-                .build();
-        InfoMessage infoMessage = new InfoMessage(response, message.getTimestamp(),
-                message.getCorrelationId());
-        context.getKafkaProducer().postMessage(replyToTopic, infoMessage);
+            SwitchFlowEntries response = SwitchFlowEntries.builder()
+                    .switchId(switchId)
+                    .flowEntries(flows)
+                    .build();
+            InfoMessage infoMessage = new InfoMessage(response, message.getTimestamp(),
+                    message.getCorrelationId());
+            context.getKafkaProducer().postMessage(replyToTopic, infoMessage);
+        } catch (SwitchOperationException e) {
+            logger.info("Dump rules is unsuccessful. Switch {} not found", request.getSwitchId());
+            ErrorData errorData = new ErrorData(ErrorType.DATA_INVALID, e.getMessage(),
+                    request.getSwitchId().toString());
+            ErrorMessage error = new ErrorMessage(errorData,
+                    System.currentTimeMillis(), message.getCorrelationId(), replyDestination);
+            context.getKafkaProducer().postMessage(replyToTopic, error);
+        }
     }
 
     /**

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/ISwitchManager.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/ISwitchManager.java
@@ -161,7 +161,7 @@ public interface ISwitchManager extends IFloodlightService {
      * @param dpid switch id
      * @return OF flow stats entries
      */
-    List<OFFlowStatsEntry> dumpFlowTable(final DatapathId dpid);
+    List<OFFlowStatsEntry> dumpFlowTable(final DatapathId dpid) throws SwitchNotFoundException;
 
     /**
      * Returns list of installed meters

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
@@ -461,11 +461,11 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
      * {@inheritDoc}
      */
     @Override
-    public List<OFFlowStatsEntry> dumpFlowTable(final DatapathId dpid) {
+    public List<OFFlowStatsEntry> dumpFlowTable(final DatapathId dpid) throws SwitchNotFoundException {
         List<OFFlowStatsEntry> entries = new ArrayList<>();
         IOFSwitch sw = ofSwitchService.getSwitch(dpid);
         if (sw == null) {
-            throw new IllegalArgumentException(String.format("Switch %s was not found", dpid));
+            throw new SwitchNotFoundException(dpid);
         }
 
         OFFactory ofFactory = sw.getOFFactory();
@@ -1220,10 +1220,10 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
      * @return open flow switch descriptor
      * @throws SwitchOperationException switch operation exception
      */
-    private IOFSwitch lookupSwitch(DatapathId dpId) throws SwitchOperationException {
+    private IOFSwitch lookupSwitch(DatapathId dpId) throws SwitchNotFoundException {
         IOFSwitch swInfo = ofSwitchService.getSwitch(dpId);
         if (swInfo == null) {
-            throw new SwitchOperationException(dpId, String.format("Switch %s was not found", dpId));
+            throw new SwitchNotFoundException(dpId);
         }
         return swInfo;
     }

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchNotFoundException.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchNotFoundException.java
@@ -4,6 +4,6 @@ import org.projectfloodlight.openflow.types.DatapathId;
 
 public class SwitchNotFoundException extends SwitchOperationException {
     public SwitchNotFoundException(DatapathId dpId) {
-        super(dpId, String.format("Switch \"%s\" is not connected", dpId));
+        super(dpId, String.format("Switch %s was not found", dpId));
     }
 }


### PR DESCRIPTION
 - replacing the IllegalArgumentException with the SwitchNotFoundException in the dumpFlowTable method in the SwitchManager class.

 Closes: #950