### PR TITLE
Make kafka encoder/decoder bolts shared

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/share/bolt/KafkaDecoder.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/share/bolt/KafkaDecoder.java
@@ -1,0 +1,68 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.share.bolt;
+
+import org.openkilda.messaging.Message;
+import org.openkilda.messaging.Utils;
+import org.openkilda.wfm.AbstractBolt;
+import org.openkilda.wfm.CommandContext;
+import org.openkilda.wfm.error.AbstractException;
+import org.openkilda.wfm.error.JsonDecodeException;
+import org.openkilda.wfm.error.PipelineException;
+import org.openkilda.wfm.topology.utils.KafkaRecordTranslator;
+
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.Values;
+
+import java.io.IOException;
+
+public abstract class KafkaDecoder extends AbstractBolt {
+    public static final String FIELD_ID_INPUT = "input";
+
+    public static final Fields STREAM_FIELDS = new Fields(FIELD_ID_INPUT, FIELD_ID_CONTEXT);
+
+    @Override
+    protected void handleInput(Tuple input) throws AbstractException {
+        String json = pullPayload(input);
+        Message message = decode(json);
+        CommandContext commandContext = new CommandContext(message);
+
+        Values output = new Values(message, commandContext);
+        getOutput().emit(input, output);
+    }
+
+    private String pullPayload(Tuple input) throws PipelineException {
+        return pullValue(input, KafkaRecordTranslator.FIELD_ID_PAYLOAD, String.class);
+    }
+
+    private Message decode(String json) throws JsonDecodeException {
+        Message value;
+
+        try {
+            value = Utils.MAPPER.readValue(json, Message.class);
+        } catch (IOException e) {
+            throw new JsonDecodeException(Message.class, json, e);
+        }
+        return value;
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer outputManager) {
+        outputManager.declare(STREAM_FIELDS);
+    }
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/share/bolt/KafkaEncoder.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/share/bolt/KafkaEncoder.java
@@ -1,0 +1,97 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.share.bolt;
+
+import org.openkilda.messaging.Message;
+import org.openkilda.messaging.MessageData;
+import org.openkilda.messaging.Utils;
+import org.openkilda.messaging.command.CommandData;
+import org.openkilda.messaging.command.CommandMessage;
+import org.openkilda.messaging.info.InfoData;
+import org.openkilda.messaging.info.InfoMessage;
+import org.openkilda.wfm.AbstractBolt;
+import org.openkilda.wfm.CommandContext;
+import org.openkilda.wfm.error.AbstractException;
+import org.openkilda.wfm.error.JsonEncodeException;
+import org.openkilda.wfm.error.PipelineException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.storm.kafka.bolt.mapper.FieldNameBasedTupleToKafkaMapper;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.Values;
+
+public abstract class KafkaEncoder extends AbstractBolt {
+    public static final String FIELD_ID_PAYLOAD = "payload";
+
+    public static final Fields STREAM_FIELDS = new Fields(
+            FieldNameBasedTupleToKafkaMapper.BOLT_KEY, FieldNameBasedTupleToKafkaMapper.BOLT_MESSAGE);
+
+    @Override
+    protected void handleInput(Tuple input) throws AbstractException {
+        MessageData payload = pullPayload(input);
+        try {
+            Message message = wrap(pullContext(input), payload);
+            String json = encode(message);
+
+            getOutput().emit(input, new Values(null, json));
+        } catch (IllegalArgumentException e) {
+            log.error(e.getMessage());
+            unhandledInput(input);
+        }
+    }
+
+    protected MessageData pullPayload(Tuple input) throws PipelineException {
+        return pullValue(input, FIELD_ID_PAYLOAD, MessageData.class);
+    }
+
+    protected Message wrap(CommandContext commandContext, MessageData payload) {
+        Message message = null;
+        if (payload instanceof CommandData) {
+            message = wrapCommand(commandContext, (CommandData) payload);
+        } else if (payload instanceof InfoData) {
+            message = wrapInfo(commandContext, (InfoData) payload);
+        } else {
+            throw new IllegalArgumentException(String.format("There is not rule to build envelope for: %s", payload));
+        }
+
+        return message;
+    }
+
+    private CommandMessage wrapCommand(CommandContext commandContext, CommandData payload) {
+        return new CommandMessage(payload, System.currentTimeMillis(), commandContext.getCorrelationId());
+    }
+
+    private InfoMessage wrapInfo(CommandContext commandContext, InfoData payload) {
+        return new InfoMessage(payload, System.currentTimeMillis(), commandContext.getCorrelationId());
+    }
+
+    private String encode(Message message) throws JsonEncodeException {
+        String value;
+        try {
+            value = Utils.MAPPER.writeValueAsString(message);
+        } catch (JsonProcessingException e) {
+            throw new JsonEncodeException(message, e);
+        }
+        return value;
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer outputManager) {
+        outputManager.declare(STREAM_FIELDS);
+    }
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/FlowStatusEncoder.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/FlowStatusEncoder.java
@@ -15,63 +15,22 @@
 
 package org.openkilda.wfm.topology.ping.bolt;
 
-import org.openkilda.messaging.Utils;
-import org.openkilda.messaging.info.InfoMessage;
+import org.openkilda.messaging.MessageData;
 import org.openkilda.messaging.info.flow.FlowPingReport;
 import org.openkilda.messaging.model.PingReport;
-import org.openkilda.wfm.AbstractBolt;
-import org.openkilda.wfm.CommandContext;
-import org.openkilda.wfm.error.AbstractException;
-import org.openkilda.wfm.error.JsonEncodeException;
 import org.openkilda.wfm.error.PipelineException;
+import org.openkilda.wfm.share.bolt.KafkaEncoder;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.storm.kafka.bolt.mapper.FieldNameBasedTupleToKafkaMapper;
-import org.apache.storm.topology.OutputFieldsDeclarer;
-import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
-import org.apache.storm.tuple.Values;
 
-public class FlowStatusEncoder extends AbstractBolt {
+public class FlowStatusEncoder extends KafkaEncoder {
     public static final String BOLT_ID = ComponentId.FLOW_STATUS_ENCODER.toString();
 
     public static final String FIELD_ID_PING_REPORT = "flow_status";
 
-    public static final Fields STREAM_FIELDS = new Fields(
-            FieldNameBasedTupleToKafkaMapper.BOLT_KEY, FieldNameBasedTupleToKafkaMapper.BOLT_MESSAGE);
-
     @Override
-    protected void handleInput(Tuple input) throws AbstractException {
-        PingReport report = pullPingReport(input);
-        InfoMessage message = wrap(input, report);
-        String json = encode(message);
-
-        Values output = new Values(null, json);
-        getOutput().emit(input, output);
-    }
-
-    private InfoMessage wrap(Tuple input, PingReport pingReport) throws PipelineException {
-        FlowPingReport payload = new FlowPingReport(pingReport);
-        CommandContext commandContext = pullContext(input);
-        return new InfoMessage(payload, System.currentTimeMillis(), commandContext.getCorrelationId());
-    }
-
-    private String encode(InfoMessage message) throws JsonEncodeException {
-        String json;
-        try {
-            json = Utils.MAPPER.writeValueAsString(message);
-        } catch (JsonProcessingException e) {
-            throw new JsonEncodeException(message, e);
-        }
-        return json;
-    }
-
-    private PingReport pullPingReport(Tuple input) throws PipelineException {
-        return pullValue(input, FIELD_ID_PING_REPORT, PingReport.class);
-    }
-
-    @Override
-    public void declareOutputFields(OutputFieldsDeclarer outputManager) {
-        outputManager.declare(STREAM_FIELDS);
+    protected MessageData pullPayload(Tuple input) throws PipelineException {
+        PingReport pingReport = pullValue(input, FIELD_ID_PING_REPORT, PingReport.class);
+        return new FlowPingReport(pingReport);
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/InputDecoder.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/InputDecoder.java
@@ -15,56 +15,8 @@
 
 package org.openkilda.wfm.topology.ping.bolt;
 
-import org.openkilda.messaging.Message;
-import org.openkilda.messaging.Utils;
-import org.openkilda.wfm.AbstractBolt;
-import org.openkilda.wfm.CommandContext;
-import org.openkilda.wfm.error.AbstractException;
-import org.openkilda.wfm.error.JsonDecodeException;
-import org.openkilda.wfm.error.PipelineException;
-import org.openkilda.wfm.topology.utils.KafkaRecordTranslator;
+import org.openkilda.wfm.share.bolt.KafkaDecoder;
 
-import org.apache.storm.topology.OutputFieldsDeclarer;
-import org.apache.storm.tuple.Fields;
-import org.apache.storm.tuple.Tuple;
-import org.apache.storm.tuple.Values;
-
-import java.io.IOException;
-
-public class InputDecoder extends AbstractBolt {
+public class InputDecoder extends KafkaDecoder {
     public static final String BOLT_ID = ComponentId.INPUT_DECODER.toString();
-
-    public static final String FIELD_ID_INPUT = "input";
-
-    public static final Fields STREAM_FIELDS = new Fields(FIELD_ID_INPUT, FIELD_ID_CONTEXT);
-
-    @Override
-    protected void handleInput(Tuple input) throws AbstractException {
-        String json = pullPayload(input);
-        Message message = decode(json);
-        CommandContext commandContext = new CommandContext(message);
-
-        Values output = new Values(message, commandContext);
-        getOutput().emit(input, output);
-    }
-
-    private String pullPayload(Tuple input) throws PipelineException {
-        return pullValue(input, KafkaRecordTranslator.FIELD_ID_PAYLOAD, String.class);
-    }
-
-    private Message decode(String json) throws JsonDecodeException {
-        Message value;
-
-        try {
-            value = Utils.MAPPER.readValue(json, Message.class);
-        } catch (IOException e) {
-            throw new JsonDecodeException(Message.class, json, e);
-        }
-        return value;
-    }
-
-    @Override
-    public void declareOutputFields(OutputFieldsDeclarer outputManager) {
-        outputManager.declare(STREAM_FIELDS);
-    }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/SpeakerEncoder.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/SpeakerEncoder.java
@@ -15,58 +15,8 @@
 
 package org.openkilda.wfm.topology.ping.bolt;
 
-import org.openkilda.messaging.Utils;
-import org.openkilda.messaging.command.CommandData;
-import org.openkilda.messaging.command.CommandMessage;
-import org.openkilda.wfm.CommandContext;
-import org.openkilda.wfm.error.AbstractException;
-import org.openkilda.wfm.error.JsonEncodeException;
-import org.openkilda.wfm.error.PipelineException;
+import org.openkilda.wfm.share.bolt.KafkaEncoder;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.storm.kafka.bolt.mapper.FieldNameBasedTupleToKafkaMapper;
-import org.apache.storm.topology.OutputFieldsDeclarer;
-import org.apache.storm.tuple.Fields;
-import org.apache.storm.tuple.Tuple;
-import org.apache.storm.tuple.Values;
-
-public class SpeakerEncoder extends Abstract {
+public class SpeakerEncoder extends KafkaEncoder {
     public static final String BOLT_ID = ComponentId.SPEAKER_ENCODER.toString();
-
-    public static final String FIELD_ID_PAYLOAD = "payload";
-
-    public static final Fields STREAM_FIELDS = new Fields(
-            FieldNameBasedTupleToKafkaMapper.BOLT_KEY, FieldNameBasedTupleToKafkaMapper.BOLT_MESSAGE);
-
-    @Override
-    protected void handleInput(Tuple input) throws AbstractException {
-        CommandData payload = pullPayload(input);
-        CommandMessage message = wrap(pullContext(input), payload);
-        String json = encode(message);
-
-        getOutput().emit(new Values(null, json));
-    }
-
-    private CommandData pullPayload(Tuple input) throws PipelineException {
-        return pullValue(input, FIELD_ID_PAYLOAD, CommandData.class);
-    }
-
-    private CommandMessage wrap(CommandContext commandContext, CommandData payload) {
-        return new CommandMessage(payload, System.currentTimeMillis(), commandContext.getCorrelationId());
-    }
-
-    private String encode(CommandMessage message) throws JsonEncodeException {
-        String value;
-        try {
-            value = Utils.MAPPER.writeValueAsString(message);
-        } catch (JsonProcessingException e) {
-            throw new JsonEncodeException(message, e);
-        }
-        return value;
-    }
-
-    @Override
-    public void declareOutputFields(OutputFieldsDeclarer outputManager) {
-        outputManager.declare(STREAM_FIELDS);
-    }
 }


### PR DESCRIPTION
This bolt's can/should be used as base for any encoder/decored bolts in
any topology.