### PR TITLE
Fix orphan meter resources

### DIFF
--- a/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jSwitchRepository.java
+++ b/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jSwitchRepository.java
@@ -84,8 +84,13 @@ public class Neo4jSwitchRepository extends Neo4jGenericRepository<Switch> implem
 
     @Override
     public void forceDelete(SwitchId switchId) {
-        getSession().query("MATCH (sw:switch {name: $name}) DETACH DELETE sw",
-                ImmutableMap.of("name", switchId.toString()));
+        transactionManager.doInTransaction(() -> {
+            getSession().query("MATCH (:switch {name: $name})-[]-(n:flow_meter) DETACH DELETE n",
+                    ImmutableMap.of("name", switchId.toString()));
+
+            getSession().query("MATCH (sw:switch {name: $name}) DETACH DELETE sw",
+                    ImmutableMap.of("name", switchId.toString()));
+        });
     }
 
     @Override


### PR DESCRIPTION
Forced switch removal must cause deallocation of related resources.

The changes:
- Make SwitchRepository.forceDelete deleting related flow_meters.