### PR TITLE
Fixed incorrect getting of port collisions

### DIFF
--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/statistics/StatisticsService.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/statistics/StatisticsService.java
@@ -153,7 +153,7 @@ public class StatisticsService implements IStatisticsService, IFloodlightModule 
                                                 rxFrameErr = etherProps.getRxFrameErr().getValue();
                                                 rxOverErr = etherProps.getRxOverErr().getValue();
                                                 rxCrcErr = etherProps.getRxCrcErr().getValue();
-                                                collisions = etherProps.getCollisions().getLength();
+                                                collisions = etherProps.getCollisions().getValue();
                                             }
                                         }
 


### PR DESCRIPTION
Wrong method (getLength() instead of getValue()) was used to get port collisions

Tests will be added by pull request #1651 because:
1. It is hard to test lambda functions
2. PR 1651 moves code from StatisticsService to separate class anyway

Closes: #1649