### PR TITLE
Add functional tests for BFD feature

### DIFF
--- a/services/src/atdd-staging/src/main/java/org/openkilda/atdd/staging/steps/TopologyVerificationSteps.java
+++ b/services/src/atdd-staging/src/main/java/org/openkilda/atdd/staging/steps/TopologyVerificationSteps.java
@@ -113,7 +113,7 @@ public class TopologyVerificationSteps implements En {
                         .flatMap(link -> {
                             //in kilda we have forward and reverse isl, that's why we have to divide into 2
                             Isl pairedLink = Isl.factory(link.getDstSwitch(), link.getDstPort(), link.getSrcSwitch(),
-                                    link.getSrcPort(), link.getMaxBandwidth(), link.getAswitch(), link.isBfd());
+                                    link.getSrcPort(), link.getMaxBandwidth(), link.getAswitch());
                             return Stream.of(link, pairedLink);
                         })
                         .map(IslMatcher::new)

--- a/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/PathHelper.groovy
+++ b/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/PathHelper.groovy
@@ -99,7 +99,7 @@ class PathHelper {
                     topology.isls.collect { it.reversed }.find(matchingIsl) ?:
                             Isl.factory(topology.switches.find { it.dpId == src.switchId }, src.portNo,
                                     topology.switches.find { it.dpId == dst.switchId }, dst.portNo,
-                                    0, null, false)
+                                    0, null)
             involvedIsls << involvedIsl
         }
         return involvedIsls

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/BfdSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/BfdSpec.groovy
@@ -4,41 +4,179 @@ import static org.junit.Assume.assumeTrue
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.tags.Tag
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.info.event.IslChangeType
+import org.openkilda.messaging.model.system.FeatureTogglesDto
 
-import spock.lang.Ignore
+import spock.lang.Narrative
 
