### PR TITLE
Misc improvements in tests

### DIFF
--- a/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/SwitchHelper.groovy
+++ b/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/SwitchHelper.groovy
@@ -71,7 +71,7 @@ class SwitchHelper {
     }
 
     @Memoized
-    String getDescription(SwitchId sw) {
+    static String getDescription(SwitchId sw) {
         northbound.activeSwitches.find { it.switchId == sw }.description
     }
 

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/BaseSpecification.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/BaseSpecification.groovy
@@ -4,6 +4,7 @@ import static org.junit.Assume.assumeTrue
 import static org.openkilda.model.MeterId.MAX_SYSTEM_RULE_METER_ID
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
+import org.openkilda.functionaltests.exception.IslNotFoundException
 import org.openkilda.functionaltests.extension.fixture.SetupOnce
 import org.openkilda.functionaltests.extension.healthcheck.HealthCheck
 import org.openkilda.functionaltests.helpers.FlowHelper
@@ -106,7 +107,10 @@ class BaseSpecification extends SpringSpecification implements SetupOnce {
             }
             links.findAll { it.state == IslChangeType.FAILED }.empty
             def topoLinks = topology.islsForActiveSwitches.collectMany {
-                [islUtils.getIslInfo(links, it).get(), islUtils.getIslInfo(links, it.reversed).get()]
+                [islUtils.getIslInfo(links, it).orElseThrow { new IslNotFoundException(it.toString()) },
+                 islUtils.getIslInfo(links, it.reversed).orElseThrow {
+                     new IslNotFoundException(it.reversed.toString())
+                 }]
             }
             def missingLinks = links - topoLinks
             missingLinks.empty

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/BaseSpecification.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/BaseSpecification.groovy
@@ -106,10 +106,10 @@ class BaseSpecification extends SpringSpecification implements SetupOnce {
                 assert northbound.activeSwitches.size() == topology.activeSwitches.size()
             }
             links.findAll { it.state == IslChangeType.FAILED }.empty
-            def topoLinks = topology.islsForActiveSwitches.collectMany {
-                [islUtils.getIslInfo(links, it).orElseThrow { new IslNotFoundException(it.toString()) },
-                 islUtils.getIslInfo(links, it.reversed).orElseThrow {
-                     new IslNotFoundException(it.reversed.toString())
+            def topoLinks = topology.islsForActiveSwitches.collectMany { isl ->
+                [islUtils.getIslInfo(links, isl).orElseThrow { new IslNotFoundException(isl.toString()) },
+                 islUtils.getIslInfo(links, isl.reversed).orElseThrow {
+                     new IslNotFoundException(isl.reversed.toString())
                  }]
             }
             def missingLinks = links - topoLinks

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
@@ -201,13 +201,13 @@ class AutoRerouteSpec extends BaseSpecification {
         Wrappers.wait(WAIT_OFFSET) { assert northbound.activeSwitches*.switchId.contains(flowPath[1].switchId) }
 
         then: "The flow is #flowStatus"
-        TimeUnit.SECONDS.sleep(discoveryInterval + rerouteDelay + WAIT_OFFSET * 2)
-        northbound.getFlowStatus(flow.id).status == flowStatus
+        TimeUnit.SECONDS.sleep(discoveryInterval + rerouteDelay + 2)
+        Wrappers.wait(WAIT_OFFSET) { assert northbound.getFlowStatus(flow.id).status == flowStatus }
 
         and: "Restore topology to the original state, remove the flow, reset toggles"
+        flowHelper.deleteFlow(flow.id)
         northbound.toggleFeature(FeatureTogglesDto.builder().flowsRerouteOnIslDiscoveryEnabled(true).build())
         broughtDownPorts.every { northbound.portUp(it.switchId, it.portNo) }
-        flowHelper.deleteFlow(flow.id)
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
@@ -57,12 +57,7 @@ class FlowCrudSpec extends BaseSpecification {
         switches.each { verifySwitchRules(it.dpId) }
 
         and: "No discrepancies when doing flow validation"
-        northbound.validateFlow(flow.id).each { direction ->
-            def discrepancies = profile == "virtual" ?
-                    direction.discrepancies.findAll { it.field != "meterId" } : //unable to validate meters for virtual
-                    direction.discrepancies
-            assert discrepancies.empty
-        }
+        northbound.validateFlow(flow.id).each { direction -> assert direction.asExpected }
 
         and: "The flow allows traffic (only applicable flows are checked)"
         try {
@@ -198,12 +193,7 @@ class FlowCrudSpec extends BaseSpecification {
         verifySwitchRules(flow.source.datapath)
 
         and: "No discrepancies when doing flow validation"
-        northbound.validateFlow(flow.id).each { direction ->
-            def discrepancies = profile == "virtual" ?
-                    direction.discrepancies.findAll { it.field != "meterId" } : //unable to validate meters for virtual
-                    direction.discrepancies
-            assert discrepancies.empty
-        }
+        northbound.validateFlow(flow.id).each { direction -> assert direction.asExpected }
 
         when: "Remove the flow"
         flowHelper.deleteFlow(flow.id)
@@ -231,9 +221,7 @@ class FlowCrudSpec extends BaseSpecification {
         flowHelper.addFlow(flow)
 
         then: "Validation of flow with zero bandwidth must be succeed"
-        northbound.validateFlow(flow.id).each { direction ->
-            assert direction.discrepancies.empty
-        }
+        northbound.validateFlow(flow.id).each { direction -> assert direction.asExpected }
 
         and: "Cleanup: delete the flow"
         flowHelper.deleteFlow(flow.id)

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowPingSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowPingSpec.groovy
@@ -17,8 +17,6 @@ import org.openkilda.testing.Constants.DefaultRule
 import org.openkilda.testing.model.topology.TopologyDefinition.Switch
 
 import org.springframework.beans.factory.annotation.Value
-import spock.lang.Ignore
-import spock.lang.Issue
 import spock.lang.Narrative
 import spock.lang.Unroll
 
@@ -98,8 +96,6 @@ class FlowPingSpec extends BaseSpecification {
         [srcSwitch, dstSwitch] << ofSwitchCombinations
     }
 
-    @Ignore
-    @Issue("https://github.com/telstra/open-kilda/issues/1865")
     @Unroll("Flow ping can detect a broken #description")
     def "Flow ping can detect a broken path"() {
         given: "A flow with at least 1 a-switch link"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MultiRerouteSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MultiRerouteSpec.groovy
@@ -48,8 +48,10 @@ class MultiRerouteSpec extends BaseSpecification {
         then: "Both flows change their paths (or go Down if no path)"
         Wrappers.wait(WAIT_OFFSET) {
             flows.each {
+                def status = northbound.getFlowStatus(it.id).status
+                assert status != FlowState.IN_PROGRESS
                 assert pathHelper.convert(northbound.getFlowPath(it.id)) != currentPath ||
-                        northbound.getFlowStatus(it.id).status == FlowState.DOWN
+                        status == FlowState.DOWN
             }
         }
 

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
@@ -361,15 +361,10 @@ class LinkSpec extends BaseSpecification {
         then: "Flows are rerouted"
         response.containsAll([flow1, flow2]*.id)
 
-        def flow1PathUpdated
-        def flow2PathUpdated
-
         Wrappers.wait(WAIT_OFFSET) {
-            flow1PathUpdated = PathHelper.convert(northbound.getFlowPath(flow1.id))
-            flow2PathUpdated = PathHelper.convert(northbound.getFlowPath(flow2.id))
-
-            assert flow1PathUpdated != flow1Path
-            assert flow2PathUpdated != flow2Path
+            [flow1, flow2].each { assert northbound.getFlowStatus(it.id).status == FlowState.UP }
+            assert PathHelper.convert(northbound.getFlowPath(flow1.id)) != flow1Path
+            assert PathHelper.convert(northbound.getFlowPath(flow2.id)) != flow2Path
         }
 
         and: "Delete flows and delete link props"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/ChaosSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/ChaosSpec.groovy
@@ -53,7 +53,7 @@ class ChaosSpec extends BaseSpecification {
         }
 
         then: "All flows remain up and valid"
-        Wrappers.wait(WAIT_OFFSET + antiflapCooldown) {
+        Wrappers.wait(WAIT_OFFSET + antiflapCooldown + discoveryInterval) {
             northbound.getAllLinks().findAll { it.state == IslChangeType.FAILED }.empty
         }
         TimeUnit.SECONDS.sleep(rerouteDelay) //all throttled reroutes should start executing

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/SimulateStatsSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/SimulateStatsSpec.groovy
@@ -65,6 +65,7 @@ class SimulateStatsSpec extends BaseSpecification {
             new FlowStatsEntry(0, it.cookie, NOVI_MAX_PACKET_COUNT, NOVI_MAX_PACKET_COUNT * MAX_PACKET_SIZE)
         })
         producer.send(new ProducerRecord(statsTopic, sw.dpId.toString(), buildMessage(data).toJson()))
+        producer.flush()
         
         then: "Corresponding entries appear in otsdb"
         def expectedMetricValueMap = [
@@ -91,6 +92,9 @@ class SimulateStatsSpec extends BaseSpecification {
 
         and: "Remove flow"
         flowHelper.deleteFlow(flow.id)
+
+        cleanup:
+        producer && producer.close()
     }
 
     private static Message buildMessage(final InfoData data) {

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortAntiflapSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortAntiflapSpec.groovy
@@ -1,14 +1,16 @@
 package org.openkilda.functionaltests.spec.switches
 
-import groovy.util.logging.Slf4j
+import static org.openkilda.testing.Constants.WAIT_OFFSET
+
 import org.openkilda.functionaltests.BaseSpecification
-import org.openkilda.functionaltests.extension.rerun.Rerun
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.functionaltests.helpers.thread.PortBlinker
 import org.openkilda.messaging.info.event.IslChangeType
 import org.openkilda.messaging.info.event.PortChangeType
 import org.openkilda.messaging.model.system.FeatureTogglesDto
 import org.openkilda.testing.model.topology.TopologyDefinition.Isl
+
+import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -16,8 +18,6 @@ import spock.lang.Issue
 import spock.lang.Narrative
 
 import java.util.concurrent.TimeUnit
-
-import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 @Slf4j
 @Narrative("""
@@ -52,8 +52,6 @@ class PortAntiflapSpec extends BaseSpecification {
         getNorthbound().toggleFeature(FeatureTogglesDto.builder().floodlightRoutePeriodicSync(true).build())
     }
 
-    //rerun is required to check the #1790 issue
-    @Rerun(times = 2)
     def "Flapping port is brought down only after antiflap warmup and stable port is brought up only after cooldown \
 timeout"() {
         given: "Switch, port and ISL related to that port"
@@ -123,9 +121,6 @@ timeout"() {
      * directly to kafka, because currently it is the only way to simulate an incredibly rapid port flapping that
      * may sometimes occur on hardware switches(overheat?)
      */
-    @Issue("https://github.com/telstra/open-kilda/issues/1827")
-    //there is a possible race condition that we exercise, so this needs couple reruns
-    @Rerun(times = 2)
     def "System properly registers events order when port flaps incredibly fast (end with Up)"() {
 
         when: "Port blinks rapidly for longer than 'antiflapWarmup' seconds, ending in UP state"
@@ -152,9 +147,6 @@ timeout"() {
      * directly to kafka, because currently it is the only way to simulate an incredibly rapid port flapping that
      * may sometimes occur on hardware switches(overheat?)
      */
-    @Issue("https://github.com/telstra/open-kilda/issues/1827")
-    //there is a possible race condition that we exercise, so this needs couple reruns
-    @Rerun(times = 2)
     def "System properly registers events order when port flaps incredibly fast (end with Down)"() {
 
         when: "Port blinks rapidly for longer than 'antiflapWarmup' seconds, ending in DOWN state"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchDeleteSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchDeleteSpec.groovy
@@ -206,13 +206,13 @@ class SwitchDeleteSpec extends BaseSpecification {
         Wrappers.wait(WAIT_OFFSET) { assert northbound.activeSwitches.any { it.switchId == sw.dpId } }
 
         // restore ISLs
-        def allSwIsls = swIsls.collectMany { [it, it.reversed] }
-        allSwIsls.each { northbound.portDown(it.srcSwitch.dpId, it.srcPort) }
-        TimeUnit.SECONDS.sleep(antiflapCooldown)
-        allSwIsls.each { northbound.portUp(it.srcSwitch.dpId, it.srcPort) }
+        swIsls.each { northbound.portDown(it.srcSwitch.dpId, it.srcPort) }
+        TimeUnit.SECONDS.sleep(antiflapMin)
+        swIsls.each { northbound.portUp(it.srcSwitch.dpId, it.srcPort) }
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             def links = northbound.getAllLinks()
-            swIsls.each { assert islUtils.getIslInfo(links, it).get().state == IslChangeType.DISCOVERED }
+            swIsls.collectMany { [it, it.reversed] }
+                  .each { assert islUtils.getIslInfo(links, it).get().state == IslChangeType.DISCOVERED }
         }
         database.resetCosts()
     }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
@@ -49,7 +49,7 @@ class SwitchFailuresSpec extends BaseSpecification {
         islUtils.getIslInfo(isl).get().state == IslChangeType.DISCOVERED
 
         and: "ISL fails after discovery timeout"
-        //TODO(rtretiak): Using big timeout here. This is an abnormal behavior, currently investigating.
+        //TODO(rtretiak): Using big timeout here. This is an abnormal behavior
         Wrappers.wait(untilIslShouldFail() / 1000 + WAIT_OFFSET * 1.5) {
             assert islUtils.getIslInfo(isl).get().state == IslChangeType.FAILED
         }
@@ -91,9 +91,7 @@ class SwitchFailuresSpec extends BaseSpecification {
         then: "The flow is UP and valid"
         Wrappers.wait(WAIT_OFFSET) {
             assert northbound.getFlowStatus(flow.id).status == FlowState.UP
-            northbound.validateFlow(flow.id).each { direction ->
-                assert direction.discrepancies.findAll { it.field != "meterId" }.empty
-            }
+            northbound.validateFlow(flow.id).each { direction -> assert direction.asExpected }
         }
 
         and: "Rules are valid on the knocked out switch"
@@ -136,9 +134,7 @@ class SwitchFailuresSpec extends BaseSpecification {
         then: "The flow is UP and valid"
         Wrappers.wait(WAIT_OFFSET) {
             assert northbound.getFlowStatus(flow.id).status == FlowState.UP
-            northbound.validateFlow(flow.id).each { direction ->
-                assert direction.discrepancies.findAll { it.field != "meterId" }.empty
-            }
+            northbound.validateFlow(flow.id).each { direction -> assert direction.asExpected }
         }
 
         and: "Rules are valid on the knocked out switch"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchValidationSingleSwFlowSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchValidationSingleSwFlowSpec.groovy
@@ -380,6 +380,9 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
             verifyMeterSectionsAreEmpty(switchValidateInfoAfterDelete)
         }
 
+        cleanup:
+        producer && producer.close()
+
         where:
         switchType   | switches
         "Centec"     | getCentecSwitches()

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchValidationSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchValidationSpec.groovy
@@ -48,7 +48,7 @@ class SwitchValidationSpec extends BaseSpecification {
 
     def "Switch validation is able to store correct information on a switch in the 'proper' section"() {
         when: "Create a flow"
-        def (Switch srcSwitch, Switch dstSwitch) = topology.activeSwitches
+        def (Switch srcSwitch, Switch dstSwitch) = topology.activeSwitches.findAll { it.ofVersion != "OF_12" }
         def flow = flowHelper.addFlow(flowHelper.randomFlow(srcSwitch, dstSwitch))
 
         then: "One meter is automatically created on the src and dst switches"
@@ -57,7 +57,7 @@ class SwitchValidationSpec extends BaseSpecification {
         srcSwitchCreatedMeterIds.size() == 1
         dstSwitchCreatedMeterIds.size() == 1
 
-        and: "The correct info is stored in the validate meter response"
+        and: "Validate switch for src and dst contains expected meters data in 'proper' section"
         def srcSwitchValidateInfo = northbound.switchValidate(srcSwitch.dpId)
         def dstSwitchValidateInfo = northbound.switchValidate(dstSwitch.dpId)
         def srcSwitchCreatedCookies = getCookiesWithMeter(srcSwitch.dpId)
@@ -115,7 +115,7 @@ class SwitchValidationSpec extends BaseSpecification {
 
     def "Switch validation is able to detect meter info into the 'misconfigured' section"() {
         when: "Create a flow"
-        def (Switch srcSwitch, Switch dstSwitch) = topology.activeSwitches
+        def (Switch srcSwitch, Switch dstSwitch) = topology.activeSwitches.findAll { it.ofVersion != "OF_12" }
         def flow = flowHelper.addFlow(flowHelper.randomFlow(srcSwitch, dstSwitch))
         def srcSwitchCreatedMeterIds = getCreatedMeterIds(srcSwitch.dpId)
         def dstSwitchCreatedMeterIds = getCreatedMeterIds(dstSwitch.dpId)
@@ -127,9 +127,11 @@ class SwitchValidationSpec extends BaseSpecification {
         database.updateFlowBandwidth(flow.id, newBandwidth)
         //at this point existing meters do not correspond with the flow
 
-        then: "Meters info is moved into the 'misconfigured' section"
+        and: "Validate src and dst switches"
         def srcSwitchValidateInfo = northbound.switchValidate(srcSwitch.dpId)
         def dstSwitchValidateInfo = northbound.switchValidate(dstSwitch.dpId)
+
+        then: "Meters info is moved into the 'misconfigured' section"
         def srcSwitchCreatedCookies = getCookiesWithMeter(srcSwitch.dpId)
         def dstSwitchCreatedCookies = getCookiesWithMeter(dstSwitch.dpId)
 
@@ -203,7 +205,7 @@ class SwitchValidationSpec extends BaseSpecification {
 
     def "Switch validation is able to detect meter info into the 'missing' section"() {
         when: "Create a flow"
-        def (Switch srcSwitch, Switch dstSwitch) = topology.activeSwitches
+        def (Switch srcSwitch, Switch dstSwitch) = topology.activeSwitches.findAll { it.ofVersion != "OF_12" }
         def flow = flowHelper.addFlow(flowHelper.randomFlow(srcSwitch, dstSwitch))
         def srcSwitchCreatedMeterIds = getCreatedMeterIds(srcSwitch.dpId)
         def dstSwitchCreatedMeterIds = getCreatedMeterIds(dstSwitch.dpId)
@@ -276,7 +278,7 @@ class SwitchValidationSpec extends BaseSpecification {
 
     def "Switch validation is able to detect meter info into the 'excess' section"() {
         when: "Create a flow"
-        def (Switch srcSwitch, Switch dstSwitch) = topology.activeSwitches
+        def (Switch srcSwitch, Switch dstSwitch) = topology.activeSwitches.findAll { it.ofVersion != "OF_12" }
         def flow = flowHelper.addFlow(flowHelper.randomFlow(srcSwitch, dstSwitch))
         def srcSwitchCreatedMeterIds = getCreatedMeterIds(srcSwitch.dpId)
         def dstSwitchCreatedMeterIds = getCreatedMeterIds(dstSwitch.dpId)
@@ -359,7 +361,13 @@ class SwitchValidationSpec extends BaseSpecification {
 
     def "Able to get empty switch validate information from the intermediate switch(flow contains > 2 switches)"() {
         given: "Two active not neighboring switches"
-        def switchPair = topologyHelper.getNotNeighboringSwitchPair()
+        def switchPair = topologyHelper.getAllNotNeighboringSwitchPairs().find { pair ->
+            def possibleDefaultPaths = pair.paths.findAll { it.size() == pair.paths.min { it.size() }.size() }
+            //ensure the path won't have only OF_12 intermediate switches
+            !possibleDefaultPaths.find { path ->
+                path[1..-2].every { it.switchId.description.contains("OF_12") }
+            }
+        }
 
         when: "Create an intermediate-switch flow"
         def flow = flowHelper.randomFlow(switchPair)
@@ -367,7 +375,8 @@ class SwitchValidationSpec extends BaseSpecification {
         def flowPath = PathHelper.convert(northbound.getFlowPath(flow.id))
 
         then: "The intermediate switch does not contain any information about meter"
-        def intermediateSwitchValidateInfo = northbound.switchValidate(flowPath[1].switchId)
+        def switchToValidate = flowPath[1..-2].find { !it.switchId.description.contains("OF_12") }
+        def intermediateSwitchValidateInfo = northbound.switchValidate(switchToValidate.switchId)
         verifyMeterSectionsAreEmpty(intermediateSwitchValidateInfo)
 
         and: "Rules are stored in the 'proper' section on the transit switch"
@@ -389,7 +398,14 @@ class SwitchValidationSpec extends BaseSpecification {
 
     def "Switch validate is able to detect rule info into the 'missing' section"() {
         given: "Two active not neighboring switches"
-        def switchPair = topologyHelper.getNotNeighboringSwitchPair()
+        def switchPair = topologyHelper.getAllNotNeighboringSwitchPairs().find { pair ->
+            def possibleDefaultPaths = pair.paths.findAll { it.size() == pair.paths.min { it.size() }.size() }
+            //ensure the path won't have only OF_12 intermediate switches
+            def hasOf13Path = !possibleDefaultPaths.find { path ->
+                path[1..-2].every { it.switchId.description.contains("OF_12") }
+            }
+            hasOf13Path && pair.src.ofVersion != "OF_12" && pair.dst.ofVersion != "OF_12"
+        }
 
         and: "Create an intermediate-switch flow"
         def flow = flowHelper.randomFlow(switchPair)
@@ -413,7 +429,7 @@ class SwitchValidationSpec extends BaseSpecification {
         dstSwitchValidateInfo.rules.proper.containsAll(createdCookies)
         verifyRuleSectionsAreEmpty(dstSwitchValidateInfo, ["missing", "excess"])
         def involvedSwitches = pathHelper.getInvolvedSwitches(flow.id)*.dpId
-        def transitSwitches = involvedSwitches[1..-2]
+        def transitSwitches = involvedSwitches[1..-2].findAll { !it.description.contains("OF_12") }
 
         transitSwitches.each { switchId ->
             def transitSwitchValidateInfo = northbound.switchValidate(switchId)
@@ -430,7 +446,7 @@ class SwitchValidationSpec extends BaseSpecification {
 
         then: "Rule info is moved into the 'missing' section on all involved switches"
         Wrappers.wait(WAIT_OFFSET) {
-            involvedSwitches.each { switchId ->
+            involvedSwitches.findAll { !it.description.contains("OF_12") }.each { switchId ->
                 def involvedSwitchValidateInfo = northbound.switchValidate(switchId)
                 assert involvedSwitchValidateInfo.rules.missing.containsAll(createdCookies)
                 assert involvedSwitchValidateInfo.rules.missing.size() == 2
@@ -443,7 +459,7 @@ class SwitchValidationSpec extends BaseSpecification {
 
         then: "Check that the switch validate request returns empty sections on all involved switches"
         Wrappers.wait(WAIT_OFFSET) {
-            involvedSwitches.each { switchId ->
+            involvedSwitches.findAll { !it.description.contains("OF_12") }.each { switchId ->
                 def switchValidateInfo = northbound.switchValidate(switchId)
                 verifyRuleSectionsAreEmpty(switchValidateInfo)
                 verifyMeterSectionsAreEmpty(switchValidateInfo)
@@ -453,7 +469,14 @@ class SwitchValidationSpec extends BaseSpecification {
 
     def "Switch validate is able to detect rule info in the 'excess' section"() {
         given: "Two active not neighboring switches"
-        def switchPair = topologyHelper.getNotNeighboringSwitchPair()
+        def switchPair = topologyHelper.getAllNotNeighboringSwitchPairs().find { pair->
+            def possibleDefaultPaths = pair.paths.findAll { it.size() == pair.paths.min { it.size() }.size() }
+            //ensure the path won't have only OF_12 intermediate switches
+            def hasOf13Path = !possibleDefaultPaths.find { path ->
+                path[1..-2].every { it.switchId.description.contains("OF_12") }
+            }
+            hasOf13Path && pair.src.ofVersion != "OF_12" && pair.dst.ofVersion != "OF_12"
+        }
 
         and: "Create an intermediate-switch flow"
         def flow = flowHelper.randomFlow(switchPair)
@@ -469,11 +492,11 @@ class SwitchValidationSpec extends BaseSpecification {
         def producer = new KafkaProducer(producerProps)
         //pick a meter id which is not yet used on src switch
         def excessMeterId = ((MIN_FLOW_METER_ID..100) - northbound.getAllMeters(switchPair.dst.dpId)
-                .meterEntries*.meterId).first()
+                                                                  .meterEntries*.meterId).first()
         producer.send(new ProducerRecord(flowTopic, switchPair.dst.dpId.toString(), buildMessage(
                 new InstallEgressFlow(UUID.randomUUID(), flow.id, 1L, switchPair.dst.dpId, 1, 2, 1, 1,
                         OutputVlanType.REPLACE)).toJson()))
-        involvedSwitches[1..-1].each { transitSw ->
+        involvedSwitches[1..-1].findAll { !it.description.contains("OF_12") }.each { transitSw ->
             producer.send(new ProducerRecord(flowTopic, transitSw.toString(), buildMessage(
                     new InstallTransitFlow(UUID.randomUUID(), flow.id, 1L, transitSw, 1, 2, 1)).toJson()))
         }
@@ -489,7 +512,7 @@ class SwitchValidationSpec extends BaseSpecification {
         newCookiesSize == createdCookies.size() + 1
 
         Wrappers.wait(WAIT_OFFSET) {
-            involvedSwitches.each { switchId ->
+            involvedSwitches.findAll { !it.description.contains("OF_12") }.each { switchId ->
                 def involvedSwitchValidateInfo = northbound.switchValidate(switchId)
                 assert involvedSwitchValidateInfo.rules.proper.containsAll(createdCookies)
                 assert involvedSwitchValidateInfo.rules.proper.size() == 2
@@ -510,7 +533,7 @@ class SwitchValidationSpec extends BaseSpecification {
             assert ["KBPS", "BURST", "STATS"].containsAll(it.flags)
             verifyBurstSizeIsCorrect(burstSize, it.burstSize)
         }
-        involvedSwitches[1..-1].each { switchId ->
+        involvedSwitches[1..-1].findAll { !it.description.contains("OF_12") }.each { switchId ->
             assert northbound.switchValidate(switchId).meters.excess.empty
         }
 
@@ -524,7 +547,7 @@ class SwitchValidationSpec extends BaseSpecification {
 
         then: "Check that the switch validate request returns empty sections on all involved switches"
         Wrappers.wait(WAIT_OFFSET) {
-            involvedSwitches.each { switchId ->
+            involvedSwitches.findAll { !it.description.contains("OF_12") }.each { switchId ->
                 def switchValidateInfo = northbound.switchValidate(switchId)
                 verifyRuleSectionsAreEmpty(switchValidateInfo)
                 verifyMeterSectionsAreEmpty(switchValidateInfo)
@@ -556,14 +579,14 @@ class SwitchValidationSpec extends BaseSpecification {
     }
 
     void verifyMeterSectionsAreEmpty(SwitchValidationResult switchValidateInfo,
-                                     List<String> sections = ["missing", "misconfigured", "proper", "excess"]) {
+            List<String> sections = ["missing", "misconfigured", "proper", "excess"]) {
         sections.each {
             assert switchValidateInfo.meters."$it".empty
         }
     }
 
     void verifyRuleSectionsAreEmpty(SwitchValidationResult switchValidateInfo,
-                                    List<String> sections = ["missing", "proper", "excess"]) {
+            List<String> sections = ["missing", "proper", "excess"]) {
         sections.each {
             assert switchValidateInfo.rules."$it".empty
         }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchValidationSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchValidationSpec.groovy
@@ -480,6 +480,7 @@ class SwitchValidationSpec extends BaseSpecification {
         producer.send(new ProducerRecord(flowTopic, switchPair.src.dpId.toString(), buildMessage(
                 new InstallIngressFlow(UUID.randomUUID(), flow.id, 1L, switchPair.src.dpId, 1, 2, 1, 1,
                         OutputVlanType.REPLACE, flow.maximumBandwidth, excessMeterId)).toJson()))
+        producer.flush()
 
         then: "System detects excess rules and store them in the 'excess' section"
         def newCookiesSize = northbound.getSwitchRules(switchPair.src.dpId).flowEntries.findAll {
@@ -529,6 +530,9 @@ class SwitchValidationSpec extends BaseSpecification {
                 verifyMeterSectionsAreEmpty(switchValidateInfo)
             }
         }
+
+        cleanup:
+        producer && producer.close()
     }
 
     @Memoized

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/toggles/FeatureTogglesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/toggles/FeatureTogglesSpec.groovy
@@ -27,7 +27,6 @@ class FeatureTogglesSpec extends BaseSpecification {
 
         then: "Error response is returned, explaining that feature toggle doesn't allow such operation"
         def e = thrown(HttpClientErrorException)
-        //TODO(rtretiak): inappropriate status code. Issue #1920
         e.statusCode == HttpStatus.FORBIDDEN
         e.responseBodyAsString.to(MessageError).errorMessage ==
                 "Could not create flow: Feature toggles not enabled for CREATE_FLOW operation."
@@ -55,7 +54,6 @@ class FeatureTogglesSpec extends BaseSpecification {
 
         then: "Error response is returned, explaining that feature toggle doesn't allow such operation"
         def e = thrown(HttpClientErrorException)
-        //TODO(rtretiak): inappropriate status code. Issue #1920
         e.statusCode == HttpStatus.FORBIDDEN
         e.responseBodyAsString.to(MessageError).errorMessage ==
                 "Could not update flow: Feature toggles not enabled for UPDATE_FLOW operation."
@@ -84,7 +82,6 @@ class FeatureTogglesSpec extends BaseSpecification {
 
         then: "Error response is returned, explaining that feature toggle doesn't allow such operation"
         def e = thrown(HttpClientErrorException)
-        //TODO(rtretiak): inappropriate status code. Issue #1920
         e.statusCode == HttpStatus.FORBIDDEN
         e.responseBodyAsString.to(MessageError).errorMessage ==
                 "Can not delete flow: Feature toggles not enabled for DELETE_FLOW operation."


### PR DESCRIPTION
- Include meterId verification during flow validations on virtual env.
- Add proper waits in order to prevent deleting 'In Progress' flows at
the end of some tests.
- Remove reruns for antiflap tests (feature proven to be stable)
- Some TODOs/Ignores resolved.
- Add missing flush/close calls on kafka producers in multiple places

closes #1865