### PR TITLE
Use real SwitchManagerConfig in unit tests

### DIFF
--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
@@ -1602,9 +1602,4 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
                 .findFirst()
                 .orElse(null);
     }
-
-    @VisibleForTesting
-    void setConfig(SwitchManagerConfig config) {
-        this.config = config;
-    }
 }

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManagerConfig.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManagerConfig.java
@@ -25,19 +25,23 @@ import javax.validation.constraints.Min;
 @Configuration
 public interface SwitchManagerConfig {
     @Key("connect-mode")
+    @Default("AUTO")
     String getConnectMode();
 
     @Key("broadcast-rate-limit")
+    @Default("200")
     int getBroadcastRateLimit();
 
     @Key("unicast-rate-limit")
+    @Default("200")
     int getUnicastRateLimit();
 
     @Key("disco-packet-size")
+    @Default("250")
     int getDiscoPacketSize();
 
     @Key("flow-meter-burst-coefficient")
-    @Default("0.1")
+    @Default("1.05")
     @Description("This coefficient is used to calculate burst size for flow meters. "
                + "Burst size will be equal to 'coefficient * bandwidth'. "
                + "Value '0.1' means that burst size will be equal to 10% of flow bandwidth.")

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/kafka/ReplaceInstallFlowTest.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/kafka/ReplaceInstallFlowTest.java
@@ -15,6 +15,7 @@
 
 package org.openkilda.floodlight.kafka;
 
+import static java.util.Collections.emptyMap;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.createMock;
@@ -32,6 +33,7 @@ import org.openkilda.floodlight.service.kafka.IKafkaProducerService;
 import org.openkilda.floodlight.service.kafka.KafkaUtilityService;
 import org.openkilda.floodlight.switchmanager.ISwitchManager;
 import org.openkilda.floodlight.switchmanager.SwitchManager;
+import org.openkilda.floodlight.switchmanager.SwitchManagerConfig;
 import org.openkilda.floodlight.switchmanager.SwitchTrackingService;
 import org.openkilda.floodlight.test.standard.OutputCommands;
 import org.openkilda.floodlight.test.standard.ReplaceSchemeOutputCommands;
@@ -46,6 +48,8 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.sabre.oss.conf4j.factory.jdkproxy.JdkProxyStaticConfigurationFactory;
+import com.sabre.oss.conf4j.source.MapConfigurationSource;
 import net.floodlightcontroller.core.IOFSwitch;
 import net.floodlightcontroller.core.SwitchDescription;
 import net.floodlightcontroller.core.internal.IOFSwitchService;
@@ -80,6 +84,8 @@ public class ReplaceInstallFlowTest {
     private IOFSwitchService ofSwitchService;
     private KafkaMessageCollector collector;
 
+    private SwitchManagerConfig config;
+
     /**
      * Returns CommandData entity constructed by data string from json resource file.
      *
@@ -94,6 +100,9 @@ public class ReplaceInstallFlowTest {
 
     @Before
     public void setUp() throws FloodlightModuleException {
+        JdkProxyStaticConfigurationFactory factory = new JdkProxyStaticConfigurationFactory();
+        config = factory.createConfiguration(SwitchManagerConfig.class, new MapConfigurationSource(emptyMap()));
+
         final SwitchManager switchManager = new SwitchManager();
         final PathVerificationService pathVerificationService = new PathVerificationService();
 
@@ -135,7 +144,8 @@ public class ReplaceInstallFlowTest {
     public void installOneSwitchNoneFlow() throws IOException, InterruptedException {
         String value = Resources.toString(getClass().getResource("/install_one_switch_none_flow.json"), Charsets.UTF_8);
         InstallOneSwitchFlow data = (InstallOneSwitchFlow) prepareData(value);
-        OFMeterMod meterCommand = scheme.installMeter(data.getBandwidth(), data.getBandwidth() / 10, data.getMeterId());
+        OFMeterMod meterCommand =
+                scheme.installMeter(data.getBandwidth(), calculateBurstSize(data.getBandwidth()), data.getMeterId());
         OFFlowAdd flowCommand = scheme.oneSwitchNoneFlowMod(data.getInputPort(), data.getOutputPort(),
                 data.getMeterId(), 123L);
         runTest(value, flowCommand, meterCommand, null, null);
@@ -146,7 +156,8 @@ public class ReplaceInstallFlowTest {
         String value = Resources.toString(
                 getClass().getResource("/install_one_switch_replace_flow.json"), Charsets.UTF_8);
         InstallOneSwitchFlow data = (InstallOneSwitchFlow) prepareData(value);
-        OFMeterMod meterCommand = scheme.installMeter(data.getBandwidth(), data.getBandwidth() / 10, data.getMeterId());
+        OFMeterMod meterCommand =
+                scheme.installMeter(data.getBandwidth(), calculateBurstSize(data.getBandwidth()), data.getMeterId());
         OFFlowAdd flowCommand = scheme.oneSwitchReplaceFlowMod(data.getInputPort(), data.getOutputPort(),
                 data.getInputVlanId(), data.getOutputVlanId(), data.getMeterId(), 123L);
         runTest(value, flowCommand, meterCommand, null, null);
@@ -156,7 +167,8 @@ public class ReplaceInstallFlowTest {
     public void installOneSwitchPushFlow() throws IOException, InterruptedException {
         String value = Resources.toString(getClass().getResource("/install_one_switch_push_flow.json"), Charsets.UTF_8);
         InstallOneSwitchFlow data = (InstallOneSwitchFlow) prepareData(value);
-        OFMeterMod meterCommand = scheme.installMeter(data.getBandwidth(), data.getBandwidth() / 10, data.getMeterId());
+        OFMeterMod meterCommand =
+                scheme.installMeter(data.getBandwidth(), calculateBurstSize(data.getBandwidth()), data.getMeterId());
         OFFlowAdd flowCommand = scheme.oneSwitchPushFlowMod(data.getInputPort(), data.getOutputPort(),
                 data.getOutputVlanId(), data.getMeterId(), 123L);
         runTest(value, flowCommand, meterCommand, null, null);
@@ -166,7 +178,8 @@ public class ReplaceInstallFlowTest {
     public void installOneSwitchPopFlow() throws IOException, InterruptedException {
         String value = Resources.toString(getClass().getResource("/install_one_switch_pop_flow.json"), Charsets.UTF_8);
         InstallOneSwitchFlow data = (InstallOneSwitchFlow) prepareData(value);
-        OFMeterMod meterCommand = scheme.installMeter(data.getBandwidth(), data.getBandwidth() / 10, data.getMeterId());
+        OFMeterMod meterCommand =
+                scheme.installMeter(data.getBandwidth(), calculateBurstSize(data.getBandwidth()), data.getMeterId());
         OFFlowAdd flowCommand = scheme.oneSwitchPopFlowMod(data.getInputPort(), data.getOutputPort(),
                 data.getInputVlanId(), data.getMeterId(), 123L);
         runTest(value, flowCommand, meterCommand, null, null);
@@ -176,7 +189,8 @@ public class ReplaceInstallFlowTest {
     public void installIngressNoneFlow() throws IOException, InterruptedException {
         String value = Resources.toString(getClass().getResource("/install_ingress_none_flow.json"), Charsets.UTF_8);
         InstallIngressFlow data = (InstallIngressFlow) prepareData(value);
-        OFMeterMod meterCommand = scheme.installMeter(data.getBandwidth(), data.getBandwidth() / 10, data.getMeterId());
+        OFMeterMod meterCommand =
+                scheme.installMeter(data.getBandwidth(), calculateBurstSize(data.getBandwidth()), data.getMeterId());
         OFFlowAdd flowCommand = scheme.ingressNoneFlowMod(data.getInputPort(), data.getOutputPort(),
                 data.getTransitVlanId(), data.getMeterId(), 123L);
         runTest(value, flowCommand, meterCommand, null, null);
@@ -186,7 +200,8 @@ public class ReplaceInstallFlowTest {
     public void installIngressReplaceFlow() throws IOException, InterruptedException {
         String value = Resources.toString(getClass().getResource("/install_ingress_replace_flow.json"), Charsets.UTF_8);
         InstallIngressFlow data = (InstallIngressFlow) prepareData(value);
-        OFMeterMod meterCommand = scheme.installMeter(data.getBandwidth(), data.getBandwidth() / 10, data.getMeterId());
+        OFMeterMod meterCommand =
+                scheme.installMeter(data.getBandwidth(), calculateBurstSize(data.getBandwidth()), data.getMeterId());
         OFFlowAdd flowCommand = scheme.ingressReplaceFlowMod(data.getInputPort(), data.getOutputPort(),
                 data.getInputVlanId(), data.getTransitVlanId(), data.getMeterId(), 123L);
         runTest(value, flowCommand, meterCommand, null, null);
@@ -196,7 +211,8 @@ public class ReplaceInstallFlowTest {
     public void installIngressPushFlow() throws IOException, InterruptedException {
         String value = Resources.toString(getClass().getResource("/install_ingress_push_flow.json"), Charsets.UTF_8);
         InstallIngressFlow data = (InstallIngressFlow) prepareData(value);
-        OFMeterMod meterCommand = scheme.installMeter(data.getBandwidth(), data.getBandwidth() / 10, data.getMeterId());
+        OFMeterMod meterCommand =
+                scheme.installMeter(data.getBandwidth(), calculateBurstSize(data.getBandwidth()), data.getMeterId());
         OFFlowAdd flowCommand = scheme.ingressPushFlowMod(data.getInputPort(), data.getOutputPort(),
                 data.getTransitVlanId(), data.getMeterId(), 123L);
         runTest(value, flowCommand, meterCommand, null, null);
@@ -206,7 +222,8 @@ public class ReplaceInstallFlowTest {
     public void installIngressPopFlow() throws IOException, InterruptedException {
         String value = Resources.toString(getClass().getResource("/install_ingress_pop_flow.json"), Charsets.UTF_8);
         InstallIngressFlow data = (InstallIngressFlow) prepareData(value);
-        OFMeterMod meterCommand = scheme.installMeter(data.getBandwidth(), data.getBandwidth() / 10, data.getMeterId());
+        OFMeterMod meterCommand =
+                scheme.installMeter(data.getBandwidth(), calculateBurstSize(data.getBandwidth()), data.getMeterId());
         OFFlowAdd flowCommand = scheme.ingressPopFlowMod(data.getInputPort(), data.getOutputPort(),
                 data.getInputVlanId(), data.getTransitVlanId(), data.getMeterId(), 123L);
         runTest(value, flowCommand, meterCommand, null, null);
@@ -326,5 +343,9 @@ public class ReplaceInstallFlowTest {
 
         replay(ofSwitchService);
         replay(iofSwitch);
+    }
+
+    private long calculateBurstSize(long bandwidth) {
+        return (long) (bandwidth * config.getFlowMeterBurstCoefficient());
     }
 }


### PR DESCRIPTION
We have implementation SwitchManagerConfig for tests with hardcoded values. The problem is that this config is used as expected config and as actual config. Some time ago flowMeterBurstCoefficient was changed from 0.1 to 1.05 but tests still use old 0.1 value. To fix it missed @Default annotations were added to the real config class and now this class is used in tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/1811)
<!-- Reviewable:end -->
