### PR TITLE
Make OpenTSDB metric prefix configurable.

### DIFF
--- a/confd/templates/atdd-staging/kilda.properties.tmpl
+++ b/confd/templates/atdd-staging/kilda.properties.tmpl
@@ -23,6 +23,8 @@ lockkeeper.endpoint={{ getv "/kilda_aswitch_endpoint" }}:{{ getv "/kilda_aswitch
 
 otsdb.endpoint=http://{{ getv "/kilda_opentsdb_hosts" }}:{{ getv "/kilda_opentsdb_port" }}
 
+opentsdb.metric.prefix = {{ getv "/kilda_opentsdb_metric_prefix" }}
+
 spring.profiles.active={{ getv "/kilda_test_profile" }}
 
 reroute.delay={{ getv "/kilda_reroute_throttling_delay_min" }}

--- a/confd/templates/wfm/topology.properties.tmpl
+++ b/confd/templates/wfm/topology.properties.tmpl
@@ -32,6 +32,7 @@ opentsdb.batch.size = {{ getv "/kilda_opentsdb_batch_size" }}
 opentsdb.flush.interval = {{ getv "/kilda_opentsdb_flush_interval" }}
 opentsdb.workers = {{ getv "/kilda_opentsdb_workers" }}
 opentsdb.client.chunked-requests.enabled = true
+opentsdb.metric.prefix = {{ getv "/kilda_opentsdb_metric_prefix" }}
 
 neo4j.uri = bolt://{{ getv "/kilda_neo4j_host" }}:{{ getv "/kilda_neo4j_bolt_port" }}
 neo4j.user = {{ getv "/kilda_neo4j_user" }}

--- a/confd/vars/main.yaml
+++ b/confd/vars/main.yaml
@@ -82,6 +82,7 @@ kilda_opentsdb_workers_datapointparserbolt: 1
 kilda_opentsdb_batch_size: 50
 kilda_opentsdb_flush_interval: 1
 kilda_opentsdb_workers: 1
+kilda_opentsdb_metric_prefix: "kilda."
 
 kilda_production_fileserver: "http://127.0.0.1"
 

--- a/services/src/functional-tests/kilda.properties.example
+++ b/services/src/functional-tests/kilda.properties.example
@@ -41,3 +41,5 @@ isl.cost.when.under.maintenance=10000
 burst.coefficient=1.05
 
 bfd.offset=200
+
+opentsdb.metric.prefix=kilda.

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowPingSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowPingSpec.groovy
@@ -16,6 +16,7 @@ import org.openkilda.northbound.dto.flows.UniFlowPingOutput
 import org.openkilda.testing.Constants.DefaultRule
 import org.openkilda.testing.model.topology.TopologyDefinition.Switch
 
+import org.springframework.beans.factory.annotation.Value
 import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Narrative
@@ -27,6 +28,9 @@ Flow ping feature sends a 'ping' packet at the one end of the flow, expecting th
 be delivered at the other end. 'Pings' the flow in both directions(forward and reverse).
 """)
 class FlowPingSpec extends BaseSpecification {
+
+    @Value('${opentsdb.metric.prefix}')
+    String metricPrefix
 
     @Unroll("Able to ping a flow with vlan between switches #srcSwitch.dpId - #dstSwitch.dpId")
     def "Able to ping a flow with vlan"(Switch srcSwitch, Switch dstSwitch) {
@@ -53,7 +57,7 @@ class FlowPingSpec extends BaseSpecification {
         and: "Unicast rule packet count is increased and logged to otsdb"
         def statsData = null
         Wrappers.wait(STATS_LOGGING_TIMEOUT, 2) {
-            statsData = otsdb.query(beforePingTime, "pen.switch.flow.system.bytes",
+            statsData = otsdb.query(beforePingTime, metricPrefix + "switch.flow.system.bytes",
                     [switchid : srcSwitch.dpId.toOtsdFormat(),
                      cookieHex: DefaultRule.VERIFICATION_UNICAST_RULE.toHexString()]).dps
             assert statsData && !statsData.empty

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslReplugSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslReplugSpec.groovy
@@ -14,12 +14,16 @@ import org.openkilda.testing.Constants.DefaultRule
 import org.openkilda.testing.model.topology.TopologyDefinition
 import org.openkilda.testing.model.topology.TopologyDefinition.Isl
 
+import org.springframework.beans.factory.annotation.Value
 import spock.lang.Narrative
 
 import java.util.concurrent.TimeUnit
 
 @Narrative("Verify scenarios around replugging ISLs between different switches/ports.")
 class IslReplugSpec extends BaseSpecification {
+
+    @Value('${opentsdb.metric.prefix}')
+    String metricPrefix
 
     def "ISL status changes to MOVED when replugging ISL into another switch"() {
         given: "A connected a-switch link"
@@ -114,7 +118,7 @@ class IslReplugSpec extends BaseSpecification {
         and: "Self-loop rule packet counter is incremented and logged in otsdb"
         def statsData = null
         Wrappers.wait(STATS_LOGGING_TIMEOUT, 2) {
-            statsData = otsdb.query(beforeReplugTime, "pen.switch.flow.system.packets",
+            statsData = otsdb.query(beforeReplugTime, metricPrefix + "switch.flow.system.packets",
                     [switchid : expectedIsl.srcSwitch.dpId.toOtsdFormat(),
                      cookieHex: DefaultRule.DROP_LOOP_RULE.toHexString()]).dps
             assert statsData && !statsData.empty

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchPortConfigSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchPortConfigSpec.groovy
@@ -9,11 +9,15 @@ import org.openkilda.messaging.info.event.IslChangeType
 import org.openkilda.testing.model.topology.TopologyDefinition.Isl
 import org.openkilda.testing.model.topology.TopologyDefinition.Switch
 
+import org.springframework.beans.factory.annotation.Value
 import spock.lang.Narrative
 import spock.lang.Unroll
 
 @Narrative("Verify that Kilda allows to properly control port state on switches (bring ports up or down).")
 class SwitchPortConfigSpec extends BaseSpecification {
+
+    @Value('${opentsdb.metric.prefix}')
+    String metricPrefix
 
     def otsdbPortUp = 1
     def otsdbPortDown = 0
@@ -34,7 +38,7 @@ class SwitchPortConfigSpec extends BaseSpecification {
         and: "Port failure is logged in OpenTSDB"
         def statsData = [:]
         Wrappers.wait(STATS_LOGGING_TIMEOUT) {
-            statsData = otsdb.query(portDownTime, "pen.switch.state",
+            statsData = otsdb.query(portDownTime, metricPrefix + "switch.state",
                     [switchid: isl.srcSwitch.dpId.toOtsdFormat(), port: isl.srcPort]).dps
             assert statsData.size() == 1
         }
@@ -53,7 +57,7 @@ class SwitchPortConfigSpec extends BaseSpecification {
 
         and: "Port UP event is logged in OpenTSDB"
         Wrappers.wait(STATS_LOGGING_TIMEOUT) {
-            statsData = otsdb.query(portUpTime, "pen.switch.state",
+            statsData = otsdb.query(portUpTime, metricPrefix + "switch.state",
                     [switchid: isl.srcSwitch.dpId.toOtsdFormat(), port: isl.srcPort]).dps
             assert statsData.size() == 1
         }

--- a/services/src/test-library/src/main/java/org/openkilda/testing/service/otsdb/OtsdbQueryService.java
+++ b/services/src/test-library/src/main/java/org/openkilda/testing/service/otsdb/OtsdbQueryService.java
@@ -28,7 +28,7 @@ public interface OtsdbQueryService {
      * @param start gather stats 'after' this date
      * @param end gather stats 'before' this date
      * @param aggregator The name of an aggregation function to use. {@link Aggregator}
-     * @param metric Metric name, e.g. "pen.switch.state"
+     * @param metric Metric name, e.g. "kilda.switch.state"
      * @param tags tags in form of key-value pairs
      * @return query results
      * @see <a href="http://opentsdb.net/docs/build/html/api_http/query/index.html:>OpenTsdb HTTP API</a>

--- a/services/wfm/src/checkstyle/checkstyle-suppress-known-issues.xml
+++ b/services/wfm/src/checkstyle/checkstyle-suppress-known-issues.xml
@@ -16,9 +16,6 @@
     <suppress files="src/main/java/org/openkilda/wfm/share/utils/FlowCollector.java" lines="66" checks="JavadocMethod"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/cache/CacheTopology.java" lines="129" checks="JavadocMethod"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/event/OFEventWfmTopologyConfig.java" lines="26" checks="AbbreviationAsWordInName"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/islstats/bolts/IslStatsBolt.java" lines="56" checks="JavadocMethod"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/islstats/bolts/IslStatsBolt.java" lines="74" checks="JavadocMethod"/>
-    <suppress files="src/main/java/org/openkilda/wfm/topology/islstats/bolts/IslStatsBolt.java" lines="82" checks="JavadocMethod"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/islstats/IslStatsTopology.java" lines="35" checks="JavadocMethod"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/islstats/IslStatsTopology.java" lines="64" checks="JavadocMethod"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/nbworker/NbWorkerTopology.java" lines="104" checks="JavadocMethod"/>

--- a/services/wfm/src/main/java/org/openkilda/wfm/share/utils/MetricFormatter.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/share/utils/MetricFormatter.java
@@ -1,0 +1,34 @@
+/* Copyright 2019 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.share.utils;
+
+import java.io.Serializable;
+
+public class MetricFormatter implements Serializable {
+    private String prefix;
+
+    public MetricFormatter(String prefix) {
+        if (prefix == null) {
+            this.prefix = "";
+        } else {
+            this.prefix = prefix;
+        }
+    }
+
+    public String format(String metric) {
+        return String.format("%s%s", prefix, metric);
+    }
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/islstats/IslStatsTopology.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/islstats/IslStatsTopology.java
@@ -42,7 +42,7 @@ public class IslStatsTopology extends AbstractTopology<IslStatsTopologyConfig> {
         logger.debug("connecting to {} topic", topoDiscoTopic);
         builder.setSpout(ISL_STATS_SPOUT_ID, createKafkaSpout(topoDiscoTopic, ISL_STATS_SPOUT_ID));
 
-        IslStatsBolt verifyIslStatsBolt = new IslStatsBolt();
+        IslStatsBolt verifyIslStatsBolt = new IslStatsBolt(topologyConfig.getMetricPrefix());
         logger.debug("starting {} bolt", ISL_STATS_BOLT_ID);
         builder.setBolt(ISL_STATS_BOLT_ID, verifyIslStatsBolt, topologyConfig.getParallelism())
                 .shuffleGrouping(ISL_STATS_SPOUT_ID);

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/islstats/IslStatsTopologyConfig.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/islstats/IslStatsTopologyConfig.java
@@ -18,6 +18,8 @@ package org.openkilda.wfm.topology.islstats;
 import org.openkilda.wfm.topology.AbstractTopologyConfig;
 
 import com.sabre.oss.conf4j.annotation.Configuration;
+import com.sabre.oss.conf4j.annotation.Default;
+import com.sabre.oss.conf4j.annotation.Key;
 
 @Configuration
 public interface IslStatsTopologyConfig extends AbstractTopologyConfig {
@@ -29,4 +31,8 @@ public interface IslStatsTopologyConfig extends AbstractTopologyConfig {
     default String getKafkaOtsdbTopic() {
         return getKafkaTopics().getOtsdbTopic();
     }
+
+    @Key("opentsdb.metric.prefix")
+    @Default("kilda.")
+    String getMetricPrefix();
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/PingTopology.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/PingTopology.java
@@ -195,7 +195,7 @@ public class PingTopology extends AbstractTopology<PingTopologyConfig> {
     }
 
     private void statsProducer(TopologyBuilder topology) {
-        StatsProducer bolt = new StatsProducer();
+        StatsProducer bolt = new StatsProducer(topologyConfig.getMetricPrefix());
         topology.setBolt(StatsProducer.BOLT_ID, bolt, scaleFactor)
                 .shuffleGrouping(PeriodicResultManager.BOLT_ID, PeriodicResultManager.STREAM_STATS_ID);
     }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/PingTopologyConfig.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/PingTopologyConfig.java
@@ -67,6 +67,10 @@ public interface PingTopologyConfig extends AbstractTopologyConfig {
         return getKafkaTopics().getOtsdbTopic();
     }
 
+    @Key("opentsdb.metric.prefix")
+    @Default("kilda.")
+    String getMetricPrefix();
+
     @Configuration
     @Key("flow.ping")
     interface PingConfig {

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/StatsProducer.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/StatsProducer.java
@@ -19,6 +19,7 @@ import org.openkilda.messaging.info.Datapoint;
 import org.openkilda.messaging.model.PingMeters;
 import org.openkilda.wfm.error.AbstractException;
 import org.openkilda.wfm.error.PipelineException;
+import org.openkilda.wfm.share.utils.MetricFormatter;
 import org.openkilda.wfm.topology.ping.model.PingContext;
 
 import org.apache.storm.topology.OutputFieldsDeclarer;
@@ -36,6 +37,12 @@ public class StatsProducer extends Abstract {
 
     public static final Fields STREAM_FIELDS = new Fields(FIELD_ID_STATS_DATAPOINT, FIELD_ID_CONTEXT);
 
+    private MetricFormatter metricFormatter;
+
+    public StatsProducer(String metricPrefix) {
+        this.metricFormatter = new MetricFormatter(metricPrefix);
+    }
+
     @Override
     protected void handleInput(Tuple input) throws AbstractException {
         PingContext pingContext = pullPingContext(input);
@@ -52,7 +59,7 @@ public class StatsProducer extends Abstract {
 
         PingMeters meters = pingContext.getMeters();
         Datapoint datapoint = new Datapoint(
-                "pen.flow.latency", pingContext.getTimestamp(), tags, meters.getNetworkLatency());
+                metricFormatter.format("flow.latency"), pingContext.getTimestamp(), tags, meters.getNetworkLatency());
         emit(input, datapoint);
     }
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/portstate/PortStateTopology.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/portstate/PortStateTopology.java
@@ -70,7 +70,7 @@ public class PortStateTopology extends AbstractTopology<PortStateTopologyConfig>
         builder.setBolt(TOPO_DISCO_PARSE_BOLT_NAME, topoDiscoParseBolt, topologyConfig.getParallelism())
                 .shuffleGrouping(TOPO_DISCO_SPOUT);
 
-        ParsePortInfoBolt parsePortInfoBolt = new ParsePortInfoBolt();
+        ParsePortInfoBolt parsePortInfoBolt = new ParsePortInfoBolt(topologyConfig.getMetricPrefix());
         builder.setBolt(PARSE_PORT_INFO_BOLT_NAME, parsePortInfoBolt, topologyConfig.getParallelism())
                 .shuffleGrouping(TOPO_DISCO_PARSE_BOLT_NAME, TopoDiscoParseBolt.TOPO_TO_PORT_INFO_STREAM)
                 .shuffleGrouping(WFM_STATS_PARSE_BOLT_NAME, WfmStatsParseBolt.WFM_TO_PARSE_PORT_INFO_STREAM);

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/portstate/PortStateTopologyConfig.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/portstate/PortStateTopologyConfig.java
@@ -18,6 +18,8 @@ package org.openkilda.wfm.topology.portstate;
 import org.openkilda.wfm.topology.AbstractTopologyConfig;
 
 import com.sabre.oss.conf4j.annotation.Configuration;
+import com.sabre.oss.conf4j.annotation.Default;
+import com.sabre.oss.conf4j.annotation.Key;
 
 @Configuration
 public interface PortStateTopologyConfig extends AbstractTopologyConfig {
@@ -37,4 +39,8 @@ public interface PortStateTopologyConfig extends AbstractTopologyConfig {
     default String getKafkaSpeakerTopic() {
         return getKafkaTopics().getSpeakerTopic();
     }
+
+    @Key("opentsdb.metric.prefix")
+    @Default("kilda.")
+    String getMetricPrefix();
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/portstate/bolt/ParsePortInfoBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/portstate/bolt/ParsePortInfoBolt.java
@@ -19,6 +19,7 @@ import org.openkilda.messaging.Utils;
 import org.openkilda.messaging.info.Datapoint;
 import org.openkilda.messaging.info.event.PortChangeType;
 import org.openkilda.messaging.info.event.PortInfoData;
+import org.openkilda.wfm.share.utils.MetricFormatter;
 import org.openkilda.wfm.topology.AbstractTopology;
 
 import com.google.common.collect.HashBasedTable;
@@ -39,9 +40,14 @@ import java.util.Map;
 
 public class ParsePortInfoBolt extends BaseRichBolt {
     private static final Logger logger = LoggerFactory.getLogger(ParsePortInfoBolt.class);
-    private static final String METRIC_NAME = "pen.switch.state";
-    private OutputCollector collector;
-    private Table<String, Integer, Map<String, String>> tagsTable;
+    private final String metricName;
+    private transient OutputCollector collector;
+    private transient Table<String, Integer, Map<String, String>> tagsTable;
+
+    public ParsePortInfoBolt(String metricPrefix) {
+        MetricFormatter metricFormatter = new MetricFormatter(metricPrefix);
+        this.metricName = metricFormatter.format("switch.state");
+    }
 
     @Override
     public void prepare(Map map, TopologyContext topologyContext, OutputCollector outputCollector) {
@@ -76,7 +82,7 @@ public class ParsePortInfoBolt extends BaseRichBolt {
     }
 
     private List<Object> makeTsdbDatapoint(PortInfoData data) throws IOException {
-        return tsdbTuple(METRIC_NAME,
+        return tsdbTuple(metricName,
                 data.getTimestamp(),
                 getStateAsInt(data),
                 getTags(data));

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/StatsTopology.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/StatsTopology.java
@@ -101,17 +101,22 @@ public class StatsTopology extends AbstractTopology<StatsTopologyConfig> {
                 .allGrouping(STATS_CACHE_FILTER_BOLT.name(), CACHE_UPDATE.name())
                 .fieldsGrouping(statsOfsBolt, StatsStreamType.CACHE_DATA.toString(), statsFields);
 
-        builder.setBolt(PORT_STATS_METRIC_GEN.name(), new PortMetricGenBolt(), parallelism)
+        builder.setBolt(PORT_STATS_METRIC_GEN.name(),
+                new PortMetricGenBolt(topologyConfig.getMetricPrefix()), parallelism)
                 .fieldsGrouping(statsOfsBolt, StatsStreamType.PORT_STATS.toString(), fieldMessage);
-        builder.setBolt(METER_CFG_STATS_METRIC_GEN.name(), new MeterConfigMetricGenBolt(), parallelism)
+        builder.setBolt(METER_CFG_STATS_METRIC_GEN.name(),
+                new MeterConfigMetricGenBolt(topologyConfig.getMetricPrefix()), parallelism)
                 .fieldsGrouping(statsOfsBolt, StatsStreamType.METER_CONFIG_STATS.toString(), fieldMessage);
-        builder.setBolt(SYSTEM_RULE_STATS_METRIC_GEN.name(), new SystemRuleMetricGenBolt(), parallelism)
+        builder.setBolt(SYSTEM_RULE_STATS_METRIC_GEN.name(),
+                new SystemRuleMetricGenBolt(topologyConfig.getMetricPrefix()), parallelism)
                 .fieldsGrouping(statsOfsBolt, StatsStreamType.SYSTEM_RULE_STATS.toString(), statsFields);
 
         logger.debug("starting flow_stats_metric_gen");
-        builder.setBolt(FLOW_STATS_METRIC_GEN.name(), new FlowMetricGenBolt(), parallelism)
+        builder.setBolt(FLOW_STATS_METRIC_GEN.name(),
+                new FlowMetricGenBolt(topologyConfig.getMetricPrefix()), parallelism)
                 .fieldsGrouping(STATS_CACHE_BOLT.name(), StatsStreamType.FLOW_STATS.toString(), statsWithCacheFields);
-        builder.setBolt(METER_STATS_METRIC_GEN.name(), new MeterStatsMetricGenBolt(), parallelism)
+        builder.setBolt(METER_STATS_METRIC_GEN.name(),
+                new MeterStatsMetricGenBolt(topologyConfig.getMetricPrefix()), parallelism)
                 .fieldsGrouping(STATS_CACHE_BOLT.name(), StatsStreamType.METER_STATS.toString(), statsWithCacheFields);
 
         String openTsdbTopic = topologyConfig.getKafkaOtsdbTopic();

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/StatsTopologyConfig.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/StatsTopologyConfig.java
@@ -18,6 +18,8 @@ package org.openkilda.wfm.topology.stats;
 import org.openkilda.wfm.topology.AbstractTopologyConfig;
 
 import com.sabre.oss.conf4j.annotation.Configuration;
+import com.sabre.oss.conf4j.annotation.Default;
+import com.sabre.oss.conf4j.annotation.Key;
 
 @Configuration
 public interface StatsTopologyConfig extends AbstractTopologyConfig {
@@ -33,4 +35,8 @@ public interface StatsTopologyConfig extends AbstractTopologyConfig {
     default String getKafkaSpeakerFlowTopic() {
         return getKafkaTopics().getSpeakerFlowTopic();
     }
+
+    @Key("opentsdb.metric.prefix")
+    @Default("kilda.")
+    String getMetricPrefix();
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/metrics/FlowMetricGenBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/metrics/FlowMetricGenBolt.java
@@ -39,6 +39,10 @@ import javax.annotation.Nullable;
  */
 public class FlowMetricGenBolt extends MetricGenBolt {
 
+    public FlowMetricGenBolt(String metricPrefix) {
+        super(metricPrefix);
+    }
+
     @Override
     protected void handleInput(Tuple input) throws AbstractException {
         Map<Long, CacheFlowEntry> dataCache = (Map<Long, CacheFlowEntry>) input.getValueByField(COOKIE_CACHE_FIELD);
@@ -95,21 +99,21 @@ public class FlowMetricGenBolt extends MetricGenBolt {
         tags.put("flowid", flowId);
         tags.put("direction", FlowDirectionHelper.findDirection(entry.getCookie()).name().toLowerCase());
 
-        emitMetric("pen.flow.raw.packets", timestamp, entry.getPacketCount(), tags);
-        emitMetric("pen.flow.raw.bytes", timestamp, entry.getByteCount(), tags);
-        emitMetric("pen.flow.raw.bits", timestamp, entry.getByteCount() * 8, tags);
+        emitMetric("flow.raw.packets", timestamp, entry.getPacketCount(), tags);
+        emitMetric("flow.raw.bytes", timestamp, entry.getByteCount(), tags);
+        emitMetric("flow.raw.bits", timestamp, entry.getByteCount() * 8, tags);
     }
 
     private void emitIngressMetrics(FlowStatsEntry entry, long timestamp, Map<String, String> tags) {
-        emitMetric("pen.flow.ingress.packets", timestamp, entry.getPacketCount(), tags);
-        emitMetric("pen.flow.ingress.bytes", timestamp, entry.getByteCount(), tags);
-        emitMetric("pen.flow.ingress.bits", timestamp, entry.getByteCount() * 8, tags);
+        emitMetric("flow.ingress.packets", timestamp, entry.getPacketCount(), tags);
+        emitMetric("flow.ingress.bytes", timestamp, entry.getByteCount(), tags);
+        emitMetric("flow.ingress.bits", timestamp, entry.getByteCount() * 8, tags);
     }
 
     private void emitEgressMetrics(FlowStatsEntry entry, long timestamp, Map<String, String> tags) {
-        emitMetric("pen.flow.packets", timestamp, entry.getPacketCount(), tags);
-        emitMetric("pen.flow.bytes", timestamp, entry.getByteCount(), tags);
-        emitMetric("pen.flow.bits", timestamp, entry.getByteCount() * 8, tags);
+        emitMetric("flow.packets", timestamp, entry.getPacketCount(), tags);
+        emitMetric("flow.bytes", timestamp, entry.getByteCount(), tags);
+        emitMetric("flow.bits", timestamp, entry.getByteCount() * 8, tags);
     }
 
     private Map<String, String> makeFlowTags(FlowStatsEntry entry, String flowId) throws FlowCookieException {

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/metrics/MeterConfigMetricGenBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/metrics/MeterConfigMetricGenBolt.java
@@ -30,6 +30,10 @@ import java.util.Map;
 
 public class MeterConfigMetricGenBolt extends MetricGenBolt {
 
+    public MeterConfigMetricGenBolt(String metricPrefix) {
+        super(metricPrefix);
+    }
+
     @Override
     protected void handleInput(Tuple input) throws AbstractException {
         InfoMessage message = (InfoMessage) input.getValueByField(MESSAGE_FIELD);
@@ -49,6 +53,6 @@ public class MeterConfigMetricGenBolt extends MetricGenBolt {
                 "switchid", switchId.toOtsdFormat(),
                 "meterId", meterId.toString()
         );
-        emitMetric("pen.switch.meters", timestamp, meterId, tags);
+        emitMetric("switch.meters", timestamp, meterId, tags);
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/metrics/MeterStatsMetricGenBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/metrics/MeterStatsMetricGenBolt.java
@@ -39,6 +39,11 @@ import javax.annotation.Nullable;
 
 @Slf4j
 public class MeterStatsMetricGenBolt extends MetricGenBolt {
+
+    public MeterStatsMetricGenBolt(String metricPrefix) {
+        super(metricPrefix);
+    }
+
     @Override
     protected void handleInput(Tuple input) throws AbstractException {
         MeterStatsData data = (MeterStatsData) input.getValueByField(STATS_FIELD);
@@ -76,9 +81,9 @@ public class MeterStatsMetricGenBolt extends MetricGenBolt {
         Map<String, String> tags = createCommonTags(switchId, meterStats.getMeterId());
         tags.put("cookieHex", createCookieForDefaultRule(meterStats.getMeterId()).toString());
 
-        emitMetric("pen.switch.flow.system.meter.packets", timestamp, meterStats.getPacketsInCount(), tags);
-        emitMetric("pen.switch.flow.system.meter.bytes", timestamp, meterStats.getByteInCount(), tags);
-        emitMetric("pen.switch.flow.system.meter.bits", timestamp, meterStats.getByteInCount() * 8, tags);
+        emitMetric("switch.flow.system.meter.packets", timestamp, meterStats.getPacketsInCount(), tags);
+        emitMetric("switch.flow.system.meter.bytes", timestamp, meterStats.getByteInCount(), tags);
+        emitMetric("switch.flow.system.meter.bits", timestamp, meterStats.getByteInCount() * 8, tags);
     }
 
     private void emitFlowMeterStats(MeterStatsEntry meterStats, Long timestamp, SwitchId switchId,
@@ -96,9 +101,9 @@ public class MeterStatsMetricGenBolt extends MetricGenBolt {
         tags.put("flowid", cacheEntry.getFlowId());
         tags.put("cookie", cacheEntry.getCookie().toString());
 
-        emitMetric("pen.flow.meter.packets", timestamp, meterStats.getPacketsInCount(), tags);
-        emitMetric("pen.flow.meter.bytes", timestamp, meterStats.getByteInCount(), tags);
-        emitMetric("pen.flow.meter.bits", timestamp, meterStats.getByteInCount() * 8, tags);
+        emitMetric("flow.meter.packets", timestamp, meterStats.getPacketsInCount(), tags);
+        emitMetric("flow.meter.bytes", timestamp, meterStats.getByteInCount(), tags);
+        emitMetric("flow.meter.bits", timestamp, meterStats.getByteInCount() * 8, tags);
     }
 
     private Map<String, String> createCommonTags(SwitchId switchId, long meterId) {

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/metrics/MetricGenBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/metrics/MetricGenBolt.java
@@ -19,6 +19,7 @@ import org.openkilda.messaging.Utils;
 import org.openkilda.messaging.info.Datapoint;
 import org.openkilda.wfm.AbstractBolt;
 import org.openkilda.wfm.error.JsonEncodeException;
+import org.openkilda.wfm.share.utils.MetricFormatter;
 import org.openkilda.wfm.topology.AbstractTopology;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -29,6 +30,12 @@ import java.util.List;
 import java.util.Map;
 
 public abstract class MetricGenBolt extends AbstractBolt {
+
+    private MetricFormatter metricFormatter;
+
+    public MetricGenBolt(String metricPrefix) {
+        this.metricFormatter = new MetricFormatter(metricPrefix);
+    }
 
     protected static List<Object> tuple(String metric, long timestamp, Number value, Map<String, String> tag)
             throws JsonEncodeException {
@@ -44,7 +51,7 @@ public abstract class MetricGenBolt extends AbstractBolt {
 
     void emitMetric(String metric, long timestamp, Number value, Map<String, String> tag) {
         try {
-            getOutput().emit(tuple(metric, timestamp, value, tag));
+            getOutput().emit(tuple(metricFormatter.format(metric), timestamp, value, tag));
         } catch (JsonEncodeException e) {
             log.error("Error during serialization of datapoint", e);
         }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/metrics/PortMetricGenBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/metrics/PortMetricGenBolt.java
@@ -30,6 +30,10 @@ import java.util.Map;
 
 public class PortMetricGenBolt extends MetricGenBolt {
 
+    public PortMetricGenBolt(String metricPrefix) {
+        super(metricPrefix);
+    }
+
     @Override
     protected void handleInput(Tuple input) throws AbstractException {
         InfoMessage message = (InfoMessage) input.getValueByField(MESSAGE_FIELD);
@@ -47,19 +51,19 @@ public class PortMetricGenBolt extends MetricGenBolt {
                 "port", String.valueOf(entry.getPortNo())
         );
 
-        emitMetric("pen.switch.rx-packets", timestamp, entry.getRxPackets(), tags);
-        emitMetric("pen.switch.tx-packets", timestamp, entry.getTxPackets(), tags);
-        emitMetric("pen.switch.rx-bytes", timestamp, entry.getRxBytes(), tags);
-        emitMetric("pen.switch.rx-bits", timestamp, entry.getRxBytes() * 8, tags);
-        emitMetric("pen.switch.tx-bytes", timestamp, entry.getTxBytes(), tags);
-        emitMetric("pen.switch.tx-bits", timestamp, entry.getTxBytes() * 8, tags);
-        emitMetric("pen.switch.rx-dropped", timestamp, entry.getRxDropped(), tags);
-        emitMetric("pen.switch.tx-dropped", timestamp, entry.getTxDropped(), tags);
-        emitMetric("pen.switch.rx-errors", timestamp, entry.getRxErrors(), tags);
-        emitMetric("pen.switch.tx-errors", timestamp, entry.getTxErrors(), tags);
-        emitMetric("pen.switch.rx-frame-error", timestamp, entry.getRxFrameErr(), tags);
-        emitMetric("pen.switch.rx-over-error", timestamp, entry.getRxOverErr(), tags);
-        emitMetric("pen.switch.rx-crc-error", timestamp, entry.getRxCrcErr(), tags);
-        emitMetric("pen.switch.collisions", timestamp, entry.getCollisions(), tags);
+        emitMetric("switch.rx-packets", timestamp, entry.getRxPackets(), tags);
+        emitMetric("switch.tx-packets", timestamp, entry.getTxPackets(), tags);
+        emitMetric("switch.rx-bytes", timestamp, entry.getRxBytes(), tags);
+        emitMetric("switch.rx-bits", timestamp, entry.getRxBytes() * 8, tags);
+        emitMetric("switch.tx-bytes", timestamp, entry.getTxBytes(), tags);
+        emitMetric("switch.tx-bits", timestamp, entry.getTxBytes() * 8, tags);
+        emitMetric("switch.rx-dropped", timestamp, entry.getRxDropped(), tags);
+        emitMetric("switch.tx-dropped", timestamp, entry.getTxDropped(), tags);
+        emitMetric("switch.rx-errors", timestamp, entry.getRxErrors(), tags);
+        emitMetric("switch.tx-errors", timestamp, entry.getTxErrors(), tags);
+        emitMetric("switch.rx-frame-error", timestamp, entry.getRxFrameErr(), tags);
+        emitMetric("switch.rx-over-error", timestamp, entry.getRxOverErr(), tags);
+        emitMetric("switch.rx-crc-error", timestamp, entry.getRxCrcErr(), tags);
+        emitMetric("switch.collisions", timestamp, entry.getCollisions(), tags);
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/metrics/SystemRuleMetricGenBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/stats/metrics/SystemRuleMetricGenBolt.java
@@ -33,6 +33,10 @@ import java.util.Map;
 @Slf4j
 public class SystemRuleMetricGenBolt extends MetricGenBolt {
 
+    public SystemRuleMetricGenBolt(String metricPrefix) {
+        super(metricPrefix);
+    }
+
     @Override
     protected void handleInput(Tuple input) throws AbstractException {
         FlowStatsData data = (FlowStatsData) input.getValueByField(STATS_FIELD);
@@ -50,8 +54,8 @@ public class SystemRuleMetricGenBolt extends MetricGenBolt {
         tags.put("switchid", switchId.toOtsdFormat());
         tags.put("cookieHex", Cookie.toString(entry.getCookie()));
 
-        emitMetric("pen.switch.flow.system.packets", timestamp, entry.getPacketCount(), tags);
-        emitMetric("pen.switch.flow.system.bytes", timestamp, entry.getByteCount(), tags);
-        emitMetric("pen.switch.flow.system.bits", timestamp, entry.getByteCount() * 8, tags);
+        emitMetric("switch.flow.system.packets", timestamp, entry.getPacketCount(), tags);
+        emitMetric("switch.flow.system.bytes", timestamp, entry.getByteCount(), tags);
+        emitMetric("switch.flow.system.bits", timestamp, entry.getByteCount() * 8, tags);
     }
 }

--- a/services/wfm/src/main/resources/topology.properties.example
+++ b/services/wfm/src/main/resources/topology.properties.example
@@ -47,6 +47,7 @@ opentsdb.batch.size = 50
 opentsdb.flush.interval = 1
 opentsdb.workers = 1
 opentsdb.client.chunked-requests.enabled = true
+opentsdb.metric.prefix = kilda.
 
 neo4j.uri = bolt://neo4j.pendev:7687
 neo4j.user = neo4j

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/islstats/bolts/IslStatsBoltTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/islstats/bolts/IslStatsBoltTest.java
@@ -70,7 +70,8 @@ public class IslStatsBoltTest {
             .build();
     private static final long TIMESTAMP = 1507433872L;
 
-    private IslStatsBolt statsBolt = new IslStatsBolt();
+    private static final String METRIC_PREFIX = "kilda.";
+    private IslStatsBolt statsBolt = new IslStatsBolt(METRIC_PREFIX);
 
     private static final String CORRELATION_ID = "system";
     private static final Destination DESTINATION = null;
@@ -85,7 +86,7 @@ public class IslStatsBoltTest {
         assertThat(tsdbTuple.size(), is(1));
 
         Datapoint datapoint = Utils.MAPPER.readValue(tsdbTuple.get(0).toString(), Datapoint.class);
-        assertEquals("pen.isl.latency", datapoint.getMetric());
+        assertEquals(METRIC_PREFIX + "isl.latency", datapoint.getMetric());
         assertEquals((Long) TIMESTAMP, datapoint.getTime());
         assertEquals(LATENCY, datapoint.getValue());
 


### PR DESCRIPTION
- OpenTSDB metric prefix is configurable;
- `pen.` is replaced by `kilda.`.

Closes: #1630, #1953.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/2026)
<!-- Reviewable:end -->
