### PR TITLE
Restore correlation id in discovery packet events

### DIFF
--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/command/CommandWrapper.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/command/CommandWrapper.java
@@ -1,0 +1,52 @@
+/* Copyright 2019 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.floodlight.command;
+
+import org.openkilda.floodlight.utils.CorrelationContext;
+import org.openkilda.floodlight.utils.CorrelationContext.CorrelationContextClosable;
+
+/**
+ * Wrap {@link Command} execution. Main goal is to setup/clean up environment.
+ *
+ * <p>One of such setup tasks - is to push correlation-id into MDC.
+ */
+public class CommandWrapper extends Command {
+    private final Command target;
+
+    public CommandWrapper(Command target) {
+        super(target.getContext());
+        this.target = target;
+    }
+
+    @Override
+    public Command call() throws Exception {
+        Command successor;
+        try (CorrelationContextClosable closable = CorrelationContext.create(getContext().getCorrelationId())) {
+            successor = target.call();
+        }
+        return successor;
+    }
+
+    @Override
+    public Command exceptional(Throwable e) {
+        return target.exceptional(e);
+    }
+
+    @Override
+    public boolean isOneShot() {
+        return target.isOneShot();
+    }
+}

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/service/CommandProcessorService.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/service/CommandProcessorService.java
@@ -19,6 +19,7 @@ import org.openkilda.floodlight.KildaCore;
 import org.openkilda.floodlight.KildaCoreConfig;
 import org.openkilda.floodlight.command.Command;
 import org.openkilda.floodlight.command.CommandContext;
+import org.openkilda.floodlight.command.CommandWrapper;
 import org.openkilda.floodlight.command.PendingCommandSubmitter;
 import org.openkilda.floodlight.utils.CommandContextFactory;
 
@@ -99,6 +100,7 @@ public class CommandProcessorService implements IService {
      * Execute command without intermediate completion check.
      */
     public void processLazy(Command command) {
+        command = wrapCommand(command);
         if (command.isOneShot()) {
             executeOneShot(command);
         } else {
@@ -117,6 +119,10 @@ public class CommandProcessorService implements IService {
     }
 
     public synchronized void markCompleted(ProcessorTask task) { }
+
+    private Command wrapCommand(Command target) {
+        return new CommandWrapper(target);
+    }
 
     private void executeOneShot(Command command) {
         executor.execute(() -> {


### PR DESCRIPTION
Due to threads switch during processing of packet-in OF messages we are losing
data in MDC. One of conecequences - produced discovery packet events
(IslInfoData) have "admin-request" as correlation-id. It make tracing impact of
this packets almost impossible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/2069)
<!-- Reviewable:end -->
