### PR TITLE
Add ability to get all meters from switch via Northbound

### DIFF
--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/converter/OfMeterConverter.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/converter/OfMeterConverter.java
@@ -1,0 +1,53 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.floodlight.converter;
+
+import org.openkilda.messaging.info.meter.MeterEntry;
+
+import org.projectfloodlight.openflow.protocol.OFMeterConfig;
+import org.projectfloodlight.openflow.protocol.OFMeterFlags;
+import org.projectfloodlight.openflow.protocol.meterband.OFMeterBandDrop;
+
+import java.util.Optional;
+
+/**
+ * Utility class that converts OFMeterConfig from the switch to kilda known format for further processing.
+ */
+public final class OfMeterConverter {
+
+    private OfMeterConverter() {}
+
+    /**
+     * Convert {@link OFMeterConfig} to format that kilda supports.
+     * @param entry meter entry to be converted.
+     * @return result of transformation.
+     */
+    public static MeterEntry toMeterEntry(OFMeterConfig entry) {
+        Optional<OFMeterBandDrop> meterBandDrop = entry.getEntries().stream()
+                .filter(ofMeterBand -> ofMeterBand instanceof OFMeterBandDrop)
+                .findAny()
+                .map(ofMeterBand -> (OFMeterBandDrop) ofMeterBand);
+        return MeterEntry.builder()
+                .version(entry.getVersion().toString())
+                .meterId(entry.getMeterId())
+                .rate(meterBandDrop.map(OFMeterBandDrop::getRate).orElse((long) 0))
+                .burstSize(meterBandDrop.map(OFMeterBandDrop::getBurstSize).orElse((long) 0))
+                .flags(entry.getFlags().stream()
+                        .map(OFMeterFlags::name)
+                        .toArray(String[]::new))
+                .build();
+    }
+}

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
@@ -21,10 +21,12 @@ import static org.openkilda.messaging.Utils.MAPPER;
 import org.openkilda.floodlight.command.CommandContext;
 import org.openkilda.floodlight.command.ping.PingRequestCommand;
 import org.openkilda.floodlight.converter.OfFlowStatsConverter;
+import org.openkilda.floodlight.converter.OfMeterConverter;
 import org.openkilda.floodlight.converter.OfPortDescConverter;
 import org.openkilda.floodlight.error.FlowCommandException;
 import org.openkilda.floodlight.error.SwitchNotFoundException;
 import org.openkilda.floodlight.error.SwitchOperationException;
+import org.openkilda.floodlight.error.UnsupportedSwitchOperationException;
 import org.openkilda.floodlight.service.CommandProcessorService;
 import org.openkilda.floodlight.service.kafka.IKafkaProducerService;
 import org.openkilda.floodlight.switchmanager.ISwitchManager;
@@ -51,6 +53,7 @@ import org.openkilda.messaging.command.flow.RemoveFlow;
 import org.openkilda.messaging.command.switches.ConnectModeRequest;
 import org.openkilda.messaging.command.switches.DeleteRulesAction;
 import org.openkilda.messaging.command.switches.DeleteRulesCriteria;
+import org.openkilda.messaging.command.switches.DumpMetersRequest;
 import org.openkilda.messaging.command.switches.DumpPortDescriptionRequest;
 import org.openkilda.messaging.command.switches.DumpRulesRequest;
 import org.openkilda.messaging.command.switches.DumpSwitchPortsDescriptionRequest;
@@ -66,6 +69,8 @@ import org.openkilda.messaging.floodlight.request.PingRequest;
 import org.openkilda.messaging.info.InfoMessage;
 import org.openkilda.messaging.info.discovery.DiscoPacketSendingConfirmation;
 import org.openkilda.messaging.info.event.PortChangeType;
+import org.openkilda.messaging.info.meter.MeterEntry;
+import org.openkilda.messaging.info.meter.SwitchMeterEntries;
 import org.openkilda.messaging.info.rule.FlowEntry;
 import org.openkilda.messaging.info.rule.SwitchFlowEntries;
 import org.openkilda.messaging.info.stats.PortStatus;
