### PR TITLE
Improve SkippedTestsLogger to process ignored tests as well

### DIFF
--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/SkippedTestsLogger.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/SkippedTestsLogger.groovy
@@ -6,6 +6,7 @@ import org.spockframework.runtime.extension.AbstractGlobalExtension
 import org.spockframework.runtime.extension.IMethodInterceptor
 import org.spockframework.runtime.extension.IMethodInvocation
 import org.spockframework.runtime.model.SpecInfo
+import spock.lang.Ignore
 
 @Slf4j
 class SkippedTestsLogger extends AbstractGlobalExtension {
@@ -13,6 +14,19 @@ class SkippedTestsLogger extends AbstractGlobalExtension {
     void visitSpec(SpecInfo spec) {
         spec.allFixtureMethods*.addInterceptor(new AssumptionInterceptor())
         spec.allFeatures*.getFeatureMethod()*.addInterceptor(new AssumptionInterceptor())
+
+        //process Ignore annotations
+        def specIgnore = spec.getAnnotation(Ignore)
+        if(specIgnore) {
+            log.warn("Ignored spec: ${spec.name}\nReason: ${specIgnore.value()}")
+        }
+        spec.features*.featureMethod.each { feature ->
+            def featureIgnore = feature.getAnnotation(Ignore)
+            if(featureIgnore) {
+                log.warn("Ignored test: ${feature.feature.spec.name}#${feature.name}\n" +
+                        "Reason: ${featureIgnore.value()}")
+            }
+        }
     }
 
     class AssumptionInterceptor implements IMethodInterceptor {

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/BfdSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/BfdSpec.groovy
@@ -7,7 +7,10 @@ import org.openkilda.functionaltests.BaseSpecification
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.info.event.IslChangeType
 
+import spock.lang.Ignore
+
 class BfdSpec extends BaseSpecification {
+    @Ignore("Feature pending")
     def "Interruption in BFD connection instantly leads to ISL failure"() {
         given: "An ISL through a-switch with a BFD session up"
         def isl = topology.islsForActiveSwitches.find { it.aswitch?.inPort && it.aswitch?.outPort && it.bfd }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/OpenTsdbSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/OpenTsdbSpec.groovy
@@ -19,11 +19,8 @@ class OpenTsdbSpec extends BaseSpecification {
     @Value('${opentsdb.metric.prefix}')
     String metricPrefix
 
-    @Issue("https://github.com/telstra/open-kilda/issues/1434")
     @Unroll("Stats are being logged for metric:#metric, tags:#tags")
     def "Basic stats are being logged"(metric, tags) {
-        requireProfiles("hardware") //due to #1434
-
         expect: "At least 1 result in the past 2 minutes"
         otsdb.query(2.minutes.ago, metric, tags).dps.size() > 0
 


### PR DESCRIPTION
-Also ignore BfdSpec as BFD is not available in Kilda atm
-Update stats test due to #1434 being fixed recently

depends on #2197 