### PR TITLE
Fix for network dump issue in floodlight router

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/bolts/DiscoveryBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/bolts/DiscoveryBolt.java
@@ -145,11 +145,11 @@ public class DiscoveryBolt extends AbstractTickStatefulBolt<InMemoryKeyValueStat
 
 
     @Override
-    public void send(Message message, String outputStream) {
+    public void send(Message message, String outputStream, boolean lookupKey) {
         try {
             String json = MAPPER.writeValueAsString(message);
             Values values;
-            if (currentTuple.getFields().contains(AbstractTopology.KEY_FIELD)
+            if (lookupKey && currentTuple.getFields().contains(AbstractTopology.KEY_FIELD)
                     && currentTuple.getValueByField(AbstractTopology.KEY_FIELD) != null) {
                 values = new Values(currentTuple.getStringByField(AbstractTopology.KEY_FIELD), json);
             } else {

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/MessageSender.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/MessageSender.java
@@ -19,7 +19,7 @@ import org.openkilda.messaging.Message;
 
 
 public interface MessageSender {
-    void send(Message message, String outputStream);
+    void send(Message message, String outputStream, boolean lookupKey);
 
     void send(Object payload, String outputStream);
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/RouterService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/RouterService.java
@@ -51,7 +51,7 @@ public class RouterService {
             AliveRequest request = new AliveRequest();
             CommandMessage message = new CommandMessage(request, System.currentTimeMillis(), UUID.randomUUID()
                     .toString());
-            routerMessageSender.send(message, Stream.formatWithRegion(Stream.SPEAKER_DISCO, region));
+            routerMessageSender.send(message, Stream.formatWithRegion(Stream.SPEAKER_DISCO, region), false);
 
         }
         floodlightTracker.checkTimeouts();
@@ -90,7 +90,7 @@ public class RouterService {
                 routerMessageSender.send(new SwitchMapping(switchId, region), Stream.REGION_NOTIFICATION);
             }
         }
-        routerMessageSender.send(message, Stream.KILDA_TOPO_DISCO);
+        routerMessageSender.send(message, Stream.KILDA_TOPO_DISCO, true);
     }
 
 
@@ -109,7 +109,7 @@ public class RouterService {
                 log.error("Received command message for the untracked switch: {} {}", switchId, message);
             } else {
                 String stream = Stream.formatWithRegion(Stream.SPEAKER_DISCO, region);
-                routerMessageSender.send(message, stream);
+                routerMessageSender.send(message, stream, false);
             }
         } else {
             log.warn("Received message without target switch from SPEAKER_DISCO stream: {}", message);
@@ -140,7 +140,7 @@ public class RouterService {
         log.info(
                 "Send network dump request (correlation-id: {})",
                 correlationId);
-        routerMessageSender.send(command, Stream.formatWithRegion(Stream.SPEAKER_DISCO, region));
+        routerMessageSender.send(command, Stream.formatWithRegion(Stream.SPEAKER_DISCO, region), false);
         return correlationId;
     }
 }


### PR DESCRIPTION
Router passes key field into tuple based on a direction of the stream.
Since request from speaker generates network dump, it shouldn't try to
pass key field to speaker. This patch address this issues