### PR TITLE
Fix the type of max bandwidth in neo4j.

### DIFF
--- a/services/topology-engine/queue-engine/topologylistener/model.py
+++ b/services/topology-engine/queue-engine/topologylistener/model.py
@@ -358,7 +358,8 @@ class LinkProps(TimestampMixin, AbstractLink):
         'time_create', 'time_modify',
         'latency', 'speed', 'available_bandwidth', 'actual', 'status'))
     props_converters = {
-        'cost': convert_integer}
+        'cost': convert_integer,
+        'max_bandwidth': convert_integer}
 
     props = Default(dict, produce=True)
     filtered = Default(set, produce=True)


### PR DESCRIPTION
This fix partially solves the issue 1076 associated with storing max bandwidth in a string type in neo4j.