### PR TITLE
#2065 Disable flow rerouting when one of the flow endpoints goes to the "down" state.

### DIFF
--- a/services/src/kilda-core/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/FlowRepository.java
+++ b/services/src/kilda-core/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/FlowRepository.java
@@ -36,7 +36,7 @@ public interface FlowRepository extends Repository<Flow> {
 
     Collection<Flow> findFlowIdsByEndpoint(SwitchId switchId, int port);
 
-    Collection<String> findActiveFlowIdsWithPortInPath(SwitchId switchId, int port);
+    Collection<String> findActiveFlowIdsWithPortInPathOverSegments(SwitchId switchId, int port);
 
     Collection<String> findDownFlowIds();
 

--- a/services/src/kilda-core/kilda-persistence-neo4j/src/test/java/org/openkilda/persistence/repositories/impl/Neo4jFlowRepositoryTest.java
+++ b/services/src/kilda-core/kilda-persistence-neo4j/src/test/java/org/openkilda/persistence/repositories/impl/Neo4jFlowRepositoryTest.java
@@ -332,13 +332,13 @@ public class Neo4jFlowRepositoryTest extends Neo4jBasedTest {
                 .build();
         flowSegmentRepository.createOrUpdate(segment);
 
-        Collection<String> foundFlowIds = flowRepository.findActiveFlowIdsWithPortInPath(TEST_SWITCH_C_ID, 100);
+        Collection<String> foundFlowIds = flowRepository
+                .findActiveFlowIdsWithPortInPathOverSegments(TEST_SWITCH_C_ID, 100);
         assertThat(foundFlowIds, Matchers.hasSize(1));
     }
 
-
     @Test
-    public void shouldFindActiveFlowIdsByEndpoint() {
+    public void shouldNotFindActiveFlowIdsByFlowEndpoint() {
         Flow forwardFlow = Flow.builder()
                 .flowId(TEST_FLOW_ID)
                 .srcSwitch(switchA)
@@ -363,12 +363,16 @@ public class Neo4jFlowRepositoryTest extends Neo4jBasedTest {
 
         flowRepository.createOrUpdate(FlowPair.builder().forward(forwardFlow).reverse(reverseFlow).build());
 
-        Collection<String> foundFlowIds = flowRepository.findActiveFlowIdsWithPortInPath(TEST_SWITCH_A_ID, 1);
-        assertThat(foundFlowIds, Matchers.hasSize(1));
+        Collection<String> foundFlowIds =
+                flowRepository.findActiveFlowIdsWithPortInPathOverSegments(TEST_SWITCH_A_ID, 1);
+        assertThat(foundFlowIds, Matchers.hasSize(0));
     }
 
     @Test
     public void shouldNotFindInactiveFlowIdsByEndpoint() {
+        Switch switchC = Switch.builder().switchId(TEST_SWITCH_C_ID).build();
+        switchRepository.createOrUpdate(switchC);
+
         Flow forwardFlow = Flow.builder()
                 .flowId(TEST_FLOW_ID)
                 .srcSwitch(switchA)
@@ -393,7 +397,17 @@ public class Neo4jFlowRepositoryTest extends Neo4jBasedTest {
 
         flowRepository.createOrUpdate(FlowPair.builder().forward(forwardFlow).reverse(reverseFlow).build());
 
-        Collection<String> foundFlowIds = flowRepository.findActiveFlowIdsWithPortInPath(TEST_SWITCH_A_ID, 1);
+        FlowSegment segment = FlowSegment.builder()
+                .flowId(TEST_FLOW_ID)
+                .srcSwitch(switchB)
+                .srcPort(1)
+                .destSwitch(switchC)
+                .destPort(100)
+                .build();
+        flowSegmentRepository.createOrUpdate(segment);
+
+        Collection<String> foundFlowIds = flowRepository
+                .findActiveFlowIdsWithPortInPathOverSegments(TEST_SWITCH_C_ID, 1);
         assertThat(foundFlowIds, Matchers.empty());
     }
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/reroute/service/RerouteService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/reroute/service/RerouteService.java
@@ -41,7 +41,7 @@ public class RerouteService {
      */
     public Collection<String> getAffectedFlowIds(SwitchId switchId, int port) {
         log.info("Get affected flow ids by node {}_{}", switchId, port);
-        return flowRepository.findActiveFlowIdsWithPortInPath(switchId, port);
+        return flowRepository.findActiveFlowIdsWithPortInPathOverSegments(switchId, port);
     }
 
     /**


### PR DESCRIPTION
- changed the query in the method of getting all active flows by endpoint.
Closes: #2065.