### PR TITLE
Rework CleanupSwitchesRule to fail on proper or missing rules

### DIFF
--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/fixture/rule/CleanupSwitchesRule.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/fixture/rule/CleanupSwitchesRule.groovy
@@ -5,9 +5,11 @@ import static org.openkilda.testing.Constants.WAIT_OFFSET
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.functionaltests.helpers.Wrappers.WaitTimeoutException
 import org.openkilda.messaging.command.switches.DeleteRulesAction
+import org.openkilda.northbound.dto.switches.RulesValidationResult
 import org.openkilda.testing.model.topology.TopologyDefinition
 import org.openkilda.testing.service.northbound.NorthboundService
 
+import groovy.transform.InheritConstructors
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -25,24 +27,61 @@ class CleanupSwitchesRule extends AbstractRuleExtension<CleanupSwitches> {
 
     @Override
     void afterTest() {
-        log.debug "Verifying that all the switches are clean"
-        try {
-            Wrappers.wait(WAIT_OFFSET) {
-                topology.activeSwitches.each { sw ->
+        topology.activeSwitches.each { sw ->
+            try {
+                Wrappers.wait(WAIT_OFFSET) {
                     def rules = northbound.validateSwitchRules(sw.dpId)
-                    assert rules.missingRules.empty
-                    assert rules.excessRules.empty
-                    assert rules.properRules.empty
+                    rules.excessRules.empty ?: failWith(new ExcessRulesException(
+                            "Switch $sw.dpId has excess rules at the end of the test.", rules))
+                    rules.properRules.empty ?: failWith(new ProperRulesException(
+                            "FATAL: there are proper rules left after the test. This usually means" +
+                                    " that a certain flow was not properly removed from database and Kilda is in an" +
+                                    " inconsistent state.\nSwitch: $sw.dpId", rules))
+                    rules.missingRules.empty ?: failWith(new MissingRulesException(
+                            "FATAL: there are missing rules left after the test. This usually means" +
+                                    " that a certain flow was not properly removed from database and Kilda is in an" +
+                                    " inconsistent state.\nSwitch: $sw.dpId", rules))
                 }
-            }
-        } catch (WaitTimeoutException e) {
-            //TODO(rtretiak): Not able to deal with randomly appearing rules from previous tests at this point.
-            //Waiting for new Kilda patch with Hub&Spoke features
-            log.warn("Switches do not appear to be cleaned at the end of the test. Force switches cleanup." +
-                    "\n\nOriginal error:\n\n$e")
-            topology.activeSwitches.each { sw ->
-                northbound.deleteSwitchRules(sw.dpId, DeleteRulesAction.IGNORE_DEFAULTS)
+            } catch (WaitTimeoutException e) {
+                //TODO(rtretiak): Not able to deal with randomly appearing rules from previous tests at this point.
+                //Waiting for new Kilda patch with Hub&Spoke features
+                def originalError = e.originalError
+                switch (originalError) {
+                    case ExcessRulesException:
+                        log.warn(originalError.message + "\nForcing switch cleanup.")
+                        northbound.deleteSwitchRules(sw.dpId, DeleteRulesAction.IGNORE_DEFAULTS)
+                        break
+                    case MissingRulesException:
+                    case ProperRulesException:
+                        //we are unable to deal with this. Kilda is inconsistent.
+                        throw originalError
+                    default:
+                        throw originalError
+
+                }
             }
         }
     }
+
+    static void failWith(Throwable t) {
+        throw t
+    }
+
+    private static abstract class RulesException extends RuntimeException {
+        RulesValidationResult rules
+
+        RulesException(String message, RulesValidationResult rules) {
+            super(message + "\nRules: $rules")
+            this.rules = rules
+        }
+    }
+
+    @InheritConstructors
+    private static class ExcessRulesException extends RulesException {}
+
+    @InheritConstructors
+    private static class MissingRulesException extends RulesException {}
+
+    @InheritConstructors
+    private static class ProperRulesException extends RulesException {}
 }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/helpers/Wrappers.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/helpers/Wrappers.groovy
@@ -47,7 +47,7 @@ class Wrappers {
     static boolean wait(double timeout, double retryInterval = 0.5, Closure closure) {
         long endTime = System.currentTimeMillis() + (long) (timeout * 1000)
         long sleepTime = (long) (retryInterval * 1000)
-        def thrown
+        Throwable thrown = null
         while (System.currentTimeMillis() < endTime) {
             try {
                 def result = closure.call()
@@ -62,11 +62,7 @@ class Wrappers {
                 sleep(sleepTime)
             }
         }
-        def message = "Condition was not satisfied within $timeout seconds"
-        if (thrown) {
-            message += ". Failed with exception:\n\n$thrown"
-        }
-        throw new WaitTimeoutException(message)
+        throw new WaitTimeoutException("Condition was not satisfied within $timeout seconds", thrown)
     }
 
     /**
@@ -99,5 +95,12 @@ class Wrappers {
     }
 
     @InheritConstructors
-    static class WaitTimeoutException extends RuntimeException {}
+    static class WaitTimeoutException extends RuntimeException {
+        Throwable originalError
+        
+        WaitTimeoutException(String message, Throwable error) {
+            super(error ? message + "\nFailed with exception:\n\n$error" : message)
+            originalError = error
+        }
+    }
 }


### PR DESCRIPTION
We are only able to deal with excess rules. Missing or proper rules on the switches should fail the build