@@ -83,6 +88,7 @@ import org.openkilda.messaging.payload.flow.OutputVlanType;
 import net.floodlightcontroller.core.IOFSwitch;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.projectfloodlight.openflow.protocol.OFFlowStatsEntry;
+import org.projectfloodlight.openflow.protocol.OFMeterConfig;
 import org.projectfloodlight.openflow.protocol.OFPortDesc;
 import org.projectfloodlight.openflow.types.DatapathId;
 import org.projectfloodlight.openflow.types.OFPort;
@@ -182,6 +188,8 @@ class RecordHandler implements Runnable {
             doDumpSwitchPortsDescriptionRequest(message, replyToTopic, replyDestination);
         } else if (data instanceof DumpPortDescriptionRequest) {
             doDumpPortDescriptionRequest(message, replyToTopic, replyDestination);
+        } else if (data instanceof DumpMetersRequest) {
+            doDumpMetersRequest(message, replyToTopic, replyDestination);
         } else {
             logger.error("unknown data type: {}", data.toString());
         }
@@ -810,6 +818,53 @@ class RecordHandler implements Runnable {
             logger.error("Unable to dump port description request", e);
             ErrorData errorData =
                     new ErrorData(ErrorType.NOT_FOUND, e.getMessage(), "Unable to dump port description request");
+            ErrorMessage error =
+                    new ErrorMessage(
+                            errorData, System.currentTimeMillis(), message.getCorrelationId(), replyDestination);
+            producerService.sendMessageAndTrack(replyToTopic, error);
+        }
+    }
+
+    private void doDumpMetersRequest(
+            CommandMessage message, String replyToTopic, Destination replyDestination) {
+        DumpMetersRequest request = (DumpMetersRequest) message.getData();
+
+        final IKafkaProducerService producerService = getKafkaProducer();
+
+        try {
+            SwitchId switchId = request.getSwitchId();
+            logger.debug("Get all meters for switch {}", switchId);
+            ISwitchManager switchManager = context.getSwitchManager();
+            List<OFMeterConfig> meterEntries = switchManager.dumpMeters(DatapathId.of(switchId.toLong()));
+            List<MeterEntry> meters = meterEntries.stream()
+                    .map(OfMeterConverter::toMeterEntry)
+                    .collect(Collectors.toList());
+
+            SwitchMeterEntries response = SwitchMeterEntries.builder()
+                    .switchId(switchId)
+                    .meterEntries(meters)
+                    .build();
+            InfoMessage infoMessage = new InfoMessage(response, message.getTimestamp(), message.getCorrelationId());
+            producerService.sendMessageAndTrack(replyToTopic, infoMessage);
+        } catch (UnsupportedSwitchOperationException e) {
+            String messageString = "Not supported: " + request.getSwitchId();
+            logger.error(messageString, e);
+            ErrorData errorData = new ErrorData(ErrorType.PARAMETERS_INVALID, e.getMessage(), messageString);
+            ErrorMessage error =
+                    new ErrorMessage(
+                            errorData, System.currentTimeMillis(), message.getCorrelationId(), replyDestination);
+            producerService.sendMessageAndTrack(replyToTopic, error);
+        } catch (SwitchNotFoundException e) {
+            logger.info("Dumping switch meters is unsuccessful. Switch {} not found", request.getSwitchId());
+            ErrorData errorData = new ErrorData(ErrorType.NOT_FOUND, e.getMessage(), request.getSwitchId().toString());
+            ErrorMessage error =
+                    new ErrorMessage(
+                            errorData, System.currentTimeMillis(), message.getCorrelationId(), replyDestination);
+            producerService.sendMessageAndTrack(replyToTopic, error);
+        } catch (SwitchOperationException e) {
+            logger.error("Unable to dump meters", e);
+            ErrorData errorData =
+                    new ErrorData(ErrorType.NOT_FOUND, e.getMessage(), "Unable to dump meters");
             ErrorMessage error =
                     new ErrorMessage(
                             errorData, System.currentTimeMillis(), message.getCorrelationId(), replyDestination);

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/command/switches/DumpMetersRequest.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/command/switches/DumpMetersRequest.java
@@ -1,0 +1,33 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.messaging.command.switches;
+
+import org.openkilda.messaging.command.CommandData;
+import org.openkilda.messaging.model.SwitchId;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Value;
+
+@Value
+public class DumpMetersRequest extends CommandData {
+
+    @JsonProperty("switch_id")
+    private SwitchId switchId;
+
+    public DumpMetersRequest(@JsonProperty("switch_id") SwitchId switchId) {
+        this.switchId = switchId;
+    }
+}

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/meter/MeterEntry.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/meter/MeterEntry.java
@@ -1,0 +1,55 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.messaging.info.meter;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Value;
+
+import java.io.Serializable;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Value
+@Builder
+public class MeterEntry implements Serializable {
+
+    @JsonProperty("meter_id")
+    private long meterId;
+    @JsonProperty("rate")
+    private long rate;
+    @JsonProperty("burst_size")
+    private long burstSize;
+    @JsonProperty("version")
+    private String version;
+    @JsonProperty("flags")
+    private String[] flags;
+
+    @JsonCreator
+    public MeterEntry(
+            @JsonProperty("meter_id") long meterId,
+            @JsonProperty("rate") long rate,
+            @JsonProperty("burst_size") long burstSize,
+            @JsonProperty("version") String version,
+            @JsonProperty("flags") String[] flags) {
+        this.meterId = meterId;
+        this.rate = rate;
+        this.burstSize = burstSize;
+        this.version = version;
+        this.flags = flags;
+    }
+}

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/meter/SwitchMeterEntries.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/meter/SwitchMeterEntries.java
@@ -1,0 +1,44 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.messaging.info.meter;
+
+import org.openkilda.messaging.info.InfoData;
+import org.openkilda.messaging.model.SwitchId;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+@Builder
+public class SwitchMeterEntries extends InfoData {
+
+    @JsonProperty(value = "switch_id")
+    private SwitchId switchId;
+    @JsonProperty(value = "meters")
+    private List<MeterEntry> meterEntries;
+
+    @JsonCreator
+    public SwitchMeterEntries(
+            @JsonProperty(value = "switch_id") SwitchId switchId,
+            @JsonProperty(value = "meters") List<MeterEntry> meterEntries) {
+        this.switchId = switchId;
+        this.meterEntries = meterEntries;
+    }
+}

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/controller/SwitchController.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/controller/SwitchController.java
@@ -25,6 +25,7 @@ import org.openkilda.messaging.command.switches.DeleteRulesCriteria.DeleteRulesC
 import org.openkilda.messaging.command.switches.InstallRulesAction;
 import org.openkilda.messaging.error.MessageError;
 import org.openkilda.messaging.error.MessageException;
+import org.openkilda.messaging.info.meter.SwitchMeterEntries;
 import org.openkilda.messaging.info.rule.SwitchFlowEntries;
 import org.openkilda.messaging.info.switches.PortDescription;
 import org.openkilda.messaging.info.switches.SwitchPortsDescription;
@@ -239,6 +240,18 @@ public class SwitchController {
     @ResponseStatus(HttpStatus.OK)
     public CompletableFuture<RulesSyncResult> syncRules(@PathVariable(name = "switch_id") SwitchId switchId) {
         return switchService.syncRules(switchId);
+    }
+
+    /**
+     * Gets meters from the switch.
+     * @param switchId switch dpid.
+     * @return list of meters exists on the switch
+     */
+    @ApiOperation(value = "Dump all meter from the switch", response = SwitchMeterEntries.class)
+    @GetMapping(path = "/{switch_id}/meters")
+    @ResponseStatus(HttpStatus.OK)
+    public CompletableFuture<SwitchMeterEntries> getMeters(@PathVariable(name = "switch_id") SwitchId switchId) {
+        return switchService.getMeters(switchId);
     }
 
     /**

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/service/SwitchService.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/service/SwitchService.java
@@ -19,6 +19,7 @@ import org.openkilda.messaging.command.switches.ConnectModeRequest;
 import org.openkilda.messaging.command.switches.DeleteRulesAction;
 import org.openkilda.messaging.command.switches.DeleteRulesCriteria;
 import org.openkilda.messaging.command.switches.InstallRulesAction;
+import org.openkilda.messaging.info.meter.SwitchMeterEntries;
 import org.openkilda.messaging.info.rule.SwitchFlowEntries;
 import org.openkilda.messaging.info.switches.PortDescription;
 import org.openkilda.messaging.info.switches.SwitchPortsDescription;
@@ -112,6 +113,13 @@ public interface SwitchService extends BasicService {
      * @return the synchronization result.
      */
     CompletableFuture<RulesSyncResult> syncRules(SwitchId switchId);
+
+    /**
+     * Dumps all meters from the switch.
+     * @param switchId switch datapath id.
+     * @return meters dump.
+     */
+    CompletableFuture<SwitchMeterEntries> getMeters(SwitchId switchId);
 
     /**
      * Removes meter from the switch.

--- a/services/src/northbound/src/main/java/org/openkilda/northbound/service/impl/SwitchServiceImpl.java
+++ b/services/src/northbound/src/main/java/org/openkilda/northbound/service/impl/SwitchServiceImpl.java
@@ -24,6 +24,7 @@ import org.openkilda.messaging.command.flow.DeleteMeterRequest;
 import org.openkilda.messaging.command.switches.ConnectModeRequest;
 import org.openkilda.messaging.command.switches.DeleteRulesAction;
 import org.openkilda.messaging.command.switches.DeleteRulesCriteria;
+import org.openkilda.messaging.command.switches.DumpMetersRequest;
 import org.openkilda.messaging.command.switches.DumpPortDescriptionRequest;
 import org.openkilda.messaging.command.switches.DumpRulesRequest;
 import org.openkilda.messaging.command.switches.DumpSwitchPortsDescriptionRequest;
@@ -36,6 +37,7 @@ import org.openkilda.messaging.command.switches.SwitchRulesSyncRequest;
 import org.openkilda.messaging.command.switches.SwitchRulesValidateRequest;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.event.SwitchInfoData;
+import org.openkilda.messaging.info.meter.SwitchMeterEntries;
 import org.openkilda.messaging.info.rule.FlowEntry;
 import org.openkilda.messaging.info.rule.SwitchFlowEntries;
 import org.openkilda.messaging.info.switches.ConnectModeResponse;
@@ -226,6 +228,16 @@ public class SwitchServiceImpl implements SwitchService {
                 System.currentTimeMillis(), syncCorrelationId, Destination.TOPOLOGY_ENGINE, northboundTopic);
 
         return messagingChannel.sendAndGet(topoEngTopic, syncCommandMessage);
+    }
+
+    @Override
+    public CompletableFuture<SwitchMeterEntries> getMeters(SwitchId switchId) {
+        String requestId = RequestCorrelationId.getId();
+        CommandWithReplyToMessage dumpCommand = new CommandWithReplyToMessage(
+                new DumpMetersRequest(switchId),
+                System.currentTimeMillis(), requestId, Destination.CONTROLLER, northboundTopic);
+        return messagingChannel.sendAndGet(floodlightTopic, dumpCommand)
+                .thenApply(SwitchMeterEntries.class::cast);
     }
 
     @Override


### PR DESCRIPTION
Add new NB API /switches/{switch_id}/meters
Add ability to get all meters from Floodlight via Kafka

This closes #988 and closes #1593.