### PR TITLE
Allow to run ElasticSearch on remote Docker.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -346,8 +346,8 @@ services:
       dockerfile: Dockerfile
     hostname: elasticsearch.pendev
     ports:
-      - "127.0.0.1:9200:9200"
-      - "127.0.0.1:9300:9300"
+      - "9200:9200"
+      - "9300:9300"
     networks:
       default:
         aliases:

--- a/tools/elk-dashboards/load.sh
+++ b/tools/elk-dashboards/load.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-ELASTICSEARCH=http://localhost:9200
+ELASTICSEARCH=http://elasticsearch.pendev:9200
 CURL=curl
 KIBANA_INDEX=".kibana"
 
-(echo > /dev/tcp/127.0.0.1/9200) >/dev/null 2>&1
+(echo > /dev/tcp/elasticsearch.pendev/9200) >/dev/null 2>&1
  result=$?
 if [[ $result -eq 0 ]]; then
 
 echo "Loading index-pattern"
-curl -X PUT --data @index_pattern.json -H 'Content-Type: application/json' 'http://localhost:9200/.kibana/index-pattern/AWUfJAj0duClWTXkEj7q'
+curl -X PUT --data @index_pattern.json -H 'Content-Type: application/json' 'http://elasticsearch.pendev:9200/.kibana/index-pattern/AWUfJAj0duClWTXkEj7q'
 echo
 
 echo "Loading dashboards to ${ELASTICSEARCH} in ${KIBANA_INDEX}"


### PR DESCRIPTION
Open ElasticSearch ports for any net interfaces not only localhost.
Change host name in elk-dashboard load script.