### PR TITLE
Meters support in switch validation.

### DIFF
--- a/services/src/api/src/main/java/org/openkilda/northbound/dto/switches/ValidationResult.java
+++ b/services/src/api/src/main/java/org/openkilda/northbound/dto/switches/ValidationResult.java
@@ -1,0 +1,49 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.northbound.dto.switches;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class ValidationResult {
+
+    @JsonProperty("rules")
+    private Diff rules;
+
+    @JsonProperty("meters")
+    private Diff meters;
+
+    @Data
+    @AllArgsConstructor
+    public static class Diff {
+        @JsonProperty("missing")
+        private List<Long> missing;
+
+        @JsonProperty("misconfigured")
+        private List<Long> misconfigured;
+
+        @JsonProperty("excess")
+        private List<Long> excess;
+
+        @JsonProperty("proper")
+        private List<Long> proper;
+    }
+}

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/switches/SyncRulesResponse.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/switches/SyncRulesResponse.java
@@ -39,16 +39,36 @@ public class SyncRulesResponse extends InfoData {
     @JsonProperty("installed_rules")
     private List<Long> installedRules;
 
+    @JsonProperty("missing_meters")
+    private List<Long> missingMeters;
+
+    @JsonProperty("misconfigured_meters")
+    private List<Long> misconfiguredMeters;
+
+    @JsonProperty("proper_meters")
+    private List<Long> properMeters;
+
+    @JsonProperty("excess_meters")
+    private List<Long> excessMeters;
+
     @JsonCreator
     public SyncRulesResponse(
             @JsonProperty("missing_rules") List<Long> missingRules,
             @JsonProperty("proper_rules") List<Long> properRules,
             @JsonProperty("excess_rules") List<Long> excessRules,
-            @JsonProperty("installed_rules") List<Long> installedRules) {
+            @JsonProperty("installed_rules") List<Long> installedRules,
+            @JsonProperty("missing_meters") List<Long> missingMeters,
+            @JsonProperty("misconfigured_meters") List<Long> misconfiguredMeters,
+            @JsonProperty("proper_meters") List<Long> properMeters,
+            @JsonProperty("excess_meters") List<Long> excessMeters) {
         this.missingRules = missingRules;
         this.properRules = properRules;
         this.excessRules = excessRules;
         this.installedRules = installedRules;
+        this.missingMeters = missingMeters;
+        this.misconfiguredMeters = misconfiguredMeters;
+        this.excessMeters = excessMeters;
+        this.properMeters = properMeters;
     }
 
     public SyncRulesResponse() {
@@ -56,5 +76,9 @@ public class SyncRulesResponse extends InfoData {
         this.properRules = Collections.emptyList();
         this.excessRules = Collections.emptyList();
         this.installedRules = Collections.emptyList();
+        this.missingMeters = Collections.emptyList();
+        this.misconfiguredMeters = Collections.emptyList();
+        this.excessMeters = Collections.emptyList();
+        this.properMeters = Collections.emptyList();
     }
 }

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/controller/SwitchController.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/controller/SwitchController.java
@@ -35,6 +35,7 @@ import org.openkilda.northbound.dto.switches.PortDto;
 import org.openkilda.northbound.dto.switches.RulesSyncResult;
 import org.openkilda.northbound.dto.switches.RulesValidationResult;
 import org.openkilda.northbound.dto.switches.SwitchDto;
+import org.openkilda.northbound.dto.switches.ValidationResult;
 import org.openkilda.northbound.service.SwitchService;
 import org.openkilda.northbound.utils.ExtraAuthRequired;
 import org.openkilda.northbound.utils.RequestCorrelationId;
@@ -227,6 +228,20 @@ public class SwitchController {
     @ResponseStatus(HttpStatus.OK)
     public CompletableFuture<RulesValidationResult> validateRules(@PathVariable(name = "switch_id") SwitchId switchId) {
         return switchService.validateRules(switchId);
+    }
+
+    /**
+     * Validate the rules and meters installed on the switch against the flows in Neo4J.
+     *
+     * @param switchId switch to validate rules on.
+     * @return the validation details.
+     */
+    @ApiOperation(value = "Validate the rules and meters installed on the switch",
+            response = ValidationResult.class)
+    @GetMapping(path = "/{switch_id}/validate")
+    @ResponseStatus(HttpStatus.OK)
+    public CompletableFuture<ValidationResult> validate(@PathVariable(name = "switch_id") SwitchId switchId) {
+        return switchService.validate(switchId);
     }
 
     /**

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/converter/SwitchMapper.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/converter/SwitchMapper.java
@@ -21,9 +21,12 @@ import org.openkilda.messaging.model.SwitchId;
 import org.openkilda.northbound.dto.switches.RulesSyncResult;
 import org.openkilda.northbound.dto.switches.RulesValidationResult;
 import org.openkilda.northbound.dto.switches.SwitchDto;
+import org.openkilda.northbound.dto.switches.ValidationResult;
+import org.openkilda.northbound.dto.switches.ValidationResult.Diff;
 
 import org.mapstruct.Mapper;
 
+import java.util.Collections;
 import java.util.List;
 
 @Mapper(componentModel = "spring")
@@ -37,6 +40,32 @@ public interface SwitchMapper {
     }
 
     RulesValidationResult toRulesValidationResult(SyncRulesResponse response);
+
+    /**
+     * Maps {@code}SyncRulesResponse{@code} to {@code}ValidationResult{@code}.
+     *
+     * @param response the {@code}SyncRulesResponse{@code}
+     * @return the result
+     */
+    default ValidationResult toValidationResult(SyncRulesResponse response) {
+        if (response == null) {
+            return null;
+        }
+        return new ValidationResult(
+                new Diff(
+                        response.getMissingRules(),
+                        Collections.emptyList(),
+                        response.getExcessRules(),
+                        response.getProperRules()
+                ),
+                new Diff(
+                        response.getMissingMeters(),
+                        response.getMisconfiguredMeters(),
+                        response.getExcessMeters(),
+                        response.getProperMeters()
+                )
+        );
+    }
 
     default String toSwithId(SwitchId switchId) {
         return switchId.toString();

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/service/SwitchService.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/service/SwitchService.java
@@ -29,6 +29,7 @@ import org.openkilda.northbound.dto.switches.PortDto;
 import org.openkilda.northbound.dto.switches.RulesSyncResult;
 import org.openkilda.northbound.dto.switches.RulesValidationResult;
 import org.openkilda.northbound.dto.switches.SwitchDto;
+import org.openkilda.northbound.dto.switches.ValidationResult;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -104,6 +105,14 @@ public interface SwitchService extends BasicService {
      * @return the validation details.
      */
     CompletableFuture<RulesValidationResult> validateRules(SwitchId switchId);
+
+    /**
+     * Validate the rules and meters installed on the switch against the flows in Neo4J.
+     *
+     * @param switchId switch to validate rules on.
+     * @return the validation details.
+     */
+    CompletableFuture<ValidationResult> validate(SwitchId switchId);
 
     /**
      * Synchronize (install) missing flows that should be on the switch but exist only in Neo4J.

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/service/impl/SwitchServiceImpl.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/service/impl/SwitchServiceImpl.java
@@ -54,6 +54,7 @@ import org.openkilda.northbound.dto.switches.PortDto;
 import org.openkilda.northbound.dto.switches.RulesSyncResult;
 import org.openkilda.northbound.dto.switches.RulesValidationResult;
 import org.openkilda.northbound.dto.switches.SwitchDto;
+import org.openkilda.northbound.dto.switches.ValidationResult;
 import org.openkilda.northbound.messaging.MessagingChannel;
 import org.openkilda.northbound.service.SwitchService;
 import org.openkilda.northbound.utils.RequestCorrelationId;
@@ -202,6 +203,19 @@ public class SwitchServiceImpl implements SwitchService {
         return messagingChannel.sendAndGet(topoEngTopic, validateCommandMessage)
                 .thenApply(SyncRulesResponse.class::cast)
                 .thenApply(switchMapper::toRulesValidationResult);
+    }
+
+    @Override
+    public CompletableFuture<ValidationResult> validate(SwitchId switchId) {
+        final String correlationId = RequestCorrelationId.getId();
+
+        CommandWithReplyToMessage validateCommandMessage = new CommandWithReplyToMessage(
+                new SwitchRulesValidateRequest(switchId),
+                System.currentTimeMillis(), correlationId, Destination.TOPOLOGY_ENGINE, northboundTopic);
+
+        return messagingChannel.sendAndGet(topoEngTopic, validateCommandMessage)
+                .thenApply(SyncRulesResponse.class::cast)
+                .thenApply(switchMapper::toValidationResult);
     }
 
     @Override

--- a/services/src/northbound/src/test/java/org/openkilda/northbound/service/SwitchServiceTest.java
+++ b/services/src/northbound/src/test/java/org/openkilda/northbound/service/SwitchServiceTest.java
@@ -71,12 +71,14 @@ public class SwitchServiceTest {
 
         // the switch has 1 excess, 1 proper and 1 missing rules
         InfoData validationResult = new SyncRulesResponse(Collections.singletonList(missingRule),
-                Collections.singletonList(properRule), Collections.singletonList(excessRule), Collections.emptyList());
+                Collections.singletonList(properRule), Collections.singletonList(excessRule), Collections.emptyList(),
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         messageExchanger.mockResponse(correlationId, validationResult);
 
         SyncRulesResponse rules = new SyncRulesResponse(
                 Collections.emptyList(), ImmutableList.of(properRule, missingRule),
-                Collections.singletonList(excessRule), Collections.singletonList(missingRule));
+                Collections.singletonList(excessRule), Collections.singletonList(missingRule),
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         messageExchanger.mockResponse(String.format("%s-sync", correlationId), rules);
 
         RulesSyncResult result = switchService.syncRules(switchId).get();
@@ -96,7 +98,8 @@ public class SwitchServiceTest {
 
         // the switch has 1 excess, 1 proper and no missing rules
         InfoData validationResult = new SyncRulesResponse(Collections.emptyList(),
-                Collections.singletonList(properRule), Collections.singletonList(excessRule), Collections.emptyList());
+                Collections.singletonList(properRule), Collections.singletonList(excessRule), Collections.emptyList(),
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         messageExchanger.mockResponse(correlationId, validationResult);
 
         RulesSyncResult result = switchService.syncRules(switchId).get();

--- a/services/topology-engine/queue-engine/topologylistener/message_utils.py
+++ b/services/topology-engine/queue-engine/topologylistener/message_utils.py
@@ -228,13 +228,17 @@ def send_dump_rules_request(switch_id, correlation_id):
                   extra=reply_to)
 
 
-def send_validation_rules_response(missing_rules, excess_rules, proper_rules,
-    correlation_id):
+def send_validation_rules_response(missing_rules, excess_rules, proper_rules, missing_meters, misconfigured_meters,
+                                   excess_meters, proper_meters, correlation_id):
     message = Message()
     message.clazz = 'org.openkilda.messaging.info.switches.SyncRulesResponse'
     message.missing_rules = list(missing_rules)
     message.excess_rules = list(excess_rules)
     message.proper_rules = list(proper_rules)
+    message.missing_meters = list(missing_meters)
+    message.misconfigured_meters = list(misconfigured_meters)
+    message.excess_meters = list(excess_meters)
+    message.proper_meters = list(proper_meters)
     send_to_topic(message, correlation_id, MT_INFO,
                   destination="NORTHBOUND",
                   topic=config.KAFKA_NORTHBOUND_TOPIC)

--- a/services/topology-engine/queue-engine/topologylistener/messageclasses.py
+++ b/services/topology-engine/queue-engine/topologylistener/messageclasses.py
@@ -743,9 +743,13 @@ class MessageItem(model.JsonSerializable):
     def validate_switch_rules(self):
         diff = flow_utils.validate_switch_rules(self.payload['switch_id'],
                                                 self.payload['flows'])
-        message_utils.send_validation_rules_response(diff["missing_rules"],
-                                                     diff["excess_rules"],
-                                                     diff["proper_rules"],
+        message_utils.send_validation_rules_response(diff['rules']['missing'],
+                                                     diff['rules']['excess'],
+                                                     diff['rules']['proper'],
+                                                     diff['meters']['missing'],
+                                                     diff['meters']['misconfigured'],
+                                                     diff['meters']['excess'],
+                                                     diff['meters']['proper'],
                                                      self.correlation_id)
         return True
 

--- a/services/topology-engine/queue-engine/topologylistener/tests/test_flow_utils.py
+++ b/services/topology-engine/queue-engine/topologylistener/tests/test_flow_utils.py
@@ -1,0 +1,100 @@
+import unittest
+from topologylistener import flow_utils
+
+COOKIE = 0x4000000000000001
+METER = 12
+
+class TestFlowUtils(unittest.TestCase):
+
+    def test_validate_switch_rules_empty(self):
+        self.check_validate_switch()
+
+    def test_validate_switch_rules_missed_rules(self):
+        self.add_flow_segment(COOKIE)
+        self.check_validate_switch(missing_rules={COOKIE})
+
+    def test_validate_switch_rules_excess_rules(self):
+        self.add_switch_rule(COOKIE)
+        self.check_validate_switch(excess_rules={COOKIE})
+
+    def test_validate_switch_rules_proper_rules(self):
+        self.add_switch_rule(COOKIE)
+        self.add_flow_segment(COOKIE)
+        self.check_validate_switch(proper_rules={COOKIE})
+
+    def test_validate_switch_rules_missed_meters(self):
+        self.add_flow(COOKIE, METER)
+        self.check_validate_switch(missing_rules={COOKIE}, missing_meters={COOKIE})
+
+    def test_validate_switch_rules_misconfigured_meters(self):
+        self.add_flow(COOKIE, METER)
+        self.add_switch_rule(COOKIE)
+        self.check_validate_switch(proper_rules={COOKIE}, misconfigured_meters={COOKIE})
+
+    def test_validate_switch_rules_excess_meters(self):
+        self.add_flow_segment(COOKIE)
+        self.add_switch_rule(COOKIE, METER)
+        self.check_validate_switch(proper_rules={COOKIE}, excess_meters={COOKIE})
+
+    def test_validate_switch_rules_excess_rules_and_meters(self):
+        self.add_switch_rule(COOKIE, METER)
+        self.check_validate_switch(excess_rules={COOKIE}, excess_meters={COOKIE})
+
+    def test_validate_switch_rules_proper_meters(self):
+        self.add_flow(COOKIE, METER)
+        self.add_switch_rule(COOKIE, METER)
+        self.check_validate_switch(proper_rules={COOKIE}, proper_meters={COOKIE})
+
+    @classmethod
+    def setUpClass(cls):
+        cls.old_get_flow_segments_by_dst_switch = flow_utils.get_flow_segments_by_dst_switch
+        cls.old_get_flows_by_src_switch = flow_utils.get_flows_by_src_switch
+
+    @classmethod
+    def tearDownClass(cls):
+        flow_utils.get_flow_segments_by_dst_switch = cls.old_get_flow_segments_by_dst_switch
+        flow_utils.get_flows_by_src_switch = cls.old_get_flows_by_src_switch
+
+    def setUp(self):
+        flow_utils.get_flow_segments_by_dst_switch = self.get_flow_segments_by_dst_switch
+        flow_utils.get_flows_by_src_switch = self.get_flows_by_src_switch
+        self.flow_segments = []
+        self.flows = []
+        self.switch_rules = []
+
+    def get_flow_segments_by_dst_switch(self, switch_id):
+        return self.flow_segments
+
+    def get_flows_by_src_switch(self, switch_id):
+        return self.flows
+
+    def add_flow_segment(self, cookie):
+        self.flow_segments.append({'cookie': cookie, 'parent_cookie': cookie})
+
+    def add_flow(self, cookie, meter_id):
+        self.flows.append({'cookie': cookie, 'meter_id': meter_id})
+
+    def add_switch_rule(self, cookie, meter_id=None):
+        self.switch_rules.append({
+            'cookie': cookie,
+            'instructions': {'instruction_goto_meter': meter_id}
+        })
+
+    def check_validate_switch(self, missing_rules=None, excess_rules=None, proper_rules=None, missing_meters=None,
+                              misconfigured_meters=None, excess_meters=None, proper_meters=None):
+        expected = {
+            'rules': {
+                'missing': missing_rules or set(),
+                'misconfigured': set(),
+                'excess': excess_rules or set(),
+                'proper': proper_rules or set()
+            },
+            'meters': {
+                'missing': missing_meters or set(),
+                'misconfigured': misconfigured_meters or set(),
+                'excess': excess_meters or set(),
+                'proper': proper_meters or set()
+            }
+        }
+        diff = flow_utils.validate_switch_rules("00:08", self.switch_rules)
+        self.assertEqual(expected, diff)


### PR DESCRIPTION
Add new NB API point /{switch}/validate for validate
rules and meters on the switch.

Close #1551.