### PR TITLE
Use correct logger object in abstract bolts

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/AbstractBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/AbstractBolt.java
@@ -18,19 +18,22 @@ package org.openkilda.wfm;
 import org.openkilda.wfm.error.AbstractException;
 import org.openkilda.wfm.error.PipelineException;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.base.BaseRichBolt;
 import org.apache.storm.tuple.Tuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.util.Map;
 
-@Slf4j
 public abstract class AbstractBolt extends BaseRichBolt {
     public static final String FIELD_ID_CONTEXT = "context";
 
-    private OutputCollector output;
+    protected transient Logger log = makeLog();
+    private transient OutputCollector output;
 
     @Override
     public void execute(Tuple input) {
@@ -90,5 +93,15 @@ public abstract class AbstractBolt extends BaseRichBolt {
 
     protected OutputCollector getOutput() {
         return output;
+    }
+
+    private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+        stream.defaultReadObject();
+
+        log = makeLog();
+    }
+
+    private Logger makeLog() {
+        return LoggerFactory.getLogger(getClass());
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/FlowOperationsBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/FlowOperationsBolt.java
@@ -23,22 +23,17 @@ import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.neo4j.driver.v1.Session;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 public class FlowOperationsBolt extends NeoOperationsBolt {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(FlowOperationsBolt.class);
-
     public FlowOperationsBolt(Auth neoAuth) {
         super(neoAuth);
     }
 
     @Override
     List<? extends InfoData> processRequest(Tuple tuple, BaseRequest request, Session session) {
-        LOGGER.warn("Received unsupported Flow Operation");
+        log.warn("Received unsupported Flow Operation");
         return null;
     }
 
@@ -46,10 +41,4 @@ public class FlowOperationsBolt extends NeoOperationsBolt {
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("response", "correlationId"));
     }
-
-    @Override
-    Logger getLogger() {
-        return LOGGER;
-    }
-
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/LinkOperationsBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/LinkOperationsBolt.java
@@ -31,8 +31,6 @@ import org.apache.storm.tuple.Tuple;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Value;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
@@ -41,9 +39,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class LinkOperationsBolt extends NeoOperationsBolt {
-
-    private static final Logger logger = LoggerFactory.getLogger(LinkOperationsBolt.class);
-
     public LinkOperationsBolt(Auth neoAuth) {
         super(neoAuth);
     }
@@ -63,7 +58,7 @@ public class LinkOperationsBolt extends NeoOperationsBolt {
     }
 
     private List<IslInfoData> getAllLinks(Session session) {
-        logger.debug("Processing get all links request");
+        log.debug("Processing get all links request");
         String q =
                 "MATCH (:switch)-[isl:isl]->(:switch) "
                         + "RETURN isl";
@@ -75,12 +70,12 @@ public class LinkOperationsBolt extends NeoOperationsBolt {
                 .map(Value::asRelationship)
                 .map(LinksConverter::toIslInfoData)
                 .collect(Collectors.toList());
-        logger.debug("Found {} links in the database", results.size());
+        log.debug("Found {} links in the database", results.size());
         return results;
     }
 
     private List<LinkPropsData> getLinkProps(LinkPropsGet request, Session session) {
-        logger.debug("Processing get link props request");
+        log.debug("Processing get link props request");
         String q = "MATCH (props:link_props) "
                 + "WHERE ({src_switch} IS NULL OR props.src_switch={src_switch}) "
                 + "AND ({src_port} IS NULL OR props.src_port={src_port}) "
@@ -108,7 +103,7 @@ public class LinkOperationsBolt extends NeoOperationsBolt {
                 .map(LinksConverter::toLinkPropsData)
                 .collect(Collectors.toList());
 
-        logger.debug("Found {} link props in the database", results.size());
+        log.debug("Found {} link props in the database", results.size());
         return results;
     }
 
@@ -116,10 +111,4 @@ public class LinkOperationsBolt extends NeoOperationsBolt {
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("response", "correlationId"));
     }
-
-    @Override
-    Logger getLogger() {
-        return logger;
-    }
-
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/NeoOperationsBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/NeoOperationsBolt.java
@@ -27,7 +27,6 @@ import org.apache.storm.tuple.Values;
 import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Session;
-import org.slf4j.Logger;
 
 import java.util.List;
 import java.util.Map;
@@ -50,7 +49,7 @@ public abstract class NeoOperationsBolt extends AbstractBolt {
     protected void handleInput(Tuple input) {
         BaseRequest request = (BaseRequest) input.getValueByField("request");
         final String correlationId = input.getStringByField("correlationId");
-        getLogger().debug("Received operation request");
+        log.debug("Received operation request");
 
         try (Session session = driver.session(request.isReadRequest() ? AccessMode.READ : AccessMode.WRITE)) {
             List<? extends InfoData> result = processRequest(input, request, session);
@@ -59,8 +58,6 @@ public abstract class NeoOperationsBolt extends AbstractBolt {
     }
 
     abstract List<? extends InfoData> processRequest(Tuple tuple, BaseRequest request, Session session);
-
-    abstract Logger getLogger();
 
     @Override
     public void cleanup() {

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/ResponseSplitterBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/ResponseSplitterBolt.java
@@ -27,8 +27,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -36,14 +34,11 @@ import java.util.List;
 import java.util.UUID;
 
 public class ResponseSplitterBolt extends AbstractBolt {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(ResponseSplitterBolt.class);
-
     @Override
     protected void handleInput(Tuple input) {
         List<InfoData> responses = (List<InfoData>) input.getValueByField("response");
         String correlationId = input.getStringByField("correlationId");
-        LOGGER.debug("Received response correlationId {}", correlationId);
+        log.debug("Received response correlationId {}", correlationId);
 
         sendChunkedResponse(responses, input, correlationId);
     }
@@ -51,7 +46,7 @@ public class ResponseSplitterBolt extends AbstractBolt {
     private void sendChunkedResponse(List<InfoData> responses, Tuple input, String requestId) {
         List<Message> messages = new ArrayList<>();
         if (CollectionUtils.isEmpty(responses)) {
-            LOGGER.debug("No records found in the database");
+            log.debug("No records found in the database");
             Message message = new ChunkedInfoMessage(null, System.currentTimeMillis(), requestId, null);
             messages.add(message);
         } else {
@@ -73,7 +68,7 @@ public class ResponseSplitterBolt extends AbstractBolt {
                 currentRequestId = nextRequestId;
             }
 
-            LOGGER.debug("Response is divided into {} messages", messages.size());
+            log.debug("Response is divided into {} messages", messages.size());
         }
 
         // emit all found messages
@@ -81,7 +76,7 @@ public class ResponseSplitterBolt extends AbstractBolt {
             try {
                 getOutput().emit(input, new Values(Utils.MAPPER.writeValueAsString(message)));
             } catch (JsonProcessingException e) {
-                LOGGER.error("Error during writing response as json", e);
+                log.error("Error during writing response as json", e);
             }
         }
     }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/RouterBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/RouterBolt.java
@@ -30,15 +30,10 @@ import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
 public class RouterBolt extends AbstractBolt {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(RouterBolt.class);
-
     @Override
     protected void handleInput(Tuple input) {
         String request = input.getString(0);
@@ -47,12 +42,12 @@ public class RouterBolt extends AbstractBolt {
         try {
             message = Utils.MAPPER.readValue(request, Message.class);
         } catch (IOException e) {
-            LOGGER.error("Error during parsing request for NBWorker topology", e);
+            log.error("Error during parsing request for NBWorker topology", e);
             return;
         }
 
         if (message instanceof CommandMessage) {
-            LOGGER.debug("Received command message {}", message);
+            log.debug("Received command message {}", message);
             CommandMessage command = (CommandMessage) message;
             CommandData data = command.getData();
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/SwitchOperationsBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/SwitchOperationsBolt.java
@@ -29,16 +29,11 @@ import org.apache.storm.tuple.Tuple;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class SwitchOperationsBolt extends NeoOperationsBolt {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(SwitchOperationsBolt.class);
-
     public SwitchOperationsBolt(Auth neoAuth) {
         super(neoAuth);
     }
@@ -79,7 +74,7 @@ public class SwitchOperationsBolt extends NeoOperationsBolt {
 
             results.add(sw);
         }
-        LOGGER.debug("Found switches: {}", results.size());
+        log.debug("Found switches: {}", results.size());
 
         return results;
     }
@@ -87,10 +82,5 @@ public class SwitchOperationsBolt extends NeoOperationsBolt {
     @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("response", "correlationId"));
-    }
-
-    @Override
-    Logger getLogger() {
-        return LOGGER;
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/Blacklist.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/Blacklist.java
@@ -20,7 +20,6 @@ import org.openkilda.wfm.error.AbstractException;
 import org.openkilda.wfm.error.PipelineException;
 import org.openkilda.wfm.topology.ping.model.PingContext;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
@@ -28,7 +27,6 @@ import org.apache.storm.tuple.Values;
 
 import java.util.HashSet;
 
-@Slf4j
 public class Blacklist extends Abstract {
     public static final String BOLT_ID = ComponentId.BLACKLIST.toString();
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/FailReporter.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/FailReporter.java
@@ -24,7 +24,6 @@ import org.openkilda.wfm.topology.ping.model.FlowRef;
 import org.openkilda.wfm.topology.ping.model.PingContext;
 import org.openkilda.wfm.topology.ping.model.PingObserver;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
@@ -36,7 +35,6 @@ import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-@Slf4j
 public class FailReporter extends Abstract {
     public static final String BOLT_ID = ComponentId.FAIL_REPORTER.toString();
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/FlowFetcher.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/FlowFetcher.java
@@ -32,14 +32,12 @@ import org.openkilda.wfm.topology.ping.model.FlowsHeap;
 import org.openkilda.wfm.topology.ping.model.PingContext;
 import org.openkilda.wfm.topology.ping.model.PingContext.Kinds;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 
-@Slf4j
 public class FlowFetcher extends Abstract {
     public static final String BOLT_ID = ComponentId.FLOW_FETCHER.toString();
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/GroupCollector.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/GroupCollector.java
@@ -23,7 +23,6 @@ import org.openkilda.wfm.topology.ping.model.Group;
 import org.openkilda.wfm.topology.ping.model.GroupId;
 import org.openkilda.wfm.topology.ping.model.PingContext;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
@@ -31,7 +30,6 @@ import org.apache.storm.tuple.Values;
 
 import java.util.concurrent.TimeUnit;
 
-@Slf4j
 public class GroupCollector extends Abstract {
     public static final String BOLT_ID = ComponentId.GROUP_COLLECTOR.toString();
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/OnDemandResultManager.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/OnDemandResultManager.java
@@ -23,7 +23,6 @@ import org.openkilda.wfm.error.PipelineException;
 import org.openkilda.wfm.topology.ping.model.Group;
 import org.openkilda.wfm.topology.ping.model.PingContext;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
@@ -33,7 +32,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
-@Slf4j
 public class OnDemandResultManager extends ResultManager {
     public static final String BOLT_ID = ComponentId.ON_DEMAND_RESULT_MANAGER.toString();
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/PeriodicPingShaping.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/PeriodicPingShaping.java
@@ -21,7 +21,6 @@ import org.openkilda.wfm.topology.ping.model.PingContext;
 import org.openkilda.wfm.topology.ping.model.PingContext.Kinds;
 import org.openkilda.wfm.topology.ping.model.ShapingBurstCalculator;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
@@ -29,7 +28,6 @@ import org.apache.storm.tuple.Values;
 
 import java.util.LinkedList;
 
-@Slf4j
 public class PeriodicPingShaping extends Abstract {
     public static final String BOLT_ID = ComponentId.PERIODIC_PING_SHAPING.toString();
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/ResultDispatcher.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/ResultDispatcher.java
@@ -19,13 +19,11 @@ import org.openkilda.wfm.error.AbstractException;
 import org.openkilda.wfm.topology.ping.model.PingContext;
 import org.openkilda.wfm.topology.ping.model.PingContext.Kinds;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 
-@Slf4j
 public class ResultDispatcher extends Abstract {
     public static final String BOLT_ID = ComponentId.RESULT_DISPATCHER.toString();
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/TickDeduplicator.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/TickDeduplicator.java
@@ -19,7 +19,6 @@ import org.openkilda.wfm.AbstractBolt;
 import org.openkilda.wfm.error.AbstractException;
 import org.openkilda.wfm.error.PipelineException;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
@@ -28,7 +27,6 @@ import org.apache.storm.utils.Utils;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
-@Slf4j
 public class TickDeduplicator extends AbstractBolt {
     public static final String BOLT_ID = ComponentId.TICK_DEDUPLICATOR.toString();
 
@@ -65,7 +63,7 @@ public class TickDeduplicator extends AbstractBolt {
 
         if (activeSourceTask == null) {
             activeSourceTask = taskId;
-            log.debug("Set {} as active source (no previous)");
+            log.debug("Set {} as active source (no previous)", activeSourceTask);
         } else {
             Long lastActiveTick = lastTick.get(activeSourceTask);
             if (lastActiveTick + tickPeriod * 2 < tick) {

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/TimeoutManager.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/TimeoutManager.java
@@ -26,7 +26,6 @@ import org.openkilda.wfm.topology.ping.model.ExpirableMap;
 import org.openkilda.wfm.topology.ping.model.PingContext;
 import org.openkilda.wfm.topology.ping.model.TimeoutDescriptor;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
@@ -35,7 +34,6 @@ import org.apache.storm.tuple.Values;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-@Slf4j
 public class TimeoutManager extends Abstract {
     public static final String BOLT_ID = ComponentId.TIMEOUT_MANAGER.toString();
 


### PR DESCRIPTION
Force abstract bolt successors to define logger object. It allow to
identify correct bolt class(using loggerName) for messages produced by
parent/abstract level.