### PR TITLE
Do not fail lab-service if openvswitch service is not running

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     command: api
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock
+    - /lib/modules:/lib/modules
     networks:
       default:
         aliases:

--- a/services/lab-service/lab/api/api.py
+++ b/services/lab-service/lab/api/api.py
@@ -66,7 +66,9 @@ class Lab:
         else:
             name = make_container_name(lab_id)
             env = {'LAB_ID': lab_id}
-            volumes = {'/var/run/docker.sock': {'bind': '/var/run/docker.sock', 'mode': 'rw'}}
+            volumes = {
+                '/var/run/docker.sock': {'bind': '/var/run/docker.sock', 'mode': 'rw'},
+                '/lib/modules': {'bind': '/lib/modules', 'mode': 'ro'}}
             docker.containers.run(LAB_SERVICE_IMAGE, command='service', environment=env, volumes=volumes, name=name,
                                   privileged=True, detach=True)
             docker.networks.get(NETWORK_NAME).connect(name, aliases=[name])


### PR DESCRIPTION
Lab service try to load openvswitch kernel module(s) on start, if they a
missing in kernel. They are missing in kernel if openvswitch are not
started on host system.

Share kernel modules with lab-service container, so it will be able to
check existing modules and trigger their loading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/2412)
<!-- Reviewable:end -->
