### PR TITLE
Use same transit VLAN for paths in both directions

### DIFF
--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
@@ -448,6 +448,12 @@ class ProtectedPathSpec extends BaseSpecification {
         then: "Flow is created with protected path"
         northbound.getFlowPath(flow.id).protectedPath
 
+        and: "One transit vlan is created for main and protected paths"
+        //TODO(andriidovhan) rewrite when new implementation of the getFlow method is merged
+        //and compare transitVlan for protected path
+        def flowInfo = database.getFlow(flow.id)
+        flowInfo.left.transitVlan == flowInfo.right.transitVlan
+
         and: "Cleanup: delete the flow and restore available bandwidth"
         flowHelper.deleteFlow(flow.id)
         isls.each { database.resetIslBandwidth(it) }

--- a/services/src/kilda-core/kilda-model/src/main/java/org/openkilda/model/Flow.java
+++ b/services/src/kilda-core/kilda-model/src/main/java/org/openkilda/model/Flow.java
@@ -355,6 +355,23 @@ public class Flow implements Serializable {
         return path;
     }
 
+    /**
+     * Return opposite pathId to passed pathId.
+     */
+    public PathId getOppositePathId(@NonNull PathId pathId) {
+        if (pathId.equals(forwardPathId)) {
+            return reversePathId;
+        } else if (pathId.equals(reversePathId)) {
+            return forwardPathId;
+        } else if (pathId.equals(protectedForwardPathId)) {
+            return protectedReversePathId;
+        } else if (pathId.equals(protectedReversePathId)) {
+            return protectedForwardPathId;
+        } else {
+            throw new IllegalArgumentException(String.format("Flow %s does not have path pathId=%s", flowId, pathId));
+        }
+    }
+
     public List<PathId> getFlowPathIds() {
         return paths.stream().map(FlowPath::getPathId).collect(Collectors.toList());
     }

--- a/services/src/kilda-core/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/TransitVlanRepository.java
+++ b/services/src/kilda-core/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/TransitVlanRepository.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 import java.util.Optional;
 
 public interface TransitVlanRepository extends Repository<TransitVlan> {
-    Collection<TransitVlan> findByPathId(PathId pathId);
+    Collection<TransitVlan> findByPathId(PathId pathId, PathId oppositePathId);
 
     /**
      * Find a transit vlan which is not assigned to any flow.

--- a/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jFlowPairRepository.java
+++ b/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jFlowPairRepository.java
@@ -56,10 +56,10 @@ public class Neo4jFlowPairRepository implements FlowPairRepository {
     }
 
     private FlowPair toFlowPair(Flow flow) {
-        TransitVlan forwardTransitVlan = transitVlanRepository.findByPathId(flow.getForwardPathId()).stream()
-                .findAny().orElse(null);
-        TransitVlan reverseTransitVlan = transitVlanRepository.findByPathId(flow.getReversePathId()).stream()
-                .findAny().orElse(null);
+        TransitVlan forwardTransitVlan = transitVlanRepository.findByPathId(
+                flow.getForwardPathId(), flow.getReversePathId()).stream().findAny().orElse(null);
+        TransitVlan reverseTransitVlan = transitVlanRepository.findByPathId(
+                flow.getReversePathId(), flow.getForwardPathId()).stream().findAny().orElse(null);
 
         return new FlowPair(flow, forwardTransitVlan, reverseTransitVlan);
     }

--- a/services/wfm/src/main/java/org/openkilda/wfm/share/flow/resources/EncapsulationResourcesProvider.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/share/flow/resources/EncapsulationResourcesProvider.java
@@ -26,7 +26,7 @@ public interface EncapsulationResourcesProvider<T extends EncapsulationResources
      *
      * @return allocated resources.
      */
-    T allocate(Flow flow, PathId pathId) throws ResourceNotAvailableException;
+    T allocate(Flow flow, PathId pathId, PathId oppositePathId) throws ResourceNotAvailableException;
 
     /**
      * Deallocates flow encapsulation resources of the path.
@@ -36,5 +36,5 @@ public interface EncapsulationResourcesProvider<T extends EncapsulationResources
     /**
      * Get allocated encapsulation resources of the flow path.
      */
-    Optional<T> get(PathId pathId);
+    Optional<T> get(PathId pathId, PathId oppositePathId);
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/share/flow/resources/FlowResourcesManager.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/share/flow/resources/FlowResourcesManager.java
@@ -130,10 +130,10 @@ public class FlowResourcesManager {
             EncapsulationResourcesProvider encapsulationResourcesProvider =
                     getEncapsulationResourcesProvider(flow.getEncapsulationType());
             forward.encapsulationResources(
-                    encapsulationResourcesProvider.allocate(flow, forwardPathId));
+                    encapsulationResourcesProvider.allocate(flow, forwardPathId, reversePathId));
 
             reverse.encapsulationResources(
-                    encapsulationResourcesProvider.allocate(flow, reversePathId));
+                    encapsulationResourcesProvider.allocate(flow, reversePathId, forwardPathId));
         }
 
         return FlowResources.builder()
