### PR TITLE
Removed duplicate dependencies from API pom.xml

### DIFF
--- a/services/src/api/pom.xml
+++ b/services/src/api/pom.xml
@@ -33,10 +33,6 @@
             <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
         </dependency>


### PR DESCRIPTION
pom.xml of API module has duplicate _jackson-annotations_ dependency. It was removed.