+@Narrative("""BFD stands for Bidirectional Forwarding Detection. For now tested only on Noviflow switches. 
+Main purpose is to detect ISL failure on switch level, which should be times faster than a regular 
+controller-involved discovery mechanism""")
+@Tags(Tag.HARDWARE)
 class BfdSpec extends BaseSpecification {
-    @Ignore("Feature pending")
-    def "Interruption in BFD connection instantly leads to ISL failure"() {
-        given: "An ISL through a-switch with a BFD session up"
-        def isl = topology.islsForActiveSwitches.find { it.aswitch?.inPort && it.aswitch?.outPort && it.bfd }
-        assumeTrue("Require at least one a-switch BFD ISL", isl as boolean)
+    
+    def "Able to create a valid BFD session between two Noviflow switches"() {
+        given: "An a-switch ISL between two Noviflow switches"
+        def isl = topology.islsForActiveSwitches.find { it.srcSwitch.noviflow && it.dstSwitch.noviflow &&
+                it.aswitch?.inPort && it.aswitch?.outPort }
+        assumeTrue("Require at least one a-switch BFD ISL between Noviflow switches", isl as boolean)
+
+        when: "Create a BFD session on the ISL"
+        def createBfdResponse = northbound.setLinkBfd(islUtils.toLinkEnableBfd(isl, true))
+
+        then: "Response reports successful installation of the session"
+        createBfdResponse.size() == 1 //TODO(rtretiak): should be '2'. See #2342
+        createBfdResponse.each {
+            assert it.enableBfd
+        }
 
         when: "Interrupt ISL connection by breaking rule on a-switch"
+        def costBeforeFailure = islUtils.getIslInfo(isl).get().cost
         lockKeeper.removeFlows([isl.aswitch])
 
-        then: "ISL immediately gets FAILED"
-        Wrappers.wait(WAIT_OFFSET) {
-            def links = northbound.getAllLinks()
-            assert islUtils.getIslInfo(links, isl).get().state == IslChangeType.FAILED
-            assert islUtils.getIslInfo(links, isl).get().actualState == IslChangeType.FAILED
-            assert islUtils.getIslInfo(links, isl.reversed).get().state == IslChangeType.FAILED
-            assert islUtils.getIslInfo(links, isl.reversed).get().actualState == IslChangeType.FAILED
+        then: "ISL immediately gets failed"
+        Wrappers.wait(WAIT_OFFSET / 2) {
+            assert northbound.getLink(isl).state == IslChangeType.FAILED
+            assert northbound.getLink(isl.reversed).state == IslChangeType.FAILED
         }
+
+        and: "Cost of ISL is unchanged"
+        islUtils.getIslInfo(isl).get().cost == costBeforeFailure
 
         when: "Restore connection"
         lockKeeper.addFlows([isl.aswitch])
 
         then: "ISL is rediscovered"
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            def links = northbound.getAllLinks()
-            assert islUtils.getIslInfo(links, isl).get().state == IslChangeType.DISCOVERED
-            assert islUtils.getIslInfo(links, isl).get().actualState == IslChangeType.DISCOVERED
-            assert islUtils.getIslInfo(links, isl.reversed).get().state == IslChangeType.DISCOVERED
-            assert islUtils.getIslInfo(links, isl.reversed).get().actualState == IslChangeType.DISCOVERED
+            assert northbound.getLink(isl).state == IslChangeType.DISCOVERED
+            assert northbound.getLink(isl.reversed).state == IslChangeType.DISCOVERED
         }
-        database.resetCosts()
+
+        when: "Remove existing BFD session"
+        def removeBfdResponse = northbound.setLinkBfd(islUtils.toLinkEnableBfd(isl, false))
+
+        then: "Response reports successful deletion of the session"
+        removeBfdResponse.size() == 1 //TODO(rtretiak): should be '2'. See #2342
+        removeBfdResponse.each {
+            assert !it.enableBfd
+        }
+
+        when: "Interrupt ISL connection by breaking rule on a-switch"
+        lockKeeper.removeFlows([isl.aswitch])
+
+        then: "ISL does not get failed immediately"
+        Wrappers.timedLoop(discoveryTimeout * 0.8) {
+            assert northbound.getLink(isl).state == IslChangeType.DISCOVERED
+            assert northbound.getLink(isl.reversed).state == IslChangeType.DISCOVERED
+        }
+
+        and: "ISL fails after discovery timeout"
+        Wrappers.wait(discoveryTimeout * 0.2 + WAIT_OFFSET) {
+            assert northbound.getLink(isl).state == IslChangeType.FAILED
+            assert northbound.getLink(isl.reversed).state == IslChangeType.FAILED
+        }
+
+        and: "Cleanup: restore broken ISL"
+        lockKeeper.addFlows([isl.aswitch])
+        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
+            assert northbound.getLink(isl).state == IslChangeType.DISCOVERED
+            assert northbound.getLink(isl.reversed).state == IslChangeType.DISCOVERED
+        }
+    }
+
+    def "Reacting on BFD events can be turned on/off by a feature toggle"() {
+        given: "An a-switch ISL between two Noviflow switches with BFD enabled"
+        def isl = topology.islsForActiveSwitches.find { it.srcSwitch.noviflow && it.dstSwitch.noviflow &&
+                it.aswitch?.inPort && it.aswitch?.outPort }
+        assumeTrue("Require at least one a-switch BFD ISL between Noviflow switches", isl as boolean)
+        northbound.setLinkBfd(islUtils.toLinkEnableBfd(isl, true))
+
+        when: "Set BFD toggle to 'off' state"
+        northbound.toggleFeature(FeatureTogglesDto.builder().useBfdForIslIntegrityCheck(false).build())
+
+        and: "Interrupt ISL connection by breaking rule on a-switch"
+        lockKeeper.removeFlows([isl.aswitch])
+
+        then: "ISL does not get FAILED immediately"
+        Wrappers.timedLoop(discoveryTimeout * 0.8) {
+            assert northbound.getLink(isl).state == IslChangeType.DISCOVERED
+            assert northbound.getLink(isl.reversed).state == IslChangeType.DISCOVERED
+        }
+
+        and: "ISL fails after discovery timeout"
+        Wrappers.wait(discoveryTimeout * 0.2 + WAIT_OFFSET) {
+            assert northbound.getLink(isl).state == IslChangeType.FAILED
+            assert northbound.getLink(isl.reversed).state == IslChangeType.FAILED
+        }
+
+        when: "Set BFD toggle back to 'on' state and restore the ISL"
+        lockKeeper.addFlows([isl.aswitch])
+        northbound.toggleFeature(FeatureTogglesDto.builder().useBfdForIslIntegrityCheck(true).build())
+        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
+            assert northbound.getLink(isl).state == IslChangeType.DISCOVERED
+            assert northbound.getLink(isl.reversed).state == IslChangeType.DISCOVERED
+        }
+
+        and: "Again interrupt ISL connection by breaking rule on a-switch"
+        lockKeeper.removeFlows([isl.aswitch])
+
+        then: "ISL immediately gets failed"
+        Wrappers.wait(WAIT_OFFSET / 2) {
+            assert northbound.getLink(isl).state == IslChangeType.FAILED
+            assert northbound.getLink(isl.reversed).state == IslChangeType.FAILED
+        }
+
+        and: "Cleanup: restore ISL and remove BFD session"
+        lockKeeper.addFlows([isl.aswitch])
+        northbound.setLinkBfd(islUtils.toLinkEnableBfd(isl, false))
+        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
+            assert northbound.getLink(isl).state == IslChangeType.DISCOVERED
+            assert northbound.getLink(isl.reversed).state == IslChangeType.DISCOVERED
+        }
+    }
+
+    def "Deleting a failed BFD link also removes the BFD session from it"() {
+        given: "An inactive a-switch link with BFD session"
+        def isl = topology.islsForActiveSwitches.find { it.srcSwitch.noviflow && it.dstSwitch.noviflow &&
+                it.aswitch?.inPort && it.aswitch?.outPort }
+        assumeTrue("Require at least one a-switch BFD ISL between Noviflow switches", isl as boolean)
+        northbound.portDown(isl.srcSwitch.dpId, isl.srcPort)
+        northbound.setLinkBfd(islUtils.toLinkEnableBfd(isl, true))
+        Wrappers.wait(WAIT_OFFSET) { assert islUtils.getIslInfo(isl).get().state == IslChangeType.FAILED }
+
+        when: "Delete the link"
+        northbound.deleteLink(islUtils.toLinkParameters(isl))
+
+        and: "Discover the removed link again"
+        northbound.portUp(isl.srcSwitch.dpId, isl.srcPort)
+        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
+            assert northbound.getLink(isl).state == IslChangeType.DISCOVERED
+            assert northbound.getLink(isl.reversed).state == IslChangeType.DISCOVERED
+        }
+
+        then: "Discovered link shows no bfd session"
+        !northbound.getLink(isl).enableBfd
+        !northbound.getLink(isl.reversed).enableBfd
+
+        and: "Acts like there is no BFD session (fails only after discovery timeout)"
+        lockKeeper.removeFlows([isl.aswitch])
+        Wrappers.timedLoop(discoveryTimeout * 0.8) {
+            assert northbound.getLink(isl).state == IslChangeType.DISCOVERED
+            assert northbound.getLink(isl.reversed).state == IslChangeType.DISCOVERED
+        }
+        Wrappers.wait(discoveryTimeout * 0.2 + WAIT_OFFSET) {
+            assert northbound.getLink(isl).state == IslChangeType.FAILED
+            assert northbound.getLink(isl.reversed).state == IslChangeType.FAILED
+        }
+
+        and: "Cleanup: restore ISL"
+        lockKeeper.addFlows([isl.aswitch])
+        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
+            assert northbound.getLink(isl).state == IslChangeType.DISCOVERED
+            assert northbound.getLink(isl.reversed).state == IslChangeType.DISCOVERED
+        }
     }
 }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslCostSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslCostSpec.groovy
