### PR TITLE
ADD test: "ISL(not BFD) is NOT FAILED earlier than discoveryTimeout is exceeded when connection is lost(not port down)"

### DIFF
--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslCostSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslCostSpec.groovy
@@ -131,4 +131,58 @@ class IslCostSpec extends BaseSpecification {
             assert islUtils.getIslInfo(links, reverseIsl).get().state == IslChangeType.DISCOVERED
         }
     }
+
+    def "ISL(not BFD) is NOT FAILED earlier than discoveryTimeout is exceeded when connection is lost(not port down)"() {
+        given: "ISL going through a-switch"
+        def isl = topology.islsForActiveSwitches.find {
+            it.aswitch?.inPort && it.aswitch?.outPort && !it.bfd
+        } ?: assumeTrue("Wasn't able to find suitable ISL", false)
+
+        assert islUtils.getIslInfo(isl).get().state == IslChangeType.DISCOVERED
+
+        double waitTime = discoveryTimeout - (discoveryTimeout * 0.2)
+        double interval = discoveryTimeout * 0.2
+        def ruleToRemove = [isl.aswitch]
+        def reverseIsl = islUtils.reverseIsl(isl)
+
+        when: "Remove a one-way flow on an a-switch for simulating lost connection(not port down)"
+        lockKeeper.removeFlows(ruleToRemove)
+
+        then: "Status of ISL is not changed to FAILED until discoveryTimeout is exceeded"
+        Wrappers.timedLoop(waitTime) {
+            def links = northbound.getAllLinks()
+            assert islUtils.getIslInfo(links, isl).get().state == IslChangeType.DISCOVERED
+            assert islUtils.getIslInfo(links, reverseIsl).get().state == IslChangeType.DISCOVERED
+            sleep((interval * 1000).toLong())
+        }
+
+        and: "Status of ISL is changed to FAILED when discoveryTimeout is exceeded"
+        /**
+         * actualState shows real state of ISL and this value is taken from DB
+         * also it allows to understand direction where issue has appeared
+         * e.g. in our case we've removed a one-way flow(A->B)
+         * the other one(B->A) still exists
+         * afterward the actualState of ISL on A side is equal to FAILED
+         * and on B side is equal to DISCOVERED
+         * */
+        Wrappers.wait(WAIT_OFFSET) {
+            def links = northbound.getAllLinks()
+            assert islUtils.getIslInfo(links, isl).get().state == IslChangeType.FAILED
+            assert islUtils.getIslInfo(links, isl).get().actualState == IslChangeType.FAILED
+            assert islUtils.getIslInfo(links, reverseIsl).get().state == IslChangeType.FAILED
+            assert islUtils.getIslInfo(links, reverseIsl).get().actualState == IslChangeType.DISCOVERED
+        }
+
+        when: "Add the removed one-way flow rule for restoring topology"
+        lockKeeper.addFlows(ruleToRemove)
+
+        then: "ISL is discovered back"
+        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
+            def links = northbound.getAllLinks()
+            assert islUtils.getIslInfo(links, isl).get().state == IslChangeType.DISCOVERED
+            assert islUtils.getIslInfo(links, isl).get().actualState == IslChangeType.DISCOVERED
+            assert islUtils.getIslInfo(links, reverseIsl).get().state == IslChangeType.DISCOVERED
+            assert islUtils.getIslInfo(links, reverseIsl).get().actualState == IslChangeType.DISCOVERED
+        }
+    }
 }

--- a/services/src/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundServiceImpl.java
+++ b/services/src/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundServiceImpl.java
@@ -506,6 +506,7 @@ public class NorthboundServiceImpl implements NorthboundService {
                 .destination(path.get(1))
                 .speed(dto.getSpeed())
                 .state(IslChangeType.from(dto.getState().toString()))
+                .actualState(IslChangeType.from(dto.getActualState().toString()))
                 .cost(dto.getCost())
                 .availableBandwidth(dto.getAvailableBandwidth())
                 .underMaintenance(dto.isUnderMaintenance())


### PR DESCRIPTION
ADD test: "ISL(not BFD) is NOT FAILED earlier than discoveryTimeout is exceed when connection is lost(not port down)"

- in case: connection is lost(not port down) 
- expect:  ISL(not BFD) is NOT FAILED earlier than discoveryTimeout is exceeded

Closes: #1981

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/2037)
<!-- Reviewable:end -->
