### PR TITLE
Avoid extra fetching of entity relations with OGM load strategy depth 1.

### DIFF
--- a/services/src/kilda-core/kilda-model/src/main/java/org/openkilda/model/Flow.java
+++ b/services/src/kilda-core/kilda-model/src/main/java/org/openkilda/model/Flow.java
@@ -28,6 +28,7 @@ import org.neo4j.ogm.annotation.GeneratedValue;
 import org.neo4j.ogm.annotation.Id;
 import org.neo4j.ogm.annotation.Property;
 import org.neo4j.ogm.annotation.RelationshipEntity;
+import org.neo4j.ogm.annotation.Required;
 import org.neo4j.ogm.annotation.StartNode;
 import org.neo4j.ogm.annotation.typeconversion.Convert;
 import org.neo4j.ogm.typeconversion.InstantStringConverter;
@@ -60,9 +61,11 @@ public class Flow implements Serializable {
 
     @NonNull
     @Property(name = "flowid")
+    @Required
     private String flowId;
 
     @Property(name = "cookie")
+    @Required
     private long cookie;
 
     @NonNull

--- a/services/src/kilda-core/kilda-model/src/main/java/org/openkilda/model/FlowSegment.java
+++ b/services/src/kilda-core/kilda-model/src/main/java/org/openkilda/model/FlowSegment.java
@@ -28,6 +28,7 @@ import org.neo4j.ogm.annotation.GeneratedValue;
 import org.neo4j.ogm.annotation.Id;
 import org.neo4j.ogm.annotation.Property;
 import org.neo4j.ogm.annotation.RelationshipEntity;
+import org.neo4j.ogm.annotation.Required;
 import org.neo4j.ogm.annotation.StartNode;
 import org.neo4j.ogm.annotation.typeconversion.Convert;
 
@@ -53,9 +54,11 @@ public class FlowSegment implements Serializable {
 
     @NonNull
     @Property(name = "flowid")
+    @Required
     private String flowId;
 
     @Property(name = "cookie")
+    @Required
     private long cookie;
 
     /**

--- a/services/src/kilda-core/kilda-model/src/main/java/org/openkilda/model/Switch.java
+++ b/services/src/kilda-core/kilda-model/src/main/java/org/openkilda/model/Switch.java
@@ -26,7 +26,8 @@ import org.neo4j.ogm.annotation.GeneratedValue;
 import org.neo4j.ogm.annotation.Id;
 import org.neo4j.ogm.annotation.NodeEntity;
 import org.neo4j.ogm.annotation.Property;
-import org.neo4j.ogm.annotation.Relationship;
+import org.neo4j.ogm.annotation.Required;
+import org.neo4j.ogm.annotation.Transient;
 import org.neo4j.ogm.annotation.typeconversion.Convert;
 
 import java.io.Serializable;
@@ -37,8 +38,8 @@ import java.util.List;
  */
 @Data
 @NoArgsConstructor
-@EqualsAndHashCode(exclude = {"entityId", "incomingLinks", "outgoingLinks", "flows", "flowSegments"})
-@ToString(exclude = {"incomingLinks", "outgoingLinks", "flows", "flowSegments"})
+@EqualsAndHashCode(exclude = {"entityId", "incomingLinks", "outgoingLinks"})
+@ToString(exclude = {"incomingLinks", "outgoingLinks"})
 @NodeEntity(label = "switch")
 public class Switch implements Serializable {
     private static final long serialVersionUID = 1L;
@@ -51,6 +52,7 @@ public class Switch implements Serializable {
 
     @Property(name = "name")
     @Convert(graphPropertyType = String.class)
+    @Required
     private SwitchId switchId;
 
     @Property(name = "state")
@@ -66,22 +68,21 @@ public class Switch implements Serializable {
 
     private String description;
 
-    @Relationship(type = "isl", direction = Relationship.INCOMING)
+    /**
+     * TODO(siakovenko): incomingLinks and outgoingLinks are marked as transient as Neo4j OGM handles load strategy
+     * "depth" improperly: when a relation entity is being loaded, OGM fetches ALL relations of start and end nodes
+     * of the requested relation. Even with the "depth" = 1.
+     */
+    @Transient
     private List<Isl> incomingLinks;
 
-    @Relationship(type = "isl", direction = Relationship.OUTGOING)
+    @Transient
     private List<Isl> outgoingLinks;
-
-    @Relationship(type = "flow", direction = Relationship.UNDIRECTED)
-    private List<Flow> flows;
-
-    @Relationship(type = "flow_segments", direction = Relationship.UNDIRECTED)
-    private List<Flow> flowSegments;
 
     @Builder(toBuilder = true)
     Switch(SwitchId switchId, SwitchStatus status, String address, String hostname, //NOSONAR
             String controller, String description,
-            List<Isl> incomingLinks, List<Isl> outgoingLinks, List<Flow> flows, List<Flow> flowSegments) {
+            List<Isl> incomingLinks, List<Isl> outgoingLinks) {
         this.switchId = switchId;
         this.status = status;
         this.address = address;
@@ -90,7 +91,5 @@ public class Switch implements Serializable {
         this.description = description;
         this.incomingLinks = incomingLinks;
         this.outgoingLinks = outgoingLinks;
-        this.flows = flows;
-        this.flowSegments = flowSegments;
     }
 }

--- a/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jFlowRepository.java
+++ b/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jFlowRepository.java
@@ -63,7 +63,7 @@ public class Neo4jFlowRepository extends Neo4jGenericRepository<Flow> implements
     public Collection<Flow> findById(String flowId) {
         Filter flowIdFilter = new Filter(FLOW_ID_PROPERTY_NAME, ComparisonOperator.EQUALS, flowId);
 
-        return getSession().loadAll(getEntityType(), flowIdFilter, DEPTH_LIST);
+        return getSession().loadAll(getEntityType(), flowIdFilter, DEPTH_LOAD_ENTITY);
     }
 
     @Override

--- a/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jFlowSegmentRepository.java
+++ b/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jFlowSegmentRepository.java
@@ -43,7 +43,7 @@ public class Neo4jFlowSegmentRepository extends Neo4jGenericRepository<FlowSegme
     public Collection<FlowSegment> findByFlowIdAndCookie(String flowId, long flowCookie) {
         Filter flowIdFilter = new Filter(FLOW_ID_PROPERTY_NAME, ComparisonOperator.EQUALS, flowId);
         Filter cookieFilter = new Filter(COOKIE_PROPERTY_NAME, ComparisonOperator.EQUALS, flowCookie);
-        return getSession().loadAll(getEntityType(), flowIdFilter.and(cookieFilter), DEPTH_LIST);
+        return getSession().loadAll(getEntityType(), flowIdFilter.and(cookieFilter), DEPTH_LOAD_ENTITY);
     }
 
     @Override

--- a/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jGenericRepository.java
+++ b/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jGenericRepository.java
@@ -34,7 +34,7 @@ import java.util.Map;
  * Base Neo4J OGM implementation of {@link Repository}.
  */
 abstract class Neo4jGenericRepository<T> implements Repository<T> {
-    static final int DEPTH_LIST = 1;
+    static final int DEPTH_LOAD_ENTITY = 1;
     static final int DEPTH_CREATE_UPDATE_ENTITY = 0;
 
     private final Neo4jSessionFactory sessionFactory;
@@ -51,7 +51,7 @@ abstract class Neo4jGenericRepository<T> implements Repository<T> {
 
     @Override
     public Collection<T> findAll() {
-        return getSession().loadAll(getEntityType(), DEPTH_LIST);
+        return getSession().loadAll(getEntityType(), DEPTH_LOAD_ENTITY);
     }
 
     @Override

--- a/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jIslRepository.java
+++ b/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jIslRepository.java
@@ -59,7 +59,7 @@ public class Neo4jIslRepository extends Neo4jGenericRepository<Isl> implements I
         srcSwitchFilter.setNestedPath(new Filter.NestedPathSegment("srcSwitch", Switch.class));
         Filter srcPortFilter = new Filter(SRC_PORT_PROPERTY_NAME, ComparisonOperator.EQUALS, srcPort);
 
-        return getSession().loadAll(getEntityType(), srcSwitchFilter.and(srcPortFilter), DEPTH_LIST);
+        return getSession().loadAll(getEntityType(), srcSwitchFilter.and(srcPortFilter), DEPTH_LOAD_ENTITY);
     }
 
     @Override
@@ -69,7 +69,7 @@ public class Neo4jIslRepository extends Neo4jGenericRepository<Isl> implements I
         dstSwitchFilter.setNestedPath(new Filter.NestedPathSegment("destSwitch", Switch.class));
         Filter dstPortFilter = new Filter(DST_PORT_PROPERTY_NAME, ComparisonOperator.EQUALS, dstPort);
 
-        return getSession().loadAll(getEntityType(), dstSwitchFilter.and(dstPortFilter), DEPTH_LIST);
+        return getSession().loadAll(getEntityType(), dstSwitchFilter.and(dstPortFilter), DEPTH_LOAD_ENTITY);
     }
 
     @Override
@@ -84,7 +84,7 @@ public class Neo4jIslRepository extends Neo4jGenericRepository<Isl> implements I
         Filter dstPortFilter = new Filter(DST_PORT_PROPERTY_NAME, ComparisonOperator.EQUALS, dstPort);
 
         Collection<Isl> isls = getSession().loadAll(getEntityType(),
-                srcSwitchFilter.and(srcPortFilter).and(dstSwitchFilter).and(dstPortFilter), DEPTH_LIST);
+                srcSwitchFilter.and(srcPortFilter).and(dstSwitchFilter).and(dstPortFilter), DEPTH_LOAD_ENTITY);
         if (isls.size() > 1) {
             throw new PersistenceException(format("Found more that 1 ISL entity with %s_%d - %s_%d",
                     srcSwitchId, srcPort, dstSwitchId, dstPort));

--- a/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jLinkPropsRepository.java
+++ b/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jLinkPropsRepository.java
@@ -58,6 +58,6 @@ public class Neo4jLinkPropsRepository extends Neo4jGenericRepository<LinkProps> 
             filters.and(new Filter(DST_PORT_PROPERTY_NAME, ComparisonOperator.EQUALS, dstPort));
         }
 
-        return getSession().loadAll(getEntityType(), filters, DEPTH_LIST);
+        return getSession().loadAll(getEntityType(), filters, DEPTH_LOAD_ENTITY);
     }
 }

--- a/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jSwitchRepository.java
+++ b/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jSwitchRepository.java
@@ -51,7 +51,7 @@ public class Neo4jSwitchRepository extends Neo4jGenericRepository<Switch> implem
 
     @Override
     public Optional<Switch> findById(SwitchId switchId) {
-        return findById(getSession(), switchId, DEPTH_LIST);
+        return findById(getSession(), switchId, DEPTH_LOAD_ENTITY);
     }
 
     private Optional<Switch> findById(Session session, SwitchId switchId, int entityLoadDepth) {


### PR DESCRIPTION
The changes prevent extra fetching of entity relations from database. These reads happen because Neo4j OGM handles load strategy"depth" improperly: when a relation entity is being loaded, OGM fetches ALL relations of start and end nodes of the requested relation. Even with the "depth" = 1.