### PR TITLE
Manage to pass kafka-key from storm to speaker

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/FloodlightRouterTopology.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/FloodlightRouterTopology.java
@@ -399,20 +399,6 @@ public class FloodlightRouterTopology extends AbstractTopology<FloodlightRouterT
         // Storm <-- kilda.topo.disco -- Floodlight
         createDiscoveryPipelines(builder, parallelism, topicsConfig);
 
-        // Part3 Request to Floodlights
-        // Storm -- kilda.speaker.flow --> Floodlight
-        // createSpeakerFlowRequestStream(builder, parallelism, topicsConfig);
-
-        // Storm -- kilda.speaker.flow.ping --> Floodlight
-        // createSpeakerFlowPingRequestStream(builder, parallelism, topicsConfig);
-
-        // Storm -- kilda.speaker --> Floodlight
-        // createSpeakerRequestStream(builder, parallelism, topicsConfig);
-
-        // Storm -- kilda.speaker.disco --> Floodlight
-        // Storm <-- kilda.topo.disco -- Floodlight
-        // createDiscoveryPipelines(builder, parallelism, topicsConfig);
-
         return builder.createTopology();
     }
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/bolts/DiscoveryBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/bolts/DiscoveryBolt.java
@@ -27,9 +27,11 @@ import org.openkilda.wfm.topology.floodlightrouter.Stream;
 import org.openkilda.wfm.topology.floodlightrouter.service.FloodlightTracker;
 import org.openkilda.wfm.topology.floodlightrouter.service.MessageSender;
 import org.openkilda.wfm.topology.floodlightrouter.service.RouterService;
+import org.openkilda.wfm.topology.floodlightrouter.service.SwitchMapping;
 import org.openkilda.wfm.topology.utils.AbstractTickStatefulBolt;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.storm.kafka.bolt.mapper.FieldNameBasedTupleToKafkaMapper;
 import org.apache.storm.state.InMemoryKeyValueState;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
