### PR TITLE
Lower log level for "lost" discovery packets

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/service/NetworkIslService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/service/NetworkIslService.java
@@ -151,7 +151,7 @@ public class NetworkIslService {
     private IslFsm locateController(IslReference reference) {
         IslFsm fsm = controller.get(reference);
         if (fsm == null) {
-            throw new IllegalStateException(String.format("There is not ISL FSM for %s", reference));
+            throw new IllegalStateException(String.format("There is no ISL FSM for %s", reference));
         }
         return fsm;
     }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/service/NetworkSwitchService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/service/NetworkSwitchService.java
@@ -147,8 +147,8 @@ public class NetworkSwitchService {
 
             case OTHER_UPDATE:
             case CACHED:
-                log.error("Invalid port event {}_{} - incomplete or deprecated",
-                          payload.getSwitchId(), payload.getPortNo());
+                log.error("Invalid port event {} for {}_{} - incomplete or deprecated",
+                          payload.getState(), payload.getSwitchId(), payload.getPortNo());
                 break;
 
             default:

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/service/NetworkWatcherService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/service/NetworkWatcherService.java
@@ -139,8 +139,8 @@ public class NetworkWatcherService {
         producedPackets.remove(packet);
 
         if (confirmedPackets.remove(packet)) {
-            log.info("Detect discovery packet lost sent via {} id:{} task:{}",
-                     packet.endpoint, packet.packetNo, taskId);
+            log.debug("Detect discovery packet lost sent via {} id:{} task:{}",
+                      packet.endpoint, packet.packetNo, taskId);
             carrier.discoveryFailed(packet.getEndpoint(), packet.packetNo, now());
         }
     }


### PR DESCRIPTION
Because discovery packets are send via all "enabled" ports and because
not all "enabled" port have an ISL on them we are loosing a lot of
discovery packets.

On production scale system log message about lost discovery packet will
be produced thouthant times per minute. It is extremelly noisy. So
lowering level for this message to debug.

Plus fix couple of typos.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/2208)
<!-- Reviewable:end -->
