### PR TITLE
[WIP] Add VxLAN encapsulation to commands.

### DIFF
--- a/services/src/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/flow/request/InstallEgressRule.java
+++ b/services/src/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/flow/request/InstallEgressRule.java
@@ -19,6 +19,7 @@ import static org.openkilda.messaging.Utils.FLOW_ID;
 
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.Cookie;
+import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.OutputVlanType;
 import org.openkilda.model.SwitchId;
 
@@ -57,10 +58,12 @@ public class InstallEgressRule extends InstallTransitRule {
                              @JsonProperty("switch_id") SwitchId switchId,
                              @JsonProperty("input_port") Integer inputPort,
                              @JsonProperty("output_port") Integer outputPort,
-                             @JsonProperty("transit_vlan_id") Integer transitVlanId,
+                             @JsonProperty("transit_tunnel_id") Integer transitTunnelId,
+                             @JsonProperty("flow_encapsulation_type") FlowEncapsulationType flowEncapsulationType,
                              @JsonProperty("output_vlan_type") OutputVlanType outputVlanType,
                              @JsonProperty("output_vlan_id") Integer outputVlanId) {
-        super(messageContext, commandId, flowId, cookie, switchId, inputPort, outputPort, transitVlanId);
+        super(messageContext, commandId, flowId, cookie, switchId, inputPort, outputPort, transitTunnelId,
+                flowEncapsulationType);
         this.outputVlanType = outputVlanType;
         this.outputVlanId = outputVlanId;
     }

--- a/services/src/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/flow/request/InstallMultiSwitchIngressRule.java
+++ b/services/src/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/flow/request/InstallMultiSwitchIngressRule.java
@@ -19,6 +19,7 @@ import static org.openkilda.messaging.Utils.FLOW_ID;
 
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.Cookie;
+import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.MeterId;
 import org.openkilda.model.OutputVlanType;
 import org.openkilda.model.SwitchId;
@@ -38,10 +39,17 @@ import java.util.UUID;
 public class InstallMultiSwitchIngressRule extends InstallIngressRule {
 
     /**
-     * The transit vlan id value.
+     * The transit tunnel id value.
      */
-    @JsonProperty("transit_vlan_id")
-    private final Integer transitVlanId;
+    @JsonProperty("transit_tunnel_id")
+    private final Integer transitTunnelId;
+
+
+    /**
+     * The encapsulation type of the flow.
+     */
+    @JsonProperty("flow_encapsulation_type")
+    private final FlowEncapsulationType flowEncapsulationType;
 
     @JsonCreator
     @Builder
@@ -56,9 +64,12 @@ public class InstallMultiSwitchIngressRule extends InstallIngressRule {
                                          @JsonProperty("bandwidth") Long bandwidth,
                                          @JsonProperty("output_vlan_type") OutputVlanType outputVlanType,
                                          @JsonProperty("input_vlan_id") Integer inputVlanId,
-                                         @JsonProperty("transit_vlan_id") Integer transitVlanId) {
+                                         @JsonProperty("transit_tunnel_id") Integer transitTunnelId,
+                                         @JsonProperty("flow_encapsulation_type")
+                                                     FlowEncapsulationType flowEncapsulationType) {
         super(messageContext, commandId, flowId, cookie, switchId, inputPort, outputPort, meterId, bandwidth,
                 outputVlanType, inputVlanId);
-        this.transitVlanId = transitVlanId;
+        this.transitTunnelId = transitTunnelId;
+        this.flowEncapsulationType = flowEncapsulationType;
     }
 }

