### PR TITLE
Mark ISL as inactive is discovery failed.

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/event/service/IslService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/event/service/IslService.java
@@ -253,8 +253,8 @@ public class IslService {
         IslStatus islStatus = IslStatus.MOVED == isl.getStatus() ? IslStatus.MOVED : IslStatus.INACTIVE;
         Collection<Isl> isls = islRepository.findBySrcEndpoint(isl.getSrcSwitch().getSwitchId(), isl.getSrcPort())
                 .stream()
-                .filter(link -> IslStatus.ACTIVE == link.getStatus()
-                              || IslStatus.MOVED == islStatus)
+                .filter(link -> islStatus != link.getStatus()
+                              || islStatus != link.getActualStatus())
                 .collect(Collectors.toList());
 
         for (Isl link : isls) {

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/event/service/IslServiceTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/event/service/IslServiceTest.java
@@ -140,7 +140,8 @@ public class IslServiceTest extends Neo4jBasedTest {
     public void shouldNotFailIslDiscoverOnNotActiveIsl() {
         Isl isl = createIsl();
         isl.setStatus(IslStatus.INACTIVE);
-        islService.createOrUpdateIsl(isl);
+        isl.setActualStatus(IslStatus.INACTIVE);
+        islRepository.createOrUpdate(isl);
 
         Isl foundIsl = islRepository.findByEndpoints(TEST_SWITCH_A_ID, TEST_SWITCH_A_PORT,
                 TEST_SWITCH_B_ID, TEST_SWITCH_B_PORT).get();


### PR DESCRIPTION
The ISL will be marked as inactive while discovery failed processing.
It's done regardless ISL previous state.