### PR TITLE
fix test according to jenkins environment

### DIFF
--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
@@ -933,9 +933,11 @@ class ProtectedPathSpec extends BaseSpecification {
         Wrappers.wait(WAIT_OFFSET) { assert northbound.getFlowStatus(flow.id).status == FlowState.UP }
 
         and: "Protected path is recalculated only"
-        def newFlowPathInfo = northbound.getFlowPath(flow.id)
-        pathHelper.convert(newFlowPathInfo) == currentPath
-        pathHelper.convert(newFlowPathInfo.protectedPath) == alternativePath
+        Wrappers.wait(WAIT_OFFSET) {
+            def newFlowPathInfo = northbound.getFlowPath(flow.id)
+            pathHelper.convert(newFlowPathInfo) == currentPath
+            pathHelper.convert(newFlowPathInfo.protectedPath) == alternativePath
+        }
 
         and: "Cleanup: Restore topology, delete flow and reset costs"
         northbound.portUp(protectedIslToBreak.dstSwitch.dpId, protectedIslToBreak.dstPort)


### PR DESCRIPTION
fix the `"System doesn't reroute main flow path when protected path is broken and new alt path is available (altPath is more preferable than mainPath)" `test according to jenkins environment

verification was wrapped into `wait`