### PR TITLE
Remove execute method override into `CoordinatedBolt`

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/AbstractBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/AbstractBolt.java
@@ -62,7 +62,7 @@ public abstract class AbstractBolt extends BaseRichBolt {
         try {
             currentTuple = input;
             commandContext = setupCommandContext();
-            handleInput(input);
+            dispatch(input);
         } catch (Exception e) {
             wrapExceptionHandler(e);
         } finally {
@@ -86,6 +86,10 @@ public abstract class AbstractBolt extends BaseRichBolt {
         payload.add(getCommandContext());
         log.debug("emit tuple into {} stream: {}", stream, payload);
         getOutput().emit(stream, input, payload);
+    }
+
+    protected void dispatch(Tuple input) throws AbstractException {
+        handleInput(input);
     }
 
     protected abstract void handleInput(Tuple input) throws AbstractException;


### PR DESCRIPTION
This method is entry point for tuple processing and AbstractBolt make
different sort of initialisazation and cleenup. If some class override
this method it must be keeped in sync with parent class.

This change allow to remove existing override of execute method. And get
rid from "keep in sync" problem completelly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/2186)
<!-- Reviewable:end -->
