### PR TITLE
#1630 Make OpenTSDB metric prefix configurable.

### DIFF
--- a/confd/templates/gui/application.properties.tmpl
+++ b/confd/templates/gui/application.properties.tmpl
@@ -25,9 +25,9 @@ spring.mvc.throw-exception-if-no-handler-found=true
 nb.base.url={{ getv "/kilda_northbound_endpoint" }}:{{ getv "/kilda_northbound_rest_port" }}/api/v1
 
 
-#OPEN TSDB Base URL
+#OPEN TSDB Base URL and metric prefix
 opentsdb.base.url=http://{{ getv "/kilda_opentsdb_hosts" }}:{{ getv "/kilda_opentsdb_port" }}
-
+opentsdb.metric.prefix = {{ getv "/kilda_opentsdb_metric_prefix" }}
 
 
 #Kilda username and password

--- a/services/src/openkilda-gui/src/main/java/org/openkilda/constants/IConstants.java
+++ b/services/src/openkilda-gui/src/main/java/org/openkilda/constants/IConstants.java
@@ -15,8 +15,16 @@
 
 package org.openkilda.constants;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -28,7 +36,24 @@ import java.util.TreeSet;
 
 public abstract class IConstants {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(IConstants.class);
+
     public static final String SESSION_OBJECT = "sessionObject";
+
+    public static final String APPLICATION_PROPERTIES_FILE = "application.properties";
+
+    private static String prefix;
+
+    static {
+        Properties p = new Properties();
+        try {
+            Resource resource = new ClassPathResource(APPLICATION_PROPERTIES_FILE);
+            p.load(new FileReader(resource.getFile()));
+            prefix = p.getProperty("opentsdb.metric.prefix");
+        } catch (IOException e) {
+            LOGGER.error("Error occurred while metric prefix getting propetry", e);
+        }
+    }
 
     private IConstants() {
 
@@ -205,7 +230,7 @@ public abstract class IConstants {
         public static final String SW_PORT_CONFIG = "sw_port_config";
         
         public static final String STORE_SETTING = "store_setting";
-        
+
         public static final String APPLICATION_SETTING = "application_setting";
         
         public static final String SW_SWITCH_UPDATE_NAME = "sw_switch_update_name";
@@ -269,53 +294,53 @@ public abstract class IConstants {
 
     public enum Metrics {
 
-        PEN_FLOW_BITS("Flow_bits", "flow.bits"),
+        FLOW_BITS("Flow_bits", "flow.bits"),
 
-        PEN_FLOW_BYTES("Flow_bytes", "flow.bytes"),
+        FLOW_BYTES("Flow_bytes", "flow.bytes"),
 
-        PEN_FLOW_PACKETS("Flow_packets", "flow.packets"),
+        FLOW_PACKETS("Flow_packets", "flow.packets"),
 
-        PEN_FLOW_INGRESS_PACKETS("Flow_ingress_packets", "flow.ingress.packets"),
+        FLOW_INGRESS_PACKETS("Flow_ingress_packets", "flow.ingress.packets"),
 
-        PEN_FLOW_RAW_PACKETS("Flow_raw_packets", "flow.raw.packets"),
+        FLOW_RAW_PACKETS("Flow_raw_packets", "flow.raw.packets"),
         
-        PEN_FLOW_RAW_BITS("Flow_raw_bits", "flow.raw.bits"),
+        FLOW_RAW_BITS("Flow_raw_bits", "flow.raw.bits"),
         
-        PEN_FLOW_RAW_BYTES("Flow_raw_bytes", "flow.raw.bytes"),
+        FLOW_RAW_BYTES("Flow_raw_bytes", "flow.raw.bytes"),
 
-        PEN_FLOW_TABLEID("Flow_tableid", "flow.tableid"),
+        FLOW_TABLEID("Flow_tableid", "flow.tableid"),
 
-        PEN_ISL_LATENCY("Isl_latency", "isl.latency"),
+        ISL_LATENCY("Isl_latency", "isl.latency"),
 
-        PEN_SWITCH_COLLISIONS("Switch_collisions", "switch.collisions"),
+        SWITCH_COLLISIONS("Switch_collisions", "switch.collisions"),
 
-        PEN_SWITCH_RX_CRC_ERROR("Switch_crcerror", "switch.rx-crc-error"),
+        SWITCH_RX_CRC_ERROR("Switch_crcerror", "switch.rx-crc-error"),
 
-        PEN_SWITCH_RX_FRAME_ERROR("Switch_frameerror", "switch.rx-frame-error"),
+        SWITCH_RX_FRAME_ERROR("Switch_frameerror", "switch.rx-frame-error"),
 
-        PEN_SWITCH_RX_OVER_ERROR("Switch_overerror", "switch.rx-over-error"),
+        SWITCH_RX_OVER_ERROR("Switch_overerror", "switch.rx-over-error"),
 
-        PEN_SWITCH_RX_BITS("Switch_bits", "switch.rx-bits"),
+        SWITCH_RX_BITS("Switch_bits", "switch.rx-bits"),
 
-        PEN_SWITCH_TX_BITS("Switch_bits", "switch.tx-bits"),
+        SWITCH_TX_BITS("Switch_bits", "switch.tx-bits"),
 
-        PEN_SWITCH_RX_BYTES("Switch_bytes", "switch.rx-bytes"),
+        SWITCH_RX_BYTES("Switch_bytes", "switch.rx-bytes"),
 
-        PEN_SWITCH_TX_BYTES("Switch_bytes", "switch.tx-bytes"),
+        SWITCH_TX_BYTES("Switch_bytes", "switch.tx-bytes"),
 
-        PEN_SWITCH_RX_DROPPED("Switch_drops", "switch.rx-dropped"),
+        SWITCH_RX_DROPPED("Switch_drops", "switch.rx-dropped"),
 
-        PEN_SWITCH_TX_DROPPED("Switch_drops", "switch.tx-dropped"),
+        SWITCH_TX_DROPPED("Switch_drops", "switch.tx-dropped"),
 
-        PEN_SWITCH_RX_ERRORS("Switch_errors", "switch.rx-errors"),
+        SWITCH_RX_ERRORS("Switch_errors", "switch.rx-errors"),
 
-        PEN_SWITCH_TX_ERRORS("Switch_errors", "switch.tx-errors"),
+        SWITCH_TX_ERRORS("Switch_errors", "switch.tx-errors"),
 
-        PEN_SWITCH_TX_PACKETS("Switch_packets", "switch.rx-packets"),
+        SWITCH_TX_PACKETS("Switch_packets", "switch.rx-packets"),
 
-        PEN_SWITCH_RX_PACKETS("Switch_packets", "switch.tx-packets"),
+        SWITCH_RX_PACKETS("Switch_packets", "switch.tx-packets"),
 
-        PEN_SWITCH_STATE("Switch_state", "switch.state");
+        SWITCH_STATE("Switch_state", "switch.state");
 
         private String tag;
         
@@ -329,7 +354,7 @@ public abstract class IConstants {
          */
         private Metrics(final String tag, final String displayTag) {
             setTag(tag);
-            setDisplayTag(displayTag);
+            setDisplayTag(prefix + displayTag);
         }
 
         /**

--- a/services/src/openkilda-gui/src/main/java/org/openkilda/constants/IConstants.java
+++ b/services/src/openkilda-gui/src/main/java/org/openkilda/constants/IConstants.java
@@ -269,53 +269,53 @@ public abstract class IConstants {
 
     public enum Metrics {
 
-        PEN_FLOW_BITS("Flow_bits", "pen.flow.bits"),
+        PEN_FLOW_BITS("Flow_bits", "flow.bits"),
 
-        PEN_FLOW_BYTES("Flow_bytes", "pen.flow.bytes"),
+        PEN_FLOW_BYTES("Flow_bytes", "flow.bytes"),
 
-        PEN_FLOW_PACKETS("Flow_packets", "pen.flow.packets"),
+        PEN_FLOW_PACKETS("Flow_packets", "flow.packets"),
 
-        PEN_FLOW_INGRESS_PACKETS("Flow_ingress_packets", "pen.flow.ingress.packets"),
+        PEN_FLOW_INGRESS_PACKETS("Flow_ingress_packets", "flow.ingress.packets"),
 
-        PEN_FLOW_RAW_PACKETS("Flow_raw_packets", "pen.flow.raw.packets"),
+        PEN_FLOW_RAW_PACKETS("Flow_raw_packets", "flow.raw.packets"),
         
-        PEN_FLOW_RAW_BITS("Flow_raw_bits", "pen.flow.raw.bits"),
+        PEN_FLOW_RAW_BITS("Flow_raw_bits", "flow.raw.bits"),
         
-        PEN_FLOW_RAW_BYTES("Flow_raw_bytes", "pen.flow.raw.bytes"),
+        PEN_FLOW_RAW_BYTES("Flow_raw_bytes", "flow.raw.bytes"),
 
-        PEN_FLOW_TABLEID("Flow_tableid", "pen.flow.tableid"),
+        PEN_FLOW_TABLEID("Flow_tableid", "flow.tableid"),
 
-        PEN_ISL_LATENCY("Isl_latency", "pen.isl.latency"),
+        PEN_ISL_LATENCY("Isl_latency", "isl.latency"),
 
-        PEN_SWITCH_COLLISIONS("Switch_collisions", "pen.switch.collisions"),
+        PEN_SWITCH_COLLISIONS("Switch_collisions", "switch.collisions"),
 
-        PEN_SWITCH_RX_CRC_ERROR("Switch_crcerror", "pen.switch.rx-crc-error"),
+        PEN_SWITCH_RX_CRC_ERROR("Switch_crcerror", "switch.rx-crc-error"),
 
-        PEN_SWITCH_RX_FRAME_ERROR("Switch_frameerror", "pen.switch.rx-frame-error"),
+        PEN_SWITCH_RX_FRAME_ERROR("Switch_frameerror", "switch.rx-frame-error"),
 
-        PEN_SWITCH_RX_OVER_ERROR("Switch_overerror", "pen.switch.rx-over-error"),
+        PEN_SWITCH_RX_OVER_ERROR("Switch_overerror", "switch.rx-over-error"),
 
-        PEN_SWITCH_RX_BITS("Switch_bits", "pen.switch.rx-bits"),
+        PEN_SWITCH_RX_BITS("Switch_bits", "switch.rx-bits"),
 
-        PEN_SWITCH_TX_BITS("Switch_bits", "pen.switch.tx-bits"),
+        PEN_SWITCH_TX_BITS("Switch_bits", "switch.tx-bits"),
 
-        PEN_SWITCH_RX_BYTES("Switch_bytes", "pen.switch.rx-bytes"),
+        PEN_SWITCH_RX_BYTES("Switch_bytes", "switch.rx-bytes"),
 
-        PEN_SWITCH_TX_BYTES("Switch_bytes", "pen.switch.tx-bytes"),
+        PEN_SWITCH_TX_BYTES("Switch_bytes", "switch.tx-bytes"),
 
-        PEN_SWITCH_RX_DROPPED("Switch_drops", "pen.switch.rx-dropped"),
+        PEN_SWITCH_RX_DROPPED("Switch_drops", "switch.rx-dropped"),
 
-        PEN_SWITCH_TX_DROPPED("Switch_drops", "pen.switch.tx-dropped"),
+        PEN_SWITCH_TX_DROPPED("Switch_drops", "switch.tx-dropped"),
 
-        PEN_SWITCH_RX_ERRORS("Switch_errors", "pen.switch.rx-errors"),
+        PEN_SWITCH_RX_ERRORS("Switch_errors", "switch.rx-errors"),
 
-        PEN_SWITCH_TX_ERRORS("Switch_errors", "pen.switch.tx-errors"),
+        PEN_SWITCH_TX_ERRORS("Switch_errors", "switch.tx-errors"),
 
-        PEN_SWITCH_TX_PACKETS("Switch_packets", "pen.switch.rx-packets"),
+        PEN_SWITCH_TX_PACKETS("Switch_packets", "switch.rx-packets"),
 
-        PEN_SWITCH_RX_PACKETS("Switch_packets", "pen.switch.tx-packets"),
+        PEN_SWITCH_RX_PACKETS("Switch_packets", "switch.tx-packets"),
 
-        PEN_SWITCH_STATE("Switch_state", "pen.switch.state");
+        PEN_SWITCH_STATE("Switch_state", "switch.state");
 
         private String tag;
         

--- a/services/src/openkilda-gui/src/main/java/org/openkilda/integration/service/StatsIntegrationService.java
+++ b/services/src/openkilda-gui/src/main/java/org/openkilda/integration/service/StatsIntegrationService.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * The Class StatsIntegrationService.
@@ -246,7 +247,10 @@ public class StatsIntegrationService {
         } else if (statsType.equals(StatsType.SWITCH_PORT)) {
             metricList = Metrics.getStartsWith("Switch_");
         }
-        return metricList;
+
+        return metricList.stream()
+                .map(metricName -> applicationProperties.getOpenTsdbMetricPrefix() + metricName)
+                .collect(Collectors.toList());
     }
 
     /**

--- a/services/src/openkilda-gui/src/main/java/org/openkilda/integration/service/StatsIntegrationService.java
+++ b/services/src/openkilda-gui/src/main/java/org/openkilda/integration/service/StatsIntegrationService.java
@@ -47,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * The Class StatsIntegrationService.
@@ -163,7 +162,7 @@ public class StatsIntegrationService {
         if (!statsType.equals(StatsType.ISL)) {
             query.setRate(Boolean.valueOf(OpenTsDb.RATE));
         }
-        if (statsType.equals(StatsType.SWITCH_PORT) && Metrics.PEN_SWITCH_STATE.getDisplayTag().equals(metric)) {
+        if (statsType.equals(StatsType.SWITCH_PORT) && Metrics.SWITCH_STATE.getDisplayTag().equals(metric)) {
             query.setRate(false);
         } else {
             if (validateDownSample(paramDownSample, query)) {
@@ -248,9 +247,7 @@ public class StatsIntegrationService {
             metricList = Metrics.getStartsWith("Switch_");
         }
 
-        return metricList.stream()
-                .map(metricName -> applicationProperties.getOpenTsdbMetricPrefix() + metricName)
-                .collect(Collectors.toList());
+        return metricList;
     }
 
     /**

--- a/services/src/openkilda-gui/src/main/java/org/openkilda/service/StatsService.java
+++ b/services/src/openkilda-gui/src/main/java/org/openkilda/service/StatsService.java
@@ -207,7 +207,7 @@ public class StatsService {
     public String getFlowLossPacketStats(String startDate, String endDate, String downsample, String flowId,
             String direction) throws IntegrationException {
         return statsIntegrationService.getStats(startDate, endDate, downsample, null, null, flowId, null, null, null,
-                null, StatsType.FLOW_LOSS_PACKET, Metrics.PEN_FLOW_INGRESS_PACKETS.getTag().replace("Flow_", ""),
+                null, StatsType.FLOW_LOSS_PACKET, Metrics.FLOW_INGRESS_PACKETS.getTag().replace("Flow_", ""),
                 direction);
     }
 

--- a/services/src/openkilda-gui/src/main/java/org/openkilda/service/StatsService.java
+++ b/services/src/openkilda-gui/src/main/java/org/openkilda/service/StatsService.java
@@ -31,6 +31,7 @@ import org.openkilda.model.PortDiscrepancy;
 import org.openkilda.model.PortInfo;
 import org.openkilda.model.SwitchPortStats;
 import org.openkilda.store.service.StoreService;
+import org.openkilda.utility.ApplicationProperties;
 import org.openkilda.utility.CollectionUtil;
 import org.openkilda.utility.IoUtil;
 
@@ -76,6 +77,9 @@ public class StatsService {
     
     @Autowired
     private PortConverter portConverter;
+
+    @Autowired
+    private ApplicationProperties applicationProperties;
 
     /**
      * Gets the stats.
@@ -328,7 +332,8 @@ public class StatsService {
                 if (!portStatsByPortNo.containsKey(port)) {
                     portStatsByPortNo.put(port, new HashMap<String, Double>());
                 }
-                portStatsByPortNo.get(port).put(stats.getMetric().replace("pen.switch.", ""),
+                portStatsByPortNo.get(port).put(
+                        stats.getMetric().replace(applicationProperties.getOpenTsdbMetricPrefix() + "switch.", ""),
                         calculateHighestValue(stats.getDps()));
             }
         }

--- a/services/src/openkilda-gui/src/main/java/org/openkilda/utility/ApplicationProperties.java
+++ b/services/src/openkilda-gui/src/main/java/org/openkilda/utility/ApplicationProperties.java
@@ -38,6 +38,9 @@ public class ApplicationProperties {
     @Value("${opentsdb.base.url}")
     private String openTsdbBaseUrl;
 
+    @Value("${opentsdb.metric.prefix}")
+    private String openTsdbMetricPrefix;
+
     @Value("${kilda.username}")
     private String kildaUsername;
 

--- a/services/src/openkilda-gui/src/main/resources/application.properties.example
+++ b/services/src/openkilda-gui/src/main/resources/application.properties.example
@@ -26,6 +26,7 @@ nb.base.url=http://northbound.pendev:8080/api/v1
 
 #OPEN TSDB Base URL
 opentsdb.base.url=http://opentsdb.pendev:4242
+opentsdb.metric.prefix = kilda.
 
 #Kilda username and password
 kilda.username = kilda

--- a/services/src/openkilda-gui/ui/src/app/common/services/dygraph.service.ts
+++ b/services/src/openkilda-gui/ui/src/app/common/services/dygraph.service.ts
@@ -333,7 +333,8 @@ export class DygraphService {
         for (let j = 0; j < data.length; j++) {
           var dataValues = typeof data[j] !== "undefined" ? data[j].dps : null;
           var metric = typeof data[j] !== "undefined" ? data[j].metric : "";
-          if (metric !== "pen.flow.packets") {
+          var tempMetric = metric.split('.').slice(1).join('.') /**remove metric prefix */
+          if(tempMetric !== "flow.packets"){
             metric = metric + "(switchid=" + data[j].tags.switchid + ", cookie="+data[j].tags['cookie']+")";
             labels.push(metric);
             var colorCode = this.getColorCode(j, color);

--- a/services/src/openkilda-gui/ui/src/app/common/services/dygraph.service.ts
+++ b/services/src/openkilda-gui/ui/src/app/common/services/dygraph.service.ts
@@ -333,8 +333,7 @@ export class DygraphService {
         for (let j = 0; j < data.length; j++) {
           var dataValues = typeof data[j] !== "undefined" ? data[j].dps : null;
           var metric = typeof data[j] !== "undefined" ? data[j].metric : "";
-          var tempMetric = metric.split('.').slice(1).join('.') /**remove metric prefix */
-          if(tempMetric !== "flow.packets"){
+
             metric = metric + "(switchid=" + data[j].tags.switchid + ", cookie="+data[j].tags['cookie']+")";
             labels.push(metric);
             var colorCode = this.getColorCode(j, color);
@@ -365,7 +364,6 @@ export class DygraphService {
                 }
               }
             }
-          }
         }
 
         let index=0;


### PR DESCRIPTION
@gauravchug, @ashishaggarwalCS  I've added configurable OpenTSDB metric prefix to GUI module, but struggle with the next line: https://github.com/telstra/open-kilda/blob/develop/services/src/openkilda-gui/ui/src/app/common/services/dygraph.service.ts#L336
Could you please help me to fix it? You can push in this PR.