### PR TITLE
Rename 'reflow_on_switch_activation' feature

### DIFF
--- a/services/src/atdd-staging/src/main/java/org/openkilda/atdd/staging/steps/NorthboundSteps.java
+++ b/services/src/atdd-staging/src/main/java/org/openkilda/atdd/staging/steps/NorthboundSteps.java
@@ -79,8 +79,8 @@ public class NorthboundSteps {
         featureToggleRequest.setCreateFlowEnabled(!featureToggleRequest.getCreateFlowEnabled());
         featureToggleRequest.setDeleteFlowEnabled(!featureToggleRequest.getDeleteFlowEnabled());
         featureToggleRequest.setPushFlowEnabled(!featureToggleRequest.getPushFlowEnabled());
-        featureToggleRequest.setReflowOnSwitchActivationEnabled(
-                !featureToggleRequest.getReflowOnSwitchActivationEnabled());
+        featureToggleRequest.setRerouteOnIslDiscoveryEnabled(
+                !featureToggleRequest.getRerouteOnIslDiscoveryEnabled());
         featureToggleRequest.setSyncRulesEnabled(!featureToggleRequest.getSyncRulesEnabled());
         featureToggleRequest.setUnpushFlowEnabled(!featureToggleRequest.getUnpushFlowEnabled());
         featureToggleRequest.setUpdateFlowEnabled(!featureToggleRequest.getUpdateFlowEnabled());

--- a/services/src/atdd/src/test/java/org/openkilda/atdd/FlowReinstallTest.java
+++ b/services/src/atdd/src/test/java/org/openkilda/atdd/FlowReinstallTest.java
@@ -63,7 +63,7 @@ public class FlowReinstallTest {
         FeatureTogglePayload result = FlowUtils.updateFeaturesStatus(desired);
 
         assertNotNull(result);
-        assertEquals(status, result.getReflowOnSwitchActivationEnabled());
-        assertEquals(desired.getReflowOnSwitchActivationEnabled(), result.getReflowOnSwitchActivationEnabled());
+        assertEquals(status, result.getRerouteOnIslDiscoveryEnabled());
+        assertEquals(desired.getRerouteOnIslDiscoveryEnabled(), result.getRerouteOnIslDiscoveryEnabled());
     }
 }

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/command/system/FeatureToggleRequest.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/command/system/FeatureToggleRequest.java
@@ -32,8 +32,8 @@ public class FeatureToggleRequest extends CommandData {
 	@JsonProperty(value = "sync_rules")
 	private Boolean syncRulesEnabled;
 
-	@JsonProperty(value = "reflow_on_switch_activation")
-	private Boolean reflowOnSwitchActivationEnabled;
+	@JsonProperty(value = "reroute_on_isl_discovery")
+	private Boolean rerouteOnIslDiscoveryEnabled;
 
 	@JsonProperty("create_flow")
 	private Boolean createFlowEnabled;
@@ -54,7 +54,7 @@ public class FeatureToggleRequest extends CommandData {
 	private String childCorrelationId;
 
 	public FeatureToggleRequest(@JsonProperty(value = "sync_rules") Boolean syncRulesEnabled,
-			@JsonProperty(value = "reflow_on_switch_activation") Boolean reflowOnSwitchActivationEnabled,
+			@JsonProperty(value = "reroute_on_isl_discovery") Boolean rerouteOnIslDiscoveryEnabled,
 			@JsonProperty("create_flow") Boolean createFlowEnabled,
 			@JsonProperty("update_flow") Boolean updateFlowEnabled,
 			@JsonProperty("delete_flow") Boolean deleteFlowEnabled,
@@ -62,7 +62,7 @@ public class FeatureToggleRequest extends CommandData {
 			@JsonProperty("unpush_flow") Boolean unpushFlowEnabled,
 			@JsonProperty(value = "child_correlation_id") String childCorrelationId) {
 		this.syncRulesEnabled = syncRulesEnabled;
-		this.reflowOnSwitchActivationEnabled = reflowOnSwitchActivationEnabled;
+		this.rerouteOnIslDiscoveryEnabled = rerouteOnIslDiscoveryEnabled;
 		this.createFlowEnabled = createFlowEnabled;
 		this.updateFlowEnabled = updateFlowEnabled;
 		this.deleteFlowEnabled = deleteFlowEnabled;

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/system/FeatureTogglesResponse.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/system/FeatureTogglesResponse.java
@@ -29,8 +29,8 @@ public class FeatureTogglesResponse extends InfoData {
     @JsonProperty(value = "sync_rules")
     private Boolean syncRulesEnabled;
 
-    @JsonProperty(value = "reflow_on_switch_activation")
-    private Boolean reflowOnSwitchActivationEnabled;
+    @JsonProperty(value = "reroute_on_isl_discovery")
+    private Boolean rerouteOnIslDiscoveryEnabled;
 
     @JsonProperty("create_flow")
     private Boolean createFlowEnabled;
@@ -48,13 +48,13 @@ public class FeatureTogglesResponse extends InfoData {
     private Boolean unpushFlowEnabled;
 
     public FeatureTogglesResponse(@JsonProperty(value = "sync_rules") Boolean syncRulesEnabled,
-            @JsonProperty(value = "reflow_on_switch_activation") Boolean reflowOnSwitchActivationEnabled,
+            @JsonProperty(value = "reroute_on_isl_discovery") Boolean rerouteOnIslDiscoveryEnabled,
             @JsonProperty("create_flow") Boolean createFlowEnabled,
             @JsonProperty("update_flow") Boolean updateFlowEnabled,
             @JsonProperty("delete_flow") Boolean deleteFlowEnabled, @JsonProperty("push_flow") Boolean pushFlowEnabled,
             @JsonProperty("unpush_flow") Boolean unpushFlowEnabled) {
         this.syncRulesEnabled = syncRulesEnabled;
-        this.reflowOnSwitchActivationEnabled = reflowOnSwitchActivationEnabled;
+        this.rerouteOnIslDiscoveryEnabled = rerouteOnIslDiscoveryEnabled;
         this.createFlowEnabled = createFlowEnabled;
         this.updateFlowEnabled = updateFlowEnabled;
         this.deleteFlowEnabled = deleteFlowEnabled;
@@ -66,8 +66,8 @@ public class FeatureTogglesResponse extends InfoData {
         return syncRulesEnabled;
     }
 
-    public Boolean getReflowOnSwitchActivationEnabled() {
-        return reflowOnSwitchActivationEnabled;
+    public Boolean getRerouteOnIslDiscoveryEnabled() {
+        return rerouteOnIslDiscoveryEnabled;
     }
 
     public Boolean getCreateFlowEnabled() {
@@ -92,8 +92,8 @@ public class FeatureTogglesResponse extends InfoData {
 
     @Override
     public String toString() {
-        return "FeatureTogglesResponse [syncRulesEnabled=" + syncRulesEnabled + ", reflowOnSwitchActivationEnabled="
-                + reflowOnSwitchActivationEnabled + ", createFlowEnabled=" + createFlowEnabled + ", updateFlowEnabled="
+        return "FeatureTogglesResponse [syncRulesEnabled=" + syncRulesEnabled + ", rerouteOnIslDiscoveryEnabled="
+                + rerouteOnIslDiscoveryEnabled + ", createFlowEnabled=" + createFlowEnabled + ", updateFlowEnabled="
                 + updateFlowEnabled + ", deleteFlowEnabled=" + deleteFlowEnabled + ", pushFlowEnabled="
                 + pushFlowEnabled + ", unpushFlowEnabled=" + unpushFlowEnabled + "]";
     }

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/payload/FeatureTogglePayload.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/payload/FeatureTogglePayload.java
@@ -24,8 +24,8 @@ public class FeatureTogglePayload {
     @JsonProperty("sync_rules")
     private Boolean syncRulesEnabled;
 
-    @JsonProperty("reflow_on_switch_activation")
-    private Boolean reflowOnSwitchActivationEnabled;
+    @JsonProperty("reroute_on_isl_discovery")
+    private Boolean rerouteOnIslDiscoveryEnabled;
 
     @JsonProperty("create_flow")
     private Boolean createFlowEnabled;
@@ -43,14 +43,14 @@ public class FeatureTogglePayload {
     private Boolean unpushFlowEnabled;
 
     public FeatureTogglePayload(@JsonProperty("sync_rules") Boolean syncRulesEnabled,
-                                @JsonProperty("reflow_on_switch_activation") Boolean reflowOnSwitchActivationEnabled,
+                                @JsonProperty("reroute_on_isl_discovery") Boolean rerouteOnIslDiscoveryEnabled,
                                 @JsonProperty("create_flow") Boolean createFlowEnabled,
                                 @JsonProperty("update_flow") Boolean updateFlowEnabled,
                                 @JsonProperty("delete_flow") Boolean deleteFlowEnabled,
                                 @JsonProperty("push_flow") Boolean pushFlowEnabled,
                                 @JsonProperty("unpush_flow") Boolean unpushFlowEnabled) {
         this.syncRulesEnabled = syncRulesEnabled;
-        this.reflowOnSwitchActivationEnabled = reflowOnSwitchActivationEnabled;
+        this.rerouteOnIslDiscoveryEnabled = rerouteOnIslDiscoveryEnabled;
         this.createFlowEnabled = createFlowEnabled;
         this.updateFlowEnabled = updateFlowEnabled;
         this.deleteFlowEnabled = deleteFlowEnabled;
@@ -60,7 +60,7 @@ public class FeatureTogglePayload {
 
     public FeatureTogglePayload(FeatureTogglePayload payload) {
         this.syncRulesEnabled = payload.syncRulesEnabled;
-        this.reflowOnSwitchActivationEnabled = payload.reflowOnSwitchActivationEnabled;
+        this.rerouteOnIslDiscoveryEnabled = payload.rerouteOnIslDiscoveryEnabled;
         this.createFlowEnabled = payload.createFlowEnabled;
         this.updateFlowEnabled = payload.updateFlowEnabled;
         this.deleteFlowEnabled = payload.deleteFlowEnabled;
@@ -70,8 +70,8 @@ public class FeatureTogglePayload {
 
     @Override
     public String toString() {
-        return "FeatureTogglePayload [syncRulesEnabled=" + syncRulesEnabled + ", reflowOnSwitchActivationEnabled="
-                + reflowOnSwitchActivationEnabled + ", createFlowEnabled=" + createFlowEnabled + ", updateFlowEnabled="
+        return "FeatureTogglePayload [syncRulesEnabled=" + syncRulesEnabled + ", rerouteOnIslDiscoveryEnabled="
+                + rerouteOnIslDiscoveryEnabled + ", createFlowEnabled=" + createFlowEnabled + ", updateFlowEnabled="
                 + updateFlowEnabled + ", deleteFlowEnabled=" + deleteFlowEnabled + ", pushFlowEnabled="
                 + pushFlowEnabled + ", unpushFlowEnabled=" + unpushFlowEnabled + "]";
     }

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/converter/FeatureTogglesMapper.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/converter/FeatureTogglesMapper.java
@@ -33,7 +33,7 @@ public interface FeatureTogglesMapper {
      * @return appropriate {@code}FeatureTogglePayload{@code}.
      */
     default FeatureTogglePayload toDto(FeatureTogglesResponse response) {
-        return new FeatureTogglePayload(response.getSyncRulesEnabled(), response.getReflowOnSwitchActivationEnabled(),
+        return new FeatureTogglePayload(response.getSyncRulesEnabled(), response.getRerouteOnIslDiscoveryEnabled(),
                 response.getCreateFlowEnabled(), response.getUpdateFlowEnabled(), response.getDeleteFlowEnabled(),
                 response.getPushFlowEnabled(), response.getUnpushFlowEnabled());
     }
@@ -51,7 +51,7 @@ public interface FeatureTogglesMapper {
      * @return appropriate {@code}FeatureToggleRequest{@code}.
      */
     default FeatureToggleRequest toRequest(FeatureTogglePayload request, String correlationId) {
-        return new FeatureToggleRequest(request.getSyncRulesEnabled(), request.getReflowOnSwitchActivationEnabled(),
+        return new FeatureToggleRequest(request.getSyncRulesEnabled(), request.getRerouteOnIslDiscoveryEnabled(),
                 request.getCreateFlowEnabled(), request.getUpdateFlowEnabled(), request.getDeleteFlowEnabled(),
                 request.getPushFlowEnabled(), request.getUnpushFlowEnabled(), correlationId);
     }

--- a/services/topology-engine/queue-engine/topologylistener/messageclasses.py
+++ b/services/topology-engine/queue-engine/topologylistener/messageclasses.py
@@ -75,7 +75,7 @@ features_status = {
 
 features_status_app_to_transport_map = {
     FEATURE_SYNC_OFRULES: 'sync_rules',
-    FEATURE_REROUTE_ON_ISL_DISCOVERY: 'reflow_on_switch_activation',
+    FEATURE_REROUTE_ON_ISL_DISCOVERY: 'reroute_on_isl_discovery',
     FEATURE_CREATE_FLOW: 'create_flow',
     FEATURE_UPDATE_FLOW: 'update_flow',
     FEATURE_DELETE_FLOW: 'delete_flow',

--- a/services/topology-engine/queue-engine/topologylistener/tests/test_config.py
+++ b/services/topology-engine/queue-engine/topologylistener/tests/test_config.py
@@ -59,7 +59,7 @@ class TestConfig(share.AbstractTest):
             p = {
                 'data': {
                     'name': 'config',
-                    'reflow_on_switch_activation': False,
+                    'reroute_on_isl_discovery': False,
                     'unpush_flow': False,
                     'sync_rules': False,
                     'push_flow': False,


### PR DESCRIPTION
The current name of the feature that enables rerouting flows on ISL discovery
is "reflow_on_switch_activation". This name doesn't reflect the proper meaning
of this feature and should be changed. If the feature is enabled, rerouting
flows starts on ISL discovery, not on switch activation. So this patch renames
the feature from "reflow_on_switch_activation" to "reroute_on_isl_discovery"
to get a more clear understanding what the feature does.

Closes #1559.