### PR TITLE
Add code meters into FL

### DIFF
--- a/confd/templates/floodlight/floodlightkilda.properties.tmpl
+++ b/confd/templates/floodlight/floodlightkilda.properties.tmpl
@@ -59,6 +59,9 @@ net.floodlightcontroller.statistics.StatisticsCollector.enable=FALSE
 net.floodlightcontroller.statistics.StatisticsCollector.collectionIntervalPortStatsSeconds=60
 net.floodlightcontroller.topology.TopologyManager.pathMetric=latency
 net.floodlightcontroller.topology.TopologyManager.maxPathsToCompute=3
+{{ if eq (getv "/kilda_environment_role") "devel" "test" }}
+org.openkilda.floodlight.KildaCore.testing-mode=YES
+{{ end }}
 #org.openkilda.floodlight.KildaCore.command-processor-workers-count = 4
 #org.openkilda.floodlight.KildaCore.command-processor-workers-limit = 32
 org.openkilda.floodlight.KildaCore.command-processor-deferred-requests-limit = {{ getv "/kilda_floodlight_command_processor_deferred_requests_limit" }}
@@ -66,9 +69,6 @@ org.openkilda.floodlight.KildaCore.command-processor-deferred-requests-limit = {
 org.openkilda.floodlight.KafkaChannel.environment-naming-prefix={{ getv "/kilda_environment_naming_prefix" }}
 org.openkilda.floodlight.KafkaChannel.bootstrap-servers={{ getv "/kilda_kafka_hosts" }}
 #org.openkilda.floodlight.KafkaChannel.heart-beat-interval=1
-{{ if eq (getv "/kilda_environment_role") "devel" "test" }}
-org.openkilda.floodlight.KafkaChannel.testing-mode=YES
-{{ end }}
 org.openkilda.floodlight.kafka.KafkaMessageCollector.consumer-executors={{ getv "/kilda_floodlight_consumer_executors" }}
 org.openkilda.floodlight.kafka.KafkaMessageCollector.consumer-disco-executors={{ getv "/kilda_floodlight_consumer_disco_executors" }}
 #org.openkilda.floodlight.kafka.KafkaMessageCollector.consumer-auto-commit-interval=1000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -318,13 +318,13 @@ services:
     container_name: floodlight
     build:
       context: services/src/floodlight-modules
-    image: "kilda/floodlight:${full_build_number:-latest}"
     ports:
       - "6653:6653"
       - "8180:8080"
       - "6655:6655"
       - "6642:6642"
       - "8081:8080"
+      - "11011"
     depends_on:
       kafka:
         condition: service_healthy

--- a/services/src/floodlight-modules/Dockerfile
+++ b/services/src/floodlight-modules/Dockerfile
@@ -15,14 +15,10 @@
 
 FROM kilda/base-ubuntu
 
-ADD src/main/resources/floodlightkilda.properties /app
-ADD src/main/resources/logback.xml /app
+ADD app /app
 ADD run-deps/floodlight.jar /app/floodlight.jar
+ADD src/main/resources/logback.xml /app
+ADD src/main/resources/floodlightkilda.properties /app
 ADD target/floodlight-modules.jar /app/floodlight-modules.jar
 
-CMD ["java", \
-    "-XX:+PrintFlagsFinal", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", \
-    "-Dlogback.configurationFile=/app/logback.xml", "-cp", \
-    "/app/floodlight.jar:/app/floodlight-modules.jar", \
-    "net.floodlightcontroller.core.Main", "-cf", "/app/floodlightkilda.properties"]
-
+CMD ["/app/entry-point.sh"]

--- a/services/src/floodlight-modules/app/entry-point.sh
+++ b/services/src/floodlight-modules/app/entry-point.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+config_file="/app/floodlightkilda.properties"
+extra_args=( )
+
+get_testing_mode_status() {
+    sed -nE -e '/^org.openkilda.floodlight.kafka.KafkaMessageCollector.testing-mode[[:space:]]*=/ {s:^.*=::; s:[[:space:]]+$::; p}' \
+        "${config_file}"
+}
+
+if [[ "$(get_testing_mode_status)" == "YES" ]]; then
+    extra_args=(
+        "${extra_args[@]}"
+        -Dcom.sun.management.jmxremote
+        -Dcom.sun.management.jmxremote.port=11011
+        -Dcom.sun.management.jmxremote.local.only=false
+        -Dcom.sun.management.jmxremote.authenticate=false
+        -Dcom.sun.management.jmxremote.ssl=false
+    )
+fi
+
+exec java \
+    -XX:+PrintFlagsFinal \
+    -XX:+UnlockExperimentalVMOptions \
+    -XX:+UseCGroupMemoryLimitForHeap \
+    "${extra_args[@]}" \
+    -Dlogback.configurationFile=/app/logback.xml \
+    -cp /app/floodlight.jar:/app/floodlight-modules.jar \
+    net.floodlightcontroller.core.Main -cf "${config_file}"

--- a/services/src/floodlight-modules/pom.xml
+++ b/services/src/floodlight-modules/pom.xml
@@ -98,6 +98,17 @@
             <groupId>org.glassfish</groupId>
             <artifactId>javax.el</artifactId>
         </dependency>
+
+        <dependency>
+          <groupId>io.dropwizard.metrics</groupId>
+          <artifactId>metrics-core</artifactId>
+          <version>${metrics.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jmx</artifactId>
+            <version>${metrics.version}</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/KafkaChannel.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/KafkaChannel.java
@@ -62,7 +62,8 @@ public class KafkaChannel implements IFloodlightModule {
 
     @Override
     public Collection<Class<? extends IFloodlightService>> getModuleDependencies() {
-        return ImmutableList.of();
+        return ImmutableList.of(
+                KildaCore.class);
     }
 
     @Override

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/KafkaChannelConfig.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/KafkaChannelConfig.java
@@ -38,13 +38,6 @@ public interface KafkaChannelConfig extends KafkaConsumerGroupConfig {
     @Min(1)
     float getHeartBeatInterval();
 
-    @Key("testing-mode")
-    String getTestingMode();
-
-    default boolean isTestingMode() {
-        return "YES".equals(getTestingMode());
-    }
-
     /**
      * Returns Kafka properties built with the configuration data for Consumer.
      */

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/KildaCoreConfig.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/KildaCoreConfig.java
@@ -34,4 +34,11 @@ public interface KildaCoreConfig {
     @Key("command-processor-idle-workers-keep-alive-seconds")
     @Default("300")
     long getCommandIdleWorkersKeepAliveSeconds();
+
+    @Key("testing-mode")
+    String getTestingMode();
+
+    default boolean isTestingMode() {
+        return "YES".equals(getTestingMode());
+    }
 }

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/command/Command.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/command/Command.java
@@ -29,7 +29,20 @@ public abstract class Command implements Callable<Command> {
         this.context = context;
     }
 
-    public Command exceptional(Throwable e) {
+    @Override
+    public Command call() {
+        Command next;
+        try {
+            next = execute();
+        } catch (Exception e) {
+            next = exceptional(e);
+        }
+        return next;
+    }
+
+    protected abstract Command execute() throws Exception;
+
+    protected Command exceptional(Throwable e) {
         log.error(String.format("Unhandled exception into %s: %s", getClass().getName(), e.getMessage()), e);
         return null;
     }
@@ -42,7 +55,7 @@ public abstract class Command implements Callable<Command> {
         return true;
     }
 
-    protected CommandContext getContext() {
+    public CommandContext getContext() {
         return context;
     }
 }

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/command/CommandMetric.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/command/CommandMetric.java
@@ -1,0 +1,56 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.floodlight.command;
+
+import org.openkilda.floodlight.service.MetricService;
+
+import com.codahale.metrics.Timer;
+
+public class CommandMetric extends Command {
+    private static final String KIND_CALL = "call";
+    private static final String KIND_EXCEPTIONAL = "exceptional";
+
+    private final MetricService metricService;
+    private final Command target;
+
+    public CommandMetric(CommandContext context, Command target) {
+        super(context);
+
+        metricService = context.getModuleContext().getServiceImpl(MetricService.class);
+        this.target = target;
+    }
+
+    @Override
+    public Command execute() throws Exception {
+        return makeTimer(KIND_CALL).time(target);
+    }
+
+    @Override
+    protected Command exceptional(Throwable e) {
+        try (Timer.Context time = makeTimer(KIND_EXCEPTIONAL).time()) {
+            return target.exceptional(e);
+        }
+    }
+
+    @Override
+    public boolean isOneShot() {
+        return target.isOneShot();
+    }
+
+    private Timer makeTimer(String kind) {
+        return metricService.timer(target.getClass(), kind);
+    }
+}

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/command/InputDispatchCommand.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/command/InputDispatchCommand.java
@@ -36,7 +36,7 @@ public class InputDispatchCommand extends Command {
     }
 
     @Override
-    public Command call() throws Exception {
+    public Command execute() throws Exception {
         for (IInputTranslator entry : subscribers) {
             Command command = entry.makeCommand(getContext(), input);
             if (command != null) {

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/command/PendingCommandSubmitter.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/command/PendingCommandSubmitter.java
@@ -39,7 +39,7 @@ public class PendingCommandSubmitter extends Command {
     }
 
     @Override
-    public Command call() throws Exception {
+    public Command execute() throws Exception {
         try {
             int count;
             int iteration = 0;

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/command/ping/PingRequestCommand.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/command/ping/PingRequestCommand.java
@@ -58,7 +58,7 @@ public class PingRequestCommand extends PingCommand {
     }
 
     @Override
-    public Command call() {
+    public Command execute() {
         try {
             checkDestination();
             send(checkSource());

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/command/ping/PingResponseCommand.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/command/ping/PingResponseCommand.java
@@ -41,7 +41,7 @@ public class PingResponseCommand extends PingCommand {
     }
 
     @Override
-    public Command call() throws Exception {
+    public Command execute() {
         log.debug("{} - {}", getClass().getCanonicalName(), input);
 
         byte[] payload = unwrap();

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/KafkaMessageCollector.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/KafkaMessageCollector.java
@@ -16,6 +16,7 @@
 package org.openkilda.floodlight.kafka;
 
 import org.openkilda.config.KafkaTopicsConfig;
+import org.openkilda.floodlight.KildaCore;
 import org.openkilda.floodlight.config.provider.FloodlightModuleConfigurationProvider;
 import org.openkilda.floodlight.pathverification.IPathVerificationService;
 import org.openkilda.floodlight.service.CommandProcessorService;
@@ -62,6 +63,7 @@ public class KafkaMessageCollector implements IFloodlightModule {
     @Override
     public Collection<Class<? extends IFloodlightService>> getModuleDependencies() {
         return ImmutableList.of(
+                KildaCore.class,
                 IPathVerificationService.class,
                 ISwitchManager.class,
                 KafkaUtilityService.class,
@@ -121,7 +123,7 @@ public class KafkaMessageCollector implements IFloodlightModule {
             ConsumerContext context = new ConsumerContext(moduleContext);
             this.handlerFactory = new RecordHandler.Factory(context);
 
-            isTestingMode = moduleContext.getServiceImpl(KafkaUtilityService.class).isTestingMode();
+            isTestingMode = moduleContext.getServiceImpl(KildaCore.class).isTestingMode();
         }
 
         private void launch(ExecutorService handlerExecutor, KafkaConsumerSetup kafkaSetup) {

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/pathverification/PathVerificationService.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/pathverification/PathVerificationService.java
@@ -183,7 +183,7 @@ public class PathVerificationService implements IFloodlightModule, IPathVerifica
     public Command makeCommand(CommandContext context, OfInput input) {
         return new Command(context) {
             @Override
-            public Command call() {
+            public Command execute() {
                 handlePacketIn(input);
                 return null;
             }

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/service/MetricService.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/service/MetricService.java
@@ -1,0 +1,52 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.floodlight.service;
+
+import org.openkilda.floodlight.KildaCore;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.jmx.JmxReporter;
+import net.floodlightcontroller.core.module.FloodlightModuleContext;
+
+public class MetricService implements IService {
+    private final MetricRegistry registry = new MetricRegistry();
+    private final JmxReporter reporter = JmxReporter.forRegistry(registry).build();
+
+    public Timer timer(Class<?> klass, String... nameChunks) {
+        return timer(MetricRegistry.name(klass, nameChunks));
+    }
+
+    public Timer timer(String namePrefix, String... nameChunks) {
+        return timer(MetricRegistry.name(namePrefix, nameChunks));
+    }
+
+    private Timer timer(String name) {
+        return registry.timer(name);
+    }
+
+    @Override
+    public void setup(FloodlightModuleContext moduleContext) {
+        KildaCore kildaCore = moduleContext.getServiceImpl(KildaCore.class);
+        if (kildaCore.isTestingMode()) {
+            setupReporting();
+        }
+    }
+
+    private void setupReporting() {
+        reporter.start();
+    }
+}

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/service/kafka/KafkaProducerProxy.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/service/kafka/KafkaProducerProxy.java
@@ -16,6 +16,7 @@
 package org.openkilda.floodlight.service.kafka;
 
 import org.openkilda.floodlight.KafkaChannel;
+import org.openkilda.floodlight.KildaCore;
 import org.openkilda.messaging.Message;
 
 import net.floodlightcontroller.core.module.FloodlightModuleContext;
@@ -61,7 +62,8 @@ public class KafkaProducerProxy implements IKafkaProducerService {
 
     @Override
     public void setup(FloodlightModuleContext moduleContext) throws FloodlightModuleException {
-        if (!owner.getConfig().isTestingMode()) {
+        KildaCore kildaCore = moduleContext.getServiceImpl(KildaCore.class);
+        if (!kildaCore.isTestingMode()) {
             target = new KafkaProducerService();
         } else {
             target = new TestAwareKafkaProducerService();

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/service/kafka/KafkaUtilityService.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/service/kafka/KafkaUtilityService.java
@@ -53,10 +53,6 @@ public class KafkaUtilityService implements IService {
         return owner.getTopics();
     }
 
-    public boolean isTestingMode() {
-        return owner.getConfig().isTestingMode();
-    }
-
     @Override
     public void setup(FloodlightModuleContext moduleContext) throws FloodlightModuleException {
         // there is nothing to initialize here

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/kafka/ReplaceInstallFlowTest.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/kafka/ReplaceInstallFlowTest.java
@@ -28,6 +28,7 @@ import static org.openkilda.messaging.Utils.MAPPER;
 import org.openkilda.config.KafkaTopicsConfig;
 import org.openkilda.floodlight.pathverification.IPathVerificationService;
 import org.openkilda.floodlight.pathverification.PathVerificationService;
+import org.openkilda.floodlight.service.MetricService;
 import org.openkilda.floodlight.service.kafka.IKafkaProducerService;
 import org.openkilda.floodlight.service.kafka.KafkaUtilityService;
 import org.openkilda.floodlight.switchmanager.ISwitchManager;
@@ -106,6 +107,7 @@ public class ReplaceInstallFlowTest {
         context.addService(IKafkaProducerService.class, createMock(IKafkaProducerService.class));
         context.addService(IPathVerificationService.class, pathVerificationService);
         context.addService(ISwitchManager.class, switchManager);
+        context.addService(MetricService.class, new MetricService());
 
         switchManager.init(context);
 

--- a/services/src/pom.xml
+++ b/services/src/pom.xml
@@ -76,6 +76,7 @@
         <glassfish-el.version>3.0.1-b09</glassfish-el.version>
         <mapstruct.version>1.2.0.Final</mapstruct.version>
         <hamcrest.version>1.3</hamcrest.version>
+        <metrics.version>4.0.0</metrics.version>
 
         <aspectj-maven-plugin.version>1.11</aspectj-maven-plugin.version>
     </properties>


### PR DESCRIPTION
Use library metrics to collect and report code timings. This timings are
required to locate performance bottlenecs.

To see collected metrict you need visualvm tool with MBeans plugin.

Start floodlight container, detirmine local port for internal port 11011
with command `docker-compose port floodlight 11011`. Create new jmx
connection into visualvm and investigate MBeans tab.

Close #996

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/1320)
<!-- Reviewable:end -->
