### PR TITLE
Handle invalid packet-in cookie

### DIFF
--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/command/ping/PingResponseCommand.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/command/ping/PingResponseCommand.java
@@ -62,9 +62,7 @@ public class PingResponseCommand extends PingCommand {
     }
 
     private byte[] unwrap() {
-        final PingService pingService = getPingService();
-
-        if (pingService.isCookieMismatch(input)) {
+        if (input.packetInCookieMismatch(PingService.OF_CATCH_RULE_COOKIE, log)) {
             return null;
         }
 
@@ -74,7 +72,7 @@ public class PingResponseCommand extends PingCommand {
             return null;
         }
 
-        return pingService.unwrapData(input.getDpId(), ethernetPackage);
+        return getPingService().unwrapData(input.getDpId(), ethernetPackage);
     }
 
     private PingData decode(byte[] payload) throws CorruptedNetworkDataException {

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/pathverification/PathVerificationService.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/pathverification/PathVerificationService.java
@@ -416,7 +416,7 @@ public class PathVerificationService implements IFloodlightModule, IPathVerifica
     void handlePacketIn(OfInput input) {
         logger.debug("{} - {}", getClass().getCanonicalName(), input);
 
-        if (isCookieMismatch(input)) {
+        if (input.packetInCookieMismatch(OF_CATCH_RULE_COOKIE, logger)) {
             return;
         }
 
@@ -527,15 +527,6 @@ public class PathVerificationService implements IFloodlightModule, IPathVerifica
             logger.error(String.format("Unhandled exception %s", input), exception);
             throw exception;
         }
-    }
-
-    private boolean isCookieMismatch(OfInput input) {
-        U64 cookie = input.packetInCookie();
-        final boolean isFiltered = cookie != null && !OF_CATCH_RULE_COOKIE.equals(cookie);
-        if (isFiltered) {
-            logger.debug("{} - cookie mismatch ({} != {})", input, OF_CATCH_RULE_COOKIE, cookie);
-        }
-        return isFiltered;
     }
 
     private long measureLatency(OfInput input, long sendTime) {

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/service/ping/PingService.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/service/ping/PingService.java
@@ -17,7 +17,6 @@ package org.openkilda.floodlight.service.ping;
 
 import org.openkilda.floodlight.SwitchUtils;
 import org.openkilda.floodlight.error.InvalidSignatureConfigurationException;
-import org.openkilda.floodlight.model.OfInput;
 import org.openkilda.floodlight.pathverification.PathVerificationService;
 import org.openkilda.floodlight.service.of.InputService;
 import org.openkilda.floodlight.switchmanager.ISwitchManager;
@@ -38,14 +37,10 @@ import org.projectfloodlight.openflow.types.EthType;
 import org.projectfloodlight.openflow.types.MacAddress;
 import org.projectfloodlight.openflow.types.TransportPort;
 import org.projectfloodlight.openflow.types.U64;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
 public class PingService implements IFloodlightService {
-    private static Logger log = LoggerFactory.getLogger(PingService.class);
-
     public static final U64 OF_CATCH_RULE_COOKIE = U64.of(ISwitchManager.VERIFICATION_UNICAST_RULE_COOKIE);
     private static final String NET_L3_ADDRESS = "127.0.0.2";
     private static final int NET_L3_PORT = PathVerificationService.VERIFICATION_PACKET_UDP_PORT + 1;
@@ -71,18 +66,6 @@ public class PingService implements IFloodlightService {
 
         InputService inputService = moduleContext.getServiceImpl(InputService.class);
         inputService.addTranslator(OFType.PACKET_IN, new PingInputTranslator());
-    }
-
-    /**
-     * Check is cookie in PACKET_IN message match this ping catch rules cookie.
-     */
-    public boolean isCookieMismatch(OfInput input) {
-        U64 cookie = input.packetInCookie();
-        final boolean isFiltered = cookie != null && !OF_CATCH_RULE_COOKIE.equals(cookie);
-        if (isFiltered) {
-            log.debug("{} - cookie mismatch ({} != {})", input, OF_CATCH_RULE_COOKIE, cookie);
-        }
-        return isFiltered;
     }
 
     /**

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/command/ping/PingResponseCommandTest.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/command/ping/PingResponseCommandTest.java
@@ -85,14 +85,12 @@ public class PingResponseCommandTest extends PingCommandTest {
 
     @Test
     public void skipByCookie() throws Exception {
-        expect(pingService.isCookieMismatch(anyObject())).andReturn(true);
-
         replayAll();
 
         OFFactory ofFactory = new OFFactoryVer13();
         OFMessage message = ofFactory.buildPacketIn()
                 .setReason(OFPacketInReason.ACTION).setXid(1)
-                .setCookie(U64.of(1))
+                .setCookie(U64.of(PingService.OF_CATCH_RULE_COOKIE.hashCode() + 1))
                 .build();
         FloodlightContext floodlightContext = new FloodlightContext();
         OfInput input = new OfInput(iofSwitch, message, floodlightContext);
@@ -103,10 +101,10 @@ public class PingResponseCommandTest extends PingCommandTest {
 
     @Test
     public void foreignPackage() throws Exception {
-        expect(pingService.isCookieMismatch(anyObject())).andReturn(false);
         expect(pingService.unwrapData(eq(dpId), anyObject())).andReturn(null);
 
         OfInput input = createMock(OfInput.class);
+        expect(input.packetInCookieMismatch(anyObject(), anyObject())).andReturn(false);
         expect(input.getPacketInPayload()).andReturn(new Ethernet());
         expect(input.getDpId()).andReturn(dpId);
 

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/model/OfInputTest.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/model/OfInputTest.java
@@ -1,0 +1,118 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.floodlight.model;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+
+import net.floodlightcontroller.core.FloodlightContext;
+import net.floodlightcontroller.core.IOFSwitch;
+import org.easymock.EasyMockSupport;
+import org.easymock.Mock;
+import org.easymock.MockType;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.projectfloodlight.openflow.protocol.OFPacketIn;
+import org.projectfloodlight.openflow.protocol.OFPacketInReason;
+import org.projectfloodlight.openflow.protocol.OFType;
+import org.projectfloodlight.openflow.protocol.ver13.OFFactoryVer13;
+import org.projectfloodlight.openflow.types.DatapathId;
+import org.projectfloodlight.openflow.types.U64;
+import org.slf4j.Logger;
+
+public class OfInputTest extends EasyMockSupport {
+    private static final U64 cookieAlpha = U64.of(1);
+    private static final U64 cookieBeta = U64.of(2);
+
+    @Mock(type = MockType.NICE)
+    private Logger callerLogger;
+
+    @Mock
+    private IOFSwitch ofSwitch;
+
+    @Before
+    public void setUp() throws Exception {
+        injectMocks(this);
+
+        expect(ofSwitch.getId()).andReturn(DatapathId.of(0xfffe000000000001L)).anyTimes();
+        expect(ofSwitch.getOFFactory()).andReturn(new OFFactoryVer13()).anyTimes();
+        expect(ofSwitch.getLatency()).andReturn(U64.of(8)).anyTimes();
+
+        replayAll();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        verifyAll();
+    }
+
+    /**
+     * Cookie match.
+     */
+    @Test
+    public void isCookieMismatch0() {
+        OfInput input = makeInput(U64.of(cookieAlpha.getValue()));
+        Assert.assertFalse(input.packetInCookieMismatch(cookieAlpha, callerLogger));
+    }
+
+    /**
+     * Reserved/invalid cookie.
+     */
+    @Test
+    public void isCookieMismatch1() {
+        OfInput input = makeInput(U64.of(-1));
+        Assert.assertFalse(input.packetInCookieMismatch(cookieAlpha, callerLogger));
+
+        input = makeInput(U64.ZERO);
+        Assert.assertFalse(input.packetInCookieMismatch(cookieAlpha, callerLogger));
+    }
+
+    /**
+     * Cookie is unsupported by protocol.
+     */
+    @Test
+    public void isCookieMismatch2() {
+        OFPacketIn message = createMock(OFPacketIn.class);
+        expect(message.getType()).andReturn(OFType.PACKET_IN).times(2);
+        expect(message.getCookie())
+                .andThrow(new UnsupportedOperationException("Forced unsupported operation exception"));
+        replay(message);
+
+        FloodlightContext messageMetadata = new FloodlightContext();
+        OfInput input = new OfInput(ofSwitch, message, messageMetadata);
+        Assert.assertFalse(input.packetInCookieMismatch(cookieAlpha, callerLogger));
+    }
+
+    /**
+     * Cookie doesn't match.
+     */
+    @Test
+    public void isCookieMismatch3() {
+        OfInput input = makeInput(cookieAlpha);
+        Assert.assertTrue(input.packetInCookieMismatch(cookieBeta, callerLogger));
+    }
+
+    private OfInput makeInput(U64 cookie) {
+        OFPacketIn message = ofSwitch.getOFFactory().buildPacketIn()
+                .setReason(OFPacketInReason.ACTION).setXid(1)
+                .setCookie(cookie)
+                .build();
+        FloodlightContext messageMetadata = new FloodlightContext();
+        return new OfInput(ofSwitch, message, messageMetadata);
+    }
+}

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/service/ping/PingServiceTest.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/service/ping/PingServiceTest.java
@@ -17,40 +17,27 @@ package org.openkilda.floodlight.service.ping;
 
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.eq;
-import static org.easymock.EasyMock.expect;
 
-import org.openkilda.floodlight.model.OfInput;
 import org.openkilda.floodlight.pathverification.PathVerificationService;
 import org.openkilda.floodlight.service.of.InputService;
 import org.openkilda.messaging.model.NetworkEndpoint;
 import org.openkilda.messaging.model.Ping;
 import org.openkilda.messaging.model.SwitchId;
 
-import net.floodlightcontroller.core.FloodlightContext;
-import net.floodlightcontroller.core.IOFSwitch;
 import net.floodlightcontroller.core.internal.IOFSwitchService;
 import net.floodlightcontroller.core.module.FloodlightModuleContext;
 import net.floodlightcontroller.packet.Ethernet;
 import org.easymock.EasyMockSupport;
-import org.easymock.Mock;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.projectfloodlight.openflow.protocol.OFPacketIn;
-import org.projectfloodlight.openflow.protocol.OFPacketInReason;
 import org.projectfloodlight.openflow.protocol.OFType;
-import org.projectfloodlight.openflow.protocol.ver13.OFFactoryVer13;
 import org.projectfloodlight.openflow.types.DatapathId;
-import org.projectfloodlight.openflow.types.U64;
 
 public class PingServiceTest extends EasyMockSupport {
     private PingService pingService = new PingService();
     private FloodlightModuleContext moduleContext = new FloodlightModuleContext();
     private PathVerificationService pathVerificationService = new PathVerificationService();
-
-    @Mock
-    private IOFSwitch switchAlpha;
-    private DatapathId dpIdAlpha = DatapathId.of(0xfffe000000000001L);
 
     @Before
     public void setUp() throws Exception {
@@ -59,77 +46,6 @@ public class PingServiceTest extends EasyMockSupport {
         moduleContext.addService(IOFSwitchService.class, createMock(IOFSwitchService.class));
         moduleContext.addService(InputService.class, createMock(InputService.class));
         moduleContext.addConfigParam(pathVerificationService, "hmac256-secret", "secret");
-
-        expect(switchAlpha.getId()).andReturn(dpIdAlpha).anyTimes();
-        expect(switchAlpha.getOFFactory()).andReturn(new OFFactoryVer13()).anyTimes();
-        expect(switchAlpha.getLatency()).andReturn(U64.of(8)).anyTimes();
-    }
-
-    /**
-     * Cookie match.
-     */
-    @Test
-    public void isCookieMismatch0() {
-        replayAll();
-
-        OFPacketIn message = switchAlpha.getOFFactory().buildPacketIn()
-                .setReason(OFPacketInReason.ACTION).setXid(1)
-                .setCookie(U64.of(PingService.OF_CATCH_RULE_COOKIE.getValue()))
-                .build();
-        FloodlightContext messageMetadata = new FloodlightContext();
-        OfInput input = new OfInput(switchAlpha, message, messageMetadata);
-
-        Assert.assertFalse(pingService.isCookieMismatch(input));
-    }
-
-    /**
-     * Reserved/invalid cookie.
-     */
-    @Test
-    public void isCookieMismatch1() {
-        replayAll();
-
-        OFPacketIn message = switchAlpha.getOFFactory().buildPacketIn()
-                .setReason(OFPacketInReason.ACTION).setXid(2)
-                .setCookie(U64.of(-1))
-                .build();
-        FloodlightContext messageMetadata = new FloodlightContext();
-        OfInput input = new OfInput(switchAlpha, message, messageMetadata);
-
-        Assert.assertFalse(pingService.isCookieMismatch(input));
-    }
-
-    /**
-     * Cookie is unsupported by protocol.
-     */
-    @Test
-    public void isCookieMismatch2() {
-        OFPacketIn message = createMock(OFPacketIn.class);
-        expect(message.getType()).andReturn(OFType.PACKET_IN).times(2);
-        expect(message.getCookie())
-                .andThrow(new UnsupportedOperationException("Forced unsupported operation exception"));
-        replayAll();
-
-        FloodlightContext messageMetadata = new FloodlightContext();
-        OfInput input = new OfInput(switchAlpha, message, messageMetadata);
-        Assert.assertFalse(pingService.isCookieMismatch(input));
-    }
-
-    /**
-     * Cookie doesn't match.
-     */
-    @Test
-    public void isCookieMismatch3() {
-        replayAll();
-
-        OFPacketIn message = switchAlpha.getOFFactory().buildPacketIn()
-                .setReason(OFPacketInReason.ACTION).setXid(3)
-                .setCookie(U64.of(PingService.OF_CATCH_RULE_COOKIE.getValue() + 1))
-                .build();
-        FloodlightContext messageMetadata = new FloodlightContext();
-        OfInput input = new OfInput(switchAlpha, message, messageMetadata);
-
-        Assert.assertTrue(pingService.isCookieMismatch(input));
     }
 
     @Test
@@ -141,6 +57,7 @@ public class PingServiceTest extends EasyMockSupport {
 
         pingService.init(moduleContext);
 
+        DatapathId dpIdAlpha = DatapathId.of(0xfffe000000000001L);
         DatapathId dpIdBeta = DatapathId.of(0xfffe000000000002L);
         Ping ping = new Ping(
                 (short) 0x100,


### PR DESCRIPTION
In some circumstances switches send invalid(0x0) value in cookie field
in OF packet-in messages. Alter cookieMismatch check to eliminate impact
such "invalid" cookies on packe-in processing.

Close #1321