### PR TITLE
Expose ElasticSearch ports.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -346,8 +346,8 @@ services:
       dockerfile: Dockerfile
     hostname: elasticsearch.pendev
     ports:
-      - "127.0.0.1:9200:9200"
-      - "127.0.0.1:9300:9300"
+      - "9200:9200"
+      - "9300:9300"
     networks:
       default:
         aliases:


### PR DESCRIPTION
Open ElasticSearch ports for any net interfaces not only localhost.