--- a/services/src/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/flow/request/InstallTransitRule.java
+++ b/services/src/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/flow/request/InstallTransitRule.java
@@ -19,6 +19,7 @@ import static org.openkilda.messaging.Utils.FLOW_ID;
 
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.Cookie;
+import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -34,8 +35,11 @@ import java.util.UUID;
 @EqualsAndHashCode(callSuper = true)
 public class InstallTransitRule extends InstallFlowRule {
 
-    @JsonProperty("transit_vlan_id")
-    protected Integer transitVlanId;
+    @JsonProperty("transit_tunnel_id")
+    protected Integer transitTunnelId;
+
+    @JsonProperty("flow_encapsulation_type")
+    protected FlowEncapsulationType flowEncapsulationType;
 
     @JsonCreator
     public InstallTransitRule(@JsonProperty("message_context") MessageContext messageContext,
@@ -45,8 +49,10 @@ public class InstallTransitRule extends InstallFlowRule {
                               @JsonProperty("switch_id") SwitchId switchId,
                               @JsonProperty("input_port") Integer inputPort,
                               @JsonProperty("output_port") Integer outputPort,
-                              @JsonProperty("transit_vlan_id") Integer transitVlanId) {
+                              @JsonProperty("transit_tunnel_id") Integer transitTunnelId,
+                              @JsonProperty("flow_encapsulation_type") FlowEncapsulationType flowEncapsulationType) {
         super(messageContext, commandId, flowId, cookie, switchId, inputPort, outputPort);
-        this.transitVlanId = transitVlanId;
+        this.transitTunnelId = transitTunnelId;
+        this.flowEncapsulationType = flowEncapsulationType;
     }
 }

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/FlowRemoveCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/FlowRemoveCommand.java
@@ -135,7 +135,9 @@ public class FlowRemoveCommand extends FlowCommand {
         if (criteria.getInPort() != null) {
             // Match either In Port or both Port & Vlan criteria.
             Match match = matchFlow(criteria.getInPort(),
-                    Optional.ofNullable(criteria.getInVlan()).orElse(0), ofFactory);
+                    Optional.ofNullable(criteria.getInVlan()).orElse(0),
+                    criteria.getFlowEncapsulationType(),
+                    ofFactory);
             builder.setMatch(match);
         } else if (criteria.getInVlan() != null) {
             // Match In Vlan criterion if In Port is not specified

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/InstallOneSwitchRuleCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/InstallOneSwitchRuleCommand.java
@@ -19,6 +19,7 @@ import static org.openkilda.messaging.Utils.ETH_TYPE;
 
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.Cookie;
+import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.MeterId;
 import org.openkilda.model.OutputVlanType;
 import org.openkilda.model.SwitchId;
@@ -46,14 +47,16 @@ public class InstallOneSwitchRuleCommand extends InstallIngressRuleCommand {
                                        @JsonProperty("switch_id") SwitchId switchId,
                                        @JsonProperty("input_port") Integer inputPort,
                                        @JsonProperty("output_port") Integer outputPort,
-                                       @JsonProperty("transit_vlan_id") Integer transitVlanId,
+                                       @JsonProperty("transit_tunnel_id") Integer transitTunnelId,
+                                       @JsonProperty("flow_encapsulation_type")
+                                                   FlowEncapsulationType flowEncapsulationType,
                                        @JsonProperty("bandwidth") Long bandwidth,
                                        @JsonProperty("input_vlan_id") Integer inputVlanId,
                                        @JsonProperty("output_vlan_type") OutputVlanType outputVlanType,
                                        @JsonProperty("meter_id") MeterId meterId,
                                        @JsonProperty("output_vlan_id") Integer outputVlanId) {
-        super(commandId, flowid, messageContext, cookie, switchId, inputPort, outputPort, transitVlanId, bandwidth,
-                inputVlanId, outputVlanType, meterId);
+        super(commandId, flowid, messageContext, cookie, switchId, inputPort, outputPort, transitTunnelId,
+                flowEncapsulationType, bandwidth, inputVlanId, outputVlanType, meterId);
         this.outputVlanId = outputVlanId;
     }
 

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/InstallTransitRuleCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/InstallTransitRuleCommand.java
@@ -21,6 +21,7 @@ import org.openkilda.floodlight.command.MessageWriter;
 import org.openkilda.floodlight.error.SwitchOperationException;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.Cookie;
+import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -44,7 +45,8 @@ import java.util.List;
 import java.util.UUID;
 
 public class InstallTransitRuleCommand extends FlowInstallCommand {
-    final Integer transitVlanId;
+    final Integer transitTunnelId;
+    final FlowEncapsulationType flowEncapsulationType;
 
     @JsonCreator
     public InstallTransitRuleCommand(@JsonProperty("command_id") UUID commandId,
@@ -54,9 +56,12 @@ public class InstallTransitRuleCommand extends FlowInstallCommand {
                                      @JsonProperty("switch_id") SwitchId switchId,
                                      @JsonProperty("input_port") Integer inputPort,
                                      @JsonProperty("output_port") Integer outputPort,
-                                     @JsonProperty("transit_vlan_id") Integer transitVlanId) {
+                                     @JsonProperty("transit_tunnel_id") Integer transitTunnelId,
+                                     @JsonProperty("flow_encapsulation_type")
+                                                 FlowEncapsulationType flowEncapsulationType) {
         super(commandId, flowId, messageContext, cookie, switchId, inputPort, outputPort);
-        this.transitVlanId = transitVlanId;
+        this.transitTunnelId = transitTunnelId;
+        this.flowEncapsulationType = flowEncapsulationType;
     }
 
     @Override
@@ -65,7 +70,7 @@ public class InstallTransitRuleCommand extends FlowInstallCommand {
         OFFactory factory = sw.getOFFactory();
         List<OFAction> actionList = new ArrayList<>();
 
-        Match match = matchFlow(inputPort, transitVlanId, factory);
+        Match match = matchFlow(inputPort, transitTunnelId, flowEncapsulationType, factory);
         actionList.add(setOutputPort(factory, OFPort.of(outputPort)));
 
         OFFlowMod flowMod = prepareFlowModBuilder(factory)

--- a/services/src/kilda-core/kilda-model/src/main/java/org/openkilda/model/FlowEncapsulationType.java
+++ b/services/src/kilda-core/kilda-model/src/main/java/org/openkilda/model/FlowEncapsulationType.java
@@ -19,6 +19,6 @@ package org.openkilda.model;
  * Represents flow encapsulation types.
  */
 public enum FlowEncapsulationType {
-    TRANSIT_VLAN
+    TRANSIT_VLAN,
+    VXLAN
 }
-

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/command/switches/DeleteRulesCriteria.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/command/switches/DeleteRulesCriteria.java
@@ -15,6 +15,8 @@
 
 package org.openkilda.messaging.command.switches;
 
+import org.openkilda.model.FlowEncapsulationType;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
@@ -36,8 +38,12 @@ public class DeleteRulesCriteria implements Serializable {
 
     @JsonProperty("in_port")
     Integer inPort;
+
     @JsonProperty("in_vlan")
     Integer inVlan;
+
+    @JsonProperty("flow_incapsulation_type")
+    FlowEncapsulationType flowEncapsulationType;
 
     @JsonProperty("priority")
     Integer priority;
@@ -50,6 +56,7 @@ public class DeleteRulesCriteria implements Serializable {
             @JsonProperty("cookie") Long cookie,
             @JsonProperty("in_port") Integer inPort,
             @JsonProperty("in_vlan") Integer inVlan,
+            @JsonProperty("flow_incapsulation_type") FlowEncapsulationType flowEncapsulationType,
             @JsonProperty("priority") Integer priority,
             @JsonProperty("out_port") Integer outPort) {
         if ((cookie == null || cookie == 0)
@@ -60,9 +67,14 @@ public class DeleteRulesCriteria implements Serializable {
             throw new IllegalArgumentException("DeleteRulesCriteria can't be constructed empty.");
         }
 
+        if (flowEncapsulationType == null) {
+            flowEncapsulationType = FlowEncapsulationType.TRANSIT_VLAN;
+        }
+
         this.cookie = cookie;
         this.inPort = inPort;
         this.inVlan = inVlan;
+        this.flowEncapsulationType = flowEncapsulationType;
         this.priority = priority;
         this.outPort = outPort;
     }


### PR DESCRIPTION
VxLAN push command still not works.

How to test
===
After kilda is up and running you can send command into FL via `kafka-console-producer.sh`.
Go to kafka container `docker exec -it kafka bash` and run `sh bin/kafka-console-producer.sh config/producer.properties --broker-list localhost:9092 --topic kilda.speaker.flow_1`.

Here are messages examples:
```
{
  "clazz": "org.openkilda.floodlight.flow.request.InstallMultiSwitchIngressRule",
  "message_context": {
    "correlationId": "4cf7ce18-fb74-4aeb-9ea1-ad6ad1e3493f",
    "createTime": 1558709882476
  },
  "command_id": "ad1ed3e1-42a0-40fa-a6a5-cac3f98d14e7",
  "flowid": "flow",
  "cookie": 4611686018427388000,
  "switch_id": "00:00:00:00:00:00:00:03",
  "input_port": 12,
  "output_port": 23,
  "meter_id": 30,
  "bandwidth": 100,
  "output_vlan_type": "NONE",
  "input_vlan_id": 1,
  "transit_tunnel_id": 1234,
  "flow_encapsulation_type": "VXLAN"
}
```
```
{
  "clazz": "org.openkilda.floodlight.flow.request.InstallTransitRule",
  "message_context": {
    "correlationId": "f7ed6278-e11d-4363-821b-388d6e4e6bcc",
    "createTime": 1558714012227
  },
  "command_id": "eced82af-60d0-4e1e-8e2c-dc33c517676e",
  "flowid": "flow",
  "cookie": 4611686018427389000,
  "switch_id": "00:00:00:90:fb:64:cd:4a",
  "input_port": 15,
  "output_port": 24,
  "transit_tunnel_id": 1234,
  "flow_encapsulation_type": "VXLAN"
}
```
```
{
  "clazz": "org.openkilda.floodlight.flow.request.InstallTransitRule",
  "message_context": {
    "correlationId": "f7ed6278-e11d-4363-821b-388d6e4e6bcc",
    "createTime": 1558714012227
  },
  "command_id": "eced82af-60d0-4e1e-8e2c-dc33c517676e",
  "flowid": "flow",
  "cookie": 4611686018427389000,
  "switch_id": "00:00:00:90:fb:64:cd:4a",
  "input_port": 15,
  "output_port": 24,
  "transit_tunnel_id": 1234,
  "flow_encapsulation_type": "VXLAN"
}
```