### PR TITLE
Fix duplication of ISL records in DiscoveryManager.

### DIFF
--- a/services/src/messaging/src/main/java/org/openkilda/messaging/ctrl/state/OFELinkBoltState.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/ctrl/state/OFELinkBoltState.java
@@ -1,15 +1,15 @@
 package org.openkilda.messaging.ctrl.state;
 
+import org.openkilda.messaging.ctrl.AbstractDumpState;
+import org.openkilda.messaging.ctrl.state.visitor.DumpStateVisitor;
+import org.openkilda.messaging.model.DiscoveryLink;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.openkilda.messaging.ctrl.AbstractDumpState;
-import org.openkilda.messaging.ctrl.state.visitor.DumpStateVisitor;
-import org.openkilda.messaging.model.DiscoveryLink;
 
-import java.util.List;
 import java.util.Set;
 
 @JsonSerialize
@@ -18,15 +18,15 @@ import java.util.Set;
 public class OFELinkBoltState extends AbstractDumpState {
 
     @JsonProperty("discovery")
-    private final List<DiscoveryLink> discovery;
+    private final Set<DiscoveryLink> discovery;
 
     @JsonProperty("filtered")
-    private final Set<?> filtered;
+    private final Set<DiscoveryLink> filtered;
 
     @JsonCreator
     public OFELinkBoltState(
-            @JsonProperty("state") List<DiscoveryLink> discovery,
-            @JsonProperty("filtered") Set<?> filtered) {
+            @JsonProperty("state") Set<DiscoveryLink> discovery,
+            @JsonProperty("filtered") Set<DiscoveryLink> filtered) {
         this.discovery = discovery;
         this.filtered = filtered;
     }
@@ -35,11 +35,11 @@ public class OFELinkBoltState extends AbstractDumpState {
         visitor.visit(this);
     }
 
-    public List<?> getDiscovery() {
+    public Set<DiscoveryLink> getDiscovery() {
         return discovery;
     }
 
-    public Set<?> getFiltered() {
+    public Set<DiscoveryLink> getFiltered() {
         return filtered;
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/event/OfeLinkBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/event/OfeLinkBolt.java
@@ -73,7 +73,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -122,7 +121,7 @@ public class OfeLinkBolt
 
     private DummyIIslFilter islFilter;
     private DiscoveryManager discovery;
-    private Map<SwitchId, List<DiscoveryLink>> linksBySwitch;
+    private Map<SwitchId, Set<DiscoveryLink>> linksBySwitch;
 
     private String dumpRequestCorrelationId = null;
     private float dumpRequestTimeout;
@@ -172,7 +171,7 @@ public class OfeLinkBolt
             payload = linksBySwitch = new HashMap<>();
             state.put(islDiscoveryTopic, payload);
         } else {
-            linksBySwitch = (Map<SwitchId, List<DiscoveryLink>>) payload;
+            linksBySwitch = (Map<SwitchId, Set<DiscoveryLink>>) payload;
         }
 
         // DiscoveryManager counts failures as failed attempts,
@@ -591,10 +590,10 @@ public class OfeLinkBolt
 
     @Override
     public AbstractDumpState dumpState() {
-        List<DiscoveryLink> links = linksBySwitch.values()
+        Set<DiscoveryLink> links = linksBySwitch.values()
                 .stream()
-                .flatMap(List::stream)
-                .collect(Collectors.toList());
+                .flatMap(Set::stream)
+                .collect(Collectors.toSet());
 
         return new OFELinkBoltState(links, islFilter.getMatchSet());
     }
@@ -613,7 +612,7 @@ public class OfeLinkBolt
     @Override
     public AbstractDumpState dumpStateBySwitchId(SwitchId switchId) {
 
-        List<DiscoveryLink> filteredDiscoveryList = linksBySwitch.get(switchId);
+        Set<DiscoveryLink> filteredDiscoveryList = linksBySwitch.get(switchId);
 
         Set<DiscoveryLink> filterdIslFilter = islFilter.getMatchSet().stream()
                 .filter(node -> node.getSource().getSwitchDpId().equals(switchId))

--- a/services/wfm/src/test/java/org/openkilda/wfm/isl/DiscoveryManagerTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/isl/DiscoveryManagerTest.java
@@ -15,8 +15,12 @@
 
 package org.openkilda.wfm.isl;
 
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.openkilda.messaging.model.DiscoveryLink;
@@ -29,6 +33,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 
 /**
@@ -337,20 +342,17 @@ public class DiscoveryManagerTest {
         dm.handleDiscovered(srcNode3.getDatapath(), srcNode3.getPortNumber(),
                 dstNode3.getDatapath(), dstNode3.getPortNumber());
 
-        List<DiscoveryLink> links;
-        links = dm.findAllBySwitch(srcNode1.getDatapath());
-        assertEquals(true, links.get(0).isActive());
-        assertEquals(true, links.get(1).isActive());
+        Set<DiscoveryLink> links = dm.findAllBySwitch(srcNode1.getDatapath());
+        assertThat(links, everyItem(hasProperty("active", is(true))));
         links = dm.findAllBySwitch(srcNode3.getDatapath());
-        assertEquals(true, links.get(0).isActive());
+        assertThat(links, everyItem(hasProperty("active", is(true))));
 
         // now send SwitchUp and confirm sw1 all go back to not found, sw2 unchanged
         dm.handleSwitchUp(srcNode1.getDatapath());
         links = dm.findAllBySwitch(srcNode1.getDatapath());
-        assertEquals(false, links.get(0).isActive());
-        assertEquals(false, links.get(1).isActive());
+        assertThat(links, everyItem(hasProperty("active", is(false))));
         links = dm.findAllBySwitch(srcNode3.getDatapath());
-        assertEquals(true, links.get(0).isActive());
+        assertThat(links, everyItem(hasProperty("active", is(true))));
 
         // now confirm they go back to found upon next Discovery.
         dm.handleDiscovered(srcNode1.getDatapath(), srcNode1.getPortNumber(),
@@ -358,10 +360,9 @@ public class DiscoveryManagerTest {
         dm.handleDiscovered(srcNode2.getDatapath(), srcNode2.getPortNumber(),
                 dstNode2.getDatapath(), dstNode2.getPortNumber());
         links = dm.findAllBySwitch(srcNode1.getDatapath());
-        assertEquals(true, links.get(0).isActive());
-        assertEquals(true, links.get(1).isActive());
+        assertThat(links, everyItem(hasProperty("active", is(true))));
         links = dm.findAllBySwitch(srcNode3.getDatapath());
-        assertEquals(true, links.get(0).isActive());
+        assertThat(links, everyItem(hasProperty("active", is(true))));
     }
 
     @Test
@@ -370,7 +371,7 @@ public class DiscoveryManagerTest {
 
         setupThreeLinks();
         // 3 nodes - 2 in sw1, one in sw2; verify dropping sw1 drops 2 nodes (1 remaining)
-        List<DiscoveryLink> links = dm.findAllBySwitch(srcNode1.getDatapath());
+        Set<DiscoveryLink> links = dm.findAllBySwitch(srcNode1.getDatapath());
         assertEquals(2, links.size());
         links = dm.findAllBySwitch(srcNode3.getDatapath());
         assertEquals(1, links.size());


### PR DESCRIPTION
The changes:
- Update DiscoveryManager to avoid duplication of ISLs on port registration.