### PR TITLE
Fix switch status update logging

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/NetworkTopologyDashboardLogger.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/NetworkTopologyDashboardLogger.java
@@ -126,12 +126,12 @@ public class NetworkTopologyDashboardLogger extends AbstractLogWrapper {
      * @param switchId a switch ID.
      * @param state a switch state.
      */
-    public void onSwitchUpdateStatus(SwitchId switchId, String state) {
+    public void onSwitchUpdateStatus(SwitchId switchId, SwitchState state) {
         Map<String, String> data = new HashMap<>();
         data.put(TAG, "switch-port-isl");
         data.put(TYPE, "switch");
         data.put(SWITCH_ID, switchId.toString());
-        data.put(STATE, state);
+        data.put(STATE, state.name());
         proceed(Level.INFO, String.format("Switch '%s' change status to '%s'", switchId, state), data);
     }
 
@@ -171,5 +171,9 @@ public class NetworkTopologyDashboardLogger extends AbstractLogWrapper {
         public NetworkTopologyDashboardLogger build(Logger logger) {
             return new NetworkTopologyDashboardLogger(logger);
         }
+    }
+
+    public enum SwitchState {
+        ONLINE, OFFLINE
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/controller/sw/SwitchFsm.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/controller/sw/SwitchFsm.java
@@ -141,7 +141,7 @@ public final class SwitchFsm extends AbstractBaseFsm<SwitchFsm, SwitchFsmState, 
     }
 
     public void setupEnter(SwitchFsmState from, SwitchFsmState to, SwitchFsmEvent event, SwitchFsmContext context) {
-        logWrapper.onSwitchAdd(switchId);
+        logWrapper.onSwitchUpdateStatus(switchId, NetworkTopologyDashboardLogger.SwitchState.ONLINE);
 
         transactionManager.doInTransaction(() -> persistSwitchData(context));
         updatePorts(context, true);
@@ -153,7 +153,7 @@ public final class SwitchFsm extends AbstractBaseFsm<SwitchFsm, SwitchFsmState, 
 
     public void offlineEnter(SwitchFsmState from, SwitchFsmState to, SwitchFsmEvent event,
                              SwitchFsmContext context) {
-        logWrapper.onSwitchUpdateStatus(switchId, SwitchFsmEvent.OFFLINE.toString());
+        logWrapper.onSwitchUpdateStatus(switchId, NetworkTopologyDashboardLogger.SwitchState.OFFLINE);
         transactionManager.doInTransaction(() -> updatePersistentStatus(SwitchStatus.INACTIVE));
 
         for (AbstractPort port : portByNumber.values()) {


### PR DESCRIPTION
Use correct (ONLINE) state indicator into dashdoard logger when switch
become online.

Create dedicated enum describing switch states inside dashboard
loggigng, to guarantee it's independence from other network topology
code. To avoid unintentional change of this status during some
refactoring/renaming inside network topology.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/2428)
<!-- Reviewable:end -->
