### PR TITLE
Fixed 'LinkSpec.Cannot delete nonexistent link' functional test

### DIFF
--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/northbound/links/LinkSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/northbound/links/LinkSpec.groovy
@@ -172,7 +172,7 @@ class LinkSpec extends BaseSpecification {
         then: "Got 404 NotFound"
         def exc = thrown(HttpClientErrorException)
         exc.rawStatusCode == 404
-        exc.responseBodyAsString.contains("ISL does not exist")
+        exc.responseBodyAsString.contains("There is no ISL")
     }
 
     def "Cannot delete active link"() {


### PR DESCRIPTION
Root cause of test fail: error message was changed