### PR TITLE
Fixed unit tests and sonar stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,10 @@ jobs:
       script:
         # JaCoCo is used to have code coverage, the agent has to be activated
         - export MAVEN_OPTS="$MAVEN_OPTS -DinteractiveMode=false -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
-        - make -C services/src
-        - mvn -f services/src/pom.xml clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar
-        - make -C services/wfm
-        - mvn -f services/wfm/pom.xml clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar
+        - make build-no-test -C services/src
+        - mvn -f services/src/pom.xml package sonar:sonar
+        - make build-no-test -C services/wfm
+        - mvn -f services/wfm/pom.xml package sonar:sonar
 
       cache:
         directories:

--- a/Makefile
+++ b/Makefile
@@ -61,14 +61,13 @@ compile:
 	$(MAKE) -C services/mininet
 	$(MAKE) -C services/lab-service/lab test
 
-.PHONY: unit unit-java-common unit-java-storm unit-py-te
-unit: update-props unit-java-common unit-java-storm unit-py-te
-unit-java-common: build-base
-	$(MAKE) -C services/src
+.PHONY: unit unit-java-common unit-java-storm
+unit: update-props unit-java-common unit-java-storm
+unit-java-common:
+	$(MAKE) build-no-test -C services/src
+	$(MAKE) unit -C services/src
 unit-java-storm: avoid-port-conflicts
 	mvn -B -f services/wfm/pom.xml test
-unit-py-te:
-	$(MAKE) -C services/topology-engine ARTIFACTS=../../artifact/topology-engine --keep-going test test-artifacts
 
 .PHONY: avoid-port-conflicts
 avoid-port-conflicts:

--- a/services/src/Makefile
+++ b/services/src/Makefile
@@ -12,6 +12,10 @@ build: projectfloodlight build-gui
 	# FIXME(surabujin): I believe there must not be "clean" phase.
 	mvn -B clean install
 
+build-no-test: projectfloodlight build-gui
+	$(MAKE) -C floodlight-modules pre-docker SHARE=../$(SHARE)
+	mvn -B install -DskipTests
+
 build-pce:
 	mvn install -pl pce -am -DskipTests
 
@@ -26,6 +30,9 @@ build-messaging:
 
 build-gui:
 	$(MAKE) -C openkilda-gui
+
+unit: projectfloodlight
+	mvn -B test
 
 clean:
 	mvn clean

--- a/services/src/projectfloodlight/Makefile
+++ b/services/src/projectfloodlight/Makefile
@@ -37,10 +37,10 @@ floodlight_install_deps += $(SHARE)/build-artifact/floodlight.jar
 endif
 
 install-floodlight: $(floodlight_install_deps)
-	mvn -B -f $(FLOODLIGHT_DIR)/pom.xml jar:jar install:install
+	mvn -B -f $(FLOODLIGHT_DIR)/pom.xml jar:jar install:install -DskipTests
 
 install-openflowj: $(OPENFLOWJ_JAR)
-	mvn -B -f $(OPENFLOWJ_DIR)/pom.xml jar:jar install:install
+	mvn -B -f $(OPENFLOWJ_DIR)/pom.xml jar:jar install:install -DskipTests
 
 clean: clean-loxigen clean-floodlight
 
@@ -52,7 +52,7 @@ $(OPENFLOWJ_DIR)/pom.xml: $(LOXIGEN_SOURCES)
 	touch $@
 
 $(OPENFLOWJ_JAR): $(OPENFLOWJ_DIR)/pom.xml
-	mvn -B -f $(OPENFLOWJ_DIR)/pom.xml clean package
+	mvn -B -f $(OPENFLOWJ_DIR)/pom.xml clean package -DskipTests
 
 openflow.lua: $(LOXIGEN_SOURCES)
 	$(MAKE) -C $(LOXIGEN_DIR) wireshark

--- a/services/wfm/Makefile
+++ b/services/wfm/Makefile
@@ -5,3 +5,6 @@ all-in-one-tested:
 
 all-in-one:
 	mvn assembly:assembly -DskipTests
+
+build-no-test:
+	mvn -B install -DskipTests

--- a/services/wfm/pom.xml
+++ b/services/wfm/pom.xml
@@ -41,6 +41,8 @@
         <aspectj-maven-plugin.version>1.11</aspectj-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
         <puppycrawl-tools-checkstyle.version>8.10</puppycrawl-tools-checkstyle.version>
+
+        <argLine>-Xmx1028m -XX:MaxPermSize=256m</argLine>
     </properties>
 
     <dependencyManagement>
@@ -541,7 +543,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20</version>
+                <version>2.22.1</version>
                 <configuration>
                     <useSystemClassLoader>false</useSystemClassLoader>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>


### PR DESCRIPTION
- Removed running unit tests in TE
- Increased Xmx and MaxPermSize, because surefire and jacoco plugins require more memory
- Increased running of "sonar" stage by skipping tests during build steps
- Added skip tests parameter for building projectfloodlight/floodlight and projectfloodlight/loxigen modules