### PR TITLE
Virtual OF meters support (OVS 2.10)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build-base:
 	docker build -t kilda/neo4j:latest services/neo4j
 	docker build -t kilda/opentsdb:latest services/opentsdb
 	docker build -t kilda/logstash:latest services/logstash
-	docker build -t kilda/python3-ubuntu:latest base/kilda-base-python3/
+	docker build -t kilda/base-lab-service:latest base/kilda-base-lab-service/
 
 build-latest: update-props build-base compile
 	docker-compose build

--- a/README.md
+++ b/README.md
@@ -16,11 +16,14 @@ The followings are required for building Kilda controller:
  - Python 3.5+
  - Docker Compose 1.20.0+
  - GNU Make 4.1+
+ - Open vSwitch 2.9+
+ 
+For testing meters on virtual environment you additionally need linux kernel 4.18+  
 
-On Ubuntu 16.04, you can install those dependancies like this:
+On Ubuntu 18.04, you can install those dependencies like this:
 
 ```
-apt-get install maven openjdk-8-jdk python python3 docker.io docker-compose virtualenv make
+apt-get install maven openjdk-8-jdk python python3 docker.io docker-compose virtualenv make openvswitch-switch linux-generic-hwe-18.04
 ```
 
 Note that your build user needs to be a member of the docker group for the build to work. Do that by adding the user to /etc/groups and logging out and back in again.

--- a/base/kilda-base-lab-service/Dockerfile
+++ b/base/kilda-base-lab-service/Dockerfile
@@ -13,7 +13,7 @@
 #   limitations under the License.
 #
 
-FROM ubuntu:xenial
+FROM ubuntu:cosmic
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/confd/templates/floodlight/floodlightkilda.properties.tmpl
+++ b/confd/templates/floodlight/floodlightkilda.properties.tmpl
@@ -83,3 +83,4 @@ org.openkilda.floodlight.switchmanager.SwitchManager.disco-packet-size=250
 org.openkilda.floodlight.switchmanager.SwitchManager.flow-meter-burst-coefficient={{ getv "/kilda_floodlight_flow_meter_burst_coefficient" }}
 org.openkilda.floodlight.switchmanager.SwitchManager.flow-meter-min-burst-size-in-kbits=1024
 org.openkilda.floodlight.switchmanager.SwitchManager.system-meter-burst-size-in-packets=4096
+org.openkilda.floodlight.switchmanager.SwitchManager.ovs-meters-enabled=false

--- a/services/lab-service/Dockerfile
+++ b/services/lab-service/Dockerfile
@@ -13,7 +13,7 @@
 #   limitations under the License.
 #
 
-FROM kilda/python3-ubuntu
+FROM kilda/base-lab-service
 
 ADD traffexam/ /exam
 WORKDIR /exam

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManagerConfig.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManagerConfig.java
@@ -60,4 +60,8 @@ public interface SwitchManagerConfig {
     @Min(0)
     @Description("This is burst size for default rule meters in packets.")
     long getSystemMeterBurstSizeInPackets();
+
+    @Key("ovs-meters-enabled")
+    @Default("false")
+    boolean isOvsMetersEnabled();
 }

--- a/services/src/floodlight-modules/src/main/resources/floodlightkilda.properties.example
+++ b/services/src/floodlight-modules/src/main/resources/floodlightkilda.properties.example
@@ -77,3 +77,4 @@ org.openkilda.floodlight.switchmanager.SwitchManager.connect-mode=AUTO
 org.openkilda.floodlight.switchmanager.SwitchManager.flow-meter-burst-coefficient=1.05
 org.openkilda.floodlight.switchmanager.SwitchManager.flow-meter-min-burst-size-in-kbits=1024
 org.openkilda.floodlight.switchmanager.SwitchManager.system-meter-burst-size-in-packets=4096
+org.openkilda.floodlight.switchmanager.SwitchManager.ovs-meters-enabled=false

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerTest.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerTest.java
@@ -54,6 +54,7 @@ import static org.openkilda.model.MeterId.MAX_SYSTEM_RULE_METER_ID;
 import static org.openkilda.model.MeterId.MIN_SYSTEM_RULE_METER_ID;
 import static org.openkilda.model.MeterId.createMeterIdForDefaultRule;
 
+import org.openkilda.floodlight.OFFactoryVer12Mock;
 import org.openkilda.floodlight.error.InvalidMeterIdException;
 import org.openkilda.floodlight.error.SwitchOperationException;
 import org.openkilda.floodlight.service.FeatureDetectorService;
@@ -517,7 +518,7 @@ public class SwitchManagerTest {
     public void shouldDeleteDefaultRulesWithoutMeters() throws Exception {
         // given
         expect(ofSwitchService.getActiveSwitch(dpid)).andStubReturn(iofSwitch);
-        expect(iofSwitch.getOFFactory()).andStubReturn(ofFactory);
+        expect(iofSwitch.getOFFactory()).andStubReturn(new OFFactoryVer12Mock());
         expect(iofSwitch.getSwitchDescription()).andStubReturn(switchDescription);
         expect(iofSwitch.getId()).andStubReturn(dpid);
         expect(switchDescription.getManufacturerDescription()).andStubReturn(OVS_MANUFACTURER);


### PR DESCRIPTION
To obtain this functionality linux kernel 4.16+ is required (tested on 4.18, on Ubuntu 4.15 LTS kernel works unstable)

Feature is **disabled** by default (by config) 
Closes #1683

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/1689)
<!-- Reviewable:end -->
