### PR TITLE
Make FSM independent (network-topology)

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/controller/DecisionMakerFsm.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/controller/DecisionMakerFsm.java
@@ -33,67 +33,6 @@ public final class DecisionMakerFsm extends AbstractBaseFsm<DecisionMakerFsm,
         DecisionMakerFsmState,
         DecisionMakerFsmEvent,
         DecisionMakerFsmContext> {
-    private static final StateMachineBuilder<DecisionMakerFsm, DecisionMakerFsmState, DecisionMakerFsmEvent,
-            DecisionMakerFsmContext> builder;
-
-    static {
-        builder = StateMachineBuilderFactory.create(
-                DecisionMakerFsm.class, DecisionMakerFsmState.class, DecisionMakerFsmEvent.class,
-                DecisionMakerFsmContext.class,
-                Endpoint.class, Long.class, Long.class);
-
-        final String verifyAndTransit = "verifyAndTransit";
-
-        // INIT
-        builder.transition()
-                .from(DecisionMakerFsmState.INIT).to(DecisionMakerFsmState.DISCOVERED)
-                .on(DecisionMakerFsmEvent.DISCOVERY);
-        builder.transition()
-                .from(DecisionMakerFsmState.INIT).to(DecisionMakerFsmState.UNSTABLE)
-                .on(DecisionMakerFsmEvent.FAIL);
-
-        // UNSTABLE
-        builder.onEntry(DecisionMakerFsmState.UNSTABLE)
-                .callMethod("saveFailTime");
-        builder.internalTransition().within(DecisionMakerFsmState.UNSTABLE).on(DecisionMakerFsmEvent.DISCOVERY)
-                .callMethod(verifyAndTransit);
-        builder.internalTransition().within(DecisionMakerFsmState.UNSTABLE).on(DecisionMakerFsmEvent.FAIL)
-                .callMethod(verifyAndTransit);
-        builder.transition()
-                .from(DecisionMakerFsmState.UNSTABLE).to(DecisionMakerFsmState.DISCOVERED)
-                .on(DecisionMakerFsmEvent.VALID_DISCOVERY);
-        builder.internalTransition().within(DecisionMakerFsmState.UNSTABLE).on(DecisionMakerFsmEvent.VALID_FAIL)
-                .callMethod("tick");
-        builder.internalTransition().within(DecisionMakerFsmState.UNSTABLE).on(DecisionMakerFsmEvent.TICK)
-                .callMethod("tick");
-        builder.transition()
-                .from(DecisionMakerFsmState.UNSTABLE).to(DecisionMakerFsmState.FAILED)
-                .on(DecisionMakerFsmEvent.FAIL_BY_TIMEOUT);
-
-        // DISCOVERED
-        builder.onEntry(DecisionMakerFsmState.DISCOVERED)
-                .callMethod("emitDiscovery");
-        builder.internalTransition()
-                .within(DecisionMakerFsmState.DISCOVERED).on(DecisionMakerFsmEvent.FAIL)
-                .callMethod(verifyAndTransit);
-        builder.internalTransition().within(DecisionMakerFsmState.DISCOVERED).on(DecisionMakerFsmEvent.DISCOVERY)
-                .callMethod(verifyAndTransit);
-        builder.transition()
-                .from(DecisionMakerFsmState.DISCOVERED).to(DecisionMakerFsmState.UNSTABLE)
-                .on(DecisionMakerFsmEvent.VALID_FAIL);
-        builder.internalTransition().within(DecisionMakerFsmState.DISCOVERED).on(DecisionMakerFsmEvent.VALID_DISCOVERY)
-                .callMethod("emitDiscovery");
-
-        // FAILED
-        builder.onEntry(DecisionMakerFsmState.FAILED)
-                .callMethod("emitFailed");
-        builder.internalTransition()
-                .within(DecisionMakerFsmState.FAILED).on(DecisionMakerFsmEvent.DISCOVERY)
-                .callMethod(verifyAndTransit);
-        builder.transition()
-                .from(DecisionMakerFsmState.FAILED).to(DecisionMakerFsmState.DISCOVERED)
-                .on(DecisionMakerFsmEvent.VALID_DISCOVERY);
-    }
 
     private final Endpoint endpoint;
     private final Long failTimeout;
@@ -101,19 +40,14 @@ public final class DecisionMakerFsm extends AbstractBaseFsm<DecisionMakerFsm,
     private Long failTime;
     private Long lastProcessedPacketId;
 
+    public static DecisionMakerFsmFactory factory() {
+        return new DecisionMakerFsmFactory();
+    }
+
     public DecisionMakerFsm(Endpoint endpoint, Long failTimeout, Long awaitTime) {
         this.endpoint = endpoint;
         this.failTimeout = failTimeout;
         this.awaitTime = awaitTime;
-    }
-
-    public static FsmExecutor<DecisionMakerFsm, DecisionMakerFsmState, DecisionMakerFsmEvent,
-            DecisionMakerFsmContext> makeExecutor() {
-        return new FsmExecutor<>(DecisionMakerFsmEvent.NEXT);
-    }
-
-    public static DecisionMakerFsm create(Endpoint endpoint, Long failTimeout, Long awaitTime) {
-        return builder.newStateMachine(DecisionMakerFsmState.INIT, endpoint, failTimeout, awaitTime);
     }
 
     // -- FSM actions --
@@ -186,6 +120,80 @@ public final class DecisionMakerFsm extends AbstractBaseFsm<DecisionMakerFsm,
     }
 
     // -- service data types --
