### PR TITLE
Change ThrotthlingBolt parallelism to 1

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/cache/transport/CacheTopology.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/cache/transport/CacheTopology.java
@@ -103,7 +103,8 @@ public class CacheTopology extends AbstractTopology<CacheTopologyConfig> {
          */
         FlowThrottlingBolt flowThrottlingBolt = new FlowThrottlingBolt(
                 topologyConfig.getRerouteThrottlingMinDelay(), topologyConfig.getRerouteThrottlingMaxDelay());
-        int newParallelism = topologyConfig.getNewParallelism();
+        // FIXME(tdurakov): current throttling implementation doesn't properly work with 2. See #1636
+        int newParallelism = 1; //topologyConfig.getNewParallelism();
         builder.setBolt(BOLT_ID_REROUTE_THROTTLING, flowThrottlingBolt, newParallelism)
                 .fieldsGrouping(BOLT_ID_CACHE, StreamType.WFM_REROUTE.toString(), new Fields(CacheBolt.FLOW_ID_FIELD));
 


### PR DESCRIPTION
Reroute throtthling should be capable for suspending
reroute of all affected flows in case of network flapping.
However due to parallelism of ThrotthlingBolt=2 and
field grouping by flow id it's not the case. Since only
50% of flows are threated by one worker.
This patch change this level of parallelism as a hotfix.
While it should be refactored so it will be possible to
set level of parallelism more than 1.

RelatedTo: #1636