### PR TITLE
py2neo upper version limit

### DIFF
--- a/services/topology-engine/Dockerfile
+++ b/services/topology-engine/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update -q \
     && pip install pytz \
     && pip install \
         'kafka-python==1.4.0' \
-        'py2neo>=4.0.0' \
+        'py2neo>=4.0.0,<4.1.2' \
         'gevent<=1.3.1' \
         python-logstash \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
py2neo starting from 4.1.2 causes several tests to fail. The main reason - it allow to use "special" characters in field names.