+
+    public static class DecisionMakerFsmFactory {
+        private final StateMachineBuilder<DecisionMakerFsm, DecisionMakerFsmState, DecisionMakerFsmEvent,
+                DecisionMakerFsmContext> builder;
+
+        DecisionMakerFsmFactory() {
+            builder = StateMachineBuilderFactory.create(
+                    DecisionMakerFsm.class, DecisionMakerFsmState.class, DecisionMakerFsmEvent.class,
+                    DecisionMakerFsmContext.class,
+                    Endpoint.class, Long.class, Long.class);
+
+            final String verifyAndTransit = "verifyAndTransit";
+
+            // INIT
+            builder.transition()
+                    .from(DecisionMakerFsmState.INIT).to(DecisionMakerFsmState.DISCOVERED)
+                    .on(DecisionMakerFsmEvent.DISCOVERY);
+            builder.transition()
+                    .from(DecisionMakerFsmState.INIT).to(DecisionMakerFsmState.UNSTABLE)
+                    .on(DecisionMakerFsmEvent.FAIL);
+
+            // UNSTABLE
+            builder.onEntry(DecisionMakerFsmState.UNSTABLE)
+                    .callMethod("saveFailTime");
+            builder.internalTransition().within(DecisionMakerFsmState.UNSTABLE).on(DecisionMakerFsmEvent.DISCOVERY)
+                    .callMethod(verifyAndTransit);
+            builder.internalTransition().within(DecisionMakerFsmState.UNSTABLE).on(DecisionMakerFsmEvent.FAIL)
+                    .callMethod(verifyAndTransit);
+            builder.transition()
+                    .from(DecisionMakerFsmState.UNSTABLE).to(DecisionMakerFsmState.DISCOVERED)
+                    .on(DecisionMakerFsmEvent.VALID_DISCOVERY);
+            builder.internalTransition().within(DecisionMakerFsmState.UNSTABLE).on(DecisionMakerFsmEvent.VALID_FAIL)
+                    .callMethod("tick");
+            builder.internalTransition().within(DecisionMakerFsmState.UNSTABLE).on(DecisionMakerFsmEvent.TICK)
+                    .callMethod("tick");
+            builder.transition()
+                    .from(DecisionMakerFsmState.UNSTABLE).to(DecisionMakerFsmState.FAILED)
+                    .on(DecisionMakerFsmEvent.FAIL_BY_TIMEOUT);
+
+            // DISCOVERED
+            builder.onEntry(DecisionMakerFsmState.DISCOVERED)
+                    .callMethod("emitDiscovery");
+            builder.internalTransition()
+                    .within(DecisionMakerFsmState.DISCOVERED).on(DecisionMakerFsmEvent.FAIL)
+                    .callMethod(verifyAndTransit);
+            builder.internalTransition().within(DecisionMakerFsmState.DISCOVERED).on(DecisionMakerFsmEvent.DISCOVERY)
+                    .callMethod(verifyAndTransit);
+            builder.transition()
+                    .from(DecisionMakerFsmState.DISCOVERED).to(DecisionMakerFsmState.UNSTABLE)
+                    .on(DecisionMakerFsmEvent.VALID_FAIL);
+            builder.internalTransition().within(DecisionMakerFsmState.DISCOVERED)
+                    .on(DecisionMakerFsmEvent.VALID_DISCOVERY)
+                    .callMethod("emitDiscovery");
+
+            // FAILED
+            builder.onEntry(DecisionMakerFsmState.FAILED)
+                    .callMethod("emitFailed");
+            builder.internalTransition()
+                    .within(DecisionMakerFsmState.FAILED).on(DecisionMakerFsmEvent.DISCOVERY)
+                    .callMethod(verifyAndTransit);
+            builder.transition()
+                    .from(DecisionMakerFsmState.FAILED).to(DecisionMakerFsmState.DISCOVERED)
+                    .on(DecisionMakerFsmEvent.VALID_DISCOVERY);
+        }
+
+        public FsmExecutor<DecisionMakerFsm, DecisionMakerFsmState, DecisionMakerFsmEvent,
+                DecisionMakerFsmContext> produceExecutor() {
+            return new FsmExecutor<>(DecisionMakerFsmEvent.NEXT);
+        }
+
+        public DecisionMakerFsm produce(Endpoint endpoint, Long failTimeout, Long awaitTime) {
+            return builder.newStateMachine(DecisionMakerFsmState.INIT, endpoint, failTimeout, awaitTime);
+        }
+    }
 
     @Data
     @Builder

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/controller/IslFsm.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/controller/IslFsm.java
@@ -63,8 +63,7 @@ import java.util.Collection;
 import java.util.Optional;
 
 @Slf4j
