### PR TITLE
#1198 Add RESET_COUNTS flag to FlowMod message

### DIFF
--- a/services/src/floodlight-modules/src/checkstyle/checkstyle-suppress-known-issues.xml
+++ b/services/src/floodlight-modules/src/checkstyle/checkstyle-suppress-known-issues.xml
@@ -98,15 +98,6 @@
     <suppress files="src/test/java/org/openkilda/floodlight/kafka/ReplaceInstallFlowTest.java" lines="28" checks="CustomImportOrder"/>
     <suppress files="src/test/java/org/openkilda/floodlight/kafka/ReplaceInstallFlowTest.java" lines="29" checks="CustomImportOrder"/>
     <suppress files="src/test/java/org/openkilda/floodlight/kafka/ReplaceInstallFlowTest.java" lines="89" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/test/standard/OutputCommands.java" lines="26" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/test/standard/OutputCommands.java" lines="27" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/test/standard/OutputCommands.java" lines="28" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/test/standard/OutputCommands.java" lines="76" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/test/standard/OutputCommands.java" lines="99" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/test/standard/OutputCommands.java" lines="129" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/test/standard/OutputCommands.java" lines="152" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/test/standard/OutputCommands.java" lines="177" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/test/standard/OutputCommands.java" lines="208" checks="JavadocMethod"/>
     <suppress files="src/test/java/org/openkilda/floodlight/OFFactoryMock.java" lines="20" checks="AbbreviationAsWordInName"/>
     <suppress files="src/test/java/org/openkilda/floodlight/OFFactoryVer12Mock.java" lines="1" checks="RegexpHeader"/>
     <suppress files="src/test/java/org/openkilda/floodlight/OFFactoryVer12Mock.java" lines="7" checks="AbbreviationAsWordInName"/>
@@ -144,17 +135,6 @@
     <suppress files="src/test/java/org/openkilda/floodlight/switchmanager/MeterPoolTest.java" lines="80" checks="WhitespaceAround"/>
     <suppress files="src/test/java/org/openkilda/floodlight/switchmanager/MeterPoolTest.java" lines="80" checks="WhitespaceAround"/>
     <suppress files="src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerOF12Test.java" lines="1" checks="RegexpHeader"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerOF12Test.java" lines="10" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerOF12Test.java" lines="11" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerOF12Test.java" lines="12" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerOF12Test.java" lines="13" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerOF12Test.java" lines="14" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerOF12Test.java" lines="15" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerOF12Test.java" lines="16" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerOF12Test.java" lines="17" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerOF12Test.java" lines="18" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerOF12Test.java" lines="19" checks="CustomImportOrder"/>
-    <suppress files="src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerOF12Test.java" lines="20" checks="CustomImportOrder"/>
     <suppress files="src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerOF12Test.java" lines="44" checks="JavadocMethod"/>
     <suppress files="src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerTest.java" lines="49" checks="CustomImportOrder"/>
     <suppress files="src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerTest.java" lines="50" checks="CustomImportOrder"/>

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerOF12Test.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerOF12Test.java
@@ -7,6 +7,8 @@ import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
 import static org.openkilda.floodlight.switchmanager.SwitchManager.DEFAULT_RULE_PRIORITY;
 
+import org.openkilda.floodlight.OFFactoryVer12Mock;
+
 import net.floodlightcontroller.core.IOFSwitch;
 import net.floodlightcontroller.core.internal.IOFSwitchService;
 import net.floodlightcontroller.core.module.FloodlightModuleContext;
@@ -16,7 +18,6 @@ import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.openkilda.floodlight.OFFactoryVer12Mock;
 import org.projectfloodlight.openflow.protocol.OFFactory;
 import org.projectfloodlight.openflow.protocol.OFFlowMod;
 import org.projectfloodlight.openflow.protocol.match.MatchField;

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/test/standard/OutputCommands.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/test/standard/OutputCommands.java
@@ -23,8 +23,10 @@ import static org.projectfloodlight.openflow.protocol.OFMeterFlags.BURST;
 import static org.projectfloodlight.openflow.protocol.OFMeterFlags.KBPS;
 import static org.projectfloodlight.openflow.protocol.OFMeterModCommand.ADD;
 
