### PR TITLE
Use virtual/hardware tags instead of assumptions directly in test

### DIFF
--- a/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/extension/TestDataLoggingExtension.groovy
+++ b/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/extension/TestDataLoggingExtension.groovy
@@ -17,14 +17,14 @@ class TestDataLoggingExtension extends AbstractGlobalExtension {
         spec.fixtureMethods*.addInterceptor(new IMethodInterceptor() {
             @Override
             void intercept(IMethodInvocation invocation) throws Throwable {
-                log.debug "Running fixture: ${invocation.spec.name}#${invocation.method.name}"
+                log.debug "Running fixture: ${invocation.spec.nameTagged}#${invocation.method.name}"
                 invocation.proceed()
             }
         })
         spec.allFeatures*.addIterationInterceptor(new IMethodInterceptor() {
             @Override
             void intercept(IMethodInvocation invocation) throws Throwable {
-                log.info "Running test: ${invocation.spec.name}#${invocation.iteration.name}"
+                log.info "Running test: ${invocation.spec.nameTagged}#${invocation.iteration.nameTagged}"
                 invocation.proceed()
             }
         })

--- a/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/extension/env/AssumeProfileExtension.groovy
+++ b/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/extension/env/AssumeProfileExtension.groovy
@@ -1,0 +1,39 @@
+package org.openkilda.functionaltests.extension.env
+
+import org.openkilda.functionaltests.extension.spring.ContextAwareGlobalExtension
+import org.openkilda.functionaltests.extension.tags.Tag
+import org.openkilda.functionaltests.extension.tags.TagExtension
+
+import org.junit.Assume
+import org.spockframework.runtime.extension.IMethodInterceptor
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.SpecInfo
+import org.springframework.beans.factory.annotation.Value
+
+/**
+ * Ensure that virtual test is not getting executed on 'hardware' env and vice-versa.
+ * This is a fallback mechanism and originally testing scope should be leveraged using tags expression.
+ *
+ * @see TagExtension
+ */
+class AssumeProfileExtension extends ContextAwareGlobalExtension {
+
+    @Value('${spring.profiles.active}')
+    String profile
+
+    @Override
+    void visitSpec(SpecInfo spec) {
+        //check before every iteration
+        spec.allFeatures*.getFeatureMethod()*.addInterceptor(new IMethodInterceptor() {
+            @Override
+            void intercept(IMethodInvocation invocation) throws Throwable {
+                def tags = TagExtension.collectAllTags(invocation.iteration)
+                if(tags.contains(Tag.VIRTUAL) || tags.contains(Tag.HARDWARE)) { //if test is profile-dependent
+                    Assume.assumeTrue("This test cannot be executed for current active profile: $profile",
+                            tags*.toString().contains(profile.toUpperCase()))
+                }
+                invocation.proceed()
+            }
+        })
+    }
+}

--- a/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/extension/spring/ContextAwareGlobalExtension.groovy
+++ b/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/extension/spring/ContextAwareGlobalExtension.groovy
@@ -1,0 +1,40 @@
+package org.openkilda.functionaltests.extension.spring
+
+import groovy.util.logging.Slf4j
+import org.spockframework.runtime.extension.AbstractGlobalExtension
+import org.spockframework.runtime.model.SpecInfo
+import org.springframework.context.ApplicationContext
+
+/**
+ * Allows to postpone 'visitSpec' execution until Spring context is actually initialized. Not expected to work if
+ * you are adding setupSpec interceptors.
+ */
+@Slf4j
+abstract class ContextAwareGlobalExtension extends AbstractGlobalExtension implements SpringContextListener {
+    { SpringContextExtension.addListener(this) }
+
+    ApplicationContext context
+    List<Closure> delayedActions = []
+
+    @Override
+    void visitSpec(SpecInfo spec) {
+        if(!context) {
+            log.debug("Register delayed visitSpec action for $spec.name")
+            delayedActions << { delayedVisitSpec(spec) }
+        } else {
+            delayedVisitSpec(spec)
+        }
+    }
+
+    void delayedVisitSpec(SpecInfo spec) { }
+
+    @Override
+    void notifyContextInitialized(ApplicationContext applicationContext) {
+        applicationContext.autowireCapableBeanFactory.autowireBean(this)
+        context = applicationContext
+        if(delayedActions) {
+            log.debug("Execute ${delayedActions.size()} delayed visitSpec actions")
+            delayedActions.each { it.call() }
+        }
+    }
+}

--- a/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/extension/tags/Tag.groovy
+++ b/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/extension/tags/Tag.groovy
@@ -6,16 +6,13 @@ package org.openkilda.functionaltests.extension.tags
  */
 enum Tag {
     //pre-defined sets
-    SMOKE, REGRESSION,
+    SMOKE, REGRESSION, ONDEMAND,
 
     //environments
     HARDWARE, VIRTUAL,
 
-    //regularity
-    ONDEMAND,
-
-    //positiveness
-    POSITIVE, NEGATIVE,
+    //additional markers
+    TOPOLOGY_DEPENDENT, //changing the environment or topology may affect the amount of iterations executed
 
     //speed
     SLOW,//usually for 1minute+ tests

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
@@ -1,9 +1,12 @@
 package org.openkilda.functionaltests.spec.flows
 
 import static org.junit.Assume.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
+import static org.openkilda.functionaltests.extension.tags.Tag.VIRTUAL
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.PathHelper
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.functionaltests.helpers.model.SwitchPair
@@ -89,9 +92,8 @@ class AutoRerouteSpec extends BaseSpecification {
         }
     }
 
+    @Tags(VIRTUAL)
     def "Flow is rerouted when an intermediate switch is disconnected"() {
-        requireProfiles("virtual")
-
         given: "An intermediate-switch flow with one alternative path at least"
         def flow = intermediateSwitchFlow(1)
         flowHelper.addFlow(flow)
@@ -126,9 +128,8 @@ class AutoRerouteSpec extends BaseSpecification {
     }
 
     @Unroll
+    @Tags(VIRTUAL)
     def "Flow goes to 'Down' status when #switchType switch is disconnected (#flowType)"() {
-        requireProfiles("virtual")
-
         given: "#flowType.capitalize()"
         //TODO(ylobankov): Remove this code once the issue #1464 is resolved.
         assumeTrue("Test is skipped because of the issue #1464", switchType != "single")
@@ -167,9 +168,8 @@ class AutoRerouteSpec extends BaseSpecification {
     }
 
     @Unroll
+    @Tags(VIRTUAL)
     def "Flow goes to 'Down' status when an intermediate switch is disconnected and there is no ability to reroute"() {
-        requireProfiles("virtual")
-
         given: "An intermediate-switch flow without alternative paths"
         def (flow, allFlowPaths) = intermediateSwitchFlow(0, true)
         flowHelper.addFlow(flow)
@@ -259,9 +259,8 @@ class AutoRerouteSpec extends BaseSpecification {
         }
     }
 
+    @Tags(VIRTUAL)
     def "Flow in 'Down' status is rerouted when connecting a new switch"() {
-        requireProfiles("virtual")
-
         given: "An intermediate-switch flow with one alternative path at least"
         def (flow, allFlowPaths) = intermediateSwitchFlow(1, true)
         flowHelper.addFlow(flow)
@@ -353,9 +352,8 @@ class AutoRerouteSpec extends BaseSpecification {
         flowHelper.deleteFlow(flow.id)
     }
 
+    @Tags(VIRTUAL)
     def "Flow in 'Up' status is not rerouted when connecting a new switch and more preferable path is available"() {
-        requireProfiles("virtual")
-
         given: "A flow with one alternative path at least"
         def (flow, allFlowPaths) = noIntermediateSwitchFlow(1, true)
         flowHelper.addFlow(flow)
@@ -387,9 +385,8 @@ class AutoRerouteSpec extends BaseSpecification {
         flowHelper.deleteFlow(flow.id)
     }
 
+    @Tags(HARDWARE)
     def "Flow is not rerouted when one of the flow ports goes down"() {
-        requireProfiles("hardware")
-
         given: "An intermediate-switch flow with one alternative path at least"
         def (flow, allFlowPaths) = intermediateSwitchFlow(1, true)
         flowHelper.addFlow(flow)

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
@@ -1,9 +1,11 @@
 package org.openkilda.functionaltests.spec.flows
 
 import static org.junit.Assume.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.TOPOLOGY_DEPENDENT
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.PathHelper
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.functionaltests.helpers.model.SwitchPair
@@ -42,6 +44,7 @@ class FlowCrudSpec extends BaseSpecification {
 
     @Unroll("Valid #data.description has traffic and no rule discrepancies \
 (#flow.source.datapath - #flow.destination.datapath)")
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Valid flow has no rule discrepancies"() {
         given: "A flow"
         def traffExam = traffExamProvider.get()
@@ -190,6 +193,7 @@ class FlowCrudSpec extends BaseSpecification {
     }
 
     @Unroll
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Able to create single switch single port flow with different vlan (#flow.source.datapath)"(FlowPayload flow) {
         given: "A flow"
         flowHelper.addFlow(flow)

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowPingSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowPingSpec.groovy
@@ -2,11 +2,13 @@ package org.openkilda.functionaltests.spec.flows
 
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs
 import static org.junit.Assume.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.TOPOLOGY_DEPENDENT
 import static org.openkilda.testing.Constants.STATS_LOGGING_TIMEOUT
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 import static spock.util.matcher.HamcrestSupport.expect
 
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.info.event.IslChangeType
 import org.openkilda.messaging.info.event.PathNode
@@ -33,6 +35,7 @@ class FlowPingSpec extends BaseSpecification {
     String metricPrefix
 
     @Unroll("Able to ping a flow with vlan between switches #srcSwitch.dpId - #dstSwitch.dpId")
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Able to ping a flow with vlan"(Switch srcSwitch, Switch dstSwitch) {
         given: "A flow with random vlan"
         def flow = flowHelper.randomFlow(srcSwitch, dstSwitch)
@@ -72,6 +75,7 @@ class FlowPingSpec extends BaseSpecification {
     }
 
     @Unroll("Able to ping a flow with no vlan between switches #srcSwitch.dpId - #dstSwitch.dpId")
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Able to ping a flow with no vlan"(Switch srcSwitch, Switch dstSwitch) {
         given: "A flow with no vlan"
         def flow = flowHelper.randomFlow(srcSwitch, dstSwitch)

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/IntentionalRerouteSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/IntentionalRerouteSpec.groovy
@@ -1,10 +1,12 @@
 package org.openkilda.functionaltests.spec.flows
 
 import static org.junit.Assume.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
 import static org.openkilda.testing.Constants.DEFAULT_COST
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.PathHelper
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.info.event.PathNode
@@ -126,10 +128,10 @@ class IntentionalRerouteSpec extends BaseSpecification {
      * Select a longest available path between 2 switches, then reroute to another long path. Run traffexam during the
      * reroute and expect no packet loss.
      */
+    @Tags(HARDWARE)
     def "Intentional flow reroute is not causing any packet loss"() {
         given: "An unmetered flow going through a long not preferable path(reroute potential)"
         //will be available on virtual as soon as we get the latest iperf installed in lab-service images
-        requireProfiles("hardware")
         assumeTrue("There should be at least two active traffgens for test execution",
                 topology.activeTraffGens.size() >= 2)
 

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ThrottlingRerouteSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ThrottlingRerouteSpec.groovy
@@ -1,9 +1,11 @@
 package org.openkilda.functionaltests.spec.flows
 
 import static org.junit.Assume.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.VIRTUAL
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.PathHelper
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.info.event.IslChangeType
@@ -29,15 +31,11 @@ System should stop refreshing the timer if 'reroute.hardtimeout' is reached and 
 for each flowId).
 """)
 @Slf4j
+@Tags(VIRTUAL)
 class ThrottlingRerouteSpec extends BaseSpecification {
 
     @Value('${reroute.hardtimeout}')
     int rerouteHardTimeout
-
-    def setupOnce() {
-        //TODO(rtretiak): unstable on 'hardware' atm, needs investigation
-        requireProfiles("virtual")
-    }
 
     def "Reroute is not performed while new reroutes are being issued"() {
         given: "Multiple flows that can be rerouted independently (use short unique paths)"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/grpc/GrpcBaseSpecification.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/grpc/GrpcBaseSpecification.groovy
@@ -1,10 +1,14 @@
 package org.openkilda.functionaltests.spec.grpc
 
+import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
+
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.messaging.info.event.SwitchInfoData
 
 import spock.lang.Shared
 
+@Tags(HARDWARE)
 class GrpcBaseSpecification extends BaseSpecification{
     @Shared
     String switchIp

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
@@ -1,10 +1,14 @@
 package org.openkilda.functionaltests.spec.links
 
 import static org.junit.Assume.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
+import static org.openkilda.functionaltests.extension.tags.Tag.VIRTUAL
 import static org.openkilda.testing.Constants.NON_EXISTENT_SWITCH_ID
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.tags.IterationTag
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.PathHelper
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.error.MessageError
@@ -174,9 +178,8 @@ class LinkSpec extends BaseSpecification {
         database.resetCosts()
     }
 
+    @Tags(VIRTUAL)
     def "ISL should immediately fail if the port went down while switch was disconnected"() {
-        requireProfiles("virtual")
-
         when: "A switch disconnects"
         def isl = topology.islsForActiveSwitches.find { it.aswitch?.inPort && it.aswitch?.outPort }
         lockKeeper.knockoutSwitch(isl.srcSwitch.dpId)
@@ -293,6 +296,7 @@ class LinkSpec extends BaseSpecification {
     }
 
     @Unroll
+    @IterationTag(tags = [HARDWARE], iterationNameRegex = /bfd link/)
     def "Able to delete an inactive #islDescription link and re-discover it back afterwards"() {
         given: "An inactive link"
         assumeTrue("Unable to locate $islDescription ISL for this test", isl as boolean)
@@ -481,9 +485,8 @@ class LinkSpec extends BaseSpecification {
         getIsl().srcSwitch.dpId | -3               | getIsl().dstSwitch.dpId | -4               | "src_port & dst_port"
     }
 
+    @Tags(VIRTUAL)
     def "Isl is able to properly fail when both src and dst switches suddenly disconnect"() {
-        requireProfiles("virtual")
-
         given: "An ISL under test"
         def isl = topology.islsForActiveSwitches.first()
 

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/StormHeavyLoadSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/StormHeavyLoadSpec.groovy
@@ -1,9 +1,11 @@
 package org.openkilda.functionaltests.spec.resilience
 
 import static groovyx.gpars.GParsPool.withPool
+import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.Message
 import org.openkilda.messaging.info.InfoData
@@ -35,9 +37,8 @@ class StormHeavyLoadSpec extends BaseSpecification {
      * Test produces multiple port up/down messages to the topo.disco kafka topic,
      * expecting that Storm will be able to swallow them and continue to operate.
      */
+    @Tags(HARDWARE)
     def "Storm does not fail under heavy load of topo.disco topic"() {
-        requireProfiles("hardware")
-
         when: "Produce massive amount of messages into topo.disco topic"
         def messages = 100000 //total sum of messages of all types produced
         def operations = 2 //port up, port down

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/StormLcmSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/StormLcmSpec.groovy
@@ -1,9 +1,11 @@
 package org.openkilda.functionaltests.spec.resilience
 
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs
+import static org.openkilda.functionaltests.extension.tags.Tag.VIRTUAL
 import static spock.util.matcher.HamcrestSupport.expect
 
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.messaging.payload.flow.FlowPayload
 
 import com.spotify.docker.client.DefaultDockerClient
@@ -23,6 +25,7 @@ verify their consistency after restart.
  * This test takes quite some time (~10+ minutes) since it redeploys all the storm topologies.
  * Aborting it in the middle of execution may lead to Kilda malfunction.
  */
+@Tags(VIRTUAL)
 class StormLcmSpec extends BaseSpecification {
     private static final String WFM_CONTAINER_NAME = "/wfm"
 

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/OpenTsdbSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/OpenTsdbSpec.groovy
@@ -1,11 +1,14 @@
 package org.openkilda.functionaltests.spec.stats
 
+import static org.openkilda.functionaltests.extension.tags.Tag.TOPOLOGY_DEPENDENT
+import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
+
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.testing.Constants.DefaultRule
 
 import groovy.time.TimeCategory
 import org.springframework.beans.factory.annotation.Value
-import spock.lang.Issue
 import spock.lang.Narrative
 import spock.lang.Shared
 import spock.lang.Unroll
@@ -20,6 +23,7 @@ class OpenTsdbSpec extends BaseSpecification {
     String metricPrefix
 
     @Unroll("Stats are being logged for metric:#metric, tags:#tags")
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Basic stats are being logged"(metric, tags) {
         expect: "At least 1 result in the past 2 minutes"
         otsdb.query(2.minutes.ago, metric, tags).dps.size() > 0
@@ -39,10 +43,9 @@ class OpenTsdbSpec extends BaseSpecification {
                    [[cookieHex: DefaultRule.VERIFICATION_BROADCAST_RULE.toHexString()]]].combinations())
     }
 
+    @Tags(HARDWARE)
     @Unroll("Stats are being logged for metric:#metric, tags:#tags")
     def "Basic stats are being logged (10min interval)"() {
-        requireProfiles("hardware")
-
         expect: "At least 1 result in the past 10 minutes"
         otsdb.query(10.minutes.ago, metric, [:]).dps.size() > 0
         where:

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/MetersSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/MetersSpec.groovy
@@ -2,10 +2,13 @@ package org.openkilda.functionaltests.spec.switches
 
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs
 import static org.junit.Assume.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.TOPOLOGY_DEPENDENT
+import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
 import static org.openkilda.model.MeterId.MAX_SYSTEM_RULE_METER_ID
 import static spock.util.matcher.HamcrestSupport.expect
 
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.error.MessageError
 import org.openkilda.messaging.info.meter.MeterEntry
@@ -36,13 +39,8 @@ class MetersSpec extends BaseSpecification {
     @Value('${burst.coefficient}')
     double burstCoefficient
 
-    def setupOnce() {
-        //TODO: remove as soon as OVS 2.10 + kernel 4.18+ get wired in and meters support will be available
-        // on virtual environments
-        requireProfiles("hardware")
-    }
-
     @Unroll
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Able to delete a meter from a #switchType switch"() {
         assumeTrue("Unable to find required switches in topology", switches as boolean)
 
@@ -74,6 +72,7 @@ class MetersSpec extends BaseSpecification {
     }
 
     @Unroll
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Unable to delete a meter with invalid ID=#meterId on a #switchType switch"() {
         assumeTrue("Unable to find required switches in topology", switches as boolean)
 
@@ -96,9 +95,8 @@ class MetersSpec extends BaseSpecification {
      * Default meters should be set in PKTPS by default in Kilda, but Centec switches only allow KBPS flag.
      * System should recalculate the PKTPS value to KBPS on Centec switches.
      */
+    @Tags(HARDWARE)
     def "Default meters should express bandwidth in kbps re-calculated from pktps on Centec switches"() {
-        requireProfiles("hardware")
-
         setup: "Collect all Centec switches"
         def switches = getCentecSwitches()
         assumeTrue("Unable to find required switches in topology", switches as boolean)
@@ -117,9 +115,8 @@ class MetersSpec extends BaseSpecification {
         }
     }
 
+    @Tags(HARDWARE)
     def "Default meters should express bandwidth in pktps on non-Centec switches"() {
-        requireProfiles("hardware") //TODO: Research how this behaves on OpenVSwitch
-
         given: "All Openflow 1.3 compatible non-Centec switches"
         def switches = getNonCentecSwitches()
         assumeTrue("Unable to find required switches in topology", switches as boolean)
@@ -137,6 +134,7 @@ class MetersSpec extends BaseSpecification {
     }
 
     @Unroll
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Meters are created/deleted when creating/deleting a single-switch flow with ignore_bandwidth=#ignoreBandwidth \
 on a #switchType switch"() {
         assumeTrue("Unable to find required switches in topology", switches as boolean)
@@ -188,6 +186,7 @@ on a #switchType switch"() {
     }
 
     @Unroll
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Meters are not created when creating a single-switch flow with maximum_bandwidth=0 on a #switchType switch"() {
         assumeTrue("Unable to find required switches in topology", switches as boolean)
 
@@ -219,6 +218,7 @@ on a #switchType switch"() {
     }
 
     @Unroll
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Source/destination switches have meters only in flow ingress rule and intermediate switches don't have \
 meters in flow rules at all (#data.flowType flow)"() {
         assumeTrue("Unable to find required switch pair in topology", data.switchPair != null)
@@ -287,9 +287,8 @@ meters in flow rules at all (#data.flowType flow)"() {
     }
 
     @Unroll
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Meter burst size is correctly set on non-Centec switches for #flowRate flow rate"() {
-        requireProfiles("hardware") //TODO: Research how this behaves on OpenVSwitch
-
         setup: "A single-switch flow with #flowRate kbps bandwidth is created on OpenFlow 1.3 compatible switch"
         def switches = getNonCentecSwitches()
         assumeTrue("Unable to find required switches in topology", switches as boolean)
@@ -335,10 +334,9 @@ meters in flow rules at all (#data.flowType flow)"() {
         flowRate << [150, 1000, 1024, 5120, 10240, 2480, 960000]
     }
 
+    @Tags([HARDWARE, TOPOLOGY_DEPENDENT])
     @Unroll("Flow burst should be correctly set on Centec switches in case of #flowRate kbps flow bandwidth")
     def "Flow burst is correctly set on Centec switches"() {
-        requireProfiles("hardware")
-
         setup: "A single-switch flow with #flowRate kbps bandwidth is created on OpenFlow 1.3 compatible Centec switch"
         def switches = getCentecSwitches()
         assumeTrue("Unable to find required switches in topology", switches as boolean)
@@ -392,9 +390,8 @@ meters in flow rules at all (#data.flowType flow)"() {
     }
 
     @Unroll
+    @Tags([TOPOLOGY_DEPENDENT])
     def "System allows to reset meter values to defaults without reinstalling rules for #data.description flow"() {
-        requireProfiles("hardware")
-
         given: "Switches combination (#data.description)"
         assumeTrue("Desired switch combination is not available in current topology", data.switches.size() > 1)
         def (Switch src, Switch dst) = data.switches[0..1]

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchDeleteSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchDeleteSpec.groovy
@@ -1,9 +1,11 @@
 package org.openkilda.functionaltests.spec.switches
 
+import static org.openkilda.functionaltests.extension.tags.Tag.VIRTUAL
 import static org.openkilda.testing.Constants.NON_EXISTENT_SWITCH_ID
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.info.event.IslChangeType
 
@@ -36,9 +38,8 @@ class SwitchDeleteSpec extends BaseSpecification {
         exc.responseBodyAsString.contains("Switch '$switchId' is in 'Active' state")
     }
 
+    @Tags(VIRTUAL)
     def "Unable to delete an inactive switch with active ISLs"() {
-        requireProfiles("virtual")
-
         given: "An inactive switch with ISLs"
         def sw = topology.getActiveSwitches()[0]
         def swIsls = topology.getRelatedIsls(sw)
@@ -66,9 +67,8 @@ class SwitchDeleteSpec extends BaseSpecification {
         }
     }
 
+    @Tags(VIRTUAL)
     def "Unable to delete an inactive switch with inactive ISLs (ISL ports are down)"() {
-        requireProfiles("virtual")
-
         given: "An inactive switch with ISLs"
         def sw = topology.getActiveSwitches()[0]
         def swIsls = topology.getRelatedIsls(sw)
@@ -105,9 +105,8 @@ class SwitchDeleteSpec extends BaseSpecification {
     }
 
     @Unroll
+    @Tags(VIRTUAL)
     def "Unable to delete an inactive switch with a #flowType flow assigned"() {
-        requireProfiles("virtual")
-
         given: "A flow going through a switch"
         flowHelper.addFlow(flow)
 
@@ -134,9 +133,8 @@ class SwitchDeleteSpec extends BaseSpecification {
         "casual"        | getFlowHelper().randomFlow(*getTopology().getActiveSwitches()[0..1])
     }
 
+    @Tags(VIRTUAL)
     def "Able to delete an inactive switch without any ISLs"() {
-        requireProfiles("virtual")
-
         given: "An inactive switch without any ISLs"
         def sw = topology.getActiveSwitches()[0]
         def swIsls = topology.getRelatedIsls(sw)
@@ -177,9 +175,8 @@ class SwitchDeleteSpec extends BaseSpecification {
         database.resetCosts()
     }
 
+    @Tags(VIRTUAL)
     def "Able to delete an active switch with active ISLs if using force delete"() {
-        requireProfiles("virtual")
-
         given: "An active switch with active ISLs"
         def sw = topology.getActiveSwitches()[0]
         def swIsls = topology.getRelatedIsls(sw)

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
@@ -1,9 +1,11 @@
 package org.openkilda.functionaltests.spec.switches
 
 import static org.junit.Assume.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.VIRTUAL
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.PathHelper
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.info.event.IslChangeType
@@ -19,12 +21,8 @@ import java.util.concurrent.TimeUnit
 This spec verifies different situations when Kilda switches suddenly disconnect from the controller.
 Note: For now it is only runnable on virtual env due to no ability to disconnect hardware switches
 """)
+@Tags(VIRTUAL)
 class SwitchFailuresSpec extends BaseSpecification {
-
-    def setupOnce() {
-        requireProfiles("virtual")
-    }
-
     def "ISL is still able to properly fail even after switches were reconnected"() {
         given: "A flow"
         def isl = topology.getIslsForActiveSwitches().find { it.aswitch && it.dstSwitch }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchMaintenanceSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchMaintenanceSpec.groovy
@@ -1,10 +1,12 @@
 package org.openkilda.functionaltests.spec.switches
 
 import static org.junit.Assume.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.VIRTUAL
 import static org.openkilda.testing.Constants.DEFAULT_COST
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.PathHelper
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.error.MessageError
@@ -154,9 +156,8 @@ class SwitchMaintenanceSpec extends BaseSpecification {
 
     // That logic will be reworked to fit new use cases
     @Ignore("Not implemented in new discovery-topology")
+    @Tags(VIRTUAL)
     def "System is correctly handling actions performing on a maintained switch disconnected from the controller"() {
-        requireProfiles("virtual")
-
         given: "An active switch under maintenance disconnected from the controller"
         def sw = topology.activeSwitches.first()
         northbound.setSwitchMaintenance(sw.dpId, true, false)

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchPortConfigSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchPortConfigSpec.groovy
@@ -1,9 +1,12 @@
 package org.openkilda.functionaltests.spec.switches
 
+import static org.openkilda.functionaltests.extension.tags.Tag.TOPOLOGY_DEPENDENT
+import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
 import static org.openkilda.testing.Constants.STATS_LOGGING_TIMEOUT
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.info.event.IslChangeType
 import org.openkilda.testing.model.topology.TopologyDefinition.Isl
@@ -23,6 +26,7 @@ class SwitchPortConfigSpec extends BaseSpecification {
     def otsdbPortDown = 0
 
     @Unroll
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Able to bring ISL-busy port down/up on an #isl.srcSwitch.ofVersion switch(#isl.srcSwitch.dpId)"() {
         when: "Bring port down on the switch"
         def portDownTime = new Date()
@@ -71,8 +75,8 @@ class SwitchPortConfigSpec extends BaseSpecification {
     }
 
     @Unroll
+    @Tags([HARDWARE, TOPOLOGY_DEPENDENT])
     def "Able to bring ISL-free port down/up on an #sw.ofVersion switch(#sw.dpId)"() {
-        requireProfiles("hardware")
         // Not checking OTSDB here, since Kilda won't log into OTSDB for isl-free ports, this is expected.
 
         when: "Bring port down on the switch"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchRulesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchRulesSpec.groovy
@@ -3,6 +3,8 @@ package org.openkilda.functionaltests.spec.switches
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs
 import static org.junit.Assume.assumeFalse
 import static org.junit.Assume.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.TOPOLOGY_DEPENDENT
+import static org.openkilda.functionaltests.extension.tags.Tag.VIRTUAL
 import static org.openkilda.model.MeterId.MIN_FLOW_METER_ID
 import static org.openkilda.testing.Constants.NON_EXISTENT_SWITCH_ID
 import static org.openkilda.testing.Constants.RULES_DELETION_TIME
@@ -11,6 +13,7 @@ import static org.openkilda.testing.Constants.WAIT_OFFSET
 import static spock.util.matcher.HamcrestSupport.expect
 
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.PathHelper
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.command.switches.DeleteRulesAction
@@ -51,6 +54,7 @@ class SwitchRulesSpec extends BaseSpecification {
     }
 
     @Unroll("Default rules are installed on an #sw.ofVersion switch(#sw.dpId)")
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Default rules are installed on switches"() {
         expect: "Default rules are installed on the switch"
         def cookies = northbound.getSwitchRules(sw.dpId).flowEntries*.cookie
@@ -60,9 +64,8 @@ class SwitchRulesSpec extends BaseSpecification {
         sw << uniqueSwitches
     }
 
+    @Tags(VIRTUAL)
     def "Default rules are installed when a new switch is connected"() {
-        requireProfiles("virtual")
-
         given: "A switch with no rules installed and not connected to the controller"
         northbound.deleteSwitchRules(srcSwitch.dpId, DeleteRulesAction.DROP_ALL)
         Wrappers.wait(RULES_DELETION_TIME) { assert northbound.getSwitchRules(srcSwitch.dpId).flowEntries.isEmpty() }
@@ -79,9 +82,8 @@ class SwitchRulesSpec extends BaseSpecification {
         cookies.sort() == srcSwitch.defaultCookies.sort()
     }
 
+    @Tags(VIRTUAL)
     def "Pre-installed rules are not deleted from a new switch connected to the controller"() {
-        requireProfiles("virtual")
-
         given: "A switch with some rules installed (including default) and not connected to the controller"
         def flow = flowHelper.randomFlow(srcSwitch, dstSwitch)
         flowHelper.addFlow(flow)
@@ -114,6 +116,7 @@ class SwitchRulesSpec extends BaseSpecification {
     }
 
     @Unroll
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Able to install default rule on an #sw.ofVersion switch(#sw.dpId, install-action=#data.installRulesAction)"() {
         assumeFalse("Unable to run the test because an OF_12 switch has one broadcast rule as the default",
                 sw.ofVersion == "OF_12" && data.installRulesAction != InstallRulesAction.INSTALL_BROADCAST)
@@ -168,6 +171,7 @@ class SwitchRulesSpec extends BaseSpecification {
     }
 
     @Unroll
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Able to install default rules on an #sw.ofVersion switch(#sw.dpId, install-action=INSTALL_DEFAULTS)"() {
         given: "A switch without any rules"
         def defaultRules = northbound.getSwitchRules(sw.dpId).flowEntries
@@ -253,6 +257,7 @@ class SwitchRulesSpec extends BaseSpecification {
     }
 
     @Unroll
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Able to delete default rule from an #sw.ofVersion switch (#sw.dpId, delete-action=#data.deleteRulesAction)"() {
         assumeFalse("Unable to run the test because an OF_12 switch has one broadcast rule as the default",
                 sw.ofVersion == "OF_12" && data.cookie != Cookie.VERIFICATION_BROADCAST_RULE_COOKIE)

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchValidationSingleSwFlowSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchValidationSingleSwFlowSpec.groovy
@@ -1,12 +1,14 @@
 package org.openkilda.functionaltests.spec.switches
 
 import static org.junit.Assume.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.TOPOLOGY_DEPENDENT
 import static org.openkilda.model.MeterId.MAX_SYSTEM_RULE_METER_ID
 import static org.openkilda.model.MeterId.MIN_FLOW_METER_ID
 import static org.openkilda.testing.Constants.NON_EXISTENT_FLOW_ID
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.SwitchHelper
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.Message
@@ -51,6 +53,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
     SwitchHelper switchHelper
 
     @Unroll
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Switch validation is able to store correct information on a #switchType switch in the 'proper' section"() {
         assumeTrue("Unable to find required switches in topology", switches as boolean)
 
@@ -104,6 +107,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
     }
 
     @Unroll
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Switch validation is able to detect meter info into the 'misconfigured' section on a #switchType switch"() {
         assumeTrue("Unable to find required switches in topology", switches as boolean)
 
@@ -173,6 +177,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
     }
 
     @Unroll
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Switch validation is able to detect meter info into the 'missing' section on a #switchType switch"() {
         assumeTrue("Unable to find required switches in topology", switches as boolean)
 
@@ -224,6 +229,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
     }
 
     @Unroll
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Switch validation is able to detect meter info into the 'excess' section on a #switchType switch"() {
         assumeTrue("Unable to find required switches in topology", switches as boolean)
 
@@ -288,6 +294,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
     }
 
     @Unroll
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Switch validation is able to detect rule info into the 'missing' section on a #switchType switch"() {
         assumeTrue("Unable to find required switches in topology", switches as boolean)
 
@@ -326,6 +333,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
     }
 
     @Unroll
+    @Tags([TOPOLOGY_DEPENDENT])
     def "Switch validation is able to detect rule info into the 'excess' section on a #switchType switch"() {
         assumeTrue("Unable to find required switches in topology", switches as boolean)
 

--- a/services/src/functional-tests/src/test/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
+++ b/services/src/functional-tests/src/test/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
@@ -2,6 +2,7 @@ org.openkilda.functionaltests.extension.spring.SpringContextExtension
 org.openkilda.functionaltests.extension.SkippedTestsLogger
 org.openkilda.functionaltests.extension.fixture.SetupOnceExtension
 org.openkilda.functionaltests.extension.tags.TagExtension
+org.openkilda.functionaltests.extension.env.AssumeProfileExtension
 org.openkilda.functionaltests.extension.env.EnvExtension
 org.openkilda.functionaltests.extension.env.VirtualEnvCleanupExtension
 org.openkilda.functionaltests.extension.env.HardwareEnvCleanupExtension


### PR DESCRIPTION
Add virtual and hardware tags on all related tests. Also add topology_dependent tag on certain tests to tag tests that depend on environment/topology they are running on. The idea is to allow running `tags="hardware and env_dependent"` in the future to reduce time for hardware runs and not retest what is already tested on virtual (at least for minor releases or when limited in time)