@@ -116,10 +116,11 @@ class IslCostSpec extends BaseSpecification {
         ]
     }
 
+    //'ISL with BFD session' case is covered in BfdSpec. Spoiler: it should act the same and don't change cost at all.
     def "ISL cost is NOT increased due to failing connection between switches (not port down)"() {
         given: "ISL going through a-switch with link props created"
         def isl = topology.islsForActiveSwitches.find {
-            it.aswitch?.inPort && it.aswitch?.outPort && !it.bfd
+            it.aswitch?.inPort && it.aswitch?.outPort
         } ?: assumeTrue("Wasn't able to find suitable ISL", false)
         def isls = northbound.getAllLinks()
         int islCost = islUtils.getIslInfo(isls, isl).get().cost

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
@@ -29,7 +29,7 @@ class LinkSpec extends BaseSpecification {
     def "Link (not BFD) status is properly changed when link connectivity is broken (not port down)"() {
         given: "A link going through a-switch"
         def isl = topology.islsForActiveSwitches.find {
-            it.aswitch?.inPort && it.aswitch?.outPort && !it.bfd
+            it.aswitch?.inPort && it.aswitch?.outPort
         } ?: assumeTrue("Wasn't able to find suitable link", false)
 
         double interval = discoveryTimeout * 0.2
@@ -324,11 +324,9 @@ class LinkSpec extends BaseSpecification {
 
         where:
         [islDescription, isl] << [
-                ["direct", getTopology().islsForActiveSwitches.find { !it.aswitch && !it.bfd }],
+                ["direct", getTopology().islsForActiveSwitches.find { !it.aswitch }],
                 ["a-switch", getTopology().islsForActiveSwitches.find {
-                    it.aswitch?.inPort && it.aswitch?.outPort && !it.bfd
-                }],
-                ["bfd", getTopology().islsForActiveSwitches.find { it.bfd }]
+                    it.aswitch?.inPort && it.aswitch?.outPort }]
         ]
     }
 

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/toggles/FeatureTogglesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/toggles/FeatureTogglesSpec.groovy
@@ -12,7 +12,8 @@ Feature Toggles is a special lever that allows to turn on/off certain Kilda feat
 creation of new flows via Northbound API. This spec verifies that Feature Toggle restrictions are applied correctly.
 """)
 /*Note that the 'flowReroute' toggle is tested under AutoRerouteSpec#"Flow goes to 'Down' status when an intermediate
-switch is disconnected and there is no ability to reroute"*/
+switch is disconnected and there is no ability to reroute".
+BFD toggle is tested in BfdSpec*/
 class FeatureTogglesSpec extends BaseSpecification {
     def "System forbids creating new flows when 'create_flow' toggle is set to false"() {
         given: "Existing flow"

--- a/services/src/performance-tests/src/main/groovy/org/openkilda/performancetests/model/CustomTopology.groovy
+++ b/services/src/performance-tests/src/main/groovy/org/openkilda/performancetests/model/CustomTopology.groovy
@@ -34,7 +34,7 @@ class CustomTopology extends TopologyDefinition {
         def dstPorts = getAllowedPortsForSwitch(dst)
         assert srcPorts, "Not enough free ports on switch $src.dpId"
         assert dstPorts, "Not enough free ports on switch $dst.dpId"
-        def isl = Isl.factory(src, srcPorts[0], dst, dstPorts[0], 1000000L, null, false)
+        def isl = Isl.factory(src, srcPorts[0], dst, dstPorts[0], 1000000L, null)
         isls << isl
         return isl
     }

--- a/services/src/test-library/src/main/java/org/openkilda/testing/model/topology/TopologyDefinition.java
+++ b/services/src/test-library/src/main/java/org/openkilda/testing/model/topology/TopologyDefinition.java
@@ -308,7 +308,6 @@ public class TopologyDefinition {
         private int dstPort;
         private long maxBandwidth;
         private ASwitchFlow aswitch;
-        private boolean isBfd;
 
         @JsonCreator
         public static Isl factory(
@@ -317,10 +316,8 @@ public class TopologyDefinition {
                 @JsonProperty("dst_switch") Switch dstSwitch,
                 @JsonProperty("dst_port") int dstPort,
                 @JsonProperty("max_bandwidth") long maxBandwidth,
-                @JsonProperty("a_switch") ASwitchFlow aswitch,
-                //we only assume bi-directional bfd sessions for ISLs
-                @JsonProperty("bfd") boolean isBfd) {
-            return new Isl(srcSwitch, srcPort, dstSwitch, dstPort, maxBandwidth, aswitch, isBfd);
+                @JsonProperty("a_switch") ASwitchFlow aswitch) {
+            return new Isl(srcSwitch, srcPort, dstSwitch, dstPort, maxBandwidth, aswitch);
         }
 
         @Override
@@ -342,7 +339,7 @@ public class TopologyDefinition {
                 reversedAsw = this.getAswitch().getReversed();
             }
             return Isl.factory(this.getDstSwitch(), this.getDstPort(), this.getSrcSwitch(),
-                    this.getSrcPort(), this.getMaxBandwidth(), reversedAsw, this.isBfd());
+                    this.getSrcPort(), this.getMaxBandwidth(), reversedAsw);
         }
     }
 

--- a/services/src/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundService.java
+++ b/services/src/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundService.java
@@ -38,6 +38,7 @@ import org.openkilda.northbound.dto.v1.flows.FlowValidationDto;
 import org.openkilda.northbound.dto.v1.flows.PingInput;
 import org.openkilda.northbound.dto.v1.flows.PingOutput;
 import org.openkilda.northbound.dto.v1.links.LinkDto;
+import org.openkilda.northbound.dto.v1.links.LinkEnableBfdDto;
 import org.openkilda.northbound.dto.v1.links.LinkMaxBandwidthDto;
 import org.openkilda.northbound.dto.v1.links.LinkParametersDto;
 import org.openkilda.northbound.dto.v1.links.LinkPropsDto;
@@ -49,6 +50,7 @@ import org.openkilda.northbound.dto.v1.switches.RulesSyncResult;
 import org.openkilda.northbound.dto.v1.switches.RulesValidationResult;
 import org.openkilda.northbound.dto.v1.switches.SwitchDto;
 import org.openkilda.northbound.dto.v1.switches.SwitchValidationResult;
+import org.openkilda.testing.model.topology.TopologyDefinition.Isl;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -137,6 +139,8 @@ public interface NorthboundService {
 
     List<IslInfoData> getAllLinks();
 
+    IslInfoData getLink(Isl isl);
+
     List<IslInfoData> getLinks(SwitchId srcSwitch, Integer srcPort, SwitchId dstSwitch, Integer dstPort);
 
     List<LinkPropsDto> getAllLinkProps();
@@ -157,6 +161,8 @@ public interface NorthboundService {
 
     LinkMaxBandwidthDto updateLinkMaxBandwidth(SwitchId srcSwitch, Integer srcPort, SwitchId dstSwitch, Integer dstPort,
                                                Long linkMaxBandwidth);
+
+    List<LinkDto> setLinkBfd(LinkEnableBfdDto link);
 
     //feature toggles
 

--- a/services/src/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundServiceImpl.java
+++ b/services/src/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundServiceImpl.java
@@ -45,6 +45,7 @@ import org.openkilda.northbound.dto.v1.flows.FlowValidationDto;
 import org.openkilda.northbound.dto.v1.flows.PingInput;
 import org.openkilda.northbound.dto.v1.flows.PingOutput;
 import org.openkilda.northbound.dto.v1.links.LinkDto;
+import org.openkilda.northbound.dto.v1.links.LinkEnableBfdDto;
 import org.openkilda.northbound.dto.v1.links.LinkMaxBandwidthDto;
 import org.openkilda.northbound.dto.v1.links.LinkMaxBandwidthRequest;
 import org.openkilda.northbound.dto.v1.links.LinkParametersDto;
@@ -58,6 +59,7 @@ import org.openkilda.northbound.dto.v1.switches.RulesValidationResult;
 import org.openkilda.northbound.dto.v1.switches.SwitchDto;
 import org.openkilda.northbound.dto.v1.switches.SwitchValidationResult;
 import org.openkilda.northbound.dto.v1.switches.UnderMaintenanceDto;
+import org.openkilda.testing.model.topology.TopologyDefinition.Isl;
 
 import com.google.common.collect.ImmutableMap;
 import lombok.extern.slf4j.Slf4j;
@@ -315,6 +317,12 @@ public class NorthboundServiceImpl implements NorthboundService {
     }
 
     @Override
+    public IslInfoData getLink(Isl isl) {
+        return getLinks(isl.getSrcSwitch().getDpId(), isl.getSrcPort(), isl.getDstSwitch().getDpId(),
+                isl.getDstPort()).get(0);
+    }
+
+    @Override
     public List<IslInfoData> getLinks(SwitchId srcSwitch, Integer srcPort, SwitchId dstSwitch, Integer dstPort) {
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString("/api/v1/links");
         if (srcSwitch != null) {
@@ -451,6 +459,15 @@ public class NorthboundServiceImpl implements NorthboundService {
         return restTemplate.exchange(uriBuilder.build().toString(), HttpMethod.PATCH,
                 new HttpEntity<>(new LinkMaxBandwidthRequest(linkMaxBandwidth), buildHeadersWithCorrelationId()),
                 LinkMaxBandwidthDto.class).getBody();
+    }
+
+    @Override
+    public List<LinkDto> setLinkBfd(LinkEnableBfdDto link) {
+        log.debug("Changing bfd status to '%s' for link %s:%s-%s:%s", link.isEnableBfd(), link.getSrcSwitch(),
+                link.getSrcPort(), link.getDstSwitch(), link.getDstPort());
+        LinkDto[] updatedLinks = restTemplate.exchange("api/v1/links/enable-bfd", HttpMethod.PATCH,
+                new HttpEntity<>(link, buildHeadersWithCorrelationId()), LinkDto[].class).getBody();
+        return Arrays.asList(updatedLinks);
     }
 
     @Override

--- a/services/src/test-library/src/main/java/org/openkilda/testing/tools/IslUtils.java
+++ b/services/src/test-library/src/main/java/org/openkilda/testing/tools/IslUtils.java
@@ -23,6 +23,7 @@ import static org.hamcrest.core.Every.everyItem;
 import org.openkilda.messaging.info.event.IslChangeType;
 import org.openkilda.messaging.info.event.IslInfoData;
 import org.openkilda.messaging.info.event.PathNode;
+import org.openkilda.northbound.dto.v1.links.LinkEnableBfdDto;
 import org.openkilda.northbound.dto.v1.links.LinkParametersDto;
 import org.openkilda.northbound.dto.v1.links.LinkPropsDto;
 import org.openkilda.northbound.dto.v1.links.LinkUnderMaintenanceDto;
@@ -147,6 +148,11 @@ public class IslUtils {
                 evacuate);
     }
 
+    public LinkEnableBfdDto toLinkEnableBfd(Isl isl, boolean bfd) {
+        return new LinkEnableBfdDto(isl.getSrcSwitch().getDpId().toString(), isl.getSrcPort(),
+                isl.getDstSwitch().getDpId().toString(), isl.getDstPort(), bfd);
+    }
+
     /**
      * Simulates a physical ISL replug from one switch-port to another switch-port. Uses a-switch.
      *
@@ -183,7 +189,7 @@ public class IslUtils {
                 replugSource ? (plugIntoSource ? dstIsl.getSrcPort() : dstIsl.getDstPort()) : srcIsl.getSrcPort(),
                 replugSource ? srcIsl.getDstSwitch() : (plugIntoSource ? dstIsl.getSrcSwitch() : dstIsl.getDstSwitch()),
                 replugSource ? srcIsl.getDstPort() : (plugIntoSource ? dstIsl.getSrcPort() : dstIsl.getDstPort()),
-                0, aswFlowForward, srcIsl.isBfd());
+                0, aswFlowForward);
     }
 
     private RetryPolicy retryPolicy() {


### PR DESCRIPTION
Also remove 'bfd' flag from TopologyDefinition and topology.yaml. Now by default we assume NO bfd sessions in the system. Any BFD session is created on demand.
New pre-condition: all switches should have proper virtual ports created beforehand.