-public final class IslFsm extends AbstractBaseFsm<IslFsm, IslFsmState, IslFsmEvent,
-        IslFsmContext> {
+public final class IslFsm extends AbstractBaseFsm<IslFsm, IslFsmState, IslFsmEvent, IslFsmContext> {
     private final IslRepository islRepository;
     private final LinkPropsRepository linkPropsRepository;
     private final FlowPathRepository flowPathRepository;
@@ -80,107 +79,10 @@ public final class IslFsm extends AbstractBaseFsm<IslFsm, IslFsmState, IslFsmEve
 
     private final DiscoveryFacts discoveryFacts;
 
-    private static final StateMachineBuilder<IslFsm, IslFsmState, IslFsmEvent, IslFsmContext> builder;
-
     private final NetworkTopologyDashboardLogger logWrapper = new NetworkTopologyDashboardLogger(log);
 
-    static {
-        builder = StateMachineBuilderFactory.create(
-                IslFsm.class, IslFsmState.class, IslFsmEvent.class, IslFsmContext.class,
-                // extra parameters
-                PersistenceManager.class, BfdManager.class, NetworkOptions.class, IslReference.class);
-
-        String updateEndpointStatusMethod = "updateEndpointStatus";
-        String updateAndPersistEndpointStatusMethod = "updateAndPersistEndpointStatus";
-
-        // INIT
-        builder.transition()
-                .from(IslFsmState.INIT).to(IslFsmState.DOWN).on(IslFsmEvent.ISL_UP)
-                .callMethod("handleInitialDiscovery");
-        builder.transition()
-                .from(IslFsmState.INIT).to(IslFsmState.DOWN).on(IslFsmEvent.ISL_DOWN)
-                .callMethod(updateAndPersistEndpointStatusMethod);
-        builder.transition()
-                .from(IslFsmState.INIT).to(IslFsmState.MOVED).on(IslFsmEvent.ISL_MOVE)
-                .callMethod(updateAndPersistEndpointStatusMethod);
-        builder.transition()
-                .from(IslFsmState.INIT).to(IslFsmState.DOWN).on(IslFsmEvent._HISTORY_DOWN);
-        builder.transition()
-                .from(IslFsmState.INIT).to(IslFsmState.UP).on(IslFsmEvent._HISTORY_UP)
-                .callMethod("historyRestoreUp");
-        builder.transition()
-                .from(IslFsmState.INIT).to(IslFsmState.MOVED).on(IslFsmEvent._HISTORY_MOVED);
-        builder.internalTransition()
-                .within(IslFsmState.INIT).on(IslFsmEvent.HISTORY)
-                .callMethod("handleHistory");
-
-        // DOWN
-        builder.transition()
-                .from(IslFsmState.DOWN).to(IslFsmState.UP_ATTEMPT).on(IslFsmEvent.ISL_UP)
-                .callMethod(updateEndpointStatusMethod);
-        builder.transition()
-                .from(IslFsmState.DOWN).to(IslFsmState.MOVED).on(IslFsmEvent.ISL_MOVE)
-                .callMethod(updateEndpointStatusMethod);
-        builder.internalTransition()
-                .within(IslFsmState.DOWN).on(IslFsmEvent.ISL_DOWN)
-                .callMethod(updateAndPersistEndpointStatusMethod);
-        builder.internalTransition()
-                .within(IslFsmState.DOWN).on(IslFsmEvent.ISL_REMOVE)
-                .callMethod("removeAttempt");
-        builder.transition()
-                .from(IslFsmState.DOWN).to(IslFsmState.DELETED).on(IslFsmEvent._ISL_REMOVE_SUCESS);
-        builder.onEntry(IslFsmState.DOWN)
-                .callMethod("downEnter");
-
-        // UP_ATTEMPT
-        builder.transition()
-                .from(IslFsmState.UP_ATTEMPT).to(IslFsmState.DOWN).on(IslFsmEvent._UP_ATTEMPT_FAIL);
-        builder.transition()
-                .from(IslFsmState.UP_ATTEMPT).to(IslFsmState.UP).on(IslFsmEvent._UP_ATTEMPT_SUCCESS);
-        builder.onEntry(IslFsmState.UP_ATTEMPT)
-                .callMethod("handleUpAttempt");
-
-        // UP
-        builder.transition()
-                .from(IslFsmState.UP).to(IslFsmState.DOWN).on(IslFsmEvent.ISL_DOWN);
-        builder.transition()
-                .from(IslFsmState.UP).to(IslFsmState.MOVED).on(IslFsmEvent.ISL_MOVE);
-        builder.onEntry(IslFsmState.UP)
-                .callMethod("upEnter");
-        builder.onExit(IslFsmState.UP)
-                .callMethod("upExit");
-
-        // MOVED
-        builder.transition()
-                .from(IslFsmState.MOVED).to(IslFsmState.UP_ATTEMPT).on(IslFsmEvent.ISL_UP)
-                .callMethod(updateEndpointStatusMethod);
-        builder.internalTransition()
-                .within(IslFsmState.MOVED).on(IslFsmEvent.ISL_DOWN)
-                .callMethod(updateAndPersistEndpointStatusMethod);
-        builder.internalTransition()
-                .within(IslFsmState.MOVED).on(IslFsmEvent.ISL_REMOVE)
-                .callMethod("removeAttempt");
-        builder.transition()
-                .from(IslFsmState.MOVED).to(IslFsmState.DELETED).on(IslFsmEvent._ISL_REMOVE_SUCESS);
-        builder.onEntry(IslFsmState.MOVED)
-                .callMethod("movedEnter");
-
-        // DELETED
-        builder.defineFinalState(IslFsmState.DELETED);
-    }
-
-    public static FsmExecutor<IslFsm, IslFsmState, IslFsmEvent, IslFsmContext> makeExecutor() {
-        return new FsmExecutor<>(IslFsmEvent.NEXT);
-    }
-
-    /**
-     * Create and properly initialize new {@link IslFsm}.
-     */
-    public static IslFsm create(PersistenceManager persistenceManager, BfdManager bfdManager, NetworkOptions options,
-                                IslReference reference) {
-        IslFsm fsm = builder.newStateMachine(IslFsmState.INIT, persistenceManager, bfdManager, options, reference);
-        fsm.start();
-        return fsm;
+    public static IslFsmFactory factory(PersistenceManager persistenceManager) {
+        return new IslFsmFactory(persistenceManager);
     }
 
     public IslFsm(PersistenceManager persistenceManager, BfdManager bfdManager, NetworkOptions options,
@@ -752,6 +654,111 @@ public final class IslFsm extends AbstractBaseFsm<IslFsm, IslFsmState, IslFsmEve
     private static class Socket {
         Anchor source;
         Anchor dest;
+    }
+
+    public static class IslFsmFactory {
+        private final PersistenceManager persistenceManager;
+        private final StateMachineBuilder<IslFsm, IslFsmState, IslFsmEvent, IslFsmContext> builder;
+
+        IslFsmFactory(PersistenceManager persistenceManager) {
+            this.persistenceManager = persistenceManager;
+
+            builder = StateMachineBuilderFactory.create(
+                    IslFsm.class, IslFsmState.class, IslFsmEvent.class, IslFsmContext.class,
+                    // extra parameters
+                    PersistenceManager.class, BfdManager.class, NetworkOptions.class, IslReference.class);
+
+            String updateEndpointStatusMethod = "updateEndpointStatus";
+            String updateAndPersistEndpointStatusMethod = "updateAndPersistEndpointStatus";
+
+            // INIT
+            builder.transition()
+                    .from(IslFsmState.INIT).to(IslFsmState.DOWN).on(IslFsmEvent.ISL_UP)
+                    .callMethod("handleInitialDiscovery");
+            builder.transition()
+                    .from(IslFsmState.INIT).to(IslFsmState.DOWN).on(IslFsmEvent.ISL_DOWN)
+                    .callMethod(updateAndPersistEndpointStatusMethod);
+            builder.transition()
+                    .from(IslFsmState.INIT).to(IslFsmState.MOVED).on(IslFsmEvent.ISL_MOVE)
+                    .callMethod(updateAndPersistEndpointStatusMethod);
+            builder.transition()
+                    .from(IslFsmState.INIT).to(IslFsmState.DOWN).on(IslFsmEvent._HISTORY_DOWN);
+            builder.transition()
+                    .from(IslFsmState.INIT).to(IslFsmState.UP).on(IslFsmEvent._HISTORY_UP)
+                    .callMethod("historyRestoreUp");
+            builder.transition()
+                    .from(IslFsmState.INIT).to(IslFsmState.MOVED).on(IslFsmEvent._HISTORY_MOVED);
+            builder.internalTransition()
+                    .within(IslFsmState.INIT).on(IslFsmEvent.HISTORY)
+                    .callMethod("handleHistory");
+
+            // DOWN
+            builder.transition()
+                    .from(IslFsmState.DOWN).to(IslFsmState.UP_ATTEMPT).on(IslFsmEvent.ISL_UP)
+                    .callMethod(updateEndpointStatusMethod);
+            builder.transition()
+                    .from(IslFsmState.DOWN).to(IslFsmState.MOVED).on(IslFsmEvent.ISL_MOVE)
+                    .callMethod(updateEndpointStatusMethod);
+            builder.internalTransition()
+                    .within(IslFsmState.DOWN).on(IslFsmEvent.ISL_DOWN)
+                    .callMethod(updateAndPersistEndpointStatusMethod);
+            builder.internalTransition()
+                    .within(IslFsmState.DOWN).on(IslFsmEvent.ISL_REMOVE)
+                    .callMethod("removeAttempt");
+            builder.transition()
+                    .from(IslFsmState.DOWN).to(IslFsmState.DELETED).on(IslFsmEvent._ISL_REMOVE_SUCESS);
+            builder.onEntry(IslFsmState.DOWN)
+                    .callMethod("downEnter");
+
+            // UP_ATTEMPT
+            builder.transition()
+                    .from(IslFsmState.UP_ATTEMPT).to(IslFsmState.DOWN).on(IslFsmEvent._UP_ATTEMPT_FAIL);
+            builder.transition()
+                    .from(IslFsmState.UP_ATTEMPT).to(IslFsmState.UP).on(IslFsmEvent._UP_ATTEMPT_SUCCESS);
+            builder.onEntry(IslFsmState.UP_ATTEMPT)
+                    .callMethod("handleUpAttempt");
+
+            // UP
+            builder.transition()
+                    .from(IslFsmState.UP).to(IslFsmState.DOWN).on(IslFsmEvent.ISL_DOWN);
+            builder.transition()
+                    .from(IslFsmState.UP).to(IslFsmState.MOVED).on(IslFsmEvent.ISL_MOVE);
+            builder.onEntry(IslFsmState.UP)
+                    .callMethod("upEnter");
+            builder.onExit(IslFsmState.UP)
+                    .callMethod("upExit");
+
+            // MOVED
+            builder.transition()
+                    .from(IslFsmState.MOVED).to(IslFsmState.UP_ATTEMPT).on(IslFsmEvent.ISL_UP)
+                    .callMethod(updateEndpointStatusMethod);
+            builder.internalTransition()
+                    .within(IslFsmState.MOVED).on(IslFsmEvent.ISL_DOWN)
+                    .callMethod(updateAndPersistEndpointStatusMethod);
+            builder.internalTransition()
+                    .within(IslFsmState.MOVED).on(IslFsmEvent.ISL_REMOVE)
+                    .callMethod("removeAttempt");
+            builder.transition()
+                    .from(IslFsmState.MOVED).to(IslFsmState.DELETED).on(IslFsmEvent._ISL_REMOVE_SUCESS);
+            builder.onEntry(IslFsmState.MOVED)
+                    .callMethod("movedEnter");
+
+            // DELETED
+            builder.defineFinalState(IslFsmState.DELETED);
+        }
+
+        public FsmExecutor<IslFsm, IslFsmState, IslFsmEvent, IslFsmContext> produceExecutor() {
+            return new FsmExecutor<>(IslFsmEvent.NEXT);
+        }
+
+        /**
+         * Create and properly initialize new {@link IslFsm}.
+         */
+        public IslFsm produce(BfdManager bfdManager, NetworkOptions options, IslReference reference) {
+            IslFsm fsm = builder.newStateMachine(IslFsmState.INIT, persistenceManager, bfdManager, options, reference);
+            fsm.start();
+            return fsm;
+        }
     }
 
     @Value

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/controller/UniIslFsm.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/controller/UniIslFsm.java
@@ -41,83 +41,8 @@ public class UniIslFsm extends AbstractBaseFsm<UniIslFsm, UniIslFsmState,
     private IslReference islReference;
     private IslDataHolder islData = null;
 
-    private static final StateMachineBuilder<UniIslFsm, UniIslFsmState, UniIslFsmEvent, UniIslFsmContext> builder;
-
-    static {
-        builder = StateMachineBuilderFactory.create(
-                UniIslFsm.class, UniIslFsmState.class, UniIslFsmEvent.class, UniIslFsmContext.class,
-                // extra parameters
-                Endpoint.class);
-
-        // INIT
-        builder.transition()
-                .from(UniIslFsmState.INIT).to(UniIslFsmState.UNKNOWN).on(UniIslFsmEvent.ACTIVATE)
-                .callMethod("handleActivate");
-
-        // UNKNOWN
-        builder.transition()
-                .from(UniIslFsmState.UNKNOWN).to(UniIslFsmState.DISCOVERY_CHOICE).on(UniIslFsmEvent.DISCOVERY);
-        builder.transition()
-                .from(UniIslFsmState.UNKNOWN).to(UniIslFsmState.DOWN).on(UniIslFsmEvent.FAIL);
-        builder.transition()
-                .from(UniIslFsmState.UNKNOWN).to(UniIslFsmState.DOWN).on(UniIslFsmEvent.PHYSICAL_DOWN);
-
-        // DISCOVERY_CHOICE
-        builder.transition()
-                .from(UniIslFsmState.DISCOVERY_CHOICE).to(UniIslFsmState.SELF_LOOP_CHOICE)
-                .on(UniIslFsmEvent._DISCOVERY_CHOICE_MOVED)
-                .callMethod("handleMoved");
-        builder.transition()
-                .from(UniIslFsmState.DISCOVERY_CHOICE).to(UniIslFsmState.UP).on(UniIslFsmEvent._DISCOVERY_CHOICE_SAME);
-        builder.onEntry(UniIslFsmState.DISCOVERY_CHOICE)
-                .callMethod("doDiscoveryChoice");
-        
-        // SELF_LOOP_CHOICE
-        builder.transition()
-                .from(UniIslFsmState.SELF_LOOP_CHOICE).to(UniIslFsmState.UP).on(UniIslFsmEvent._SELF_LOOP_CHOICE_FALSE);
-        builder.transition()
-                .from(UniIslFsmState.SELF_LOOP_CHOICE).to(UniIslFsmState.UNKNOWN)
-                .on(UniIslFsmEvent._SELF_LOOP_CHOICE_TRUE);
-        builder.onEntry(UniIslFsmState.SELF_LOOP_CHOICE)
-                .callMethod("doSelfLoopChoice");
-
-        // UP
-        builder.transition()
-                .from(UniIslFsmState.UP).to(UniIslFsmState.DISCOVERY_CHOICE).on(UniIslFsmEvent.DISCOVERY);
-        builder.transition()
-                .from(UniIslFsmState.UP).to(UniIslFsmState.DOWN).on(UniIslFsmEvent.FAIL);
-        builder.transition()
-                .from(UniIslFsmState.UP).to(UniIslFsmState.DOWN).on(UniIslFsmEvent.PHYSICAL_DOWN);
-        builder.transition()
-                .from(UniIslFsmState.UP).to(UniIslFsmState.BFD).on(UniIslFsmEvent.BFD_UP);
-        builder.onEntry(UniIslFsmState.UP)
-                .callMethod("upEnter");
-
-        // DOWN
-        builder.transition()
-                .from(UniIslFsmState.DOWN).to(UniIslFsmState.DISCOVERY_CHOICE).on(UniIslFsmEvent.DISCOVERY);
-        builder.transition()
-                .from(UniIslFsmState.DOWN).to(UniIslFsmState.BFD).on(UniIslFsmEvent.BFD_UP);
-        builder.onEntry(UniIslFsmState.DOWN)
-                .callMethod("downEnter");
-
-        // BFD
-        builder.transition()
-                .from(UniIslFsmState.BFD).to(UniIslFsmState.DOWN).on(UniIslFsmEvent.PHYSICAL_DOWN);
-        builder.transition()
-                .from(UniIslFsmState.BFD).to(UniIslFsmState.DOWN).on(UniIslFsmEvent.BFD_DOWN);
-        builder.transition()
-                .from(UniIslFsmState.BFD).to(UniIslFsmState.UP).on(UniIslFsmEvent.BFD_KILL);
-        builder.onEntry(UniIslFsmState.BFD)
-                .callMethod("bfdEnter");
-    }
-
-    public static FsmExecutor<UniIslFsm, UniIslFsmState, UniIslFsmEvent, UniIslFsmContext> makeExecutor() {
-        return new FsmExecutor<>(UniIslFsmEvent.NEXT);
-    }
-
-    public static UniIslFsm create(Endpoint endpoint) {
-        return builder.newStateMachine(UniIslFsmState.INIT, endpoint);
+    public static UniIslFsmFactory factory() {
+        return new UniIslFsmFactory();
     }
 
     public UniIslFsm(Endpoint endpoint) {
@@ -223,6 +148,89 @@ public class UniIslFsm extends AbstractBaseFsm<UniIslFsm, UniIslFsmState,
     }
 
     // -- service data types --
+
+    public static class UniIslFsmFactory {
+        private final StateMachineBuilder<UniIslFsm, UniIslFsmState, UniIslFsmEvent, UniIslFsmContext> builder;
+
+        UniIslFsmFactory() {
+            builder = StateMachineBuilderFactory.create(
+                    UniIslFsm.class, UniIslFsmState.class, UniIslFsmEvent.class, UniIslFsmContext.class,
+                    // extra parameters
+                    Endpoint.class);
+
+            // INIT
+            builder.transition()
+                    .from(UniIslFsmState.INIT).to(UniIslFsmState.UNKNOWN).on(UniIslFsmEvent.ACTIVATE)
+                    .callMethod("handleActivate");
+
+            // UNKNOWN
+            builder.transition()
+                    .from(UniIslFsmState.UNKNOWN).to(UniIslFsmState.DISCOVERY_CHOICE).on(UniIslFsmEvent.DISCOVERY);
+            builder.transition()
+                    .from(UniIslFsmState.UNKNOWN).to(UniIslFsmState.DOWN).on(UniIslFsmEvent.FAIL);
+            builder.transition()
+                    .from(UniIslFsmState.UNKNOWN).to(UniIslFsmState.DOWN).on(UniIslFsmEvent.PHYSICAL_DOWN);
+
+            // DISCOVERY_CHOICE
+            builder.transition()
+                    .from(UniIslFsmState.DISCOVERY_CHOICE).to(UniIslFsmState.SELF_LOOP_CHOICE)
+                    .on(UniIslFsmEvent._DISCOVERY_CHOICE_MOVED)
+                    .callMethod("handleMoved");
+            builder.transition()
+                    .from(UniIslFsmState.DISCOVERY_CHOICE).to(UniIslFsmState.UP)
+                    .on(UniIslFsmEvent._DISCOVERY_CHOICE_SAME);
+            builder.onEntry(UniIslFsmState.DISCOVERY_CHOICE)
+                    .callMethod("doDiscoveryChoice");
+
+            // SELF_LOOP_CHOICE
+            builder.transition()
+                    .from(UniIslFsmState.SELF_LOOP_CHOICE).to(UniIslFsmState.UP)
+                    .on(UniIslFsmEvent._SELF_LOOP_CHOICE_FALSE);
+            builder.transition()
+                    .from(UniIslFsmState.SELF_LOOP_CHOICE).to(UniIslFsmState.UNKNOWN)
+                    .on(UniIslFsmEvent._SELF_LOOP_CHOICE_TRUE);
+            builder.onEntry(UniIslFsmState.SELF_LOOP_CHOICE)
+                    .callMethod("doSelfLoopChoice");
+
+            // UP
+            builder.transition()
+                    .from(UniIslFsmState.UP).to(UniIslFsmState.DISCOVERY_CHOICE).on(UniIslFsmEvent.DISCOVERY);
+            builder.transition()
+                    .from(UniIslFsmState.UP).to(UniIslFsmState.DOWN).on(UniIslFsmEvent.FAIL);
+            builder.transition()
+                    .from(UniIslFsmState.UP).to(UniIslFsmState.DOWN).on(UniIslFsmEvent.PHYSICAL_DOWN);
+            builder.transition()
+                    .from(UniIslFsmState.UP).to(UniIslFsmState.BFD).on(UniIslFsmEvent.BFD_UP);
+            builder.onEntry(UniIslFsmState.UP)
+                    .callMethod("upEnter");
+
+            // DOWN
+            builder.transition()
+                    .from(UniIslFsmState.DOWN).to(UniIslFsmState.DISCOVERY_CHOICE).on(UniIslFsmEvent.DISCOVERY);
+            builder.transition()
+                    .from(UniIslFsmState.DOWN).to(UniIslFsmState.BFD).on(UniIslFsmEvent.BFD_UP);
+            builder.onEntry(UniIslFsmState.DOWN)
+                    .callMethod("downEnter");
+
+            // BFD
+            builder.transition()
+                    .from(UniIslFsmState.BFD).to(UniIslFsmState.DOWN).on(UniIslFsmEvent.PHYSICAL_DOWN);
+            builder.transition()
+                    .from(UniIslFsmState.BFD).to(UniIslFsmState.DOWN).on(UniIslFsmEvent.BFD_DOWN);
+            builder.transition()
+                    .from(UniIslFsmState.BFD).to(UniIslFsmState.UP).on(UniIslFsmEvent.BFD_KILL);
+            builder.onEntry(UniIslFsmState.BFD)
+                    .callMethod("bfdEnter");
+        }
+
+        public FsmExecutor<UniIslFsm, UniIslFsmState, UniIslFsmEvent, UniIslFsmContext> produceExecutor() {
+            return new FsmExecutor<>(UniIslFsmEvent.NEXT);
+        }
+
+        public UniIslFsm produce(Endpoint endpoint) {
+            return builder.newStateMachine(UniIslFsmState.INIT, endpoint);
+        }
+    }
 
     @Value
     @Builder

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/controller/port/PortFsm.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/controller/port/PortFsm.java
@@ -19,7 +19,6 @@ import org.openkilda.messaging.info.event.IslInfoData;
 import org.openkilda.model.Isl;
 import org.openkilda.wfm.share.utils.AbstractBaseFsm;
 import org.openkilda.wfm.share.utils.FsmExecutor;
-import org.openkilda.wfm.topology.network.NetworkTopologyDashboardLogger;
 import org.openkilda.wfm.topology.network.controller.port.PortFsm.PortFsmContext;
 import org.openkilda.wfm.topology.network.controller.port.PortFsm.PortFsmEvent;
 import org.openkilda.wfm.topology.network.controller.port.PortFsm.PortFsmState;
@@ -40,82 +39,14 @@ public final class PortFsm extends AbstractBaseFsm<PortFsm, PortFsmState, PortFs
 
     private final PortReportFsm reportFsm;
 
-    private static final StateMachineBuilder<PortFsm, PortFsmState, PortFsmEvent, PortFsmContext> builder;
-
-    static {
-        builder = StateMachineBuilderFactory.create(
-                PortFsm.class, PortFsmState.class, PortFsmEvent.class, PortFsmContext.class,
-                // extra parameters
-                NetworkTopologyDashboardLogger.Builder.class, Endpoint.class, Isl.class);
-
-        // INIT
-        builder.transition()
-                .from(PortFsmState.INIT).to(PortFsmState.OPERATIONAL).on(PortFsmEvent.ONLINE);
-        builder.transition()
-                .from(PortFsmState.INIT).to(PortFsmState.UNOPERATIONAL).on(PortFsmEvent.OFFLINE);
-        builder.onEntry(PortFsmState.INIT)
-                .callMethod("setupUniIsl");
-
-        // OPERATIONAL
-        builder.transition()
-                .from(PortFsmState.OPERATIONAL).to(PortFsmState.UNOPERATIONAL).on(PortFsmEvent.OFFLINE);
-        builder.transition()
-                .from(PortFsmState.OPERATIONAL).to(PortFsmState.FINISH).on(PortFsmEvent.PORT_DEL);
-        builder.defineSequentialStatesOn(PortFsmState.OPERATIONAL,
-                                         PortFsmState.UNKNOWN, PortFsmState.UP, PortFsmState.DOWN);
-
-        // UNOPERATIONAL
-        builder.transition()
-                .from(PortFsmState.UNOPERATIONAL).to(PortFsmState.OPERATIONAL).on(PortFsmEvent.ONLINE);
-        builder.transition()
-                .from(PortFsmState.UNOPERATIONAL).to(PortFsmState.FINISH).on(PortFsmEvent.PORT_DEL);
-        builder.internalTransition().within(PortFsmState.UNOPERATIONAL).on(PortFsmEvent.FAIL)
-                .callMethod("proxyFail");
-
-        // UNKNOWN
-        builder.transition()
-                .from(PortFsmState.UNKNOWN).to(PortFsmState.UP).on(PortFsmEvent.PORT_UP);
-        builder.transition()
-                .from(PortFsmState.UNKNOWN).to(PortFsmState.DOWN).on(PortFsmEvent.PORT_DOWN);
-
-        // UP
-        builder.transition()
-                .from(PortFsmState.UP).to(PortFsmState.DOWN).on(PortFsmEvent.PORT_DOWN);
-        builder.internalTransition().within(PortFsmState.UP).on(PortFsmEvent.DISCOVERY)
-                .callMethod("proxyDiscovery");
-        builder.internalTransition().within(PortFsmState.UP).on(PortFsmEvent.FAIL)
-                .callMethod("proxyFail");
-        builder.onEntry(PortFsmState.UP)
-                .callMethod("upEnter");
-
-        // DOWN
-        builder.transition()
-                .from(PortFsmState.DOWN).to(PortFsmState.UP).on(PortFsmEvent.PORT_UP);
-        builder.internalTransition().within(PortFsmState.DOWN).on(PortFsmEvent.FAIL)
-                .callMethod("proxyFail");
-        builder.onEntry(PortFsmState.DOWN)
-                .callMethod("downEnter");
-
-        // FINISH
-        builder.onEntry(PortFsmState.FINISH)
-                .callMethod("finish");
-
+    public static PortFsmFactory factory() {
+        return new PortFsmFactory();
     }
 
-    public static FsmExecutor<PortFsm, PortFsmState, PortFsmEvent, PortFsmContext> makeExecutor() {
-        return new FsmExecutor<>(PortFsmEvent.NEXT);
-    }
-
-    public static PortFsm create(NetworkTopologyDashboardLogger.Builder dashboalrdLoggerBuilder,
-                                 Endpoint endpoint, Isl history) {
-        return builder.newStateMachine(PortFsmState.INIT, dashboalrdLoggerBuilder, endpoint, history);
-    }
-
-    public PortFsm(NetworkTopologyDashboardLogger.Builder dashboardLoggerBuilder, Endpoint endpoint, Isl history) {
+    public PortFsm(PortReportFsm reportFsm, Endpoint endpoint, Isl history) {
+        this.reportFsm = reportFsm;
         this.endpoint = endpoint;
         this.history = history;
-
-        reportFsm = PortReportFsm.create(dashboardLoggerBuilder, this.endpoint);
     }
 
     // -- FSM actions --
@@ -153,6 +84,78 @@ public final class PortFsm extends AbstractBaseFsm<PortFsm, PortFsmState, PortFs
     // -- private/service methods --
 
     // -- service data types --
+
+    public static class PortFsmFactory {
+        private final StateMachineBuilder<PortFsm, PortFsmState, PortFsmEvent, PortFsmContext> builder;
+
+        PortFsmFactory() {
+            builder = StateMachineBuilderFactory.create(
+                    PortFsm.class, PortFsmState.class, PortFsmEvent.class, PortFsmContext.class,
+                    // extra parameters
+                    PortReportFsm.class, Endpoint.class, Isl.class);
+
+            // INIT
+            builder.transition()
+                    .from(PortFsmState.INIT).to(PortFsmState.OPERATIONAL).on(PortFsmEvent.ONLINE);
+            builder.transition()
+                    .from(PortFsmState.INIT).to(PortFsmState.UNOPERATIONAL).on(PortFsmEvent.OFFLINE);
+            builder.onEntry(PortFsmState.INIT)
+                    .callMethod("setupUniIsl");
+
+            // OPERATIONAL
+            builder.transition()
+                    .from(PortFsmState.OPERATIONAL).to(PortFsmState.UNOPERATIONAL).on(PortFsmEvent.OFFLINE);
+            builder.transition()
+                    .from(PortFsmState.OPERATIONAL).to(PortFsmState.FINISH).on(PortFsmEvent.PORT_DEL);
+            builder.defineSequentialStatesOn(PortFsmState.OPERATIONAL,
+                                             PortFsmState.UNKNOWN, PortFsmState.UP, PortFsmState.DOWN);
+
+            // UNOPERATIONAL
+            builder.transition()
+                    .from(PortFsmState.UNOPERATIONAL).to(PortFsmState.OPERATIONAL).on(PortFsmEvent.ONLINE);
+            builder.transition()
+                    .from(PortFsmState.UNOPERATIONAL).to(PortFsmState.FINISH).on(PortFsmEvent.PORT_DEL);
+            builder.internalTransition().within(PortFsmState.UNOPERATIONAL).on(PortFsmEvent.FAIL)
+                    .callMethod("proxyFail");
+
+            // UNKNOWN
+            builder.transition()
+                    .from(PortFsmState.UNKNOWN).to(PortFsmState.UP).on(PortFsmEvent.PORT_UP);
+            builder.transition()
+                    .from(PortFsmState.UNKNOWN).to(PortFsmState.DOWN).on(PortFsmEvent.PORT_DOWN);
+
+            // UP
+            builder.transition()
+                    .from(PortFsmState.UP).to(PortFsmState.DOWN).on(PortFsmEvent.PORT_DOWN);
+            builder.internalTransition().within(PortFsmState.UP).on(PortFsmEvent.DISCOVERY)
+                    .callMethod("proxyDiscovery");
+            builder.internalTransition().within(PortFsmState.UP).on(PortFsmEvent.FAIL)
+                    .callMethod("proxyFail");
+            builder.onEntry(PortFsmState.UP)
+                    .callMethod("upEnter");
+
+            // DOWN
+            builder.transition()
+                    .from(PortFsmState.DOWN).to(PortFsmState.UP).on(PortFsmEvent.PORT_UP);
+            builder.internalTransition().within(PortFsmState.DOWN).on(PortFsmEvent.FAIL)
+                    .callMethod("proxyFail");
+            builder.onEntry(PortFsmState.DOWN)
+                    .callMethod("downEnter");
+
+            // FINISH
+            builder.onEntry(PortFsmState.FINISH)
+                    .callMethod("finish");
+        }
+
+        public FsmExecutor<PortFsm, PortFsmState, PortFsmEvent, PortFsmContext> produceExecutor() {
+            return new FsmExecutor<>(PortFsmEvent.NEXT);
+        }
+
+        public PortFsm produce(PortReportFsm.PortReportFsmFactory reportFactory,
+                               Endpoint endpoint, Isl history) {
+            return builder.newStateMachine(PortFsmState.INIT, reportFactory.produce(endpoint), endpoint, history);
+        }
+    }
 
     @Value
     @Builder

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/service/NetworkBfdGlobalToggleService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/service/NetworkBfdGlobalToggleService.java
@@ -17,7 +17,6 @@ package org.openkilda.wfm.topology.network.service;
 
 import org.openkilda.model.FeatureToggles;
 import org.openkilda.persistence.PersistenceManager;
-import org.openkilda.persistence.repositories.FeatureTogglesRepository;
 import org.openkilda.wfm.share.utils.FsmExecutor;
 import org.openkilda.wfm.topology.network.controller.BfdGlobalToggleFsm;
 import org.openkilda.wfm.topology.network.error.BfdGlobalToggleControllerNotFoundException;
@@ -33,18 +32,18 @@ import java.util.Map;
 public class NetworkBfdGlobalToggleService {
     private final IBfdGlobalToggleCarrier carrier;
 
-    private final FeatureTogglesRepository featureTogglesRepository;
-
+    private final BfdGlobalToggleFsm.BfdGlobalToggleFsmFactory controllerFactory;
     private final Map<Endpoint, BfdGlobalToggleFsm> controllerByEndpoint = new HashMap<>();
 
     private final FsmExecutor<BfdGlobalToggleFsm, BfdGlobalToggleFsm.BfdGlobalToggleFsmState,
-            BfdGlobalToggleFsm.BfdGlobalToggleFsmEvent, BfdGlobalToggleFsm.BfdGlobalToggleFsmContext> controllerExecutor
-            = BfdGlobalToggleFsm.makeExecutor();
+            BfdGlobalToggleFsm.BfdGlobalToggleFsmEvent,
+            BfdGlobalToggleFsm.BfdGlobalToggleFsmContext> controllerExecutor;
 
     public NetworkBfdGlobalToggleService(IBfdGlobalToggleCarrier carrier, PersistenceManager persistenceManager) {
         this.carrier = carrier;
 
-        this.featureTogglesRepository = persistenceManager.getRepositoryFactory().createFeatureTogglesRepository();
+        controllerFactory = BfdGlobalToggleFsm.factory(persistenceManager);
+        controllerExecutor = controllerFactory.produceExecutor();
     }
 
     /**
@@ -58,7 +57,7 @@ public class NetworkBfdGlobalToggleService {
                             + " existing handler)", endpoint));
         }
 
-        BfdGlobalToggleFsm fsm = BfdGlobalToggleFsm.create(carrier, endpoint, featureTogglesRepository);
+        BfdGlobalToggleFsm fsm = controllerFactory.produce(carrier, endpoint);
         controllerByEndpoint.put(endpoint, fsm);
     }
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/service/NetworkBfdPortService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/service/NetworkBfdPortService.java
@@ -40,17 +40,20 @@ public class NetworkBfdPortService {
     private final IBfdPortCarrier carrier;
     private final PersistenceManager persistenceManager;
 
+    private final BfdPortFsm.BfdPortFsmFactory controllerFactory;
     private final Map<Endpoint, BfdPortFsm> controllerByPhysicalPort = new HashMap<>();
     private final Map<Endpoint, BfdPortFsm> controllerByLogicalPort = new HashMap<>();
     private final List<BfdPortFsm> pendingCleanup = new LinkedList<>();
     private final Map<Endpoint, IslReference> autostart = new HashMap<>();
 
-    private final FsmExecutor<BfdPortFsm, BfdPortFsmState, BfdPortFsmEvent, BfdPortFsmContext> controllerExecutor
-            = BfdPortFsm.makeExecutor();
+    private final FsmExecutor<BfdPortFsm, BfdPortFsmState, BfdPortFsmEvent, BfdPortFsmContext> controllerExecutor;
 
     public NetworkBfdPortService(IBfdPortCarrier carrier, PersistenceManager persistenceManager) {
         this.carrier = carrier;
         this.persistenceManager = persistenceManager;
+
+        controllerFactory = BfdPortFsm.factory();
+        controllerExecutor = controllerFactory.produceExecutor();
     }
 
     /**
@@ -59,7 +62,7 @@ public class NetworkBfdPortService {
     public void setup(Endpoint endpoint, int physicalPortNumber) {
         log.info("BFD-port service receive SETUP request for {} (physical-port:{})",
                   endpoint, physicalPortNumber);
-        BfdPortFsm controller = BfdPortFsm.create(persistenceManager, endpoint, physicalPortNumber);
+        BfdPortFsm controller = controllerFactory.produce(persistenceManager, endpoint, physicalPortNumber);
 
         BfdPortFsmContext context = BfdPortFsmContext.builder(carrier).build();
         controllerExecutor.fire(controller, BfdPortFsmEvent.HISTORY, context);

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/service/NetworkPortService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/service/NetworkPortService.java
@@ -23,6 +23,7 @@ import org.openkilda.wfm.topology.network.controller.port.PortFsm;
 import org.openkilda.wfm.topology.network.controller.port.PortFsm.PortFsmContext;
 import org.openkilda.wfm.topology.network.controller.port.PortFsm.PortFsmEvent;
 import org.openkilda.wfm.topology.network.controller.port.PortFsm.PortFsmState;
+import org.openkilda.wfm.topology.network.controller.port.PortReportFsm;
 import org.openkilda.wfm.topology.network.model.Endpoint;
 import org.openkilda.wfm.topology.network.model.LinkStatus;
 
@@ -34,17 +35,25 @@ import java.util.Map;
 
 @Slf4j
 public class NetworkPortService {
+    private final PortFsm.PortFsmFactory controllerFactory;
+    private final PortReportFsm.PortReportFsmFactory reportFactory;
     private final Map<Endpoint, PortFsm> controller = new HashMap<>();
-    private final FsmExecutor<PortFsm, PortFsmState, PortFsmEvent, PortFsmContext> controllerExecutor
-            = PortFsm.makeExecutor();
+    private final FsmExecutor<PortFsm, PortFsmState, PortFsmEvent, PortFsmContext> controllerExecutor;
 
     private final IPortCarrier carrier;
 
-    private NetworkTopologyDashboardLogger.Builder dashboardLoggerBuilder;
-
     public NetworkPortService(IPortCarrier carrier) {
+        this(carrier, NetworkTopologyDashboardLogger.builder());
+    }
+
+    @VisibleForTesting
+    NetworkPortService(IPortCarrier carrier, NetworkTopologyDashboardLogger.Builder dashboardLoggerBuilder) {
         this.carrier = carrier;
-        this.dashboardLoggerBuilder = NetworkTopologyDashboardLogger.builder();
+
+        controllerFactory = PortFsm.factory();
+        controllerExecutor = controllerFactory.produceExecutor();
+
+        reportFactory = PortReportFsm.factory(dashboardLoggerBuilder);
     }
 
     /**
@@ -53,7 +62,7 @@ public class NetworkPortService {
     public void setup(Endpoint endpoint, Isl history) {
         log.info("Port service receive setup request for {}", endpoint);
         // TODO: try to switch on atomic action i.e. port-setup + online|offline action in one event
-        PortFsm portFsm = PortFsm.create(dashboardLoggerBuilder, endpoint, history);
+        PortFsm portFsm = controllerFactory.produce(reportFactory, endpoint, history);
         controller.put(endpoint, portFsm);
     }
 
@@ -129,13 +138,6 @@ public class NetworkPortService {
         PortFsmContext context = PortFsmContext.builder(carrier).build();
 
         controllerExecutor.fire(portFsm, PortFsmEvent.FAIL, context);
-    }
-
-    // -- for tests --
-
-    @VisibleForTesting
-    public void setDashboardLoggerBuilder(NetworkTopologyDashboardLogger.Builder builder) {
-        dashboardLoggerBuilder = builder;
     }
 
     // -- private --

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/service/NetworkUniIslService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/service/NetworkUniIslService.java
@@ -31,15 +31,17 @@ import java.util.Map;
 
 @Slf4j
 public class NetworkUniIslService {
+    private final UniIslFsm.UniIslFsmFactory controllerFactory;
     private final Map<Endpoint, UniIslFsm> controller = new HashMap<>();
-
-    private final FsmExecutor<UniIslFsm, UniIslFsmState, UniIslFsmEvent, UniIslFsmContext> controllerExecutor
-            = UniIslFsm.makeExecutor();
+    private final FsmExecutor<UniIslFsm, UniIslFsmState, UniIslFsmEvent, UniIslFsmContext> controllerExecutor;
 
     private final IUniIslCarrier carrier;
 
     public NetworkUniIslService(IUniIslCarrier carrier) {
         this.carrier = carrier;
+
+        controllerFactory = UniIslFsm.factory();
+        controllerExecutor = controllerFactory.produceExecutor();
     }
 
     /**
@@ -47,7 +49,7 @@ public class NetworkUniIslService {
      */
     public void uniIslSetup(Endpoint endpoint, Isl history) {
         log.info("Uni-ISL service receive SETUP request for {}", endpoint);
-        UniIslFsm fsm = UniIslFsm.create(endpoint);
+        UniIslFsm fsm = controllerFactory.produce(endpoint);
         UniIslFsmContext context = UniIslFsmContext.builder(carrier)
                 .history(history)
                 .build();

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/network/service/NetworkPortServiceTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/network/service/NetworkPortServiceTest.java
@@ -167,13 +167,10 @@ public class NetworkPortServiceTest {
     }
 
     private NetworkPortService makeService() {
-        NetworkPortService service = new NetworkPortService(carrier);
-
         NetworkTopologyDashboardLogger.Builder dashboardLoggerBuilder = mock(
                 NetworkTopologyDashboardLogger.Builder.class);
         when(dashboardLoggerBuilder.build(any(Logger.class))).thenReturn(dashboardLogger);
 
-        service.setDashboardLoggerBuilder(dashboardLoggerBuilder);
-        return service;
+        return new NetworkPortService(carrier, dashboardLoggerBuilder);
     }
 }


### PR DESCRIPTION
Get rid from shared(stored on class level) FSM builders into network
topology. Because of lazy initialization FSM can randonly fail due to
simultaneous "access" to shared data stored into squirrelframework
library.

So each bolt/service must create it's own FSM builder to avoid interbolt
data sharing.

Issue #2457

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/2463)
<!-- Reviewable:end -->
