### PR TITLE
Rework TagExtension for new tags format. Introduce IterationTags

### DIFF
--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/tags/IterationTag.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/tags/IterationTag.groovy
@@ -14,7 +14,7 @@ import java.lang.annotation.Target
 @Retention(RetentionPolicy.RUNTIME)
 @interface IterationTag {
     Tag[] tags() default [] //these tags will be applied to iterations that are matched by 'iterationNameRegex'
-    String iterationNameRegex() default ".*" //Regex used to match certain iteration's name. Full match.
+    String iterationNameRegex() default ".*" //Regex used to match certain iteration's name. Partial match.
     /**Additional limitation when unable to exactly pin-point certain iteration(s) by name.
      Will pick first N iterations matched by iterationNameRegex*/
     int take() default 2147483647

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/tags/IterationTag.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/tags/IterationTag.groovy
@@ -1,0 +1,21 @@
+package org.openkilda.functionaltests.extension.tags
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+/**
+ * Allows to put tags on certain iterations of data-driven test (test with 'where' block).
+ * Multiple IterationTag annotations can be put via {@link IterationTags}
+ * See {@link TagExtension}
+ */
+@Target([ElementType.METHOD])
+@Retention(RetentionPolicy.RUNTIME)
+@interface IterationTag {
+    Tag[] tags() default [] //these tags will be applied to iterations that are matched by 'iterationNameRegex'
+    String iterationNameRegex() default ".*" //Regex used to match certain iteration's name. Full match.
+    /**Additional limitation when unable to exactly pin-point certain iteration(s) by name.
+     Will pick first N iterations matched by iterationNameRegex*/
+    int take() default 2147483647
+}

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/tags/IterationTags.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/tags/IterationTags.groovy
@@ -1,17 +1,15 @@
 package org.openkilda.functionaltests.extension.tags
 
 import java.lang.annotation.ElementType
-import java.lang.annotation.Inherited
 import java.lang.annotation.Retention
 import java.lang.annotation.RetentionPolicy
 import java.lang.annotation.Target
 
 /**
- * Container annotation for {@link Tag}
+ * Container annotation for multiple {@link IterationTag}
  */
-@Target([ElementType.TYPE, ElementType.METHOD])
+@Target([ElementType.METHOD])
 @Retention(RetentionPolicy.RUNTIME)
-@Inherited
-@interface Tags {
-    Tag[] value() default []
+@interface IterationTags {
+    IterationTag[] value()
 }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/tags/Tag.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/tags/Tag.groovy
@@ -2,7 +2,7 @@ package org.openkilda.functionaltests.extension.tags
 
 /**
  * All available tags go here.
- * See {@link TagExtension}
+ * See {@link TagExtension}, {@link Tags}, {@link IterationTags}
  */
 enum Tag {
     //regularity

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/tags/Tag.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/tags/Tag.groovy
@@ -5,6 +5,12 @@ package org.openkilda.functionaltests.extension.tags
  * See {@link TagExtension}, {@link Tags}, {@link IterationTags}
  */
 enum Tag {
+    //pre-defined sets
+    SMOKE, REGRESSION,
+
+    //environments
+    HARDWARE, VIRTUAL,
+
     //regularity
     ONDEMAND,
 

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/tags/TagExtension.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/tags/TagExtension.groovy
@@ -3,80 +3,127 @@ package org.openkilda.functionaltests.extension.tags
 import static org.openkilda.functionaltests.extension.ExtensionHelper.isFeatureSpecial
 
 import groovy.util.logging.Slf4j
+import org.junit.AssumptionViolatedException
 import org.spockframework.runtime.extension.AbstractGlobalExtension
-import org.spockframework.runtime.model.MethodInfo
+import org.spockframework.runtime.extension.IMethodInterceptor
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.FeatureInfo
 import org.spockframework.runtime.model.SpecInfo
 
 /**
- * Use these system properties to leverage test suite by tags: includeTags, excludeTags.
- * Pass comma-separated list of properties as a value. If not passing a value to **includeTags**, then
- * all tests are included by default (even without tags). In order to get a list of available tags look at the
- * {@link Tag} enum. For example, to run slow+positive test suite, excluding
- * ondemand tests, execute the following command:
- * {@code mvn clean test -Pfunctional -DincludeTags=positive,slow -DexcludeTags=ondemand}
- * <br>
+ * A list of tags may be supplied to a build by setting 'tags' system property.
+ * Tag expression is basically a boolean expression, that consists of typical operators AND, OR, NOT applied to
+ * certain tags. List of allowed tags can be found in {@link Tag} enum. Also, round brackets can be used to build more
+ * complex expressions.<br>
+ * Example: {@code -Dtags="not ondemand or (positive and negative)"}<br>
+ * In order to tag a certain test use annotation {@link Tags}, {@link IterationTags} or {@link IterationTag}.<br>
+ *
  * Any spec will get its parent's tags, too. As well as any test method will get all the spec's tags.
  */
 @Slf4j
 class TagExtension extends AbstractGlobalExtension {
 
-    static final String INCLUDE_PROPERTY_NAME = "includeTags"
-    static final String EXCLUDE_PROPERTY_NAME = "excludeTags"
+    static final String TAGS_PROPERTY_NAME = "tags"
+
+    static Set<String> specialLiterals = ["NOT", "AND", "OR", "(", ")"]
+    static Set<String> tagLiterals = Tag.values()*.toString()
 
     void visitSpec(SpecInfo spec) {
-        List<Tag> includeTags = getBuildTags(INCLUDE_PROPERTY_NAME)
-        List<Tag> excludeTags = getBuildTags(EXCLUDE_PROPERTY_NAME)
-        if (includeTags != [null]) {
-            spec.excluded = true
-            spec.getAllFeatures().each { feature ->
-                if (!isFeatureSpecial(feature)) {
-                    feature.excluded = true
-                }
-            }
+        String tagsExpression = System.getProperty(TAGS_PROPERTY_NAME)
+        if (!tagsExpression) {
+            return
         }
-        spec.getAllFeatures().each { feature ->
-            def tags = collectAllTags(feature.featureMethod)
-            if (tags.containsAll(includeTags)) {
-                log.debug("Feature '$feature.name' with tags $tags is included in the test run")
-                spec.excluded = false
-                feature.excluded = false
-            }
-            if (tags.containsAll(excludeTags)) {
-                log.debug("Feature '$feature.name' with tags $tags is excluded from the test run")
-                feature.excluded = true
-                if (spec.getAllFeatures().every { it.excluded }) {
-                    spec.excluded = true
-                }
+        spec.getAllFeatures().findAll { !isFeatureSpecial(it) }.each { feature ->
+            def tags = collectAllTagsAnnotations(feature).collectMany { it.value().toList() } as Set
+            def iterationTags = (feature.featureMethod.getAnnotation(IterationTags)?.value()?.toList() ?: [] +
+                    feature.featureMethod.getAnnotation(IterationTag)).findAll()
+            feature.excluded = !matches(tagsExpression, tags)
+            if (iterationTags) {
+                feature.addIterationInterceptor(new IMethodInterceptor() {
+                    /*This stores how many times did we match a certain iteration tag.
+                     Use this when calculating 'take' limitation for the iteration tag*/
+                    Map<IterationTag, Integer> tagExecutions = iterationTags.collectEntries { [(it): 0] }
+
+                    @Override
+                    void intercept(IMethodInvocation invocation) throws Throwable {
+                        //look for iteration which matches our iteration name regexp
+                        Map<IterationTag, Integer> applicableITags = tagExecutions.findAll { itag, exec ->
+                            invocation.iteration.name.matches(itag.iterationNameRegex())
+                        }
+                        //If no applicable iteration tags found, try checking whether top-level tags allow execution
+                        if (applicableITags.isEmpty() && matches(tagsExpression, tags)) {
+                            invocation.proceed()
+                            return
+                        }
+                        //otherwise, look whether any of found iteration tags allow further execution
+                        def allowingTag = applicableITags.find { itag, executions ->
+                            matches(tagsExpression,
+                                    (tags + applicableITags.keySet().collectMany { it.tags().toList() }) as Set) &&
+                                    executions < itag.take()
+                        }
+                        if (allowingTag) {
+                            allowingTag.value++
+                            invocation.proceed()
+                        } else {
+                            throw new AssumptionViolatedException("This iteration does not match the provided tags " +
+                                    "expression: \"$tagsExpression\"")
+                        }
+                    }
+                })
             }
         }
     }
 
-    private Set<Tag> collectAllTags(MethodInfo method) {
+    private List<Tags> collectAllTagsAnnotations(FeatureInfo feature) {
         def tags = []
-        def annotation = method.getAnnotation(Tags)
+        def annotation = feature.featureMethod.getAnnotation(Tags)
         if (annotation) {
-            tags.addAll(annotation.value())
+            tags << annotation
         }
-        tags.addAll(collectAllSpecTags(method.getParent()))
-        return tags as Set<Tag>
+        tags.addAll(collectAllTagsAnnotations(feature.featureMethod.getParent()))
+        return tags
     }
 
-    private Set<Tag> collectAllSpecTags(SpecInfo spec) {
+    private List<Tags> collectAllTagsAnnotations(SpecInfo spec) {
         def tags = []
         def annotation = spec.getAnnotation(Tags)
         if (annotation) {
-            tags.addAll(annotation.value())
+            tags << annotation
         }
         def superSpec = spec.getSuperSpec()
         if (superSpec) {
-            tags.addAll(collectAllSpecTags(superSpec))
+            tags.addAll(collectAllTagsAnnotations(superSpec))
         }
-        return tags as Set<Tag>
+        return tags
     }
 
-    private static List<Tag> getBuildTags(String propertyName) {
-        return System.getProperty(propertyName, "").split(",").findAll { it != "" }.collect {
-            Tag.valueOf(it.toUpperCase())
-        } ?: [null]
+    /**
+     * Check whether given tags expression evaluates into 'true' for given list of tags.
+     */
+    private static boolean matches(String tagsExpression, Set<Tag> tags) {
+        def literals = tagsExpression
+                .replaceAll(/[()]/, / $0 /)
+                .replaceAll(/\s+/, " ")
+                .split(" ")
+        return Eval.me(literals.collect {
+            def literal = it.toUpperCase()
+            if (literal == "AND") {
+                "&&"
+            } else if (literal == "OR") {
+                "||"
+            } else if (literal == "NOT") {
+                "!"
+            } else if (literal in specialLiterals) {
+                literal
+            } else if (literal in tagLiterals) {
+                if (tags.contains(Tag.valueOf(literal))) {
+                    "true"
+                } else {
+                    "false"
+                }
+            } else {
+                throw new UnknownTagLiteralException("Unknown literal: $literal")
+            }
+        }.join(" "))
     }
 }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/tags/UnknownTagLiteralException.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/extension/tags/UnknownTagLiteralException.groovy
@@ -1,0 +1,7 @@
+package org.openkilda.functionaltests.extension.tags
+
+import groovy.transform.InheritConstructors
+
+@InheritConstructors
+class UnknownTagLiteralException extends RuntimeException {
+}


### PR DESCRIPTION
Reworked TagExtension. Now use new 'tags expression' syntax during build to match test tags.
Introduce `IterationTags` that is aimed to allow tagging certain iterations of data-driven test.