### PR TITLE
Slightly improve lab service api parallelism

### DIFF
--- a/services/lab-service/lab/api/api.py
+++ b/services/lab-service/lab/api/api.py
@@ -201,7 +201,7 @@ def flush_labs_api():
 
 
 def main():
-    server_th = run_thread(lambda: app.run(host='0.0.0.0', port=8288))
+    server_th = run_thread(lambda: app.run(host='0.0.0.0', port=8288, threaded=True))
 
     def teardown():
         logger.info('Terminating...')

--- a/services/lab-service/lab/service/service.py
+++ b/services/lab-service/lab/service/service.py
@@ -43,7 +43,7 @@ def main():
 
         logger.info("Running rest server")
         lockkeeper_app = init_app(topo.switches)
-        lockkeeper_proc = run_process(lambda: lockkeeper_app.run('0.0.0.0', 5001))
+        lockkeeper_proc = run_process(lambda: lockkeeper_app.run('0.0.0.0', 5001, threaded=True))
     except Exception as ex:
         requests.post(activate_url, json={'error': traceback.format_exc()})
         raise ex


### PR DESCRIPTION
since lab_service uses flask witchout wsgi it's
worth at lease enable threaded mode that is provided by
see for details:
https://werkzeug.palletsprojects.com/en/0.15.x/serving/#werkzeug.serving.run_simple