### PR TITLE
#907 Fix the error display when using incorrect character in TE.

### DIFF
--- a/services/topology-engine/queue-engine/topologylistener/messageclasses.py
+++ b/services/topology-engine/queue-engine/topologylistener/messageclasses.py
@@ -239,7 +239,7 @@ class MessageItem(model.JsonSerializable):
             else:
                 raise exc.NotImplementedError(
                     'link props request {}'.format(self.get_message_type()))
-        except exc.Error as e:
+        except Exception as e:
             payload = message_utils.make_link_props_response(
                 self.payload, None, error=str(e))
             message_utils.send_link_props_response(


### PR DESCRIPTION

 - fixed the error display when using incorrect character when creating link props.