### PR TITLE
Revert "add test: check that protected flow allows traffic on main/protected paths"

### DIFF
--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
@@ -15,16 +15,12 @@ import org.openkilda.messaging.payload.flow.FlowState
 import org.openkilda.model.Cookie
 import org.openkilda.model.SwitchId
 import org.openkilda.testing.model.topology.TopologyDefinition.Switch
-import org.openkilda.testing.service.traffexam.TraffExamService
-import org.openkilda.testing.tools.FlowTrafficExamBuilder
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.client.HttpClientErrorException
 import spock.lang.Ignore
 import spock.lang.Narrative
 import spock.lang.Unroll
-
-import javax.inject.Provider
 
 @Narrative("""Protected path - it is pre-calculated, reserved, and deployed (except ingress rule),
 so we can switch traffic fast.
@@ -40,9 +36,6 @@ Main and protected paths can't use the same link.""")
 class ProtectedPathSpec extends BaseSpecification {
     @Autowired
     SwitchHelper switchHelper
-
-    @Autowired
-    Provider<TraffExamService> traffExamProvider
 
     @Unroll
     def "Able to create a flow with protected path when maximumBandwidth=#bandwidth, vlan=#vlanId"() {
@@ -645,22 +638,17 @@ class ProtectedPathSpec extends BaseSpecification {
     }
 
     def "Able to swap main and protected paths manually"() {
-        given: "A simple flow"
-        def tgSwitches = topology.getActiveTraffGens()*.getSwitchConnected()
-        def switchPair = topologyHelper.getAllNotNeighboringSwitchPairs().find {
-            def allowsTraffexam = it.src in tgSwitches && it.dst in tgSwitches
-            def usesUniqueSwitches = it.paths.collectMany { pathHelper.getInvolvedSwitches(it) }
-                    .unique { it.dpId }.size() > 3
-            return allowsTraffexam && usesUniqueSwitches
-        }
+        given: "Two active not neighboring switches with two possible paths at least"
+        def (Switch srcSwitch, Switch dstSwitch) = getNotNeighboringSwitchPair(2)
 
-        def flow = flowHelper.randomFlow(switchPair, true)
+        and: "Create a flow without protected path"
+        def flow = flowHelper.randomFlow(srcSwitch, dstSwitch)
         flow.allocateProtectedPath = false
         flowHelper.addFlow(flow)
         assert !northbound.getFlowPath(flow.id).protectedPath
 
         and: "Cookies are created by flow"
-        def createdCookies = northbound.getSwitchRules(switchPair.src.dpId).flowEntries.findAll {
+        def createdCookies = northbound.getSwitchRules(srcSwitch.dpId).flowEntries.findAll {
             !Cookie.isDefaultRule(it.cookie)
         }*.cookie
         assert createdCookies.size() == 2
@@ -678,7 +666,7 @@ class ProtectedPathSpec extends BaseSpecification {
         and: "Rules for main and protected paths are created"
         Wrappers.wait(WAIT_OFFSET) { flowHelper.verifyRulesOnProtectedFlow(flow.id) }
 
-        def cookiesAfterEnablingProtectedPath = northbound.getSwitchRules(switchPair.src.dpId).flowEntries.findAll {
+        def cookiesAfterEnablingProtectedPath = northbound.getSwitchRules(srcSwitch.dpId).flowEntries.findAll {
             !Cookie.isDefaultRule(it.cookie)
         }*.cookie
         // two for main path + one for protected path
@@ -692,18 +680,9 @@ class ProtectedPathSpec extends BaseSpecification {
         def protectedSwitches = pathHelper.getInvolvedSwitches(currentProtectedPath)
         protectedSwitches.each { verifySwitchRules(it.dpId) }
 
-        and: "The flow allows traffic(on the main path)"
-        def traffExam = traffExamProvider.get()
-        def exam = new FlowTrafficExamBuilder(topology, traffExam).buildBidirectionalExam(flow, 0)
-        [exam.forward, exam.reverse].each { direction ->
-            def resources = traffExam.startExam(direction)
-            direction.setResources(resources)
-            assert traffExam.waitExam(direction).hasTraffic()
-        }
-
         when: "Swap flow paths"
-        def srcSwitchCreatedMeterIds = getCreatedMeterIds(switchPair.src.dpId)
-        def dstSwitchCreatedMeterIds = getCreatedMeterIds(switchPair.dst.dpId)
+        def srcSwitchCreatedMeterIds = getCreatedMeterIds(srcSwitch.dpId)
+        def dstSwitchCreatedMeterIds = getCreatedMeterIds(dstSwitch.dpId)
         def currentLastUpdate = northbound.getFlow(flow.id).lastUpdated
         northbound.swapFlowPath(flow.id)
 
@@ -720,8 +699,8 @@ class ProtectedPathSpec extends BaseSpecification {
         currentLastUpdate < northbound.getFlow(flow.id).lastUpdated
 
         and: "New meter is created on the src and dst switches"
-        def newSrcSwitchCreatedMeterIds = getCreatedMeterIds(switchPair.src.dpId)
-        def newDstSwitchCreatedMeterIds = getCreatedMeterIds(switchPair.dst.dpId)
+        def newSrcSwitchCreatedMeterIds = getCreatedMeterIds(srcSwitch.dpId)
+        def newDstSwitchCreatedMeterIds = getCreatedMeterIds(dstSwitch.dpId)
         newSrcSwitchCreatedMeterIds.sort() != srcSwitchCreatedMeterIds.sort()
         newDstSwitchCreatedMeterIds.sort() != dstSwitchCreatedMeterIds.sort()
 
@@ -730,7 +709,7 @@ class ProtectedPathSpec extends BaseSpecification {
 
         and: "Old meter is deleted on the src and dst switches"
         Wrappers.wait(WAIT_OFFSET) {
-            [switchPair.src.dpId, switchPair.dst.dpId].each { switchId ->
+            [srcSwitch.dpId, dstSwitch.dpId].each { switchId ->
                 def switchValidateInfo = northbound.validateSwitch(switchId)
                 assert switchValidateInfo.meters.proper.size() == 1
                 assert switchValidateInfo.rules.proper.size() == 3
@@ -772,13 +751,6 @@ class ProtectedPathSpec extends BaseSpecification {
         and: "No rule discrepancies on every switch of the flow on the protected path)"
         def newProtectedSwitches = pathHelper.getInvolvedSwitches(newCurrentProtectedPath)
         newProtectedSwitches.each { verifySwitchRules(it.dpId) }
-
-        and: "The flow allows traffic(on the protected path)"
-        [exam.forward, exam.reverse].each { direction ->
-            def resources = traffExam.startExam(direction)
-            direction.setResources(resources)
-            assert traffExam.waitExam(direction).hasTraffic()
-        }
 
         and: "Cleanup: revert system to original state"
         flowHelper.deleteFlow(flow.id)
@@ -861,7 +833,7 @@ class ProtectedPathSpec extends BaseSpecification {
         northbound.portDown(currentIsls[0].dstSwitch.dpId, currentIsls[0].dstPort)
 
         then: "Flow state is still DOWN"
-        Wrappers.timedLoop(WAIT_OFFSET) { assert northbound.getFlowStatus(flow.id).status == FlowState.DOWN }
+        Wrappers.timedLoop(WAIT_OFFSET){ assert northbound.getFlowStatus(flow.id).status == FlowState.DOWN }
 
         when: "Try to swap paths when main/protected paths are not available"
         northbound.swapFlowPath(flow.id)
@@ -877,7 +849,7 @@ class ProtectedPathSpec extends BaseSpecification {
         northbound.portUp(currentIsls[0].dstSwitch.dpId, currentIsls[0].dstPort)
 
         then: "Flow state is still DOWN"
-        Wrappers.timedLoop(WAIT_OFFSET) { assert northbound.getFlowStatus(flow.id).status == FlowState.DOWN }
+        Wrappers.timedLoop(WAIT_OFFSET){ assert northbound.getFlowStatus(flow.id).status == FlowState.DOWN }
 
         when: "Try to swap paths when the main path is available and the protected path is not available"
         northbound.swapFlowPath(flow.id)
@@ -893,8 +865,7 @@ class ProtectedPathSpec extends BaseSpecification {
         northbound.portUp(protectedIsls[0].dstSwitch.dpId, protectedIsls[0].dstPort)
 
         then: "Flow state is changed to UP"
-        //it often fails in scope of the whole spec on the hardware env, that's why '* 1.5' is added
-        Wrappers.wait(discoveryInterval * 1.5 + WAIT_OFFSET) {
+        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             assert northbound.getFlowStatus(flow.id).status == FlowState.UP
         }
 

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchValidationSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchValidationSpec.groovy
@@ -505,12 +505,12 @@ class SwitchValidationSpec extends BaseSpecification {
         producer.flush()
 
         then: "System detects excess rules and store them in the 'excess' section"
-        Wrappers.wait(WAIT_OFFSET) {
-            def newCookiesSize = northbound.getSwitchRules(switchPair.src.dpId).flowEntries.findAll {
-                !Cookie.isDefaultRule(it.cookie)
-            }.size()
-            newCookiesSize == createdCookies.size() + 1
+        def newCookiesSize = northbound.getSwitchRules(switchPair.src.dpId).flowEntries.findAll {
+            !Cookie.isDefaultRule(it.cookie)
+        }.size()
+        newCookiesSize == createdCookies.size() + 1
 
+        Wrappers.wait(WAIT_OFFSET) {
             involvedSwitches.findAll { !it.description.contains("OF_12") }.each { switchId ->
                 def involvedSwitchValidateInfo = northbound.validateSwitch(switchId)
                 assert involvedSwitchValidateInfo.rules.proper.containsAll(createdCookies)


### PR DESCRIPTION
Reverts telstra/open-kilda#2367
The test "System doesn't reroute main flow path when protected path is broken and new alt path is available(altPath is more preferable than mainPath)" is unstable and cause build failures.