### PR TITLE
Collect storm exceptions

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/error/ImplementationError.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/error/ImplementationError.java
@@ -13,7 +13,7 @@
  *   limitations under the License.
  */
 
-package org.openkilda.wfm;
+package org.openkilda.wfm.error;
 
 public class ImplementationError extends Error {
     public ImplementationError(String message) {

--- a/services/wfm/src/main/java/org/openkilda/wfm/protocol/AbstractMessage.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/protocol/AbstractMessage.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.wfm.protocol;
 
-import org.openkilda.wfm.ImplementationError;
+import org.openkilda.wfm.error.ImplementationError;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.storm.tuple.Fields;


### PR DESCRIPTION
Move ImplementationError into package dedicated for storm exceptions
org.openkilda.wfm.error.

Related to #606