### PR TITLE
Misunderstanding/illusage lombok's magic

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/share/hubandspoke/WorkerBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/share/hubandspoke/WorkerBolt.java
@@ -110,7 +110,11 @@ public abstract class WorkerBolt extends CoordinatedBolt {
         private String streamToHub;
         private String hubComponent;
         private String workerSpoutComponent;
+
+        @Builder.Default
         private int defaultTimeout = 100;
+
+        @Builder.Default
         private boolean autoAck = true;
     }
 }

--- a/services/wfm/src/test/java/org/openkilda/wfm/share/hubandspoke/WorkerBoltTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/share/hubandspoke/WorkerBoltTest.java
@@ -1,0 +1,33 @@
+/* Copyright 2019 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.share.hubandspoke;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class WorkerBoltTest {
+    @Test
+    public void ensureConfigDefaultValues() {
+        WorkerBolt.Config config = WorkerBolt.Config.builder()
+                .streamToHub("hub-stream")
+                .hubComponent("hub")
+                .workerSpoutComponent("spout")
+                .build();
+
+        Assert.assertTrue(config.isAutoAck());
+        Assert.assertEquals(config.getDefaultTimeout(), 100);
+    }
+}


### PR DESCRIPTION
Lombok's "@Builder" do not use values assigned to fields on class level
as field's defaults. It require to mark them with "@Builder.Default" to collect
their values as defaults.

As result - incorrect understanding of code and it's behaviour by
reader, with all possilbe negative impact of it.