### PR TITLE
Fix the spam of warnings "CorrelationId was not sent, generated one".

### DIFF
--- a/services/src/northbound-service/northbound/src/main/java/org/openkilda/northbound/utils/RequestCorrelationFilter.java
+++ b/services/src/northbound-service/northbound/src/main/java/org/openkilda/northbound/utils/RequestCorrelationFilter.java
@@ -50,7 +50,7 @@ public class RequestCorrelationFilter extends OncePerRequestFilter {
         String correlationId = request.getHeader(CORRELATION_ID);
         if (StringUtils.isBlank(correlationId)) {
             correlationId = UUID.randomUUID().toString();
-            LOGGER.warn("CorrelationId was not sent, generated one: {}", correlationId);
+            LOGGER.info("CorrelationId was not sent, generated one: {}", correlationId);
         } else {
             correlationId = RequestCorrelationId.chain(UUID.randomUUID().toString(), correlationId);
             LOGGER.trace("Found correlationId in header. Chaining: {}", correlationId);


### PR DESCRIPTION
Closes: #2073. 