### PR TITLE
Fix dpid format in FL for default drop loop rule

### DIFF
--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
@@ -786,7 +786,7 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
         } else {
             Builder builder = ofFactory.buildMatch();
             builder.setExact(MatchField.ETH_DST, MacAddress.of(VERIFICATION_BCAST_PACKET_DST));
-            builder.setExact(MatchField.ETH_SRC, MacAddress.of(dpid));
+            builder.setExact(MatchField.ETH_SRC, dpidToMac(sw));
             Match match = builder.build();
 
             OFFlowMod flowMod = buildFlowMod(ofFactory, match, null, null,

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerTest.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerTest.java
@@ -696,6 +696,7 @@ public class SwitchManagerTest {
         expect(ofSwitchService.getActiveSwitch(dpid)).andStubReturn(iofSwitch);
         expect(iofSwitch.getOFFactory()).andStubReturn(ofFactory);
         expect(iofSwitch.getSwitchDescription()).andStubReturn(switchDescription);
+        expect(iofSwitch.getId()).andStubReturn(dpid);
         expect(switchDescription.getManufacturerDescription()).andStubReturn("");
         expect(iofSwitch.write(capture(capture))).andReturn(true);
         expectLastCall();


### PR DESCRIPTION
MacAddress.of(Datapath dpid) fails if receives non-zero first two octets. Since it is not valid in our case, need to use another way to get MacAddress.

- Fixes atdd tests