### PR TITLE
Add test to verify flow is 'Down' when disconnecting switch

### DIFF
--- a/services/src/atdd/src/test/resources/features/mvp.1/FlowFFR.feature
+++ b/services/src/atdd/src/test/resources/features/mvp.1/FlowFFR.feature
@@ -64,7 +64,7 @@ Feature: Flow failover, failure and recovery
   Scenario: ISL failover followed by failure followed by recovery
 
     Developer notes:
-      1. The Given scenario is too long and consists of tests in itself, nedd to shorten.
+      1. The Given scenario is too long and consists of tests in itself, need to shorten.
       2. Interesting use of multiple When/Then blocs. Can we consolidate?
 
     Given a clean flow topology

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/northbound/flows/AutoRerouteSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/northbound/flows/AutoRerouteSpec.groovy
@@ -13,6 +13,7 @@ import org.openkilda.messaging.payload.flow.FlowState
 import org.openkilda.testing.model.topology.TopologyDefinition
 import org.openkilda.testing.model.topology.TopologyDefinition.Switch
 import org.openkilda.testing.service.database.Database
+import org.openkilda.testing.service.lockkeeper.LockKeeperService
 import org.openkilda.testing.service.northbound.NorthboundService
 import org.openkilda.testing.tools.IslUtils
 