-import net.floodlightcontroller.util.FlowModUtils;
 import org.openkilda.floodlight.OFFactoryMock;
+
+import net.floodlightcontroller.util.FlowModUtils;
+
 import org.projectfloodlight.openflow.protocol.OFFactory;
 import org.projectfloodlight.openflow.protocol.OFFlowAdd;
 import org.projectfloodlight.openflow.protocol.OFMeterMod;
@@ -73,6 +75,14 @@ public interface OutputCommands {
         return ingressMatchVlanIdFlowMod(inputPort, outputPort, inputVlan, transitVlan, meterId, cookie);
     }
 
+    /**
+     * Builds a FlowMod command for transit rule.
+     *
+     * @param inputPort     Input Port for Match section
+     * @param outputPort    Output Port for Instructions section
+     * @param transitVlan   Transit Vlan for Match section
+     * @param cookie        Cookie
+     */
     default OFFlowAdd transitFlowMod(int inputPort, int outputPort, int transitVlan, long cookie) {
         return ofFactory.buildFlowAdd()
                 .setCookie(U64.of(cookie & FLOW_COOKIE_MASK))
@@ -96,6 +106,16 @@ public interface OutputCommands {
                 .build();
     }
 
+    /**
+     * Builds a FlowMod command for a Single Switch flow with Vlans.
+     *
+     * @param inputPort     Input Port for Match section
+     * @param outputPort    Output Port for Instructions section
+     * @param inputVlan     Ingress Vlan for Match section
+     * @param outputVlan    Egress Vlan for Instructions section
+     * @param meterId       Meter ID
+     * @param cookie        Cookie
+     */
     default OFFlowAdd oneSwitchReplaceFlowMod(int inputPort, int outputPort, int inputVlan, int outputVlan,
                                               long meterId, long cookie) {
         return ofFactory.buildFlowAdd()
@@ -126,6 +146,14 @@ public interface OutputCommands {
                 .build();
     }
 
+    /**
+     * Builds a FlowMod command for a Single Switch flow (full-port to full-port).
+     *
+     * @param inputPort     Input Port for Match section
+     * @param outputPort    Output Port for Instructions section
+     * @param meterId       Meter ID
+     * @param cookie        Cookie
+     */
     default OFFlowAdd oneSwitchNoneFlowMod(int inputPort, int outputPort, long meterId, long cookie) {
         return ofFactory.buildFlowAdd()
                 .setCookie(U64.of(cookie & FLOW_COOKIE_MASK))
@@ -149,6 +177,15 @@ public interface OutputCommands {
                 .build();
     }
 
+    /**
+     * Builds a FlowMod command for a Single Switch flow with Vlan in ingress side only.
+     *
+     * @param inputPort     Input Port for Match section
+     * @param outputPort    Output Port for Instructions section
+     * @param inputVlan     Ingress Vlan for Match section
+     * @param meterId       Meter ID
+     * @param cookie        Cookie
+     */
     default OFFlowAdd oneSwitchPopFlowMod(int inputPort, int outputPort, int inputVlan, long meterId, long cookie) {
         return ofFactory.buildFlowAdd()
                 .setCookie(U64.of(cookie & FLOW_COOKIE_MASK))
@@ -174,6 +211,15 @@ public interface OutputCommands {
                 .build();
     }
 
+    /**
+     * Builds a FlowMod command for a Single Switch flow with Vlan in egress side only.
+     *
+     * @param inputPort     Input Port for Match section
+     * @param outputPort    Output Port for Instructions section
+     * @param outputVlan    Egress Vlan for Instructions section
+     * @param meterId       Meter ID
+     * @param cookie        Cookie
+     */
     default OFFlowAdd oneSwitchPushFlowMod(int inputPort, int outputPort, int outputVlan, long meterId, long cookie) {
         return ofFactory.buildFlowAdd()
                 .setCookie(U64.of(cookie & FLOW_COOKIE_MASK))
@@ -205,6 +251,13 @@ public interface OutputCommands {
                 .build();
     }
 
+    /**
+     * Builds a MeterMod command.
+     *
+     * @param bandwidth    Maximum allowed Bandwidth for flow
+     * @param burstSize    Burst size for a meter
+     * @param meterId      Meter ID
+     */
     default OFMeterMod installMeter(long bandwidth, long burstSize, long meterId) {
         return ofFactory.buildMeterMod()
                 .setMeterId(meterId)

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/test/standard/OutputCommands.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/test/standard/OutputCommands.java
@@ -15,6 +15,7 @@
 
 package org.openkilda.floodlight.test.standard;
 
+import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.openkilda.floodlight.switchmanager.SwitchManager.DEFAULT_RULE_PRIORITY;
 import static org.openkilda.floodlight.switchmanager.SwitchManager.FLOW_COOKIE_MASK;
@@ -29,6 +30,7 @@ import net.floodlightcontroller.util.FlowModUtils;
 
 import org.projectfloodlight.openflow.protocol.OFFactory;
 import org.projectfloodlight.openflow.protocol.OFFlowAdd;
+import org.projectfloodlight.openflow.protocol.OFFlowModFlags;
 import org.projectfloodlight.openflow.protocol.OFMeterMod;
 import org.projectfloodlight.openflow.protocol.match.MatchField;
 import org.projectfloodlight.openflow.types.EthType;
@@ -124,6 +126,7 @@ public interface OutputCommands {
                 .setIdleTimeout(FlowModUtils.INFINITE_TIMEOUT)
                 .setBufferId(OFBufferId.NO_BUFFER)
                 .setPriority(DEFAULT_RULE_PRIORITY)
+                .setFlags(singleton(OFFlowModFlags.RESET_COUNTS))
                 .setMatch(ofFactory.buildMatch()
                         .setExact(MatchField.IN_PORT, OFPort.of(inputPort))
                         .setExact(MatchField.VLAN_VID, OFVlanVidMatch.ofVlan(inputVlan))
@@ -161,6 +164,7 @@ public interface OutputCommands {
                 .setIdleTimeout(FlowModUtils.INFINITE_TIMEOUT)
                 .setBufferId(OFBufferId.NO_BUFFER)
                 .setPriority(DEFAULT_RULE_PRIORITY)
+                .setFlags(singleton(OFFlowModFlags.RESET_COUNTS))
                 .setMatch(ofFactory.buildMatch()
                         .setExact(MatchField.IN_PORT, OFPort.of(inputPort))
                         .build())
@@ -193,6 +197,7 @@ public interface OutputCommands {
                 .setIdleTimeout(FlowModUtils.INFINITE_TIMEOUT)
                 .setBufferId(OFBufferId.NO_BUFFER)
                 .setPriority(DEFAULT_RULE_PRIORITY)
+                .setFlags(singleton(OFFlowModFlags.RESET_COUNTS))
                 .setMatch(ofFactory.buildMatch()
                         .setExact(MatchField.IN_PORT, OFPort.of(inputPort))
                         .setExact(MatchField.VLAN_VID, OFVlanVidMatch.ofVlan(inputVlan))
@@ -227,6 +232,7 @@ public interface OutputCommands {
                 .setIdleTimeout(FlowModUtils.INFINITE_TIMEOUT)
                 .setBufferId(OFBufferId.NO_BUFFER)
                 .setPriority(DEFAULT_RULE_PRIORITY)
+                .setFlags(singleton(OFFlowModFlags.RESET_COUNTS))
                 .setMatch(ofFactory.buildMatch()
                         .setExact(MatchField.IN_PORT, OFPort.of(inputPort))
                         .build())

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/test/standard/PushSchemeOutputCommands.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/test/standard/PushSchemeOutputCommands.java
@@ -15,6 +15,7 @@
 
 package org.openkilda.floodlight.test.standard;
 
+import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.openkilda.floodlight.switchmanager.SwitchManager.DEFAULT_RULE_PRIORITY;
 import static org.openkilda.floodlight.switchmanager.SwitchManager.FLOW_COOKIE_MASK;
@@ -22,6 +23,7 @@ import static org.openkilda.messaging.Utils.ETH_TYPE;
 
 import net.floodlightcontroller.util.FlowModUtils;
 import org.projectfloodlight.openflow.protocol.OFFlowAdd;
+import org.projectfloodlight.openflow.protocol.OFFlowModFlags;
 import org.projectfloodlight.openflow.protocol.match.MatchField;
 import org.projectfloodlight.openflow.types.EthType;
 import org.projectfloodlight.openflow.types.OFBufferId;
@@ -45,6 +47,7 @@ public class PushSchemeOutputCommands implements OutputCommands {
                 .setIdleTimeout(FlowModUtils.INFINITE_TIMEOUT)
                 .setBufferId(OFBufferId.NO_BUFFER)
                 .setPriority(DEFAULT_RULE_PRIORITY)
+                .setFlags(singleton(OFFlowModFlags.RESET_COUNTS))
                 .setMatch(ofFactory.buildMatch()
                         .setExact(MatchField.IN_PORT, OFPort.of(inputPort))
                         .setExact(MatchField.VLAN_VID, OFVlanVidMatch.ofVlan(inputVlan))
@@ -80,6 +83,7 @@ public class PushSchemeOutputCommands implements OutputCommands {
                 .setIdleTimeout(FlowModUtils.INFINITE_TIMEOUT)
                 .setBufferId(OFBufferId.NO_BUFFER)
                 .setPriority(DEFAULT_RULE_PRIORITY)
+                .setFlags(singleton(OFFlowModFlags.RESET_COUNTS))
                 .setMatch(ofFactory.buildMatch()
                         .setExact(MatchField.IN_PORT, OFPort.of(inputPort))
                         .build())

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/test/standard/ReplaceSchemeOutputCommands.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/test/standard/ReplaceSchemeOutputCommands.java
@@ -15,12 +15,14 @@
 
 package org.openkilda.floodlight.test.standard;
 
+import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.openkilda.floodlight.switchmanager.SwitchManager.DEFAULT_RULE_PRIORITY;
 import static org.openkilda.floodlight.switchmanager.SwitchManager.FLOW_COOKIE_MASK;
 
 import net.floodlightcontroller.util.FlowModUtils;
 import org.projectfloodlight.openflow.protocol.OFFlowAdd;
+import org.projectfloodlight.openflow.protocol.OFFlowModFlags;
 import org.projectfloodlight.openflow.protocol.match.MatchField;
 import org.projectfloodlight.openflow.types.OFBufferId;
 import org.projectfloodlight.openflow.types.OFPort;
@@ -39,6 +41,7 @@ public class ReplaceSchemeOutputCommands extends PushSchemeOutputCommands {
                 .setIdleTimeout(FlowModUtils.INFINITE_TIMEOUT)
                 .setBufferId(OFBufferId.NO_BUFFER)
                 .setPriority(DEFAULT_RULE_PRIORITY)
+                .setFlags(singleton(OFFlowModFlags.RESET_COUNTS))
                 .setMatch(ofFactory.buildMatch()
                         .setExact(MatchField.IN_PORT, OFPort.of(inputPort))
                         .setExact(MatchField.VLAN_VID, OFVlanVidMatch.ofVlan(inputVlan))


### PR DESCRIPTION
In order to reset count for ingress rule on update (reroute), we should set RESET_COUNTS flag for FlowMod message. See "OpenFlow (v1.3.0) Switch Specification", section "6.4 Flow Table Modification Messages" for details.

Resolves: #1198