### PR TITLE
Revert the refactoring of FlowSegmentRepository.findByFlowIdAndCookie

### DIFF
--- a/services/src/kilda-core/kilda-model/src/main/java/org/openkilda/model/Switch.java
+++ b/services/src/kilda-core/kilda-model/src/main/java/org/openkilda/model/Switch.java
@@ -72,6 +72,7 @@ public class Switch implements Serializable {
      * TODO(siakovenko): incomingLinks and outgoingLinks are marked as transient as Neo4j OGM handles load strategy
      * "depth" improperly: when a relation entity is being loaded, OGM fetches ALL relations of start and end nodes
      * of the requested relation. Even with the "depth" = 1.
+     * See {@link org.neo4j.ogm.session.request.strategy.impl.SchemaRelationshipLoadClauseBuilder}
      */
     @Transient
     private List<Isl> incomingLinks;

--- a/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jFlowSegmentRepository.java
+++ b/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jFlowSegmentRepository.java
@@ -21,8 +21,9 @@ import org.openkilda.persistence.TransactionManager;
 import org.openkilda.persistence.repositories.FlowSegmentRepository;
 
 import com.google.common.collect.ImmutableMap;
+import org.neo4j.ogm.cypher.ComparisonOperator;
+import org.neo4j.ogm.cypher.Filter;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -40,16 +41,9 @@ public class Neo4jFlowSegmentRepository extends Neo4jGenericRepository<FlowSegme
 
     @Override
     public Collection<FlowSegment> findByFlowIdAndCookie(String flowId, long flowCookie) {
-        Map<String, Object> parameters = ImmutableMap.of(
-                "flow_cookie", flowCookie,
-                "flow_id", flowId
-        );
-
-        String query = "MATCH (src) - [fs:flow_segment {  cookie: $flow_cookie,  flowid: $flow_id }] -> (dst) "
-                     + "RETURN src, fs, dst";
-        Collection<FlowSegment> flowSegments = new ArrayList<>();
-        getSession().query(getEntityType(), query, parameters).forEach(flowSegments::add);
-        return flowSegments;
+        Filter flowIdFilter = new Filter(FLOW_ID_PROPERTY_NAME, ComparisonOperator.EQUALS, flowId);
+        Filter cookieFilter = new Filter(COOKIE_PROPERTY_NAME, ComparisonOperator.EQUALS, flowCookie);
+        return getSession().loadAll(getEntityType(), flowIdFilter.and(cookieFilter), DEPTH_LOAD_ENTITY);
     }
 
     @Override


### PR DESCRIPTION
Revert the refactoring of FlowSegmentRepository.findByFlowIdAndCookie as Transient in Switch entity solves the issue with fetching of extra relations. See #1728