### PR TITLE
Use OF groups for discovery process

### DIFF
--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/feature/GroupPacketOutController.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/feature/GroupPacketOutController.java
@@ -1,0 +1,40 @@
+/* Copyright 2019 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.floodlight.feature;
+
+import org.openkilda.messaging.model.SpeakerSwitchView;
+import org.openkilda.messaging.model.SpeakerSwitchView.Feature;
+
+import net.floodlightcontroller.core.IOFSwitch;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Optional;
+
+public class GroupPacketOutController extends AbstractFeature {
+
+    public static final String CENTEC_MANUFACTURED = "Centec";
+
+    @Override
+    public Optional<SpeakerSwitchView.Feature> discover(IOFSwitch sw) {
+        Optional<SpeakerSwitchView.Feature> empty = Optional.empty();
+        if (StringUtils.containsIgnoreCase(
+                sw.getSwitchDescription().getManufacturerDescription(), CENTEC_MANUFACTURED)) {
+            return empty;
+        }
+
+        return Optional.of(Feature.GROUP_PACKET_OUT_CONTROLLER);
+    }
+}

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/service/FeatureDetectorService.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/service/FeatureDetectorService.java
@@ -18,6 +18,7 @@ package org.openkilda.floodlight.service;
 import org.openkilda.floodlight.feature.AbstractFeature;
 import org.openkilda.floodlight.feature.BfdFeature;
 import org.openkilda.floodlight.feature.BfdReviewFeature;
+import org.openkilda.floodlight.feature.GroupPacketOutController;
 import org.openkilda.floodlight.feature.MeterFeature;
 import org.openkilda.messaging.model.SpeakerSwitchView.Feature;
 
@@ -38,7 +39,8 @@ public class FeatureDetectorService implements IService {
         features = ImmutableList.of(
                 new MeterFeature(),
                 new BfdFeature(),
-                new BfdReviewFeature());
+                new BfdReviewFeature(),
+                new GroupPacketOutController());
     }
 
     /**

--- a/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
+++ b/services/src/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
@@ -59,6 +59,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
 import net.floodlightcontroller.core.FloodlightContext;
 import net.floodlightcontroller.core.IFloodlightProviderService;
@@ -73,8 +74,10 @@ import net.floodlightcontroller.restserver.IRestApiService;
 import net.floodlightcontroller.util.FlowModUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.projectfloodlight.openflow.protocol.OFActionType;
 import org.projectfloodlight.openflow.protocol.OFBarrierReply;
 import org.projectfloodlight.openflow.protocol.OFBarrierRequest;
+import org.projectfloodlight.openflow.protocol.OFBucket;
 import org.projectfloodlight.openflow.protocol.OFErrorMsg;
 import org.projectfloodlight.openflow.protocol.OFFactory;
 import org.projectfloodlight.openflow.protocol.OFFlowDelete;
@@ -83,6 +86,12 @@ import org.projectfloodlight.openflow.protocol.OFFlowModFlags;
 import org.projectfloodlight.openflow.protocol.OFFlowStatsEntry;
 import org.projectfloodlight.openflow.protocol.OFFlowStatsReply;
 import org.projectfloodlight.openflow.protocol.OFFlowStatsRequest;
+import org.projectfloodlight.openflow.protocol.OFGroupAdd;
+import org.projectfloodlight.openflow.protocol.OFGroupDelete;
+import org.projectfloodlight.openflow.protocol.OFGroupDescStatsEntry;
+import org.projectfloodlight.openflow.protocol.OFGroupDescStatsReply;
+import org.projectfloodlight.openflow.protocol.OFGroupDescStatsRequest;
+import org.projectfloodlight.openflow.protocol.OFGroupType;
 import org.projectfloodlight.openflow.protocol.OFMessage;
 import org.projectfloodlight.openflow.protocol.OFMeterConfig;
 import org.projectfloodlight.openflow.protocol.OFMeterConfigStatsReply;
@@ -95,6 +104,8 @@ import org.projectfloodlight.openflow.protocol.OFPortDesc;
 import org.projectfloodlight.openflow.protocol.OFPortMod;
 import org.projectfloodlight.openflow.protocol.OFType;
 import org.projectfloodlight.openflow.protocol.action.OFAction;
+import org.projectfloodlight.openflow.protocol.action.OFActionOutput;
+import org.projectfloodlight.openflow.protocol.action.OFActionSetField;
 import org.projectfloodlight.openflow.protocol.action.OFActions;
 import org.projectfloodlight.openflow.protocol.instruction.OFInstructionApplyActions;
 import org.projectfloodlight.openflow.protocol.instruction.OFInstructionMeter;
@@ -121,6 +132,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -152,6 +164,7 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
     public static final int FLOW_PRIORITY = FlowModUtils.PRIORITY_HIGH;
     public static final int BDF_DEFAULT_PORT = 3784;
     public static final int MIN_RATE_IN_KBPS = 64;
+    public static final int ROUND_TRIP_LATENCY_GROUP_ID = 1;
 
     // This is invalid VID mask - it cut of highest bit that indicate presence of VLAN tag on package. But valid mask
     // 0x1FFF lead to rule reject during install attempt on accton based switches.
@@ -774,10 +787,28 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
             }
         }
 
-        logger.debug("Installing verification rule for {}", dpid);
-        ArrayList<OFAction> actionList = new ArrayList<>(3);
-        actionList.add(actionSendToController(sw));
-        actionList.add(actionSetDstMac(sw, dpIdToMac(sw.getId())));
+        ArrayList<OFAction> actionList = new ArrayList<>();
+
+        if (isBroadcast && featureDetectorService.detectSwitch(sw).contains(Feature.GROUP_PACKET_OUT_CONTROLLER)) {
+            logger.debug("Installing round trip latency group actions on switch {}", dpid);
+
+            try {
+                OFGroup group = installRoundTripLatencyGroup(sw);
+                actionList.add(ofFactory.actions().group(group));
+                logger.debug("Round trip latency group was installed on switch {}", dpid);
+            } catch (OfInstallException | UnsupportedOperationException e) {
+                String message = String.format(
+                        "Couldn't install round trip latency group on switch %s. "
+                        + "Standard discovery actions will be installed instead. Error: %s", dpid, e.getMessage());
+                logger.warn(message, e);
+
+                actionList.add(actionSetDstMac(sw, dpIdToMac(sw.getId())));
+                actionList.add(actionSendToController(sw));
+            }
+        } else {
+            actionList.add(actionSendToController(sw));
+            actionList.add(actionSetDstMac(sw, dpIdToMac(sw.getId())));
+        }
 
         long cookie = isBroadcast ? VERIFICATION_BROADCAST_RULE_COOKIE : VERIFICATION_UNICAST_RULE_COOKIE;
         long meterId = createMeterIdForDefaultRule(cookie).getValue();
@@ -794,6 +825,98 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
         String flowname = (isBroadcast) ? "Broadcast" : "Unicast";
         flowname += "--VerificationFlow--" + dpid.toString();
         pushFlow(sw, flowname, flowMod);
+    }
+
+    private OFGroup installRoundTripLatencyGroup(IOFSwitch sw) throws OfInstallException {
+        Optional<OFGroupDescStatsEntry> groupDesc = getGroup(sw, ROUND_TRIP_LATENCY_GROUP_ID);
+
+        if (groupDesc.isPresent()) {
+            if (validateRoundTripLatencyGroup(sw.getId(), groupDesc.get())) {
+                logger.debug("Skip installation of round trip latency group on switch {}. Group exists.", sw.getId());
+                return groupDesc.get().getGroup();
+            } else {
+                logger.debug("Found invalid round trip latency group on switch {}. Need to be deleted.", sw.getId());
+                deleteGroup(sw, ROUND_TRIP_LATENCY_GROUP_ID);
+            }
+        }
+
+        OFGroupAdd groupAdd = getInstallRoundTripLatencyGroupInstruction(sw);
+
+        pushFlow(sw, "--InstallGroup--", groupAdd);
+        sendBarrierRequest(sw);
+
+        return OFGroup.of(ROUND_TRIP_LATENCY_GROUP_ID);
+    }
+
+    private void deleteGroup(IOFSwitch sw, int groupId) throws OfInstallException {
+        OFGroupDelete groupDelete = sw.getOFFactory().buildGroupDelete()
+                .setGroup(OFGroup.of(groupId))
+                .setGroupType(OFGroupType.ALL)
+                .build();
+
+        pushFlow(sw, "--DeleteGroup--", groupDelete);
+        sendBarrierRequest(sw);
+    }
+
+    @VisibleForTesting
+    OFGroupAdd getInstallRoundTripLatencyGroupInstruction(IOFSwitch sw) {
+        OFFactory ofFactory = sw.getOFFactory();
+        List<OFBucket> bucketList = new ArrayList<>();
+        bucketList.add(ofFactory
+                .buildBucket()
+                .setActions(Lists.newArrayList(
+                        actionSetDstMac(sw, dpIdToMac(sw.getId())),
+                        actionSendToController(sw)))
+                .setWatchPort(OFPort.ANY)
+                .setWatchGroup(OFGroup.ANY)
+                .build());
+
+        return ofFactory.buildGroupAdd()
+                .setGroup(OFGroup.of(ROUND_TRIP_LATENCY_GROUP_ID))
+                .setGroupType(OFGroupType.ALL)
+                .setBuckets(bucketList)
+                .build();
+    }
+
+    @VisibleForTesting
+    boolean validateRoundTripLatencyGroup(DatapathId dpId, OFGroupDescStatsEntry groupDesc) {
+        return groupDesc.getBuckets().size() == 1
+                && validateRoundTripSendToControllerBucket(dpId, groupDesc.getBuckets().get(0));
+    }
+
+    private boolean validateRoundTripSendToControllerBucket(DatapathId dpId, OFBucket bucket) {
+        List<OFAction> actions = bucket.getActions();
+        return actions.size() == 2
+                && actions.get(0).getType() == OFActionType.SET_FIELD       // first action is set Dst mac address
+                && dpIdToMac(dpId).equals(((OFActionSetField) actions.get(0)).getField().getValue())
+                && actions.get(1).getType() == OFActionType.OUTPUT          // second action is send to controller
+                && OFPort.CONTROLLER.equals(((OFActionOutput) actions.get(1)).getPort());
+    }
+
+    private List<OFGroupDescStatsEntry> dumpGroups(IOFSwitch sw) {
+        OFFactory ofFactory = sw.getOFFactory();
+        OFGroupDescStatsRequest groupRequest = ofFactory.buildGroupDescStatsRequest().build();
+
+        List<OFGroupDescStatsReply> replies;
+
+        try {
+            ListenableFuture<List<OFGroupDescStatsReply>> future = sw.writeStatsRequest(groupRequest);
+            replies = future.get(10, TimeUnit.SECONDS);
+        } catch (ExecutionException | InterruptedException | TimeoutException e) {
+            logger.error(String.format("Could not dump groups on switch %s.", sw.getId()), e);
+            return Collections.emptyList();
+        }
+
+        return replies.stream()
+                .map(OFGroupDescStatsReply::getEntries)
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
+    }
+
+    private Optional<OFGroupDescStatsEntry> getGroup(IOFSwitch sw, int groupId) {
+        return dumpGroups(sw).stream()
+                .filter(groupDesc -> groupDesc.getGroup().getGroupNumber() == groupId)
+                .findFirst();
     }
 
     /**

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/service/FeatureDetectorServiceTest.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/service/FeatureDetectorServiceTest.java
@@ -16,6 +16,10 @@
 package org.openkilda.floodlight.service;
 
 import static org.easymock.EasyMock.expect;
+import static org.openkilda.messaging.model.SpeakerSwitchView.Feature.BFD;
+import static org.openkilda.messaging.model.SpeakerSwitchView.Feature.BFD_REVIEW;
+import static org.openkilda.messaging.model.SpeakerSwitchView.Feature.GROUP_PACKET_OUT_CONTROLLER;
+import static org.openkilda.messaging.model.SpeakerSwitchView.Feature.METERS;
 
 import org.openkilda.messaging.model.SpeakerSwitchView.Feature;
 
@@ -52,31 +56,37 @@ public class FeatureDetectorServiceTest extends EasyMockSupport {
     @Test
     public void metersCommon() {
         discoveryCheck(makeSwitchMock("Common Inc", "Soft123", OFVersion.OF_13),
-                       ImmutableSet.of(Feature.METERS));
+                       ImmutableSet.of(GROUP_PACKET_OUT_CONTROLLER, METERS));
     }
 
     @Test
     public void metersOf12() {
         discoveryCheck(makeSwitchMock("Common Inc", "Soft123", OFVersion.OF_12),
-                       ImmutableSet.of());
+                       ImmutableSet.of(GROUP_PACKET_OUT_CONTROLLER));
     }
 
     @Test
     public void metersNicira() {
         discoveryCheck(makeSwitchMock("Nicira, Inc.", "Soft123", OFVersion.OF_13),
-                       ImmutableSet.of());
+                       ImmutableSet.of(GROUP_PACKET_OUT_CONTROLLER));
     }
 
     @Test
     public void bfdCommon() {
         discoveryCheck(makeSwitchMock("NoviFlow Inc", "NW400.4.0", OFVersion.OF_13),
-                       ImmutableSet.of(Feature.BFD, Feature.METERS));
+                       ImmutableSet.of(GROUP_PACKET_OUT_CONTROLLER, BFD, METERS));
     }
 
     @Test
     public void bfdReview() {
         discoveryCheck(makeSwitchMock("NoviFlow Inc", "NW400.4.0", OFVersion.OF_14),
-                       ImmutableSet.of(Feature.BFD, Feature.BFD_REVIEW, Feature.METERS));
+                       ImmutableSet.of(GROUP_PACKET_OUT_CONTROLLER, BFD, BFD_REVIEW, METERS));
+    }
+
+    @Test
+    public void roundTripCentec() {
+        discoveryCheck(makeSwitchMock("2004-2016 Centec Networks Inc", "2.8.16.21", OFVersion.OF_13),
+                       ImmutableSet.of(METERS));
     }
 
     private void discoveryCheck(IOFSwitch sw, Set<Feature> expectedFeatures) {

--- a/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerTest.java
+++ b/services/src/floodlight-modules/src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerTest.java
@@ -24,6 +24,7 @@ import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.isA;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -36,6 +37,7 @@ import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
 import static org.hamcrest.core.Every.everyItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.openkilda.floodlight.Constants.inputPort;
 import static org.openkilda.floodlight.Constants.inputVlanId;
 import static org.openkilda.floodlight.Constants.meterId;
@@ -43,7 +45,10 @@ import static org.openkilda.floodlight.Constants.outputPort;
 import static org.openkilda.floodlight.Constants.outputVlanId;
 import static org.openkilda.floodlight.Constants.transitVlanId;
 import static org.openkilda.floodlight.switchmanager.ISwitchManager.OVS_MANUFACTURER;
+import static org.openkilda.floodlight.switchmanager.SwitchManager.ROUND_TRIP_LATENCY_GROUP_ID;
 import static org.openkilda.floodlight.test.standard.PushSchemeOutputCommands.ofFactory;
+import static org.openkilda.messaging.model.SpeakerSwitchView.Feature.BFD;
+import static org.openkilda.messaging.model.SpeakerSwitchView.Feature.GROUP_PACKET_OUT_CONTROLLER;
 import static org.openkilda.model.Cookie.CATCH_BFD_RULE_COOKIE;
 import static org.openkilda.model.Cookie.DROP_RULE_COOKIE;
 import static org.openkilda.model.Cookie.DROP_VERIFICATION_LOOP_RULE_COOKIE;
@@ -60,7 +65,6 @@ import org.openkilda.floodlight.service.FeatureDetectorService;
 import org.openkilda.floodlight.test.standard.OutputCommands;
 import org.openkilda.floodlight.test.standard.ReplaceSchemeOutputCommands;
 import org.openkilda.messaging.command.switches.DeleteRulesCriteria;
-import org.openkilda.messaging.model.SpeakerSwitchView.Feature;
 import org.openkilda.model.OutputVlanType;
 import org.openkilda.model.SwitchId;
 
@@ -68,6 +72,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.sabre.oss.conf4j.factory.jdkproxy.JdkProxyStaticConfigurationFactory;
@@ -86,26 +91,35 @@ import org.junit.Before;
 import org.junit.Test;
 import org.projectfloodlight.openflow.protocol.OFBarrierReply;
 import org.projectfloodlight.openflow.protocol.OFBarrierRequest;
+import org.projectfloodlight.openflow.protocol.OFBucket;
 import org.projectfloodlight.openflow.protocol.OFFlowMod;
 import org.projectfloodlight.openflow.protocol.OFFlowModCommand;
 import org.projectfloodlight.openflow.protocol.OFFlowStatsEntry;
 import org.projectfloodlight.openflow.protocol.OFFlowStatsReply;
 import org.projectfloodlight.openflow.protocol.OFFlowStatsRequest;
+import org.projectfloodlight.openflow.protocol.OFGroupAdd;
+import org.projectfloodlight.openflow.protocol.OFGroupDescStatsEntry;
+import org.projectfloodlight.openflow.protocol.OFGroupDescStatsReply;
+import org.projectfloodlight.openflow.protocol.OFGroupDescStatsRequest;
+import org.projectfloodlight.openflow.protocol.OFGroupType;
 import org.projectfloodlight.openflow.protocol.OFMeterConfig;
 import org.projectfloodlight.openflow.protocol.OFMeterConfigStatsReply;
 import org.projectfloodlight.openflow.protocol.OFMeterConfigStatsRequest;
 import org.projectfloodlight.openflow.protocol.OFMeterFlags;
 import org.projectfloodlight.openflow.protocol.OFMeterMod;
 import org.projectfloodlight.openflow.protocol.OFMeterModCommand;
+import org.projectfloodlight.openflow.protocol.action.OFActionOutput;
+import org.projectfloodlight.openflow.protocol.action.OFActionSetField;
 import org.projectfloodlight.openflow.protocol.match.MatchField;
 import org.projectfloodlight.openflow.protocol.meterband.OFMeterBandDrop;
 import org.projectfloodlight.openflow.types.DatapathId;
+import org.projectfloodlight.openflow.types.OFGroup;
+import org.projectfloodlight.openflow.types.OFPort;
 import org.projectfloodlight.openflow.types.U64;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -172,15 +186,18 @@ public class SwitchManagerTest {
         OFFlowMod catchRule = capture.get(CATCH_BFD_RULE_COOKIE).getValue();
 
         assertEquals(scheme.installDropFlowRule(), dropFlow);
-        assertEquals(scheme.installVerificationBroadcastRule(defaultDpid), verificationBroadcast);
+        assertEquals(scheme.installVerificationBroadcastRule(), verificationBroadcast);
         assertEquals(scheme.installVerificationUnicastRule(defaultDpid), verificationUnicast);
         assertEquals(scheme.installDropLoopRule(defaultDpid), dropLoop);
         assertEquals(scheme.installBfdCatchRule(defaultDpid), catchRule);
     }
 
     private Map<Long, Capture<OFFlowMod>> prepareForDefaultRuleInstall() throws Exception {
-        ListenableFuture<List<OFMeterConfigStatsReply>> ofStatsFuture = mock(ListenableFuture.class);
-        OFMeterConfigStatsReply statsReply = mock(OFMeterConfigStatsReply.class);
+        ListenableFuture<List<OFMeterConfigStatsReply>> ofMeterFuture = mock(ListenableFuture.class);
+        ListenableFuture<List<OFGroupDescStatsReply>> ofGroupFuture = mock(ListenableFuture.class);
+        OFMeterConfigStatsReply meterReply = mock(OFMeterConfigStatsReply.class);
+        OFGroupDescStatsReply groupReply = mock(OFGroupDescStatsReply.class);
+        mockGetGroupsRequest(ImmutableList.of(ROUND_TRIP_LATENCY_GROUP_ID));
         mockGetMetersRequest(ImmutableList.of(meterId), true, 10L);
 
         Capture<OFFlowMod> captureDropFlow = EasyMock.newCapture();
@@ -194,7 +211,8 @@ public class SwitchManagerTest {
         expect(iofSwitch.getOFFactory()).andStubReturn(ofFactory);
         expect(iofSwitch.getId()).andReturn(defaultDpid).times(10);
         expect(iofSwitch.getSwitchDescription()).andStubReturn(switchDescription);
-        expect(iofSwitch.writeStatsRequest(anyObject(OFMeterConfigStatsRequest.class))).andStubReturn(ofStatsFuture);
+        expect(iofSwitch.writeStatsRequest(isA(OFMeterConfigStatsRequest.class))).andStubReturn(ofMeterFuture);
+        expect(iofSwitch.writeStatsRequest(isA(OFGroupDescStatsRequest.class))).andStubReturn(ofGroupFuture);
         expect(iofSwitch.write(capture(captureDropFlow))).andReturn(true).times(1);
         expect(iofSwitch.write(capture(captureVerificationBroadcast))).andReturn(true).times(2);
         expect(iofSwitch.write(capture(captureVerificationUnicast))).andReturn(true).times(2);
@@ -205,16 +223,20 @@ public class SwitchManagerTest {
         expect(iofSwitch.writeRequest(anyObject(OFBarrierRequest.class)))
                 .andReturn(Futures.immediateFuture(createMock(OFBarrierReply.class))).times(2);
 
-        expect(ofStatsFuture.get(anyLong(), anyObject())).andStubReturn(Collections.singletonList(statsReply));
+        expect(ofMeterFuture.get(anyLong(), anyObject())).andStubReturn(Collections.singletonList(meterReply));
+        expect(ofGroupFuture.get(anyLong(), anyObject())).andStubReturn(Collections.singletonList(groupReply));
 
         expect(switchDescription.getManufacturerDescription()).andReturn("").times(8);
-        expect(featureDetectorService.detectSwitch(iofSwitch)).andStubReturn(Collections.singleton(Feature.BFD));
+        expect(featureDetectorService.detectSwitch(iofSwitch)).andStubReturn(
+                Sets.newHashSet(BFD, GROUP_PACKET_OUT_CONTROLLER));
         expectLastCall();
 
         replay(ofSwitchService);
         replay(iofSwitch);
-        replay(ofStatsFuture);
-        replay(statsReply);
+        replay(ofMeterFuture);
+        replay(ofGroupFuture);
+        replay(meterReply);
+        replay(groupReply);
         replay(switchDescription);
         replay(featureDetectorService);
         return ImmutableMap.of(DROP_RULE_COOKIE, captureDropFlow,
@@ -1024,13 +1046,45 @@ public class SwitchManagerTest {
         expect(switchDescription.getManufacturerDescription()).andStubReturn(StringUtils.EMPTY);
         Capture<OFFlowMod> capture = EasyMock.newCapture();
         expect(iofSwitch.write(capture(capture))).andStubReturn(true);
-        expect(featureDetectorService.detectSwitch(iofSwitch)).andReturn(new HashSet<Feature>());
+        expect(featureDetectorService.detectSwitch(iofSwitch))
+                .andReturn(Sets.newHashSet(GROUP_PACKET_OUT_CONTROLLER))
+                .times(2);
         mockBarrierRequest();
         mockGetMetersRequest(Lists.newArrayList(unicastMeterId, broadcastMeterId), true, expectedRate);
+        mockGetGroupsRequest(Lists.newArrayList(ROUND_TRIP_LATENCY_GROUP_ID));
         replay(ofSwitchService, iofSwitch, switchDescription, featureDetectorService);
 
         switchManager.installDefaultRules(iofSwitch.getId());
     }
+
+    @Test
+    public void validateRoundTripLatencyGroup() {
+        OFGroupAdd groupAdd = getOfGroupAddInstruction();
+        assertTrue(runValidateRoundTripLatencyGroup(groupAdd.getBuckets()));
+    }
+
+    private OFGroupAdd getOfGroupAddInstruction() {
+        expect(iofSwitch.getOFFactory()).andStubReturn(ofFactory);
+        expect(iofSwitch.getId()).andStubReturn(dpid);
+        replay(iofSwitch);
+
+        return switchManager.getInstallRoundTripLatencyGroupInstruction(iofSwitch);
+    }
+
+    private boolean runValidateRoundTripLatencyGroup(List<OFBucket> buckets) {
+        return runValidateRoundTripLatencyGroup(ROUND_TRIP_LATENCY_GROUP_ID, buckets);
+    }
+
+    private boolean runValidateRoundTripLatencyGroup(int groupId, List<OFBucket> buckets) {
+        OFGroupDescStatsEntry entry = ofFactory.buildGroupDescStatsEntry()
+                .setGroup(OFGroup.of(groupId))
+                .setGroupType(OFGroupType.ALL)
+                .setBuckets(buckets)
+                .build();
+
+        return switchManager.validateRoundTripLatencyGroup(dpid, entry);
+    }
+
 
     private void mockBarrierRequest() throws InterruptedException, ExecutionException, TimeoutException {
         OFBarrierReply ofBarrierReply = mock(OFBarrierReply.class);
@@ -1067,7 +1121,7 @@ public class SwitchManagerTest {
         expect(ofStatsFuture.get(anyLong(), anyObject())).andStubReturn(singletonList(ofFlowStatsReply));
         replay(ofStatsFuture);
 
-        expect(iofSwitch.writeStatsRequest(anyObject(OFFlowStatsRequest.class))).andReturn(ofStatsFuture);
+        expect(iofSwitch.writeStatsRequest(isA(OFFlowStatsRequest.class))).andReturn(ofStatsFuture);
     }
 
 
@@ -1134,7 +1188,44 @@ public class SwitchManagerTest {
         expect(ofStatsFuture.get(anyLong(), anyObject())).andStubReturn(Collections.singletonList(statsReply));
 
         replay(statsReply, ofStatsFuture);
-        expect(iofSwitch.writeStatsRequest(anyObject(OFMeterConfigStatsRequest.class)))
+        expect(iofSwitch.writeStatsRequest(isA(OFMeterConfigStatsRequest.class)))
                 .andStubReturn(ofStatsFuture);
+    }
+
+    private void mockGetGroupsRequest(List<Integer> groupIds) throws Exception {
+        List<OFGroupDescStatsEntry> meterConfigs = new ArrayList<>(groupIds.size());
+        for (Integer groupId : groupIds) {
+            OFBucket bucket = mock(OFBucket.class);
+
+            OFActionSetField setDestMacAction = ofFactory.actions()
+                    .buildSetField()
+                    .setField(ofFactory.oxms()
+                            .buildEthDst()
+                            .setValue(switchManager.dpIdToMac(dpid))
+                            .build())
+                    .build();
+
+            OFActionOutput sendToControllerAction = ofFactory.actions().output(OFPort.CONTROLLER, 0xFFFFFFFF);
+
+            expect(bucket.getActions()).andStubReturn(
+                    Lists.newArrayList(setDestMacAction, sendToControllerAction));
+
+            OFGroupDescStatsEntry groupEntry = mock(OFGroupDescStatsEntry.class);
+            expect(groupEntry.getGroup()).andStubReturn(OFGroup.of(groupId));
+            expect(groupEntry.getBuckets()).andStubReturn(Lists.newArrayList(bucket));
+
+            replay(bucket, groupEntry);
+            meterConfigs.add(groupEntry);
+        }
+
+        OFGroupDescStatsReply statsReply = mock(OFGroupDescStatsReply.class);
+        expect(statsReply.getEntries()).andStubReturn(meterConfigs);
+
+        ListenableFuture<List<OFGroupDescStatsReply>> ofStatsFuture = mock(ListenableFuture.class);
+        expect(ofStatsFuture.get(anyLong(), anyObject())).andStubReturn(Collections.singletonList(statsReply));
+
+        expect(iofSwitch.writeStatsRequest(isA(OFGroupDescStatsRequest.class)))
+                .andStubReturn(ofStatsFuture);
+        replay(statsReply, ofStatsFuture);
     }
 }

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/model/SpeakerSwitchView.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/model/SpeakerSwitchView.java
@@ -78,6 +78,7 @@ public class SpeakerSwitchView implements Serializable {
     public enum Feature {
         METERS,
         BFD,
-        BFD_REVIEW
+        BFD_REVIEW,
+        GROUP_PACKET_OUT_CONTROLLER
     }
 }


### PR DESCRIPTION
It's a preparation patch for round trip latency feature.
It adds OF group to send discovery packets to the controller

Related to #580

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/2325)
<!-- Reviewable:end -->
