### PR TITLE
Downgraded neo4j-driver version to < 1.7.0

### DIFF
--- a/services/topology-engine-rest/Dockerfile
+++ b/services/topology-engine-rest/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
         nginx \
         sqlite \
     && pip install \
-        neo4j-driver \
+        'neo4j-driver<1.7.0' \
         kafka \
         flask \
         flask-login \


### PR DESCRIPTION
The python neo4j driver does not support compatibility with 1.6.2, it breaks the deployment