@@ -31,6 +32,8 @@ class AutoRerouteSpec extends BaseSpecification {
     @Autowired
     NorthboundService northboundService
     @Autowired
+    LockKeeperService lockKeeperService
+    @Autowired
     Database db
     @Autowired
     IslUtils islUtils
@@ -39,14 +42,17 @@ class AutoRerouteSpec extends BaseSpecification {
     int rerouteDelay
     @Value('${discovery.interval}')
     int discoveryInterval
+    @Value('${discovery.timeout}')
+    int discoveryTimeout
 
-    def "Flow should go Down when its link fails and there is no ability to reroute"() {
+    def "Flow goes to 'Down' status when one of the flow ISLs fails and there is no ability to reroute"() {
         given: "A flow"
         def (Switch srcSwitch, Switch dstSwitch) = topology.getActiveSwitches()[0..1]
         def allPaths = db.getPaths(srcSwitch.dpId, dstSwitch.dpId)*.path
         def flow = flowHelper.randomFlow(srcSwitch, dstSwitch)
         northboundService.addFlow(flow)
         def currentPath = PathHelper.convert(northboundService.getFlowPath(flow.id))
+        assert Wrappers.wait(WAIT_OFFSET) { northboundService.getFlowStatus(flow.id).status == FlowState.UP }
 
         and: "Ports that lead to alternative paths are brought down to deny alternative paths"
         def altPaths = allPaths.findAll { it != currentPath }
@@ -80,6 +86,59 @@ class AutoRerouteSpec extends BaseSpecification {
         }
     }
 
+    def "Flow goes to 'Down' status when an intermediate switch is disconnected and there is no ability to reroute"() {
+        requireProfiles("virtual")
+
+        given: "Two active not neighboring switches"
+        def switches = topology.getActiveSwitches()
+        def links = northboundService.getAllLinks()
+        def (Switch srcSwitch, Switch dstSwitch) = [switches, switches].combinations()
+                .findAll { src, dst -> src != dst }.find { Switch src, Switch dst ->
+            links.every { link ->
+                def switchIds = link.path*.switchId
+                !(switchIds.contains(src.dpId) && switchIds.contains(dst.dpId))
+            }
+        } ?: assumeTrue("No suiting switches found", false)
+
+        and: "A flow without alternative paths"
+        def flow = flowHelper.randomFlow(srcSwitch, dstSwitch)
+        northboundService.addFlow(flow)
+        def currentPath = PathHelper.convert(northboundService.getFlowPath(flow.id))
+        assert Wrappers.wait(WAIT_OFFSET) { northboundService.getFlowStatus(flow.id).status == FlowState.UP }
+
+        def allPaths = db.getPaths(srcSwitch.dpId, dstSwitch.dpId)*.path
+        def altPaths = allPaths.findAll { it != currentPath && it.first().portNo != currentPath.first().portNo }
+        List<PathNode> broughtDownPorts = []
+        altPaths.unique { it.first() }.each { path ->
+            def src = path.first()
+            broughtDownPorts.add(src)
+            northboundService.portDown(src.switchId, src.portNo)
+        }
+
+        when: "An intermediate switch is disconnected"
+        lockKeeperService.knockoutSwitch(currentPath[1].switchId)
+
+        then: "Flow becomes 'Down'"
+        Wrappers.wait(discoveryTimeout + rerouteDelay + WAIT_OFFSET * 2) {
+            northboundService.getFlowStatus(flow.id).status == FlowState.DOWN
+        }
+
+        when: "The intermediate switch is connected back"
+        lockKeeperService.reviveSwitch(currentPath[1].switchId)
+
+        then: "Flow becomes 'Up'"
+        Wrappers.wait(rerouteDelay + discoveryInterval + WAIT_OFFSET) {
+            northboundService.getFlowStatus(flow.id).status == FlowState.UP
+        }
+
+        and: "Restore topology to original state, remove flow"
+        broughtDownPorts.every { northboundService.portUp(it.switchId, it.portNo) }
+        northboundService.deleteFlow(flow.id)
+        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
+            northboundService.getAllLinks().every { it.state != IslChangeType.FAILED }
+        }
+    }
+
     def "Flow in 'Down' status tries to reroute when discovering a new ISL"() {
         given: "Two active switches and a flow with one alternate path at least"
         def switches = topology.getActiveSwitches()
@@ -88,8 +147,7 @@ class AutoRerouteSpec extends BaseSpecification {
                 .findAll { src, dst -> src != dst }.find { Switch src, Switch dst ->
             possibleFlowPaths = db.getPaths(src.dpId, dst.dpId)*.path.sort { it.size() }
             possibleFlowPaths.size() > 1
-        }
-        assumeTrue("No suiting switches found", srcSwitch && dstSwitch)
+        } ?: assumeTrue("No suiting switches found", false)
 
         def flow = flowHelper.randomFlow(srcSwitch, dstSwitch)
         flow.maximumBandwidth = 1000
@@ -141,8 +199,7 @@ class AutoRerouteSpec extends BaseSpecification {
                 .findAll { src, dst -> src != dst }.find { Switch src, Switch dst ->
             possibleFlowPaths = db.getPaths(src.dpId, dst.dpId)*.path.sort { it.size() }
             possibleFlowPaths.size() > 1
-        }
-        assumeTrue("No suiting switches found", srcSwitch && dstSwitch)
+        } ?: assumeTrue("No suiting switches found", false)
 
         def flow = flowHelper.randomFlow(srcSwitch, dstSwitch)
         flow.maximumBandwidth = 1000

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/northbound/flows/BandwidthSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/northbound/flows/BandwidthSpec.groovy
@@ -1,5 +1,6 @@
 package org.openkilda.functionaltests.spec.northbound.flows
 
+import static org.junit.Assume.assumeTrue
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.BaseSpecification
@@ -42,8 +43,7 @@ class BandwidthSpec extends BaseSpecification {
                 def switchIds = link.path*.switchId
                 !(switchIds.contains(src.dpId) && switchIds.contains(dst.dpId))
             }
-        }
-        assert srcSwitch && dstSwitch
+        } ?: assumeTrue("No suiting switches found", false)
 
         when: "Create a flow with a valid bandwidth"
         def maximumBandwidth = 1000
@@ -101,8 +101,7 @@ class BandwidthSpec extends BaseSpecification {
                 .findAll { src, dst -> src != dst }.find { Switch src, Switch dst ->
             possibleFlowPaths = db.getPaths(src.dpId, dst.dpId)*.path.sort { it.size() }
             possibleFlowPaths.size() > 1
-        }
-        assert srcSwitch && dstSwitch
+        } ?: assumeTrue("No suiting switches found", false)
 
         // Make the first path more preferable than others.
         possibleFlowPaths[1..-1].each { pathHelper.makePathMorePreferable(possibleFlowPaths.first(), it) }
@@ -144,7 +143,6 @@ class BandwidthSpec extends BaseSpecification {
         def switches = topology.getActiveSwitches()
         def (Switch srcSwitch, Switch dstSwitch) = [switches, switches].combinations()
                 .find { Switch src, Switch dst -> src != dst }
-        assert srcSwitch && dstSwitch
 
         when: "Create a flow with a bandwidth that exceeds available bandwidth on ISL"
         def possibleFlowPaths = db.getPaths(srcSwitch.dpId, dstSwitch.dpId)*.path
@@ -170,7 +168,6 @@ class BandwidthSpec extends BaseSpecification {
         def switches = topology.getActiveSwitches()
         def (Switch srcSwitch, Switch dstSwitch) = [switches, switches].combinations()
                 .find { Switch src, Switch dst -> src != dst }
-        assert srcSwitch && dstSwitch
 
         when: "Create a flow with a valid bandwidth"
         def maximumBandwidth = 1000
@@ -209,7 +206,6 @@ class BandwidthSpec extends BaseSpecification {
         def switches = topology.getActiveSwitches()
         def (Switch srcSwitch, Switch dstSwitch) = [switches, switches].combinations()
                 .find { Switch src, Switch dst -> src != dst }
-        assert srcSwitch && dstSwitch
 
         when: "Create a flow with a bandwidth that exceeds available bandwidth on ISL (ignore_bandwidth = true)"
         def flow = flowHelper.randomFlow(srcSwitch, dstSwitch)
@@ -236,9 +232,7 @@ class BandwidthSpec extends BaseSpecification {
     def "Able to update bandwidth to maximum link speed without using alternate links"() {
         given: "Two active neighboring switches"
         def isl = topology.getIslsForActiveSwitches().first()
-        def srcSwitch = isl.srcSwitch
-        def dstSwitch = isl.dstSwitch
-        assert srcSwitch && dstSwitch
+        def (srcSwitch, dstSwitch) = [isl.srcSwitch, isl.dstSwitch]
 
         when: "Create a flow with a valid small bandwidth"
         def maximumBandwidth = 1000


### PR DESCRIPTION
The idea of the test is to verify flow goes to 'Down' status when
an intermediate switch is disconnected and there is no ability to reroute.

Part of #1454.