### PR TITLE
Add error response for CRUD Flow when features disabled

### DIFF
--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/toggles/FeatureTogglesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/toggles/FeatureTogglesSpec.groovy
@@ -3,9 +3,8 @@ package org.openkilda.functionaltests.spec.toggles
 import org.openkilda.functionaltests.BaseSpecification
 import org.openkilda.messaging.error.MessageError
 import org.openkilda.messaging.model.system.FeatureTogglesDto
-
 import org.springframework.http.HttpStatus
-import org.springframework.web.client.HttpServerErrorException
+import org.springframework.web.client.HttpClientErrorException
 import spock.lang.Narrative
 
 @Narrative("""
@@ -27,9 +26,9 @@ class FeatureTogglesSpec extends BaseSpecification {
         northbound.addFlow(flowHelper.randomFlow(topology.activeSwitches[0], topology.activeSwitches[1]))
 
         then: "Error response is returned, explaining that feature toggle doesn't allow such operation"
-        def e = thrown(HttpServerErrorException)
+        def e = thrown(HttpClientErrorException)
         //TODO(rtretiak): inappropriate status code. Issue #1920
-        e.statusCode == HttpStatus.INTERNAL_SERVER_ERROR
+        e.statusCode == HttpStatus.FORBIDDEN
         e.responseBodyAsString.to(MessageError).errorMessage ==
                 "Could not create flow: Feature toggles not enabled for CREATE_FLOW operation."
 
@@ -55,9 +54,9 @@ class FeatureTogglesSpec extends BaseSpecification {
         northbound.updateFlow(flow.id, flow.tap { it.description = it.description + "updated" })
 
         then: "Error response is returned, explaining that feature toggle doesn't allow such operation"
-        def e = thrown(HttpServerErrorException)
+        def e = thrown(HttpClientErrorException)
         //TODO(rtretiak): inappropriate status code. Issue #1920
-        e.statusCode == HttpStatus.INTERNAL_SERVER_ERROR
+        e.statusCode == HttpStatus.FORBIDDEN
         e.responseBodyAsString.to(MessageError).errorMessage ==
                 "Could not update flow: Feature toggles not enabled for UPDATE_FLOW operation."
 
@@ -84,9 +83,9 @@ class FeatureTogglesSpec extends BaseSpecification {
         northbound.deleteFlow(flow.id)
 
         then: "Error response is returned, explaining that feature toggle doesn't allow such operation"
-        def e = thrown(HttpServerErrorException)
+        def e = thrown(HttpClientErrorException)
         //TODO(rtretiak): inappropriate status code. Issue #1920
-        e.statusCode == HttpStatus.INTERNAL_SERVER_ERROR
+        e.statusCode == HttpStatus.FORBIDDEN
         e.responseBodyAsString.to(MessageError).errorMessage ==
                 "Can not delete flow: Feature toggles not enabled for DELETE_FLOW operation."
 

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/error/ErrorType.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/error/ErrorType.java
@@ -84,7 +84,12 @@ public enum ErrorType {
     /**
      * The error message for invalid request credentials.
      */
-    AUTH_FAILED("Invalid credentials");
+    AUTH_FAILED("Invalid credentials"),
+
+    /**
+     * The error message for not permitted operation.
+     */
+    NOT_PERMITTED("Operation not permitted");
 
     /**
      * The text type value.

--- a/services/src/northbound-service/northbound/src/main/java/org/openkilda/northbound/utils/NorthboundExceptionHandler.java
+++ b/services/src/northbound-service/northbound/src/main/java/org/openkilda/northbound/utils/NorthboundExceptionHandler.java
@@ -74,6 +74,9 @@ public class NorthboundExceptionHandler extends ResponseEntityExceptionHandler {
             case INTERNAL_ERROR:
                 status = HttpStatus.INTERNAL_SERVER_ERROR;
                 break;
+            case NOT_PERMITTED:
+                status = HttpStatus.FORBIDDEN;
+                break;
             default:
                 status = HttpStatus.INTERNAL_SERVER_ERROR;
                 break;

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/CrudBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/CrudBolt.java
@@ -71,6 +71,7 @@ import org.openkilda.persistence.repositories.RepositoryFactory;
 import org.openkilda.wfm.ctrl.CtrlAction;
 import org.openkilda.wfm.ctrl.ICtrlBolt;
 import org.openkilda.wfm.error.ClientException;
+import org.openkilda.wfm.error.FeatureTogglesNotEnabledException;
 import org.openkilda.wfm.error.FlowNotFoundException;
 import org.openkilda.wfm.share.bolt.HistoryBolt;
 import org.openkilda.wfm.share.cache.ResourceCache;
@@ -357,6 +358,9 @@ public class CrudBolt
         } catch (FlowAlreadyExistException e) {
             throw new MessageException(message.getCorrelationId(), System.currentTimeMillis(),
                     ErrorType.ALREADY_EXISTS, errorType, e.getMessage());
+        } catch (FeatureTogglesNotEnabledException e) {
+            throw new MessageException(message.getCorrelationId(), System.currentTimeMillis(),
+                    ErrorType.NOT_PERMITTED, errorType, "Feature push flow is disabled");
         } catch (Exception e) {
             throw new MessageException(message.getCorrelationId(), System.currentTimeMillis(),
                     ErrorType.CREATION_FAILURE, errorType, e.getMessage());
@@ -392,6 +396,9 @@ public class CrudBolt
         } catch (FlowNotFoundException e) {
             throw new MessageException(message.getCorrelationId(), System.currentTimeMillis(),
                     ErrorType.NOT_FOUND, errorType, e.getMessage());
+        } catch (FeatureTogglesNotEnabledException e) {
+            throw new MessageException(message.getCorrelationId(), System.currentTimeMillis(),
+                    ErrorType.NOT_PERMITTED, errorType, "Feature unpush flow is disabled");
         } catch (Exception e) {
             throw new MessageException(message.getCorrelationId(), System.currentTimeMillis(),
                     ErrorType.DELETION_FAILURE, errorType, e.getMessage());
@@ -415,6 +422,9 @@ public class CrudBolt
         } catch (FlowNotFoundException e) {
             throw new MessageException(message.getCorrelationId(), System.currentTimeMillis(),
                     ErrorType.NOT_FOUND, errorType, e.getMessage());
+        } catch (FeatureTogglesNotEnabledException e) {
+            throw new MessageException(message.getCorrelationId(), System.currentTimeMillis(),
+                    ErrorType.NOT_PERMITTED, errorType, "Feature toggles not enabled for DELETE_FLOW operation.");
         } catch (Exception e) {
             throw new MessageException(message.getCorrelationId(), System.currentTimeMillis(),
                     ErrorType.DELETION_FAILURE, errorType, e.getMessage());
@@ -457,6 +467,9 @@ public class CrudBolt
         } catch (FlowNotFoundException e) {
             throw new MessageException(message.getCorrelationId(), System.currentTimeMillis(),
                     ErrorType.NOT_FOUND, errorType, "The flow not found :  " + e.getMessage());
+        } catch (FeatureTogglesNotEnabledException e) {
+            throw new MessageException(message.getCorrelationId(), System.currentTimeMillis(),
+                    ErrorType.NOT_PERMITTED, errorType, "Feature toggles not enabled for CREATE_FLOW operation.");
         } catch (Exception e) {
             throw new MessageException(message.getCorrelationId(), System.currentTimeMillis(),
                     ErrorType.CREATION_FAILURE, errorType, e.getMessage());
@@ -588,6 +601,9 @@ public class CrudBolt
         } catch (UnroutableFlowException e) {
             throw new MessageException(message.getCorrelationId(), System.currentTimeMillis(),
                     ErrorType.NOT_FOUND, errorType, "Not enough bandwidth found or path not found");
+        } catch (FeatureTogglesNotEnabledException e) {
+            throw new MessageException(message.getCorrelationId(), System.currentTimeMillis(),
+                    ErrorType.NOT_PERMITTED, errorType, "Feature toggles not enabled for UPDATE_FLOW operation.");
         } catch (Exception e) {
             throw new MessageException(message.getCorrelationId(), System.currentTimeMillis(),
                     ErrorType.UPDATE_FAILURE, errorType, e.getMessage());


### PR DESCRIPTION
Add error responses for Create/Update/Delete etc. operations with flow, when similar features are disabled.

Closes: #1920 