### PR TITLE
#1229 Recovery of max bandwidth when deleting link props.

### DIFF
--- a/services/topology-engine/queue-engine/topologylistener/isl_utils.py
+++ b/services/topology-engine/queue-engine/topologylistener/isl_utils.py
@@ -333,6 +333,9 @@ def del_props(tx, isl, props):
           (:switch {name: $dst_switch})""") + '\nREMOVE '.join(remove)
     db.log_query('ISL drop props', q, p)
     stats = tx.run(q, p).stats()
+    if 'max_bandwidth' in props:
+        db_isl = fetch(tx, isl)
+        set_props(tx, isl, {'max_bandwidth': db_isl.get('default_max_bandwidth', 0)})
     return stats['contains_updates']
 
 

--- a/services/topology-engine/queue-engine/topologylistener/messageclasses.py
+++ b/services/topology-engine/queue-engine/topologylistener/messageclasses.py
@@ -380,6 +380,7 @@ class MessageItem(model.JsonSerializable):
                 'latency': latency,
                 'speed': speed,
                 'max_bandwidth': available_bandwidth,
+                'default_max_bandwidth': available_bandwidth,
                 'actual': 'active'})
 
             isl_utils.update_status(tx, isl, mtime=self.timestamp)


### PR DESCRIPTION

When deleting the link props, the max bandwidth is restored from the database.

Closes: #1229