### PR TITLE
Changed default ISL discovery timeout

### DIFF
--- a/confd/vars/main.yaml
+++ b/confd/vars/main.yaml
@@ -57,7 +57,7 @@ kilda_kafka_te_consumer_group: "kilda-tpe"
 
 # interval in ticks (seconds) between sending disco packets
 kilda_discovery_interval: 3
-kilda_discovery_timeout: "9"
+kilda_discovery_timeout: "15"
 # discovery_limit of -1 is forever
 # 28000 is about a day (test every 3 seconds, 20 failures per minute, 1200 per hour ..
 kilda_discovery_limit: "-1"


### PR DESCRIPTION
Because our discovery timeout was almost the same as 'rerouteDelay', sometimes the flow won't evacuate from ISL after a port down and the subsequent 'isl down' due to discovery timeout will re-trigger the flow reroute, delaying the actual reroute for another 'rerouteDelay' seconds.
related to #1428 