### PR TITLE
REFACTOR: rename method according to internal convention

### DIFF
--- a/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/SwitchHelper.groovy
+++ b/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/SwitchHelper.groovy
@@ -75,6 +75,20 @@ class SwitchHelper {
         northbound.activeSwitches.find { it.switchId == sw }.description
     }
 
+     /**
+     * This method calculates expected burst for different types of switches. The common burst equals to
+     * `rate * burstCoefficient`. There are couple exceptions though:<br>
+     * <b>Noviflow</b>: Does not use our common burst coefficient and overrides it with its own coefficient (see static
+     * variables at the top of the class).<br>
+     * <b>Centec</b>: Follows our burst coefficient policy, except for restrictions for the minimum and maximum burst.
+     * In cases when calculated burst is higher or lower of the Centec max/min - the max/min burst value will be used
+     * instead.
+     *
+     * @param sw switchId where burst is being calculated. Needed to get the switch manufacturer and apply special
+     * calculations if required
+     * @param rate meter rate which is used to calculate burst
+     * @return the expected burst value for given switch and rate
+     */
     def getExpectedBurst(SwitchId sw, long rate) {
         def descr = getDescription(sw).toLowerCase()
         if (descr.contains("noviflow")) {

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchValidationSingleSwFlowSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchValidationSingleSwFlowSpec.groovy
@@ -69,7 +69,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
         meterIds.size() == 2
 
         and: "The correct info is stored in the 'proper' section"
-        def switchValidateInfo = northbound.switchValidate(sw.dpId)
+        def switchValidateInfo = northbound.validateSwitch(sw.dpId)
         switchValidateInfo.meters.proper.collect { it.meterId }.containsAll(meterIds)
 
         def createdCookies = getCookiesWithMeter(sw.dpId)
@@ -95,7 +95,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
 
         then: "Check that the switch validate request returns empty sections"
         Wrappers.wait(WAIT_OFFSET) {
-            def switchValidateInfoAfterDelete = northbound.switchValidate(sw.dpId)
+            def switchValidateInfoAfterDelete = northbound.validateSwitch(sw.dpId)
             verifyRuleSectionsAreEmpty(switchValidateInfoAfterDelete)
             verifyMeterSectionsAreEmpty(switchValidateInfoAfterDelete)
         }
@@ -127,7 +127,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
         //at this point existing meters do not correspond with the flow
 
         then: "Meters info is moved into the 'misconfigured' section"
-        def switchValidateInfo = northbound.switchValidate(sw.dpId)
+        def switchValidateInfo = northbound.validateSwitch(sw.dpId)
         def createdCookies = getCookiesWithMeter(sw.dpId)
         switchValidateInfo.meters.misconfigured.meterId.size() == 2
         switchValidateInfo.meters.misconfigured*.meterId.containsAll(meterIds)
@@ -156,7 +156,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
         database.updateFlowBandwidth(flow.id, flow.maximumBandwidth)
 
         then: "Misconfigured meters are moved into the 'proper' section"
-        def switchValidateInfoRestored = northbound.switchValidate(sw.dpId)
+        def switchValidateInfoRestored = northbound.validateSwitch(sw.dpId)
         switchValidateInfoRestored.meters.proper*.meterId.containsAll(meterIds)
         verifyMeterSectionsAreEmpty(switchValidateInfoRestored, ["missing", "misconfigured", "excess"])
 
@@ -165,7 +165,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
 
         then: "Check that the switch validate request returns empty sections"
         Wrappers.wait(WAIT_OFFSET) {
-            def switchValidateInfoAfterDelete = northbound.switchValidate(sw.dpId)
+            def switchValidateInfoAfterDelete = northbound.validateSwitch(sw.dpId)
             verifyRuleSectionsAreEmpty(switchValidateInfoAfterDelete)
             verifyMeterSectionsAreEmpty(switchValidateInfoAfterDelete)
         }
@@ -194,7 +194,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
 
         then: "Meters info/rules are moved into the 'missing' section"
         Long burstSize = switchHelper.getExpectedBurst(sw.dpId, flow.maximumBandwidth)
-        def switchValidateInfo = northbound.switchValidate(sw.dpId)
+        def switchValidateInfo = northbound.validateSwitch(sw.dpId)
         def createdCookies = getCookiesWithMeter(sw.dpId)
         switchValidateInfo.meters.missing.meterId.size() == 2
         switchValidateInfo.rules.missing.containsAll(createdCookies)
@@ -217,7 +217,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
 
         then: "Check that the switch validate request returns empty sections"
         Wrappers.wait(WAIT_OFFSET) {
-            def switchValidateInfoAfterDelete = northbound.switchValidate(sw.dpId)
+            def switchValidateInfoAfterDelete = northbound.validateSwitch(sw.dpId)
             verifyRuleSectionsAreEmpty(switchValidateInfoAfterDelete)
             verifyMeterSectionsAreEmpty(switchValidateInfoAfterDelete)
         }
@@ -242,7 +242,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
         Long burstSize = switchHelper.getExpectedBurst(sw.dpId, flow.maximumBandwidth)
 
         then: "Rules and meters are created"
-        def swValidateInfo = northbound.switchValidate(sw.dpId)
+        def swValidateInfo = northbound.validateSwitch(sw.dpId)
         swValidateInfo.meters.proper.meterId.size() == 2
         swValidateInfo.rules.proper.size() == 2
 
@@ -251,7 +251,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
         database.updateFlowMeterId(flow.id, newMeterId)
 
         then: "Origin meters are moved into the 'excess' section"
-        def switchValidateInfo = northbound.switchValidate(sw.dpId)
+        def switchValidateInfo = northbound.validateSwitch(sw.dpId)
         switchValidateInfo.meters.excess.meterId.size() == 2
         switchValidateInfo.meters.excess.collect { it.meterId }.containsAll(metersIds)
         switchValidateInfo.meters.excess.each {
@@ -282,7 +282,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
 
         then: "Check that the switch validate request returns empty sections"
         Wrappers.wait(WAIT_OFFSET) {
-            def switchValidateInfoAfterDelete = northbound.switchValidate(sw.dpId)
+            def switchValidateInfoAfterDelete = northbound.validateSwitch(sw.dpId)
             verifyRuleSectionsAreEmpty(switchValidateInfoAfterDelete)
             verifyMeterSectionsAreEmpty(switchValidateInfoAfterDelete)
         }
@@ -309,7 +309,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
         northbound.deleteSwitchRules(sw.dpId, DeleteRulesAction.IGNORE_DEFAULTS)
 
         then: "Rule info is moved into the 'missing' section"
-        def switchValidateInfo = northbound.switchValidate(sw.dpId)
+        def switchValidateInfo = northbound.validateSwitch(sw.dpId)
         switchValidateInfo.rules.missing.containsAll(createdCookies)
 
         and: "The rest fields in the 'rule' section are empty"
@@ -321,7 +321,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
 
         then: "Check that the switch validate request returns empty sections"
         Wrappers.wait(WAIT_OFFSET) {
-            def switchValidateInfoAfterDelete = northbound.switchValidate(sw.dpId)
+            def switchValidateInfoAfterDelete = northbound.validateSwitch(sw.dpId)
             verifyRuleSectionsAreEmpty(switchValidateInfoAfterDelete)
             verifyMeterSectionsAreEmpty(switchValidateInfoAfterDelete)
         }
@@ -339,7 +339,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
 
         setup: "Select a #switchType switch and no meters/rules exist on a switch"
         def sw = switches.first()
-        def switchValidateInfoInitState = northbound.switchValidate(sw.dpId)
+        def switchValidateInfoInitState = northbound.validateSwitch(sw.dpId)
         verifyRuleSectionsAreEmpty(switchValidateInfoInitState)
         verifyMeterSectionsAreEmpty(switchValidateInfoInitState)
 
@@ -364,7 +364,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
         //they will be added after the next line
         def switchValidateInfo
         Wrappers.wait(WAIT_OFFSET) {
-            switchValidateInfo = northbound.switchValidate(sw.dpId)
+            switchValidateInfo = northbound.validateSwitch(sw.dpId)
             //excess egress/ingress/transit rules are added
             switchValidateInfo.rules.excess.size() == 3
         }
@@ -383,7 +383,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
         northbound.deleteSwitchRules(sw.dpId, DeleteRulesAction.IGNORE_DEFAULTS)
         northbound.deleteMeter(sw.dpId, excessMeterId)
         Wrappers.wait(WAIT_OFFSET) {
-            def switchValidateInfoAfterDelete = northbound.switchValidate(sw.dpId)
+            def switchValidateInfoAfterDelete = northbound.validateSwitch(sw.dpId)
             verifyRuleSectionsAreEmpty(switchValidateInfoAfterDelete)
             verifyMeterSectionsAreEmpty(switchValidateInfoAfterDelete)
         }
@@ -403,7 +403,7 @@ class SwitchValidationSingleSwFlowSpec extends BaseSpecification {
         assumeTrue("Unable to find required switches in topology", sw as boolean)
 
         when: "Try to invoke the switch validate request"
-        northbound.switchValidate(sw.dpId)
+        northbound.validateSwitch(sw.dpId)
 
         then: "Human readable error is returned"
         def exc = thrown(HttpClientErrorException)

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchValidationSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchValidationSpec.groovy
@@ -58,8 +58,8 @@ class SwitchValidationSpec extends BaseSpecification {
         dstSwitchCreatedMeterIds.size() == 1
 
         and: "Validate switch for src and dst contains expected meters data in 'proper' section"
-        def srcSwitchValidateInfo = northbound.switchValidate(srcSwitch.dpId)
-        def dstSwitchValidateInfo = northbound.switchValidate(dstSwitch.dpId)
+        def srcSwitchValidateInfo = northbound.validateSwitch(srcSwitch.dpId)
+        def dstSwitchValidateInfo = northbound.validateSwitch(dstSwitch.dpId)
         def srcSwitchCreatedCookies = getCookiesWithMeter(srcSwitch.dpId)
         def dstSwitchCreatedCookies = getCookiesWithMeter(dstSwitch.dpId)
 
@@ -104,8 +104,8 @@ class SwitchValidationSpec extends BaseSpecification {
 
         then: "Check that the switch validate request returns empty sections"
         Wrappers.wait(WAIT_OFFSET) {
-            def srcSwitchValidateInfoAfterDelete = northbound.switchValidate(srcSwitch.dpId)
-            def dstSwitchValidateInfoAfterDelete = northbound.switchValidate(dstSwitch.dpId)
+            def srcSwitchValidateInfoAfterDelete = northbound.validateSwitch(srcSwitch.dpId)
+            def dstSwitchValidateInfoAfterDelete = northbound.validateSwitch(dstSwitch.dpId)
             [srcSwitchValidateInfoAfterDelete, dstSwitchValidateInfoAfterDelete].each {
                 verifyRuleSectionsAreEmpty(it)
                 verifyMeterSectionsAreEmpty(it)
@@ -128,8 +128,8 @@ class SwitchValidationSpec extends BaseSpecification {
         //at this point existing meters do not correspond with the flow
 
         and: "Validate src and dst switches"
-        def srcSwitchValidateInfo = northbound.switchValidate(srcSwitch.dpId)
-        def dstSwitchValidateInfo = northbound.switchValidate(dstSwitch.dpId)
+        def srcSwitchValidateInfo = northbound.validateSwitch(srcSwitch.dpId)
+        def dstSwitchValidateInfo = northbound.validateSwitch(dstSwitch.dpId)
 
         then: "Meters info is moved into the 'misconfigured' section"
         def srcSwitchCreatedCookies = getCookiesWithMeter(srcSwitch.dpId)
@@ -179,8 +179,8 @@ class SwitchValidationSpec extends BaseSpecification {
         database.updateFlowBandwidth(flow.id, flow.maximumBandwidth)
 
         then: "Misconfigured meters are moved into the 'proper' section"
-        def srcSwitchValidateInfoRestored = northbound.switchValidate(srcSwitch.dpId)
-        def dstSwitchValidateInfoRestored = northbound.switchValidate(dstSwitch.dpId)
+        def srcSwitchValidateInfoRestored = northbound.validateSwitch(srcSwitch.dpId)
+        def dstSwitchValidateInfoRestored = northbound.validateSwitch(dstSwitch.dpId)
 
         srcSwitchValidateInfoRestored.meters.proper*.meterId.containsAll(srcSwitchCreatedMeterIds)
         dstSwitchValidateInfoRestored.meters.proper*.meterId.containsAll(dstSwitchCreatedMeterIds)
@@ -194,8 +194,8 @@ class SwitchValidationSpec extends BaseSpecification {
 
         then: "Check that the switch validate request returns empty sections"
         Wrappers.wait(WAIT_OFFSET) {
-            def srcSwitchValidateInfoAfterDelete = northbound.switchValidate(srcSwitch.dpId)
-            def dstSwitchValidateInfoAfterDelete = northbound.switchValidate(dstSwitch.dpId)
+            def srcSwitchValidateInfoAfterDelete = northbound.validateSwitch(srcSwitch.dpId)
+            def dstSwitchValidateInfoAfterDelete = northbound.validateSwitch(dstSwitch.dpId)
             [srcSwitchValidateInfoAfterDelete, dstSwitchValidateInfoAfterDelete].each {
                 verifyRuleSectionsAreEmpty(it)
                 verifyMeterSectionsAreEmpty(it)
@@ -216,7 +216,7 @@ class SwitchValidationSpec extends BaseSpecification {
         northbound.deleteMeter(srcSwitch.dpId, srcSwitchCreatedMeterIds[0])
 
         then: "Meters info/rules are moved into the 'missing' section on the srcSwitch only"
-        def srcSwitchValidateInfo = northbound.switchValidate(srcSwitch.dpId)
+        def srcSwitchValidateInfo = northbound.validateSwitch(srcSwitch.dpId)
         srcSwitchValidateInfo.rules.missing.size() == 1
         srcSwitchValidateInfo.rules.missing == srcSwitchCreatedCookies
         srcSwitchValidateInfo.rules.proper.size() == 1
@@ -241,7 +241,7 @@ class SwitchValidationSpec extends BaseSpecification {
 
         and: "Meters info/rules are NOT moved into the 'missing' section on the dstSwitch"
         def createdCookies = srcSwitchCreatedCookies + dstSwitchCreatedCookies
-        def dstSwitchValidateInfo = northbound.switchValidate(dstSwitch.dpId)
+        def dstSwitchValidateInfo = northbound.validateSwitch(dstSwitch.dpId)
         dstSwitchValidateInfo.rules.proper.size() == 2
         dstSwitchValidateInfo.rules.proper.containsAll(createdCookies)
 
@@ -267,8 +267,8 @@ class SwitchValidationSpec extends BaseSpecification {
 
         then: "Check that the switch validate request returns empty sections"
         Wrappers.wait(WAIT_OFFSET) {
-            def srcSwitchValidateInfoAfterDelete = northbound.switchValidate(srcSwitch.dpId)
-            def dstSwitchValidateInfoAfterDelete = northbound.switchValidate(dstSwitch.dpId)
+            def srcSwitchValidateInfoAfterDelete = northbound.validateSwitch(srcSwitch.dpId)
+            def dstSwitchValidateInfoAfterDelete = northbound.validateSwitch(dstSwitch.dpId)
             [srcSwitchValidateInfoAfterDelete, dstSwitchValidateInfoAfterDelete].each {
                 verifyRuleSectionsAreEmpty(it)
                 verifyMeterSectionsAreEmpty(it)
@@ -288,8 +288,8 @@ class SwitchValidationSpec extends BaseSpecification {
         database.updateFlowMeterId(flow.id, newMeterId)
 
         then: "Origin meters are moved into the 'excess' section on the src and dst switches"
-        def srcSwitchValidateInfo = northbound.switchValidate(srcSwitch.dpId)
-        def dstSwitchValidateInfo = northbound.switchValidate(dstSwitch.dpId)
+        def srcSwitchValidateInfo = northbound.validateSwitch(srcSwitch.dpId)
+        def dstSwitchValidateInfo = northbound.validateSwitch(dstSwitch.dpId)
 
         [srcSwitchValidateInfo, dstSwitchValidateInfo].each {
             assert it.meters.excess.meterId.size() == 1
@@ -349,8 +349,8 @@ class SwitchValidationSpec extends BaseSpecification {
 
         then: "Check that the switch validate request returns empty sections"
         Wrappers.wait(WAIT_OFFSET) {
-            def srcSwitchValidateInfoAfterDelete = northbound.switchValidate(srcSwitch.dpId)
-            def dstSwitchValidateInfoAfterDelete = northbound.switchValidate(dstSwitch.dpId)
+            def srcSwitchValidateInfoAfterDelete = northbound.validateSwitch(srcSwitch.dpId)
+            def dstSwitchValidateInfoAfterDelete = northbound.validateSwitch(dstSwitch.dpId)
             [srcSwitchValidateInfoAfterDelete, dstSwitchValidateInfoAfterDelete].each {
                 verifyRuleSectionsAreEmpty(it)
                 verifyMeterSectionsAreEmpty(it)
@@ -376,7 +376,7 @@ class SwitchValidationSpec extends BaseSpecification {
 
         then: "The intermediate switch does not contain any information about meter"
         def switchToValidate = flowPath[1..-2].find { !it.switchId.description.contains("OF_12") }
-        def intermediateSwitchValidateInfo = northbound.switchValidate(switchToValidate.switchId)
+        def intermediateSwitchValidateInfo = northbound.validateSwitch(switchToValidate.switchId)
         verifyMeterSectionsAreEmpty(intermediateSwitchValidateInfo)
 
         and: "Rules are stored in the 'proper' section on the transit switch"
@@ -389,7 +389,7 @@ class SwitchValidationSpec extends BaseSpecification {
         then: "Check that the switch validate request returns empty sections"
         flowPath.each {
             if (switchHelper.getDescription(it.switchId).contains("OF_13")) {
-                def switchValidateInfo = northbound.switchValidate(it.switchId)
+                def switchValidateInfo = northbound.validateSwitch(it.switchId)
                 verifyMeterSectionsAreEmpty(switchValidateInfo)
                 verifyRuleSectionsAreEmpty(switchValidateInfo)
             }
@@ -420,19 +420,19 @@ class SwitchValidationSpec extends BaseSpecification {
         northbound.deleteSwitchRules(switchPair.src.dpId, DeleteRulesAction.IGNORE_DEFAULTS)
 
         then: "Rule info is moved into the 'missing' section on the srcSwitch"
-        def srcSwitchValidateInfo = northbound.switchValidate(switchPair.src.dpId)
+        def srcSwitchValidateInfo = northbound.validateSwitch(switchPair.src.dpId)
         srcSwitchValidateInfo.rules.missing.containsAll(createdCookies)
         verifyRuleSectionsAreEmpty(srcSwitchValidateInfo, ["proper", "excess"])
 
         and: "Rule info is NOT moved into the 'missing' section on the dstSwitch and transit switches"
-        def dstSwitchValidateInfo = northbound.switchValidate(switchPair.dst.dpId)
+        def dstSwitchValidateInfo = northbound.validateSwitch(switchPair.dst.dpId)
         dstSwitchValidateInfo.rules.proper.containsAll(createdCookies)
         verifyRuleSectionsAreEmpty(dstSwitchValidateInfo, ["missing", "excess"])
         def involvedSwitches = pathHelper.getInvolvedSwitches(flow.id)*.dpId
         def transitSwitches = involvedSwitches[1..-2].findAll { !it.description.contains("OF_12") }
 
         transitSwitches.each { switchId ->
-            def transitSwitchValidateInfo = northbound.switchValidate(switchId)
+            def transitSwitchValidateInfo = northbound.validateSwitch(switchId)
             assert transitSwitchValidateInfo.rules.proper.containsAll(createdCookies)
             assert transitSwitchValidateInfo.rules.proper.size() == 2
             verifyRuleSectionsAreEmpty(transitSwitchValidateInfo, ["missing", "excess"])
@@ -447,7 +447,7 @@ class SwitchValidationSpec extends BaseSpecification {
         then: "Rule info is moved into the 'missing' section on all involved switches"
         Wrappers.wait(WAIT_OFFSET) {
             involvedSwitches.findAll { !it.description.contains("OF_12") }.each { switchId ->
-                def involvedSwitchValidateInfo = northbound.switchValidate(switchId)
+                def involvedSwitchValidateInfo = northbound.validateSwitch(switchId)
                 assert involvedSwitchValidateInfo.rules.missing.containsAll(createdCookies)
                 assert involvedSwitchValidateInfo.rules.missing.size() == 2
                 verifyRuleSectionsAreEmpty(involvedSwitchValidateInfo, ["proper", "excess"])
@@ -460,7 +460,7 @@ class SwitchValidationSpec extends BaseSpecification {
         then: "Check that the switch validate request returns empty sections on all involved switches"
         Wrappers.wait(WAIT_OFFSET) {
             involvedSwitches.findAll { !it.description.contains("OF_12") }.each { switchId ->
-                def switchValidateInfo = northbound.switchValidate(switchId)
+                def switchValidateInfo = northbound.validateSwitch(switchId)
                 verifyRuleSectionsAreEmpty(switchValidateInfo)
                 verifyMeterSectionsAreEmpty(switchValidateInfo)
             }
@@ -513,7 +513,7 @@ class SwitchValidationSpec extends BaseSpecification {
 
         Wrappers.wait(WAIT_OFFSET) {
             involvedSwitches.findAll { !it.description.contains("OF_12") }.each { switchId ->
-                def involvedSwitchValidateInfo = northbound.switchValidate(switchId)
+                def involvedSwitchValidateInfo = northbound.validateSwitch(switchId)
                 assert involvedSwitchValidateInfo.rules.proper.containsAll(createdCookies)
                 assert involvedSwitchValidateInfo.rules.proper.size() == 2
                 verifyRuleSectionsAreEmpty(involvedSwitchValidateInfo, ["missing"])
@@ -525,7 +525,7 @@ class SwitchValidationSpec extends BaseSpecification {
 
         and: "System detects excess meter on the srcSwitch only"
         Long burstSize = switchHelper.getExpectedBurst(switchPair.src.dpId, flow.maximumBandwidth)
-        def validateSwitchInfo = northbound.switchValidate(switchPair.src.dpId)
+        def validateSwitchInfo = northbound.validateSwitch(switchPair.src.dpId)
         assert validateSwitchInfo.meters.excess.size() == 1
         assert validateSwitchInfo.meters.excess.each {
             assert it.rate == flow.maximumBandwidth
@@ -534,7 +534,7 @@ class SwitchValidationSpec extends BaseSpecification {
             verifyBurstSizeIsCorrect(burstSize, it.burstSize)
         }
         involvedSwitches[1..-1].findAll { !it.description.contains("OF_12") }.each { switchId ->
-            assert northbound.switchValidate(switchId).meters.excess.empty
+            assert northbound.validateSwitch(switchId).meters.excess.empty
         }
 
         // TODO(andriidovhan) add synchronizeSwitch and check that rule inflo is moved back into the 'proper' section
@@ -548,7 +548,7 @@ class SwitchValidationSpec extends BaseSpecification {
         then: "Check that the switch validate request returns empty sections on all involved switches"
         Wrappers.wait(WAIT_OFFSET) {
             involvedSwitches.findAll { !it.description.contains("OF_12") }.each { switchId ->
-                def switchValidateInfo = northbound.switchValidate(switchId)
+                def switchValidateInfo = northbound.validateSwitch(switchId)
                 verifyRuleSectionsAreEmpty(switchValidateInfo)
                 verifyMeterSectionsAreEmpty(switchValidateInfo)
             }

--- a/services/src/performance-tests/src/test/groovy/org/openkilda/performancetests/spec/EnduranceSpec.groovy
+++ b/services/src/performance-tests/src/test/groovy/org/openkilda/performancetests/spec/EnduranceSpec.groovy
@@ -83,7 +83,7 @@ idle. Step repeats pre-defined number of times"
                 soft.checkSucceeds { northbound.validateFlow(flow.id).each { assert it.asExpected } }
             }
             topo.switches.each { sw ->
-                def validation = northbound.switchValidate(sw.dpId)
+                def validation = northbound.validateSwitch(sw.dpId)
                 soft.checkSucceeds { assert validation.rules.missing.empty, sw }
                 soft.checkSucceeds { assert validation.rules.excess.empty, sw }
                 soft.checkSucceeds { assert validation.meters.missing.empty, sw }

--- a/services/src/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundService.java
+++ b/services/src/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundService.java
@@ -116,7 +116,7 @@ public interface NorthboundService {
 
     SwitchMeterEntries getAllMeters(SwitchId switchId);
 
-    SwitchValidationResult switchValidate(SwitchId switchId);
+    SwitchValidationResult validateSwitch(SwitchId switchId);
 
     DeleteSwitchResult deleteSwitch(SwitchId switchId, boolean force);
 

--- a/services/src/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundServiceImpl.java
+++ b/services/src/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundServiceImpl.java
@@ -472,7 +472,7 @@ public class NorthboundServiceImpl implements NorthboundService {
     }
 
     @Override
-    public SwitchValidationResult switchValidate(SwitchId switchId) {
+    public SwitchValidationResult validateSwitch(SwitchId switchId) {
         log.debug("Switch validating '{}'", switchId);
         return restTemplate.exchange("/api/v1/switches/{switch_id}/validate", HttpMethod.GET,
                 new HttpEntity(buildHeadersWithCorrelationId()), SwitchValidationResult.class, switchId).getBody();


### PR DESCRIPTION
REFACTOR:

- rename method switchValidate -> validateSwitch;
- remove TODO in the MetersSpec file(allow to run this spec on virt env);
- replace the getExpectedBurst method by helper method in the MetersSpec;
