### PR TITLE
ADD: negative test for non-existent flowID(get, synchronize, reroute, validate)

### DIFF
--- a/services/src/test-library/src/main/java/org/openkilda/testing/Constants.java
+++ b/services/src/test-library/src/main/java/org/openkilda/testing/Constants.java
@@ -18,6 +18,8 @@ package org.openkilda.testing;
 import org.openkilda.model.Cookie;
 import org.openkilda.model.SwitchId;
 
+import java.util.UUID;
+
 public final class Constants {
     public static final Integer DEFAULT_COST = 700;
     public static final Integer WAIT_OFFSET = 10;
@@ -27,6 +29,7 @@ public final class Constants {
     public static final Integer RULES_INSTALLATION_TIME = 5;
     public static final Integer STATS_LOGGING_TIMEOUT = 70;
     public static final SwitchId NON_EXISTENT_SWITCH_ID = new SwitchId("de:ad:be:ef:de:ad:be:ef");
+    public static final String NON_EXISTENT_FLOW_ID = "non-existent-" + UUID.randomUUID().toString();
 
     private Constants() {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
negative tests for testing a non-existent flowID were added 
 the following requests are covered:
- get
- validate
- synchronize
- validate

> **NOTE:** negative test for switch is already pushed and can be find at  https://github.com/telstra/open-kilda/commit/e6285364c8fd68b644a0c00447b6a66aed4699be

Closes: https://github.com/telstra/open-kilda/issues/1843