### PR TITLE
Add FailfastExtension to replace the maven failfast mechanism

### DIFF
--- a/services/src/functional-tests/pom.xml
+++ b/services/src/functional-tests/pom.xml
@@ -128,7 +128,6 @@
                         <version>${surefire.version}</version>
                         <configuration>
                             <testFailureIgnore>false</testFailureIgnore>
-                            <skipAfterFailureCount>1</skipAfterFailureCount>
                             <redirectTestOutputToFile>false</redirectTestOutputToFile>
                             <printSummary>true</printSummary>
                             <useFile>false</useFile>

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/failfast/FailFastExtension.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/failfast/FailFastExtension.groovy
@@ -1,0 +1,49 @@
+package org.openkilda.functionaltests.extension.failfast
+
+import org.junit.AssumptionViolatedException
+import org.spockframework.runtime.extension.AbstractGlobalExtension
+import org.spockframework.runtime.extension.IMethodInterceptor
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.SpecInfo
+
+/**
+ * This implements our Failfast policy: ensures that execution is stopped after first test failure.
+ */
+class FailFastExtension extends AbstractGlobalExtension {
+    
+    String failedTest
+
+    @Override
+    void visitSpec(SpecInfo spec) {
+        spec.allFeatures*.addInterceptor(new IMethodInterceptor() {
+            @Override
+            void intercept(IMethodInvocation invocation) throws Throwable {
+                //check before every feature. Will not unroll the test in case of failure to reduce the amount
+                //of failed tests output
+                checkForFailedTest()
+                invocation.proceed()
+            }
+        })
+        spec.allFeatures*.getFeatureMethod()*.addInterceptor(new IMethodInterceptor() {
+            @Override
+            void intercept(IMethodInvocation invocation) throws Throwable {
+                //check before every iteration in order to stop further execution if test has multiple iterations(Unroll)
+                checkForFailedTest()
+                try {
+                    invocation.proceed()
+                } catch(Throwable t) {
+                    if(!(t in AssumptionViolatedException)) {
+                        failedTest = invocation.iteration.name
+                    }
+                    throw t
+                }
+            }
+        })    
+    }
+
+    void checkForFailedTest() {
+        if(failedTest) {
+            throw new PreviousTestFailedError("Unable to run until '$failedTest' is fixed")
+        }
+    }
+}

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/failfast/PreviousTestFailedError.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/failfast/PreviousTestFailedError.groovy
@@ -1,0 +1,7 @@
+package org.openkilda.functionaltests.extension.failfast
+
+import groovy.transform.InheritConstructors
+
+@InheritConstructors
+class PreviousTestFailedError extends RuntimeException {
+}

--- a/services/src/functional-tests/src/test/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
+++ b/services/src/functional-tests/src/test/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
@@ -5,3 +5,4 @@ org.openkilda.functionaltests.extension.VirtualEnvExtension
 org.openkilda.functionaltests.extension.healthcheck.HealthCheckExtension
 org.openkilda.functionaltests.extension.FeatureOrderExtension
 org.openkilda.functionaltests.extension.TestDataLoggingExtension
+org.openkilda.functionaltests.extension.failfast.FailFastExtension


### PR DESCRIPTION
Maven failfast mechanism produced several problems:
1. Was not working in IDE, thus leading to misleading test results
2. Not working correctly with `spock-reports`, leading to a NPE in certain cases when test failed:
```
java.lang.NullPointerException: Cannot invoke method leftShift() on null object
...
```