@@ -201,7 +201,8 @@ public class FlowResourcesManager {
      * Get allocated encapsulation resources of the flow path.
      */
     public Optional<EncapsulationResources> getEncapsulationResources(PathId pathId,
+                                                                      PathId oppositePathId,
                                                                       FlowEncapsulationType encapsulationType) {
-        return getEncapsulationResourcesProvider(encapsulationType).get(pathId);
+        return getEncapsulationResourcesProvider(encapsulationType).get(pathId, oppositePathId);
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/service/BaseFlowService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/service/BaseFlowService.java
@@ -67,8 +67,8 @@ public class BaseFlowService {
                 .collect(Collectors.toList());
     }
 
-    protected TransitVlan findTransitVlan(PathId pathId) {
-        return transitVlanRepository.findByPathId(pathId).stream()
+    protected TransitVlan findTransitVlan(PathId pathId, PathId oppositePathId) {
+        return transitVlanRepository.findByPathId(pathId, oppositePathId).stream()
                 .findAny().orElse(null);
     }
 
@@ -81,18 +81,20 @@ public class BaseFlowService {
                             .reversePath(flow.getReversePath())
                             //TODO: hard-coded encapsulation will be removed in Flow H&S
                             .forwardEncapsulation(TransitVlanEncapsulation.builder()
-                                    .transitVlan(findTransitVlan(flow.getForwardPathId()))
+                                    .transitVlan(findTransitVlan(flow.getForwardPathId(), flow.getReversePathId()))
                                     .build())
                             .reverseEncapsulation(TransitVlanEncapsulation.builder()
-                                    .transitVlan(findTransitVlan(flow.getReversePathId()))
+                                    .transitVlan(findTransitVlan(flow.getReversePathId(), flow.getForwardPathId()))
                                     .build())
                             .protectedForwardPath(flow.getProtectedForwardPath())
                             .protectedReversePath(flow.getProtectedReversePath())
                             .protectedForwardEncapsulation(TransitVlanEncapsulation.builder()
-                                    .transitVlan(findTransitVlan(flow.getProtectedForwardPathId()))
+                                    .transitVlan(findTransitVlan(flow.getProtectedForwardPathId(),
+                                                                 flow.getProtectedReversePathId()))
                                     .build())
                             .protectedReverseEncapsulation(TransitVlanEncapsulation.builder()
-                                    .transitVlan(findTransitVlan(flow.getProtectedReversePathId()))
+                                    .transitVlan(findTransitVlan(flow.getProtectedReversePathId(),
+                                                                 flow.getProtectedForwardPathId()))
                                     .build())
                             .build()
                 );

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/service/FlowService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/service/FlowService.java
@@ -300,7 +300,7 @@ public class FlowService extends BaseFlowService {
             flowPathRepository.lockInvolvedSwitches(flowPaths.toArray(new FlowPath[0]));
 
             List<FlowPathWithEncapsulation> flowPathWithEncapsulations = flowPaths.stream()
-                    .map(this::getFlowPathWithEncapsulation)
+                    .map(path -> getFlowPathWithEncapsulation(flow, path))
                     .collect(Collectors.toList());
 
             // Remove flow and all associated paths
@@ -1044,12 +1044,12 @@ public class FlowService extends BaseFlowService {
                 .orElse(null);
     }
 
-    private FlowPathWithEncapsulation getFlowPathWithEncapsulation(FlowPath flowPath) {
+    private FlowPathWithEncapsulation getFlowPathWithEncapsulation(Flow flow, FlowPath path) {
         //TODO: hard-coded encapsulation will be removed in Flow H&S
-        TransitVlan transitVlan = findTransitVlan(flowPath.getPathId());
+        TransitVlan transitVlan = findTransitVlan(path.getPathId(), flow.getOppositePathId(path.getPathId()));
 
         return FlowPathWithEncapsulation.builder()
-                .flowPath(flowPath)
+                .flowPath(path)
                 .encapsulation(TransitVlanEncapsulation.builder().transitVlan(transitVlan).build())
                 .build();
     }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/SwapPathsAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/SwapPathsAction.java
@@ -109,13 +109,15 @@ public class SwapPathsAction extends
                 .forward(PathResources.builder()
                         .pathId(forwardPath.getPathId())
                         .meterId(forwardPath.getMeterId())
-                        .encapsulationResources(resourcesManager.getEncapsulationResources(forwardPath.getPathId(),
+                        .encapsulationResources(resourcesManager.getEncapsulationResources(
+                                forwardPath.getPathId(), reversePath.getPathId(),
                                 flow.getEncapsulationType()).orElse(null))
                         .build())
                 .reverse(PathResources.builder()
                         .pathId(reversePath.getPathId())
                         .meterId(reversePath.getMeterId())
-                        .encapsulationResources(resourcesManager.getEncapsulationResources(reversePath.getPathId(),
+                        .encapsulationResources(resourcesManager.getEncapsulationResources(
+                                reversePath.getPathId(), forwardPath.getPathId(),
                                 flow.getEncapsulationType()).orElse(null))
                         .build())
                 .build();

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/switchmanager/service/impl/CommandBuilderImpl.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/switchmanager/service/impl/CommandBuilderImpl.java
@@ -93,7 +93,9 @@ public class CommandBuilderImpl implements CommandBuilder {
                             } else {
                                 PathSegment foundIngressSegment = flowPath.getSegments().get(0);
                                 int transitVlan =
-                                        transitVlanRepository.findByPathId(flowPath.getPathId()).stream()
+                                        transitVlanRepository.findByPathId(
+                                                flowPath.getPathId(), flow.getOppositePathId(flowPath.getPathId()))
+                                                .stream()
                                                 .findAny()
                                                 .map(TransitVlan::getVlan).orElse(0);
                                 commands.add(buildInstallIngressRuleCommand(flow, flowPath,
@@ -120,7 +122,8 @@ public class CommandBuilderImpl implements CommandBuilder {
         Flow flow = foundFlow.get();
 
         int transitVlan =
-                transitVlanRepository.findByPathId(flowPath.getPathId()).stream()
+                transitVlanRepository.findByPathId(flowPath.getPathId(),
+                                                   flow.getOppositePathId(flowPath.getPathId())).stream()
                         .findAny()
                         .map(TransitVlan::getVlan).orElse(0);
 

--- a/services/wfm/src/test/java/org/openkilda/wfm/Neo4jBasedTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/Neo4jBasedTest.java
@@ -56,7 +56,9 @@ public abstract class Neo4jBasedTest {
 
     @AfterClass
     public static void stopEmbeddedNeo4j() {
-        embeddedNeo4jDb.stop();
+        if (embeddedNeo4jDb != null) {
+            embeddedNeo4jDb.stop();
+        }
     }
 
     @After

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowCreateServiceTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowCreateServiceTest.java
@@ -418,9 +418,9 @@ public class FlowCreateServiceTest {
                 .build();
 
         when(flowResourcesManager.allocateFlowResources(any(Flow.class))).thenReturn(flowResources);
-        when(transitVlanRepository.findByPathId(flowResources.getForward().getPathId()))
+        when(transitVlanRepository.findByPathId(forwardResources.getPathId(), reverseResources.getPathId()))
                 .thenReturn(getTransitVlans(flowResources, true));
-        when(transitVlanRepository.findByPathId(flowResources.getReverse().getPathId()))
+        when(transitVlanRepository.findByPathId(reverseResources.getPathId(), forwardResources.getPathId()))
                 .thenReturn(getTransitVlans(flowResources, false));
     }
 

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteServiceTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteServiceTest.java
@@ -713,15 +713,19 @@ public class FlowRerouteServiceTest {
 
         when(flowResourcesManager.allocateFlowResources(any())).thenReturn(flowResources);
 
-        when(transitVlanRepository.findByPathId(eq(NEW_FORWARD_FLOW_PATH))).thenReturn(Collections.singletonList(
-                TransitVlan.builder().flowId(FLOW_ID).pathId(NEW_FORWARD_FLOW_PATH).vlan(101).build()));
-        when(transitVlanRepository.findByPathId(eq(NEW_REVERSE_FLOW_PATH))).thenReturn(Collections.singletonList(
-                TransitVlan.builder().flowId(FLOW_ID).pathId(NEW_REVERSE_FLOW_PATH).vlan(102).build()));
+        when(transitVlanRepository.findByPathId(eq(NEW_FORWARD_FLOW_PATH), eq(NEW_REVERSE_FLOW_PATH)))
+                .thenReturn(Collections.singletonList(
+                        TransitVlan.builder().flowId(FLOW_ID).pathId(NEW_FORWARD_FLOW_PATH).vlan(101).build()));
+        when(transitVlanRepository.findByPathId(eq(NEW_REVERSE_FLOW_PATH), eq(NEW_FORWARD_FLOW_PATH)))
+                .thenReturn(Collections.singletonList(
+                        TransitVlan.builder().flowId(FLOW_ID).pathId(NEW_REVERSE_FLOW_PATH).vlan(102).build()));
 
-        when(transitVlanRepository.findByPathId(eq(OLD_FORWARD_FLOW_PATH))).thenReturn(Collections.singletonList(
-                TransitVlan.builder().flowId(FLOW_ID).pathId(NEW_FORWARD_FLOW_PATH).vlan(201).build()));
-        when(transitVlanRepository.findByPathId(eq(OLD_REVERSE_FLOW_PATH))).thenReturn(Collections.singletonList(
-                TransitVlan.builder().flowId(FLOW_ID).pathId(NEW_REVERSE_FLOW_PATH).vlan(202).build()));
+        when(transitVlanRepository.findByPathId(eq(OLD_FORWARD_FLOW_PATH), eq(OLD_REVERSE_FLOW_PATH)))
+                .thenReturn(Collections.singletonList(
+                        TransitVlan.builder().flowId(FLOW_ID).pathId(NEW_FORWARD_FLOW_PATH).vlan(201).build()));
+        when(transitVlanRepository.findByPathId(eq(OLD_REVERSE_FLOW_PATH), eq(OLD_FORWARD_FLOW_PATH)))
+                .thenReturn(Collections.singletonList(
+                        TransitVlan.builder().flowId(FLOW_ID).pathId(NEW_REVERSE_FLOW_PATH).vlan(202).build()));
 
         return flowResources;
     }

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/service/TransitVlanCommandFactoryTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/service/TransitVlanCommandFactoryTest.java
@@ -86,8 +86,8 @@ public class TransitVlanCommandFactoryTest extends Neo4jBasedTest {
         assertEquals(flow.getFlowId(), installEgressRule.getFlowId());
         assertEquals(destSwitch.getSwitchId(), installEgressRule.getSwitchId());
         assertEquals(flow.getForwardPath().getCookie(), installEgressRule.getCookie());
-        TransitVlan forwardVlan = vlanRepository.findByPathId(flow.getForwardPathId()).stream()
-                .findAny()
+        TransitVlan forwardVlan = vlanRepository.findByPathId(flow.getForwardPathId(), flow.getReversePathId())
+                .stream().findAny()
                 .orElseThrow(() -> new IllegalStateException("Vlan should be present"));
         assertEquals(forwardVlan.getVlan(), (int) installEgressRule.getTransitVlanId());
         assertEquals(flow.getDestVlan(), (int) installEgressRule.getOutputVlanId());
@@ -118,8 +118,8 @@ public class TransitVlanCommandFactoryTest extends Neo4jBasedTest {
         assertEquals(flow.getForwardPath().getCookie(), forwardEgressRule.getCookie());
         assertEquals(flow.getForwardPath().getSegments().get(0).getDestPort(), (int) forwardEgressRule.getInputPort());
         assertEquals(flow.getDestPort(), (int) forwardEgressRule.getOutputPort());
-        TransitVlan forwardVlan = vlanRepository.findByPathId(flow.getForwardPathId()).stream()
-                .findAny()
+        TransitVlan forwardVlan = vlanRepository.findByPathId(flow.getForwardPathId(), flow.getReversePathId())
+                .stream().findAny()
                 .orElseThrow(() -> new IllegalStateException("Vlan should be present"));
         assertEquals(forwardVlan.getVlan(), (int) forwardEgressRule.getTransitVlanId());
         assertEquals(flow.getDestVlan(), (int) forwardEgressRule.getOutputVlanId());
@@ -133,8 +133,8 @@ public class TransitVlanCommandFactoryTest extends Neo4jBasedTest {
         assertEquals(flow.getReversePath().getCookie(), reverseEgressRule.getCookie());
         assertEquals(flow.getReversePath().getSegments().get(0).getDestPort(), (int) reverseEgressRule.getInputPort());
         assertEquals(flow.getSrcPort(), (int) reverseEgressRule.getOutputPort());
-        TransitVlan reverseVlan = vlanRepository.findByPathId(flow.getReversePathId()).stream()
-                .findAny()
+        TransitVlan reverseVlan = vlanRepository.findByPathId(flow.getReversePathId(), flow.getForwardPathId())
+                .stream().findAny()
                 .orElseThrow(() -> new IllegalStateException("Vlan should be present"));
         assertEquals(reverseVlan.getVlan(), (int) reverseEgressRule.getTransitVlanId());
         assertEquals(flow.getSrcVlan(), (int) reverseEgressRule.getOutputVlanId());
@@ -165,8 +165,8 @@ public class TransitVlanCommandFactoryTest extends Neo4jBasedTest {
         assertEquals(flow.getForwardPath().getSegments().get(0).getDestPort(), (int) srcSwitchRule.getInputPort());
         assertEquals(flow.getDestPort(), (int) srcSwitchRule.getOutputPort());
 
-        TransitVlan forwardVlan = vlanRepository.findByPathId(flow.getForwardPathId()).stream()
-                .findAny()
+        TransitVlan forwardVlan = vlanRepository.findByPathId(flow.getForwardPathId(), flow.getReversePathId())
+                .stream().findAny()
                 .orElseThrow(() -> new IllegalStateException("Vlan should be present"));
         assertEquals(forwardVlan.getVlan(), (int) srcSwitchRule.getTransitVlanId());
         assertEquals(flow.getDestVlan(), (int) srcSwitchRule.getOutputVlanId());
@@ -197,8 +197,8 @@ public class TransitVlanCommandFactoryTest extends Neo4jBasedTest {
         assertEquals(transitIncomeSegment.getDestPort(), (int) commandForTransitSwitch.getInputPort());
         PathSegment transitOutcomeSegment = flow.getForwardPath().getSegments().get(1);
         assertEquals(transitOutcomeSegment.getSrcPort(), (int) commandForTransitSwitch.getOutputPort());
-        TransitVlan forwardVlan = vlanRepository.findByPathId(flow.getForwardPathId()).stream()
-                .findAny()
+        TransitVlan forwardVlan = vlanRepository.findByPathId(flow.getForwardPathId(), flow.getReversePathId())
+                .stream().findAny()
                 .orElseThrow(() -> new IllegalStateException("Vlan should be present"));
         assertEquals(forwardVlan.getVlan(), (int) commandForTransitSwitch.getTransitVlanId());
 
@@ -236,8 +236,8 @@ public class TransitVlanCommandFactoryTest extends Neo4jBasedTest {
         assertEquals(flow.getFlowId(), sourceSwitchRule.getFlowId());
         assertEquals(flow.getForwardPath().getCookie(), sourceSwitchRule.getCookie());
         assertEquals(flow.getSrcVlan(), (int) sourceSwitchRule.getInputVlanId());
-        TransitVlan forwardVlan = vlanRepository.findByPathId(flow.getForwardPathId()).stream()
-                .findAny()
+        TransitVlan forwardVlan = vlanRepository.findByPathId(flow.getForwardPathId(), flow.getReversePathId())
+                .stream().findAny()
                 .orElseThrow(() -> new IllegalStateException("Vlan should be present"));
         assertEquals(forwardVlan.getVlan(), (int) sourceSwitchRule.getTransitVlanId());
         assertEquals(0, (long) sourceSwitchRule.getBandwidth());
@@ -248,8 +248,8 @@ public class TransitVlanCommandFactoryTest extends Neo4jBasedTest {
         assertEquals(flow.getFlowId(), destSwitchRule.getFlowId());
         assertEquals(flow.getReversePath().getCookie(), destSwitchRule.getCookie());
         assertEquals(flow.getDestVlan(), (int) destSwitchRule.getInputVlanId());
-        TransitVlan reverseVlan = vlanRepository.findByPathId(flow.getReversePathId()).stream()
-                .findAny()
+        TransitVlan reverseVlan = vlanRepository.findByPathId(flow.getReversePathId(), flow.getForwardPathId())
+                .stream().findAny()
                 .orElseThrow(() -> new IllegalStateException("Vlan should be present"));
         assertEquals(reverseVlan.getVlan(), (int) destSwitchRule.getTransitVlanId());
         assertEquals(0, (long) destSwitchRule.getBandwidth());
@@ -275,8 +275,8 @@ public class TransitVlanCommandFactoryTest extends Neo4jBasedTest {
         assertEquals(flow.getForwardPath().getCookie(), sourceSwitchRule.getCookie());
         assertEquals(flow.getFlowId(), sourceSwitchRule.getFlowId());
         assertEquals(flow.getSrcVlan(), (int) sourceSwitchRule.getInputVlanId());
-        TransitVlan forwardVlan = vlanRepository.findByPathId(flow.getForwardPathId()).stream()
-                .findAny()
+        TransitVlan forwardVlan = vlanRepository.findByPathId(flow.getForwardPathId(), flow.getReversePathId())
+                .stream().findAny()
                 .orElseThrow(() -> new IllegalStateException("Vlan should be present"));
         assertEquals(forwardVlan.getVlan(), (int) sourceSwitchRule.getTransitVlanId());
         assertEquals(flow.getBandwidth(), (long) sourceSwitchRule.getBandwidth());
@@ -287,8 +287,8 @@ public class TransitVlanCommandFactoryTest extends Neo4jBasedTest {
         assertEquals(flow.getReversePath().getCookie(), destSwitchRule.getCookie());
         assertEquals(flow.getFlowId(), destSwitchRule.getFlowId());
         assertEquals(flow.getDestVlan(), (int) destSwitchRule.getInputVlanId());
-        TransitVlan reverseVlan = vlanRepository.findByPathId(flow.getReversePathId()).stream()
-                .findAny()
+        TransitVlan reverseVlan = vlanRepository.findByPathId(flow.getReversePathId(), flow.getForwardPathId())
+                .stream().findAny()
                 .orElseThrow(() -> new IllegalStateException("Vlan should be present"));
         assertEquals(reverseVlan.getVlan(), (int) destSwitchRule.getTransitVlanId());
         assertEquals(flow.getBandwidth(), (long) destSwitchRule.getBandwidth());
@@ -403,8 +403,8 @@ public class TransitVlanCommandFactoryTest extends Neo4jBasedTest {
         assertEquals(transitIncomeSegment.getDestPort(), (int) forwardTransitSwitchCriteria.getInPort());
         PathSegment transitOutcomeSegment = flow.getForwardPath().getSegments().get(1);
         assertEquals(transitOutcomeSegment.getSrcPort(), (int) forwardTransitSwitchCriteria.getOutPort());
-        TransitVlan forwardVlan = vlanRepository.findByPathId(flow.getForwardPathId()).stream()
-                .findAny()
+        TransitVlan forwardVlan = vlanRepository.findByPathId(flow.getForwardPathId(), flow.getReversePathId())
+                .stream().findAny()
                 .orElseThrow(() -> new IllegalStateException("Vlan should be present"));
         assertEquals(forwardVlan.getVlan(), (int) forwardTransitSwitchCriteria.getInVlan());
 
@@ -449,8 +449,8 @@ public class TransitVlanCommandFactoryTest extends Neo4jBasedTest {
         assertEquals(flow.getForwardPath().getSegments().get(0).getDestPort(),
                 (int) forwardEgressSwitchCriteria.getInPort());
         assertEquals(flow.getDestPort(), (int) forwardEgressSwitchCriteria.getOutPort());
-        TransitVlan forwardVlan = vlanRepository.findByPathId(flow.getForwardPathId()).stream()
-                .findAny()
+        TransitVlan forwardVlan = vlanRepository.findByPathId(flow.getForwardPathId(), flow.getReversePathId())
+                .stream().findAny()
                 .orElseThrow(() -> new IllegalStateException("Vlan should be present"));
         assertEquals(forwardVlan.getVlan(), (int) forwardEgressSwitchCriteria.getInVlan());
 
@@ -465,8 +465,8 @@ public class TransitVlanCommandFactoryTest extends Neo4jBasedTest {
         assertEquals(flow.getReversePath().getSegments().get(0).getDestPort(),
                 (int) reverseEgressSwitchCriteria.getInPort());
         assertEquals(flow.getSrcPort(), (int) reverseEgressSwitchCriteria.getOutPort());
-        TransitVlan reverseVlan = vlanRepository.findByPathId(flow.getReversePathId()).stream()
-                .findAny()
+        TransitVlan reverseVlan = vlanRepository.findByPathId(flow.getReversePathId(), flow.getForwardPathId())
+                .stream().findAny()
                 .orElseThrow(() -> new IllegalStateException("Vlan should be present"));
         assertEquals(reverseVlan.getVlan(), (int) reverseEgressSwitchCriteria.getInVlan());
     }

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/switchmanager/service/impl/CommandBuilderImplTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/switchmanager/service/impl/CommandBuilderImplTest.java
@@ -47,7 +47,9 @@ import org.openkilda.wfm.topology.switchmanager.service.CommandBuilder;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -74,6 +76,8 @@ public class CommandBuilderImplTest {
     }
 
     private static class PersistenceManagerBuilder {
+        private final Map<SwitchId, Switch> switchStorage = new HashMap<>();
+
         private FlowRepository flowRepository = mock(FlowRepository.class);
         private FlowPathRepository flowPathRepository = mock(FlowPathRepository.class);
         private TransitVlanRepository transitVlanRepository = mock(TransitVlanRepository.class);
@@ -92,7 +96,8 @@ public class CommandBuilderImplTest {
 
             FlowPath flowPath = FlowPath.builder()
                     .flow(flow)
-                    .pathId(new PathId(UUID.randomUUID().toString()))
+                    .pathId(new PathId(String.format(
+                            "(%s-%s)--%s", srcSwitchId.toOtsdFormat(), destSwitchId.toOtsdFormat(), UUID.randomUUID())))
                     .srcSwitch(srcSwitch)
                     .destSwitch(destSwitch)
                     .cookie(new Cookie(cookie))
@@ -113,7 +118,7 @@ public class CommandBuilderImplTest {
                     .pathId(flowPath.getPathId())
                     .vlan(transitVlan)
                     .build();
-            when(transitVlanRepository.findByPathId(eq(flowPath.getPathId())))
+            when(transitVlanRepository.findByPathId(flowPath.getPathId(), null))
                     .thenReturn(singleton(transitVlanEntity));
 
             return flowPath;


### PR DESCRIPTION
Increase possible simultaneous flows count in system up to ~4k.

Issue #2386

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/2397)
<!-- Reviewable:end -->
