### PR TITLE
Extend kafka producer API to allow key field usage

### DIFF
--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/service/kafka/DefaultWorker.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/service/kafka/DefaultWorker.java
@@ -19,14 +19,13 @@ import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
-public class DefaultWorker extends AbstractWorker {
-    public DefaultWorker(Producer<String, String> kafkaProducer, String topic) {
-        super(kafkaProducer, topic);
+class DefaultWorker extends AbstractWorker {
+    DefaultWorker(Producer<String, String> kafkaProducer) {
+        super(kafkaProducer);
     }
 
     @Override
-    protected SendStatus send(String payload, Callback callback) {
-        ProducerRecord<String, String> record = new ProducerRecord<>(getTopic(), payload);
-        return new SendStatus(getKafkaProducer().send(record, callback));
+    SendStatus send(ProducerRecord<String, String> record, Callback callback) {
+        return new SendStatus(kafkaProducer.send(record, callback));
     }
 }

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/service/kafka/IKafkaProducerService.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/service/kafka/IKafkaProducerService.java
@@ -27,5 +27,7 @@ public interface IKafkaProducerService extends IService {
 
     void sendMessageAndTrack(String topic, Message message);
 
+    void sendMessageAndTrack(String topic, String key, Message message);
+
     SendStatus sendMessage(String topic, Message message);
 }

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/service/kafka/KafkaProducerProxy.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/service/kafka/KafkaProducerProxy.java
@@ -55,6 +55,11 @@ public class KafkaProducerProxy implements IKafkaProducerService {
     }
 
     @Override
+    public void sendMessageAndTrack(String topic, String key, Message message) {
+        target.sendMessageAndTrack(topic, key, message);
+    }
+
+    @Override
     public SendStatus sendMessage(String topic, Message message) {
         return target.sendMessage(topic, message);
     }


### PR DESCRIPTION
To be able to keep correct order of produced switch events kafka's key
field is required. If all produced events for particullar switch will
use same value for key field, kafka guarantee order preservation on
consumer side.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/1705)
<!-- Reviewable:end -->