@@ -43,7 +45,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
 
 public class DiscoveryBolt extends AbstractTickStatefulBolt<InMemoryKeyValueState<String, RouterService>>
         implements MessageSender {
@@ -92,7 +93,7 @@ public class DiscoveryBolt extends AbstractTickStatefulBolt<InMemoryKeyValueStat
         currentTuple = input;
         Message message = null;
         try {
-            String json = input.getValueByField(AbstractTopology.MESSAGE_FIELD).toString();
+            String json = input.getStringByField(AbstractTopology.MESSAGE_FIELD);
             message = MAPPER.readValue(json, Message.class);
             switch (sourceComponent) {
                 case ComponentType.KILDA_TOPO_DISCO_KAFKA_SPOUT:
@@ -125,14 +126,12 @@ public class DiscoveryBolt extends AbstractTickStatefulBolt<InMemoryKeyValueStat
 
     @Override
     public void declareOutputFields(OutputFieldsDeclarer outputFieldsDeclarer) {
+        Fields kafkaFields = new Fields(FieldNameBasedTupleToKafkaMapper.BOLT_KEY,
+                                        FieldNameBasedTupleToKafkaMapper.BOLT_MESSAGE);
         for (String region : floodlights) {
-            outputFieldsDeclarer.declareStream(Stream.formatWithRegion(Stream.SPEAKER_DISCO, region),
-                    new Fields(AbstractTopology.MESSAGE_FIELD));
-            outputFieldsDeclarer.declareStream(Stream.formatWithRegion(Stream.SPEAKER, region),
-                    new Fields(AbstractTopology.MESSAGE_FIELD));
+            outputFieldsDeclarer.declareStream(Stream.formatWithRegion(Stream.SPEAKER_DISCO, region), kafkaFields);
         }
-        outputFieldsDeclarer.declareStream(Stream.KILDA_TOPO_DISCO,
-                new Fields(AbstractTopology.KEY_FIELD, AbstractTopology.MESSAGE_FIELD));
+        outputFieldsDeclarer.declareStream(Stream.KILDA_TOPO_DISCO, kafkaFields);
         outputFieldsDeclarer.declareStream(Stream.REGION_NOTIFICATION, new Fields(AbstractTopology.MESSAGE_FIELD));
     }
 
@@ -143,26 +142,35 @@ public class DiscoveryBolt extends AbstractTickStatefulBolt<InMemoryKeyValueStat
         super.prepare(map, topologyContext, outputCollector);
     }
 
+    // MessageSender implementation
 
     @Override
-    public void send(Message message, String outputStream, boolean lookupKey) {
-        try {
-            String json = MAPPER.writeValueAsString(message);
-            Values values;
-            if (lookupKey && currentTuple.getFields().contains(AbstractTopology.KEY_FIELD)
-                    && currentTuple.getValueByField(AbstractTopology.KEY_FIELD) != null) {
-                values = new Values(currentTuple.getStringByField(AbstractTopology.KEY_FIELD), json);
-            } else {
-                values = new Values(json);
-            }
-            outputCollector.emit(outputStream, currentTuple, values);
-        } catch (JsonProcessingException e) {
-            logger.error("failed to serialize message {}", message);
-        }
+    public void emitSpeakerMessage(Message message, String region) {
+        emitSpeakerMessage(pullKeyFromCurrentTuple(), message, region);
     }
 
     @Override
-    public void send(String key, Message message, String outputStream) {
+    public void emitSpeakerMessage(String key, Message message, String region) {
+        String stream = Stream.formatWithRegion(Stream.SPEAKER_DISCO, region);
+        send(key, message, stream);
+    }
+
+    @Override
+    public void emitControllerMessage(Message message) {
+        emitControllerMessage(pullKeyFromCurrentTuple(), message);
+    }
+
+    @Override
+    public void emitControllerMessage(String key, Message message) {
+        send(key, message, Stream.KILDA_TOPO_DISCO);
+    }
+
+    @Override
+    public void emitRegionNotification(SwitchMapping mapping) {
+        outputCollector.emit(Stream.REGION_NOTIFICATION, currentTuple, new Values(mapping));
+    }
+
+    private void send(String key, Message message, String outputStream) {
         try {
             String json = MAPPER.writeValueAsString(message);
             Values values = new Values(key, json);
@@ -172,10 +180,12 @@ public class DiscoveryBolt extends AbstractTickStatefulBolt<InMemoryKeyValueStat
         }
     }
 
-    @Override
-    public void send(Object payload, String outputStream) {
-        Values values = new Values(payload);
-        outputCollector.emit(outputStream, currentTuple, values);
+    private String pullKeyFromCurrentTuple() {
+        String key = null;
+        if (currentTuple.getFields().contains(AbstractTopology.KEY_FIELD)) {
+            key = currentTuple.getStringByField(AbstractTopology.KEY_FIELD);
+        }
+        return key;
     }
 
     private void doNetworkDump() {

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/bolts/ReplyBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/bolts/ReplyBolt.java
@@ -20,6 +20,7 @@ import org.openkilda.wfm.error.AbstractException;
 import org.openkilda.wfm.topology.AbstractTopology;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.storm.kafka.bolt.mapper.FieldNameBasedTupleToKafkaMapper;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
@@ -44,7 +45,8 @@ public class ReplyBolt extends AbstractBolt {
 
     @Override
     public void declareOutputFields(OutputFieldsDeclarer outputFieldsDeclarer) {
-        outputFieldsDeclarer.declareStream(outputStream, new Fields(AbstractTopology.KEY_FIELD,
-                AbstractTopology.MESSAGE_FIELD));
+        Fields fields = new Fields(FieldNameBasedTupleToKafkaMapper.BOLT_KEY,
+                                   FieldNameBasedTupleToKafkaMapper.BOLT_MESSAGE);
+        outputFieldsDeclarer.declareStream(outputStream, fields);
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/bolts/RequestBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/bolts/RequestBolt.java
@@ -25,8 +25,10 @@ import org.openkilda.wfm.topology.floodlightrouter.Stream;
 import org.openkilda.wfm.topology.floodlightrouter.service.RouterUtils;
 import org.openkilda.wfm.topology.floodlightrouter.service.SwitchMapping;
 import org.openkilda.wfm.topology.floodlightrouter.service.SwitchTracker;
+import org.openkilda.wfm.topology.utils.KafkaRecordTranslator;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.storm.kafka.bolt.mapper.FieldNameBasedTupleToKafkaMapper;
 import org.apache.storm.state.InMemoryKeyValueState;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
@@ -62,16 +64,14 @@ public class RequestBolt extends BaseStatefulBolt<InMemoryKeyValueState<String, 
                 updateSwitchMapping((SwitchMapping) input.getValueByField(
                         AbstractTopology.MESSAGE_FIELD));
             } else {
-                String json = input.getValueByField(AbstractTopology.MESSAGE_FIELD).toString();
+                String json = pullRequest(input);
                 Message message = MAPPER.readValue(json, Message.class);
 
                 SwitchId switchId = RouterUtils.lookupSwitchIdInCommandMessage(message);
                 if (switchId != null) {
                     String region = switchTracker.lookupRegion(switchId);
                     if (region != null) {
-                        String targetStream = Stream.formatWithRegion(outputStream, region);
-                        Values values = new Values(json);
-                        outputCollector.emit(targetStream, input, values);
+                        proxyRequestToSpeaker(input, region);
                     } else {
                         log.error("Unable to lookup region for message: {}", json);
                     }
@@ -85,6 +85,25 @@ public class RequestBolt extends BaseStatefulBolt<InMemoryKeyValueState<String, 
         } finally {
             outputCollector.ack(input);
         }
+    }
+
+    protected void proxyRequestToSpeaker(Tuple input, String region) {
+        String targetStream = Stream.formatWithRegion(outputStream, region);
+        String key = pullRequestKey(input);
+        String value = pullRequest(input);
+        outputCollector.emit(targetStream, input, makeSpeakerTuple(key, value));
+    }
+
+    protected String pullRequest(Tuple input) {
+        return input.getStringByField(KafkaRecordTranslator.FIELD_ID_PAYLOAD);
+    }
+
+    protected String pullRequestKey(Tuple input) {
+        return input.getStringByField(KafkaRecordTranslator.FIELD_ID_KEY);
+    }
+
+    protected Values makeSpeakerTuple(String key, String json) {
+        return new Values(key, json);
     }
 
     /**
@@ -105,15 +124,14 @@ public class RequestBolt extends BaseStatefulBolt<InMemoryKeyValueState<String, 
         switchTracker = tracker;
     }
 
-
     protected void updateSwitchMapping(SwitchMapping mapping) {
         switchTracker.updateRegion(mapping);
     }
 
-
     @Override
     public void declareOutputFields(OutputFieldsDeclarer outputFieldsDeclarer) {
-        Fields fields = new Fields(AbstractTopology.MESSAGE_FIELD);
+        Fields fields = new Fields(FieldNameBasedTupleToKafkaMapper.BOLT_KEY,
+                                   FieldNameBasedTupleToKafkaMapper.BOLT_MESSAGE);
         if (regions == null || regions.isEmpty()) {
             outputFieldsDeclarer.declareStream(outputStream, fields);
         } else {

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/FloodlightTracker.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/FloodlightTracker.java
@@ -18,7 +18,6 @@ package org.openkilda.wfm.topology.floodlightrouter.service;
 import org.openkilda.messaging.info.InfoMessage;
 import org.openkilda.messaging.info.switches.UnmanagedSwitchNotification;
 import org.openkilda.model.SwitchId;
-import org.openkilda.wfm.topology.floodlightrouter.Stream;
 
 import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.slf4j.Slf4j;
@@ -152,7 +151,7 @@ public class FloodlightTracker {
             UnmanagedSwitchNotification notification = new UnmanagedSwitchNotification(sw);
             InfoMessage message = new InfoMessage(notification, System.currentTimeMillis(), UUID.randomUUID()
                     .toString());
-            messageSender.send(sw.toString(), message, Stream.KILDA_TOPO_DISCO);
+            messageSender.emitControllerMessage(sw.toString(), message);
         }
     }
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/MessageSender.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/MessageSender.java
@@ -19,9 +19,13 @@ import org.openkilda.messaging.Message;
 
 
 public interface MessageSender {
-    void send(Message message, String outputStream, boolean lookupKey);
+    void emitSpeakerMessage(Message message, String region);
 
-    void send(Object payload, String outputStream);
+    void emitSpeakerMessage(String key, Message message, String region);
 
-    void send(String key, Message message, String outputStream);
+    void emitControllerMessage(Message message);
+
+    void emitControllerMessage(String key, Message message);
+
+    void emitRegionNotification(SwitchMapping mapping);
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/RouterService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/RouterService.java
@@ -27,7 +27,6 @@ import org.openkilda.messaging.info.discovery.NetworkDumpSwitchData;
 import org.openkilda.messaging.info.event.PortInfoData;
 import org.openkilda.messaging.info.event.SwitchInfoData;
 import org.openkilda.model.SwitchId;
-import org.openkilda.wfm.topology.floodlightrouter.Stream;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -51,8 +50,7 @@ public class RouterService {
             AliveRequest request = new AliveRequest();
             CommandMessage message = new CommandMessage(request, System.currentTimeMillis(), UUID.randomUUID()
                     .toString());
-            routerMessageSender.send(message, Stream.formatWithRegion(Stream.SPEAKER_DISCO, region), false);
-
+            routerMessageSender.emitSpeakerMessage(message.getCorrelationId(), message, region);
         }
         floodlightTracker.checkTimeouts();
         floodlightTracker.handleUnmanagedSwitches(routerMessageSender);
@@ -69,7 +67,7 @@ public class RouterService {
             InfoMessage infoMessage = (InfoMessage) message;
             InfoData infoData = infoMessage.getData();
             SwitchId switchId = null;
-            String region = ((InfoMessage) message).getRegion();
+            String region = infoMessage.getRegion();
             handleResponseFromSpeaker(routerMessageSender, region, message.getTimestamp());
             if (infoData instanceof AliveResponse) {
                 AliveResponse aliveResponse = (AliveResponse) infoData;
@@ -87,14 +85,11 @@ public class RouterService {
 
             // NOTE(tdurakov): need to notify of a mapping update
             if (switchId != null && region != null && floodlightTracker.updateSwitchRegion(switchId, region)) {
-                routerMessageSender.send(new SwitchMapping(switchId, region), Stream.REGION_NOTIFICATION);
+                routerMessageSender.emitRegionNotification(new SwitchMapping(switchId, region));
             }
         }
-        routerMessageSender.send(message, Stream.KILDA_TOPO_DISCO, true);
+        routerMessageSender.emitControllerMessage(message);
     }
-
-
-
 
     /**
      * Process request to speaker disco.
@@ -108,8 +103,7 @@ public class RouterService {
             if (region == null) {
                 log.error("Received command message for the untracked switch: {} {}", switchId, message);
             } else {
-                String stream = Stream.formatWithRegion(Stream.SPEAKER_DISCO, region);
-                routerMessageSender.send(message, stream, false);
+                routerMessageSender.emitSpeakerMessage(message, region);
             }
         } else {
             log.warn("Received message without target switch from SPEAKER_DISCO stream: {}", message);
@@ -129,18 +123,14 @@ public class RouterService {
      * Send network dump requests for target region.
      * @param routerMessageSender sender
      * @param region target
-     * @return requested correlation id
      */
-    public String sendNetworkRequest(MessageSender routerMessageSender, String region) {
+    public void sendNetworkRequest(MessageSender routerMessageSender, String region) {
         String correlationId = UUID.randomUUID().toString();
         CommandMessage command = new CommandMessage(new NetworkCommandData(),
                 System.currentTimeMillis(), correlationId,
                 Destination.CONTROLLER);
 
-        log.info(
-                "Send network dump request (correlation-id: {})",
-                correlationId);
-        routerMessageSender.send(command, Stream.formatWithRegion(Stream.SPEAKER_DISCO, region), false);
-        return correlationId;
+        log.info("Send network dump request (correlation-id: {})", correlationId);
+        routerMessageSender.emitSpeakerMessage(correlationId, command, region);
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/islstats/bolts/IslStatsBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/islstats/bolts/IslStatsBolt.java
@@ -23,6 +23,7 @@ import org.openkilda.messaging.info.InfoMessage;
 import org.openkilda.messaging.info.event.IslInfoData;
 import org.openkilda.wfm.share.utils.MetricFormatter;
 import org.openkilda.wfm.topology.AbstractTopology;
+import org.openkilda.wfm.topology.utils.KafkaRecordTranslator;
 
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
@@ -70,7 +71,7 @@ public class IslStatsBolt extends BaseRichBolt {
     }
 
     private String getJson(Tuple tuple) {
-        return tuple.getString(0);
+        return tuple.getStringByField(KafkaRecordTranslator.FIELD_ID_PAYLOAD);
     }
 
     public Message getMessage(String json) throws IOException {

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/utils/KafkaRecordTranslator.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/utils/KafkaRecordTranslator.java
@@ -25,12 +25,14 @@ import java.util.List;
 public class KafkaRecordTranslator<K, V> implements RecordTranslator<K, V> {
     private static final long serialVersionUID = 1L;
 
+    public static final String FIELD_ID_KEY = "key";
     public static final String FIELD_ID_PAYLOAD = "message";
-    public static final Fields FIELDS = new Fields(FIELD_ID_PAYLOAD);
+    // FIXME(surabujin): keep payload at index 0 because some code grab it in following way: `tuple.getString(0)`
+    public static final Fields FIELDS = new Fields(FIELD_ID_PAYLOAD, FIELD_ID_KEY);
 
     @Override
     public List<Object> apply(ConsumerRecord<K, V> record) {
-        return new Values(record.value());
+        return new Values(record.value(), record.key());
     }
 
     @Override

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/utils/MessageTranslator.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/utils/MessageTranslator.java
@@ -27,8 +27,10 @@ import org.apache.storm.tuple.Values;
 import java.util.List;
 
 public class MessageTranslator extends KafkaRecordTranslator<String, Message> {
-    public static final String KEY_FIELD = "key";
-    public static final Fields STREAM_FIELDS = new Fields(KEY_FIELD, FIELD_ID_PAYLOAD, FIELD_ID_CONTEXT);
+    // use FIELD_ID_KEY instead
+    @Deprecated
+    public static final String KEY_FIELD = FIELD_ID_KEY;
+    public static final Fields STREAM_FIELDS = new Fields(FIELD_ID_KEY, FIELD_ID_PAYLOAD, FIELD_ID_CONTEXT);
 
     @Override
     public List<Object> apply(ConsumerRecord<String, Message> record) {

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/floodlightrouter/bolts/DiscoveryBoltTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/floodlightrouter/bolts/DiscoveryBoltTest.java
@@ -1,0 +1,297 @@
+/* Copyright 2019 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.floodlightrouter.bolts;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.openkilda.messaging.Message;
+import org.openkilda.messaging.command.CommandMessage;
+import org.openkilda.messaging.command.discovery.DiscoverIslCommandData;
+import org.openkilda.messaging.info.InfoMessage;
+import org.openkilda.messaging.info.discovery.DiscoPacketSendingConfirmation;
+import org.openkilda.messaging.info.event.SwitchChangeType;
+import org.openkilda.messaging.info.event.SwitchInfoData;
+import org.openkilda.messaging.model.NetworkEndpoint;
+import org.openkilda.model.SwitchId;
+import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.persistence.repositories.FeatureTogglesRepository;
+import org.openkilda.persistence.repositories.RepositoryFactory;
+import org.openkilda.wfm.topology.floodlightrouter.ComponentType;
+import org.openkilda.wfm.topology.floodlightrouter.Stream;
+import org.openkilda.wfm.topology.floodlightrouter.service.RouterService;
+import org.openkilda.wfm.topology.utils.KeyValueKafkaRecordTranslator;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Value;
+import org.apache.storm.state.InMemoryKeyValueState;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.TupleImpl;
+import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.Utils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DiscoveryBoltTest {
+    private static final long ALIVE_INTERVAL = 1L;
+    private static final long ALIVE_TIMEOUT = 5L;
+    private static final long DUMP_INTERVAL = 60L;
+    
+    private static final String REGION_ONE = "1";
+    private static final String REGION_TWO = "2";
+
+    private static final SwitchId switchAlpha = new SwitchId(1);
+
+    public static final String FIELD_ID_KEY = "key";
+    public static final String FIELD_ID_MESSAGE = "message";
+    private static final Fields STREAM_SPEAKER_FIELDS = new Fields(FIELD_ID_KEY, FIELD_ID_MESSAGE);
+    private static final Fields STREAM_CONSUMER_FIELDS = STREAM_SPEAKER_FIELDS;
+    private static final Fields STREAM_REGION_NOTIFICATION_FIELDS = new Fields(FIELD_ID_MESSAGE);
+
+    private static final InMemoryKeyValueState<String, RouterService> subjectStateStorage
+            = new InMemoryKeyValueState<>();
+    private static final Map<String, Integer> componentNameToTaskId = new HashMap<>();
+    private static final Map<Integer, String> taskIdToComponentName = new HashMap<>();
+    private static final Map<StreamDescriptor, Fields> streamFields = new HashMap<>();
+
+    private static final ObjectMapper JsonMapper = new ObjectMapper();
+
+    static {
+        int idx = 0;
+        componentNameToTaskId.put(ComponentType.KILDA_TOPO_DISCO_KAFKA_SPOUT, idx++);
+        componentNameToTaskId.put(ComponentType.SPEAKER_DISCO_KAFKA_SPOUT, idx++);
+
+        componentNameToTaskId.forEach((key, value) -> taskIdToComponentName.put(value, key));
+
+        Fields kafkaSpoutFields = KeyValueKafkaRecordTranslator.FIELDS;
+        streamFields.put(new StreamDescriptor(ComponentType.KILDA_TOPO_DISCO_KAFKA_SPOUT, Utils.DEFAULT_STREAM_ID),
+                         kafkaSpoutFields);
+        streamFields.put(new StreamDescriptor(ComponentType.SPEAKER_DISCO_KAFKA_SPOUT, Utils.DEFAULT_STREAM_ID),
+                         kafkaSpoutFields);
+    }
+
+    @Mock
+    private PersistenceManager persistenceManager;
+
+    @Mock
+    private FeatureTogglesRepository featureTogglesRepository;
+
+    @Mock
+    private TopologyContext topologyContext;
+
+    @Mock
+    private OutputCollector outputCollector;
+
+    private final Map<String, String> topologyConfig = Collections.emptyMap();
+
+    private DiscoveryBolt subject;
+
+    @Before
+    public void setUp() {
+        Set<String> regions = new HashSet<>();
+        regions.add(REGION_ONE);
+        regions.add(REGION_TWO);
+
+        RepositoryFactory repositoryFactory = Mockito.mock(RepositoryFactory.class);
+        when(persistenceManager.getRepositoryFactory()).thenReturn(repositoryFactory);
+        when(repositoryFactory.createFeatureTogglesRepository()).thenReturn(featureTogglesRepository);
+
+        doAnswer(invocation -> taskIdToComponentName.get(invocation.getArgument(0)))
+                .when(topologyContext).getComponentId(any(Integer.class));
+        doAnswer(invocation -> streamFields.get(new StreamDescriptor(invocation.getArgument(0),
+                                                                     invocation.getArgument(1))))
+                .when(topologyContext).getComponentOutputFields(any(String.class), any(String.class));
+
+        subject = new DiscoveryBolt(persistenceManager, regions,
+                                    ALIVE_TIMEOUT, ALIVE_INTERVAL, DUMP_INTERVAL);
+        subject.prepare(topologyConfig, topologyContext, outputCollector);
+        subject.initState(subjectStateStorage);
+    }
+
+    @Test
+    public void verifyStreamDefinition() {
+        OutputFieldsDeclarer streamManager = Mockito.mock(OutputFieldsDeclarer.class);
+        subject.declareOutputFields(streamManager);
+
+        verify(streamManager).declareStream(Stream.formatWithRegion(Stream.SPEAKER_DISCO, REGION_ONE),
+                                            STREAM_SPEAKER_FIELDS);
+        verify(streamManager).declareStream(Stream.formatWithRegion(Stream.SPEAKER_DISCO, REGION_TWO),
+                                            STREAM_SPEAKER_FIELDS);
+        verify(streamManager).declareStream(Stream.KILDA_TOPO_DISCO, STREAM_CONSUMER_FIELDS);
+        verify(streamManager).declareStream(Stream.REGION_NOTIFICATION, STREAM_REGION_NOTIFICATION_FIELDS);
+    }
+
+    @Test
+    public void verifyConsumerToSpeakerTupleFormat() throws JsonProcessingException {
+        injectSwitch();
+
+        CommandMessage discoveryRequest = new CommandMessage(
+                new DiscoverIslCommandData(switchAlpha, 1, 1L), 2, "discovery-request");
+        Tuple discoveryRequestTuple = makeTuple(
+                makeConsumerTuple(null, discoveryRequest),
+                ComponentType.SPEAKER_DISCO_KAFKA_SPOUT, Utils.DEFAULT_STREAM_ID);
+
+        subject.doWork(discoveryRequestTuple);
+
+        verify(outputCollector).emit(eq(Stream.formatWithRegion(Stream.SPEAKER_DISCO, REGION_ONE)),
+                                     eq(discoveryRequestTuple),
+                                     argThat(values -> verifyConsumerTupleFormat(values)));
+
+        verify(outputCollector).ack(any(Tuple.class));
+        verifyNoMoreInteractions(outputCollector);
+
+    }
+
+    @Test
+    public void verifySpeakerToConsumerTupleFormat() throws JsonProcessingException {
+        injectSwitch();
+
+        InfoMessage discoveryConfirmation = new InfoMessage(
+                new DiscoPacketSendingConfirmation(new NetworkEndpoint(switchAlpha, 1), 1L),
+                3L, "discovery-confirmation", REGION_ONE);
+        Tuple discoveryConfirmationTuple = makeTuple(
+                makeSpeakerTuple(null, discoveryConfirmation),
+                ComponentType.KILDA_TOPO_DISCO_KAFKA_SPOUT, Utils.DEFAULT_STREAM_ID);
+
+        subject.doWork(discoveryConfirmationTuple);
+
+        verify(outputCollector).emit(eq(Stream.KILDA_TOPO_DISCO), eq(discoveryConfirmationTuple),
+                                     argThat(values -> verifyConsumerTupleFormat(values)));
+        verify(outputCollector).ack(any(Tuple.class));
+        verifyNoMoreInteractions(outputCollector);
+
+    }
+
+    @Test
+    public void verifyConsumerToSpeakerKeyPropagation() throws JsonProcessingException {
+        injectSwitch();
+
+        CommandMessage discoveryRequest = new CommandMessage(
+                new DiscoverIslCommandData(switchAlpha, 1, 2L), 4L, "discovery-request");
+        String requestKey = "discovery-request";
+        Tuple discoveryRequestTuple2 = makeTuple(
+                makeConsumerTuple(requestKey, discoveryRequest),
+                ComponentType.SPEAKER_DISCO_KAFKA_SPOUT, Utils.DEFAULT_STREAM_ID);
+
+        subject.doWork(discoveryRequestTuple2);
+
+        verify(outputCollector).emit(eq(Stream.formatWithRegion(Stream.SPEAKER_DISCO, REGION_ONE)),
+                                     eq(discoveryRequestTuple2),
+                                     argThat(values -> verifyConsumerTupleFormat(values, requestKey)));
+
+        verify(outputCollector).ack(any(Tuple.class));
+        verifyNoMoreInteractions(outputCollector);
+    }
+
+    @Test
+    public void verifySpeakerToConsumerKeyPropagation() throws JsonProcessingException {
+        injectSwitch();
+
+        InfoMessage discoveryConfirmation = new InfoMessage(
+                new DiscoPacketSendingConfirmation(new NetworkEndpoint(switchAlpha, 1), 1L),
+                3L, "discovery-confirmation", REGION_ONE);
+        String responseKey = "discovery-confirmation";
+        Tuple discoveryConfirmationTuple = makeTuple(
+                makeSpeakerTuple(responseKey, discoveryConfirmation),
+                ComponentType.KILDA_TOPO_DISCO_KAFKA_SPOUT, Utils.DEFAULT_STREAM_ID);
+
+        subject.doWork(discoveryConfirmationTuple);
+
+        verify(outputCollector).emit(eq(Stream.KILDA_TOPO_DISCO), eq(discoveryConfirmationTuple),
+                                     argThat(values -> verifyConsumerTupleFormat(values, responseKey)));
+        verify(outputCollector).ack(any(Tuple.class));
+        verifyNoMoreInteractions(outputCollector);
+    }
+
+    private void injectSwitch() throws JsonProcessingException {
+        // populate switch-to-region map
+        InfoMessage switchInfo = new InfoMessage(new SwitchInfoData(switchAlpha, SwitchChangeType.ACTIVATED),
+                                                 1, "init-sw-map", REGION_ONE);
+        subject.doWork(makeTuple(makeSpeakerTuple(null, switchInfo),
+                                 ComponentType.KILDA_TOPO_DISCO_KAFKA_SPOUT, Utils.DEFAULT_STREAM_ID));
+        reset(outputCollector);
+    }
+
+    private boolean verifySpeakerTupleFormat(List<Object> payload) {
+        return verifySpeakerTupleFormat(payload, null);
+    }
+
+    private boolean verifySpeakerTupleFormat(List<Object> payload, String expectKey) {
+        return verifyConsumerTupleFormat(payload, expectKey);
+    }
+
+    private boolean verifyConsumerTupleFormat(List<Object> payload) {
+        return verifyConsumerTupleFormat(payload, null);
+    }
+
+    private boolean verifyConsumerTupleFormat(List<Object> payload, String expectKey) {
+        return payload.size() == 2 && isNullOrString(payload.get(0), expectKey) && isNullOrString(payload.get(1));
+    }
+
+    private boolean isNullOrString(Object value) {
+        return isNullOrString(value, null);
+    }
+
+    private boolean isNullOrString(Object value, String expect) {
+        if (expect != null) {
+            return expect.equals(value);
+        }
+        return value == null || value instanceof String;
+    }
+
+    private Tuple makeTuple(Values payload, String component, String stream) {
+        Integer taskId = componentNameToTaskId.get(component);
+        return new TupleImpl(topologyContext, payload, taskId, stream);
+    }
+
+    private Values makeConsumerTuple(String key, Message payload) throws JsonProcessingException {
+        return makeSpeakerTuple(key, payload);
+    }
+
+    private Values makeSpeakerTuple(String key, Message payload) throws JsonProcessingException {
+        String json = JsonMapper.writeValueAsString(payload);
+        return new Values(key, json);
+    }
+
+    @Value
+    private static class StreamDescriptor {
+        private String componentName;
+        private String streamName;
+    }
+}

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/floodlightrouter/service/FloodlightTrackerTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/floodlightrouter/service/FloodlightTrackerTest.java
@@ -132,6 +132,6 @@ public class FloodlightTrackerTest {
         floodlightTracker.switchRegionMap.put(SWITCH_ID_TWO, REGION_TWO);
         MessageSender sender = mock(MessageSender.class);
         floodlightTracker.handleUnmanagedSwitches(sender);
-        verify(sender, times(2)).send(any(), (Message) any(), any());
+        verify(sender, times(2)).emitControllerMessage(any(), any(Message.class));
     }
 }

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/opentsdb/OpenTsdbTopologyTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/opentsdb/OpenTsdbTopologyTest.java
@@ -68,7 +68,7 @@ public class OpenTsdbTopologyTest extends StableAbstractStormTest {
             OpenTsdbTopology topology = new TestingTargetTopology(new TestingKafkaBolt());
 
             sources.addMockData(OpenTsdbTopology.OTSDB_SPOUT_ID,
-                    new Values(MAPPER.writeValueAsString(datapoint)));
+                    new Values(MAPPER.writeValueAsString(datapoint), null));
             completeTopologyParam.setMockedSources(sources);
 
             StormTopology stormTopology = topology.createTopology();
@@ -91,7 +91,7 @@ public class OpenTsdbTopologyTest extends StableAbstractStormTest {
             OpenTsdbTopology topology = new TestingTargetTopology(new TestingKafkaBolt());
 
             sources.addMockData(OpenTsdbTopology.OTSDB_SPOUT_ID,
-                    new Values(jsonDatapoint), new Values(jsonDatapoint));
+                    new Values(jsonDatapoint, null), new Values(jsonDatapoint, null));
             completeTopologyParam.setMockedSources(sources);
 
             StormTopology stormTopology = topology.createTopology();
@@ -116,7 +116,7 @@ public class OpenTsdbTopologyTest extends StableAbstractStormTest {
             OpenTsdbTopology topology = new TestingTargetTopology(new TestingKafkaBolt());
 
             sources.addMockData(OpenTsdbTopology.OTSDB_SPOUT_ID,
-                    new Values(jsonDatapoint1), new Values(jsonDatapoint2));
+                    new Values(jsonDatapoint1, null), new Values(jsonDatapoint2, null));
             completeTopologyParam.setMockedSources(sources);
 
             StormTopology stormTopology = topology.createTopology();


### PR DESCRIPTION
Read and proxy kafka-key into floodlightrouter topology. Kafka-key required to match request/response pairs in topologies that use H&S approach.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/2238)
<!-- Reviewable:end -->
