### PR TITLE
Fix anonymous authentication for NB health-check

### DIFF
--- a/services/src/northbound-service/northbound/src/main/java/org/openkilda/northbound/config/SecurityConfig.java
+++ b/services/src/northbound-service/northbound/src/main/java/org/openkilda/northbound/config/SecurityConfig.java
@@ -93,7 +93,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.csrf().disable()
-                .authorizeRequests().antMatchers("/health-check").permitAll().and()
+                .authorizeRequests().antMatchers("/v1/health-check").permitAll().and()
                 .authorizeRequests().anyRequest().fullyAuthenticated().and()
                 .httpBasic().authenticationEntryPoint(authenticationEntryPoint).and()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);


### PR DESCRIPTION
Fix (allow) anonymous authentication for health-check endpoint in Northbound.