### PR TITLE
RTL Part 3: Handle RTL packet in Floodlight

### DIFF
--- a/services/src/configuration/src/main/java/org/openkilda/config/KafkaTopicsConfig.java
+++ b/services/src/configuration/src/main/java/org/openkilda/config/KafkaTopicsConfig.java
@@ -195,4 +195,12 @@ public interface KafkaTopicsConfig {
     @Key("topo.switch.manager.region")
     @Default("kilda.topo.switch.manager")
     String getTopoSwitchManagerRegionTopic();
+
+    @Key("topo.isl.latency")
+    @Default("kilda.topo.isl.latency.storm")
+    String getTopoIslLatencyTopic();
+
+    @Key("topo.isl.latency.region")
+    @Default("kilda.topo.isl.latency")
+    String getTopoIslLatencyRegionTopic();
 }

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/KafkaChannel.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/KafkaChannel.java
@@ -103,6 +103,10 @@ public class KafkaChannel implements IFloodlightModule {
         return formatTopicWithRegion(topics.getStatsRegionTopic());
     }
 
+    public String getIslLatencyTopic() {
+        return formatTopicWithRegion(topics.getTopoIslLatencyRegionTopic());
+    }
+
     public String getFlowTopic() {
         return formatTopicWithRegion(topics.getFlowRegionTopic());
     }

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/ping/PingResponseCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/ping/PingResponseCommand.java
@@ -62,7 +62,7 @@ public class PingResponseCommand extends PingCommand {
     }
 
     private byte[] unwrap() {
-        if (input.packetInCookieMismatch(PingService.OF_CATCH_RULE_COOKIE, log)) {
+        if (input.packetInCookieMismatchAll(log, PingService.OF_CATCH_RULE_COOKIE)) {
             return null;
         }
 

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/feature/GroupPacketOutFeature.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/feature/GroupPacketOutFeature.java
@@ -15,23 +15,28 @@
 
 package org.openkilda.floodlight.feature;
 
+import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
+
 import org.openkilda.messaging.model.SpeakerSwitchView;
 import org.openkilda.messaging.model.SpeakerSwitchView.Feature;
 
 import net.floodlightcontroller.core.IOFSwitch;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Optional;
 
-public class GroupPacketOutController extends AbstractFeature {
+public class GroupPacketOutFeature extends AbstractFeature {
 
     public static final String CENTEC_MANUFACTURED = "Centec";
+    public static final String ACTON_MANUFACTURED = "Sonus";
 
     @Override
     public Optional<SpeakerSwitchView.Feature> discover(IOFSwitch sw) {
         Optional<SpeakerSwitchView.Feature> empty = Optional.empty();
-        if (StringUtils.containsIgnoreCase(
-                sw.getSwitchDescription().getManufacturerDescription(), CENTEC_MANUFACTURED)) {
+        if (containsIgnoreCase(sw.getSwitchDescription().getManufacturerDescription(), CENTEC_MANUFACTURED)) {
+            return empty;
+        }
+
+        if (containsIgnoreCase(sw.getSwitchDescription().getManufacturerDescription(), ACTON_MANUFACTURED)) {
             return empty;
         }
 

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/model/OfInput.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/model/OfInput.java
@@ -68,12 +68,12 @@ public class OfInput {
     }
 
     /**
-     * Check current packet(PACKET_IN) cookie value is mismatched with expected value.
+     * Check current packet(PACKET_IN) cookie value is mismatched with all expected values.
      */
-    public boolean packetInCookieMismatch(U64 expected, Logger log) {
+    public boolean packetInCookieMismatchAll(Logger log, U64... expected) {
         boolean isMismatched = packetInCookieMismatchCheck(expected);
         if (isMismatched) {
-            log.debug("{} - cookie mismatch (expected:{} != actual:{})", this, expected, packetInCookie());
+            log.warn("{} - cookie mismatch (expected one of:{}, actual:{})", this, expected, packetInCookie());
         }
         return isMismatched;
     }
@@ -107,7 +107,7 @@ public class OfInput {
         return String.format("%s ===> %s.%s:%d", dpId, message.getType(), message.getVersion(), message.getXid());
     }
 
-    private boolean packetInCookieMismatchCheck(U64 expected) {
+    private boolean packetInCookieMismatchCheck(U64... expectedCookies) {
         U64 actual = packetInCookie();
 
         if (actual == null) {
@@ -120,7 +120,12 @@ public class OfInput {
             return false;
         }
 
-        return !actual.equals(expected);
+        for (U64 expected : expectedCookies) {
+            if (actual.equals(expected)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static Ethernet extractPacketInPayload(OFMessage message, FloodlightContext context) {

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/pathverification/DiscoveryPacket.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/pathverification/DiscoveryPacket.java
@@ -41,10 +41,13 @@ public class DiscoveryPacket extends BasePacket {
     private LLDPTLV chassisId;
     private LLDPTLV portId;
     private LLDPTLV ttl;
+    private boolean roundTripLatency;
+
     @Default
     private List<LLDPTLV> optionalTlvList = new ArrayList<>();
 
-    DiscoveryPacket(Data data) {
+    DiscoveryPacket(Data data, boolean roundTripLatency) {
+        this.roundTripLatency = roundTripLatency;
         deserialize(data.getData(), 0, data.getData().length);
     }
 

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/pathverification/DiscoveryPacketData.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/pathverification/DiscoveryPacketData.java
@@ -31,4 +31,8 @@ class DiscoveryPacketData {
     private OFPort remotePort;
     private Long packetId;
     private boolean signed;
+
+    public boolean hasRoundTripLatencyInfo() {
+        return switchT0 > 0;
+    }
 }

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/pathverification/PathVerificationService.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/pathverification/PathVerificationService.java
@@ -19,6 +19,8 @@ import static org.openkilda.floodlight.pathverification.DiscoveryPacket.CHASSIS_
 import static org.openkilda.floodlight.pathverification.DiscoveryPacket.OPTIONAL_LLDPTV_PACKET_TYPE;
 import static org.openkilda.floodlight.pathverification.DiscoveryPacket.PORT_ID_LLDPTV_PACKET_TYPE;
 import static org.openkilda.floodlight.pathverification.DiscoveryPacket.TTL_LLDPTV_PACKET_TYPE;
+import static org.openkilda.messaging.model.SpeakerSwitchView.Feature.GROUP_PACKET_OUT_CONTROLLER;
+import static org.openkilda.messaging.model.SpeakerSwitchView.Feature.NOVIFLOW_COPY_FIELD;
 
 import org.openkilda.floodlight.KafkaChannel;
 import org.openkilda.floodlight.command.Command;
@@ -28,6 +30,7 @@ import org.openkilda.floodlight.model.OfInput;
 import org.openkilda.floodlight.pathverification.type.PathType;
 import org.openkilda.floodlight.pathverification.web.PathVerificationServiceWebRoutable;
 import org.openkilda.floodlight.service.CommandProcessorService;
+import org.openkilda.floodlight.service.FeatureDetectorService;
 import org.openkilda.floodlight.service.kafka.IKafkaProducerService;
 import org.openkilda.floodlight.service.kafka.KafkaUtilityService;
 import org.openkilda.floodlight.service.of.IInputTranslator;
@@ -35,9 +38,12 @@ import org.openkilda.floodlight.service.of.InputService;
 import org.openkilda.floodlight.service.ping.PingService;
 import org.openkilda.floodlight.utils.CorrelationContext;
 import org.openkilda.messaging.Message;
+import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.InfoMessage;
 import org.openkilda.messaging.info.event.IslChangeType;
 import org.openkilda.messaging.info.event.IslInfoData;
+import org.openkilda.messaging.info.event.IslOneWayLatency;
+import org.openkilda.messaging.info.event.IslRoundTripLatency;
 import org.openkilda.messaging.info.event.PathNode;
 import org.openkilda.model.Cookie;
 import org.openkilda.model.SwitchId;
@@ -75,6 +81,8 @@ import org.projectfloodlight.openflow.protocol.OFPortDescPropEthernet;
 import org.projectfloodlight.openflow.protocol.OFType;
 import org.projectfloodlight.openflow.protocol.OFVersion;
 import org.projectfloodlight.openflow.protocol.action.OFAction;
+import org.projectfloodlight.openflow.protocol.action.OFActions;
+import org.projectfloodlight.openflow.protocol.oxm.OFOxms;
 import org.projectfloodlight.openflow.types.DatapathId;
 import org.projectfloodlight.openflow.types.EthType;
 import org.projectfloodlight.openflow.types.IPv4Address;
@@ -95,6 +103,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class PathVerificationService implements IFloodlightModule, IPathVerificationService, IInputTranslator {
     private static final Logger logger = LoggerFactory.getLogger(PathVerificationService.class);
@@ -102,6 +111,7 @@ public class PathVerificationService implements IFloodlightModule, IPathVerifica
             String.format("%s.ISL", PathVerificationService.class.getName()));
 
     public static final U64 OF_CATCH_RULE_COOKIE = U64.of(Cookie.VERIFICATION_BROADCAST_RULE_COOKIE);
+    public static final U64 OF_ROUND_TRIP_RULE_COOKIE = U64.of(Cookie.ROUND_TRIP_LATENCY_RULE_COOKIE);
 
     public static final int DISCOVERY_PACKET_UDP_PORT = 61231;
     public static final int LATENCY_PACKET_UDP_PORT = 61232;
@@ -145,10 +155,12 @@ public class PathVerificationService implements IFloodlightModule, IPathVerifica
 
     private IKafkaProducerService producerService;
     private IOFSwitchService switchService;
+    private FeatureDetectorService featureDetectorService;
 
     private PathVerificationServiceConfig config;
 
     private String topoDiscoTopic;
+    private String islLatencyTopic;
     private String region;
     private double islBandwidthQuotient = 1.0;
     private Algorithm algorithm;
@@ -200,6 +212,7 @@ public class PathVerificationService implements IFloodlightModule, IPathVerifica
 
         switchService = context.getServiceImpl(IOFSwitchService.class);
         producerService = context.getServiceImpl(IKafkaProducerService.class);
+        featureDetectorService = context.getServiceImpl(FeatureDetectorService.class);
     }
 
     @VisibleForTesting
@@ -229,6 +242,7 @@ public class PathVerificationService implements IFloodlightModule, IPathVerifica
         KafkaChannel kafkaChannel = context.getServiceImpl(KafkaUtilityService.class).getKafkaChannel();
         logger.info("region: {}", kafkaChannel.getRegion());
         topoDiscoTopic = context.getServiceImpl(KafkaUtilityService.class).getKafkaChannel().getTopoDiscoTopic();
+        islLatencyTopic = context.getServiceImpl(KafkaUtilityService.class).getKafkaChannel().getIslLatencyTopic();
         region = context.getServiceImpl(KafkaUtilityService.class).getKafkaChannel().getRegion();
         InputService inputService = context.getServiceImpl(InputService.class);
         inputService.addTranslator(OFType.PACKET_IN, this);
@@ -256,8 +270,25 @@ public class PathVerificationService implements IFloodlightModule, IPathVerifica
     protected List<OFAction> getDiscoveryActions(IOFSwitch sw, OFPort port) {
         // set actions
         List<OFAction> actions = new ArrayList<>();
+        if (featureDetectorService.detectSwitch(sw).contains(NOVIFLOW_COPY_FIELD)) {
+            actions.add(actionAddTxTimestamp(sw, ROUND_TRIP_LATENCY_T0_OFFSET));
+        } else {
+            logger.debug("Switch {} does not support round trip latency", sw.getId());
+        }
         actions.add(sw.getOFFactory().actions().buildOutput().setPort(port).build());
         return actions;
+    }
+
+    private OFAction actionAddTxTimestamp(final IOFSwitch sw, int offset) {
+        OFOxms oxms = sw.getOFFactory().oxms();
+        OFActions actions = sw.getOFFactory().actions();
+        return actions.buildNoviflowCopyField()
+                .setNBits(ROUND_TRIP_LATENCY_TIMESTAMP_SIZE)
+                .setSrcOffset(0)
+                .setDstOffset(offset)
+                .setOxmSrcHeader(oxms.buildNoviflowTxtimestamp().getTypeLen())
+                .setOxmDstHeader(oxms.buildNoviflowPacketOffset().getTypeLen())
+                .build();
     }
 
     @Override
@@ -441,16 +472,18 @@ public class PathVerificationService implements IFloodlightModule, IPathVerifica
             if (ip.getPayload() instanceof UDP) {
                 UDP udp = (UDP) ip.getPayload();
 
-                if (isUdpHasSpecifiedSrdDstPort(udp, DISCOVERY_PACKET_UDP_PORT)) {
-                    return new DiscoveryPacket((Data) udp.getPayload());
+                if (isUdpHasSpecifiedSrdDstPort(udp, DISCOVERY_PACKET_UDP_PORT, DISCOVERY_PACKET_UDP_PORT)) {
+                    return new DiscoveryPacket((Data) udp.getPayload(), false);
+                } else if (isUdpHasSpecifiedSrdDstPort(udp, DISCOVERY_PACKET_UDP_PORT, LATENCY_PACKET_UDP_PORT)) {
+                    return new DiscoveryPacket((Data) udp.getPayload(), true);
                 }
             }
         }
         return null;
     }
 
-    private boolean isUdpHasSpecifiedSrdDstPort(UDP udp, int port) {
-        return udp.getSourcePort().getPort() == port && udp.getDestinationPort().getPort() == port;
+    private boolean isUdpHasSpecifiedSrdDstPort(UDP udp, int srcPort, int dstPort) {
+        return udp.getSourcePort().getPort() == srcPort && udp.getDestinationPort().getPort() == dstPort;
     }
 
     /**
@@ -469,10 +502,28 @@ public class PathVerificationService implements IFloodlightModule, IPathVerifica
         return seconds * TEN_TO_NINE + nanoseconds;
     }
 
+    /**
+     * Calculate latency of the ISL.
+     * @param switchId Switch ID of endpoint which received packet
+     * @param port port of endpoint which received packet
+     * @param switchT0 sent packet timestamp in nanoseconds
+     * @param switchT1 receive packet timestamp in nanoseconds
+     * @return long
+     */
+    @VisibleForTesting
+    static long calculateRoundTripLatency(SwitchId switchId, int port, long switchT0, long switchT1) {
+        if (switchT0 <= 0 || switchT1 <= 0) {
+            logger.warn("Invalid round trip latency timestamps on endpoint {}_{}. t0 = '{}', t1 = '{}'.",
+                    switchId, port, switchT0, switchT1);
+            return -1;
+        }
+        return switchT1 - switchT0;
+    }
+
     void handlePacketIn(OfInput input) {
         logger.debug("{} - {}", getClass().getCanonicalName(), input);
 
-        if (input.packetInCookieMismatch(OF_CATCH_RULE_COOKIE, logger)) {
+        if (input.packetInCookieMismatchAll(logger, OF_CATCH_RULE_COOKIE, OF_ROUND_TRIP_RULE_COOKIE)) {
             return;
         }
 
@@ -502,7 +553,12 @@ public class PathVerificationService implements IFloodlightModule, IPathVerifica
                 return;
             }
 
-            handleDiscoveryPacket(input, destSwitch, data);
+            if (discoveryPacket.isRoundTripLatency()) {
+                handleRoundTripLatency(data, input);
+            } else {
+                handleDiscoveryPacket(input, destSwitch, data);
+            }
+
         } catch (UnsupportedOperationException exception) {
             logger.error("could not parse packet_in message: {}", exception.getMessage(), exception);
         } catch (Exception exception) {
@@ -539,6 +595,55 @@ public class PathVerificationService implements IFloodlightModule, IPathVerifica
 
         producerService.sendMessageAndTrack(topoDiscoTopic, source.getSwitchId().toString(), message);
         logger.debug("packet_in processed for {}-{}", input.getDpId(), inPort);
+
+        long oneWayLatency = measureLatency(input, data.getTimestamp());
+        IslOneWayLatency islOneWayLatency = new IslOneWayLatency(
+                source.getSwitchId(),
+                source.getPortNo(),
+                destination.getSwitchId(),
+                destination.getPortNo(),
+                oneWayLatency,
+                data.getPacketId(),
+                data.hasRoundTripLatencyInfo(),
+                featureDetectorService.detectSwitch(destSwitch).contains(NOVIFLOW_COPY_FIELD),
+                featureDetectorService.detectSwitch(destSwitch).contains(GROUP_PACKET_OUT_CONTROLLER));
+
+        sendLatency(islOneWayLatency, source.getSwitchId());
+    }
+
+    private void handleRoundTripLatency(DiscoveryPacketData packetData, OfInput input) {
+        SwitchId switchId = new SwitchId(input.getDpId().getLong());
+        int port = OFMessageUtils.getInPort((OFPacketIn) input.getMessage()).getPortNumber();
+        logIsl.debug("got round trip packet: {}_{}, T0: {}, T1: {}, id:{}",
+                switchId, port, packetData.getSwitchT0(), packetData.getSwitchT1(), packetData.getPacketId());
+
+        SwitchId switchIdFromPacket = new SwitchId(packetData.getRemoteSwitchId().getLong());
+        int portFromPacket = packetData.getRemotePort().getPortNumber();
+
+        if (!Objects.equals(switchId, switchIdFromPacket) || port != portFromPacket) {
+            logger.warn("Endpoint from round trip latency package and endpoint from which the package was received "
+                            + "are different. Endpoint from package: {}-{}. "
+                            + "Endpoint from which package was received: {}-{}",
+                    switchIdFromPacket, portFromPacket, switchId, port);
+            return;
+        }
+
+        long roundTripLatency = calculateRoundTripLatency(
+                switchId, port, packetData.getSwitchT0(), packetData.getSwitchT1());
+
+        IslRoundTripLatency islRoundTripLatency = new IslRoundTripLatency(switchId, port, roundTripLatency,
+                packetData.getPacketId());
+        sendLatency(islRoundTripLatency, switchId);
+        logger.debug("Round trip latency packet processed for endpoint {}_{}. "
+                        + "t0 timestamp {}, t1 timestamp {}, latency {}.", switchId, port,
+                packetData.getSwitchT0(), packetData.getSwitchT1(), roundTripLatency);
+    }
+
+    private void sendLatency(InfoData latencyData, SwitchId switchId) {
+        // will be uncommented in next commit
+        // InfoMessage infoMessage = new InfoMessage(
+        //        latencyData, System.currentTimeMillis(), CorrelationContext.getId(), null, region);
+        // producerService.sendMessageAndTrack(islLatencyTopic, switchId.toString(), infoMessage);
     }
 
     @VisibleForTesting

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/FeatureDetectorService.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/FeatureDetectorService.java
@@ -19,7 +19,7 @@ import org.openkilda.floodlight.config.provider.FloodlightModuleConfigurationPro
 import org.openkilda.floodlight.feature.AbstractFeature;
 import org.openkilda.floodlight.feature.BfdFeature;
 import org.openkilda.floodlight.feature.BfdReviewFeature;
-import org.openkilda.floodlight.feature.GroupPacketOutController;
+import org.openkilda.floodlight.feature.GroupPacketOutFeature;
 import org.openkilda.floodlight.feature.LimitedBurstSizeFeature;
 import org.openkilda.floodlight.feature.MeterFeature;
 import org.openkilda.floodlight.feature.NoviFlowCopyFieldFeature;
@@ -64,7 +64,7 @@ public class FeatureDetectorService implements IService {
                 new MeterFeature(config.isOvsMetersEnabled()),
                 new BfdFeature(),
                 new BfdReviewFeature(),
-                new GroupPacketOutController(),
+                new GroupPacketOutFeature(),
                 new ResetCountsFlagFeature(),
                 new LimitedBurstSizeFeature(),
                 new NoviFlowCopyFieldFeature());

--- a/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/FloodlightTestCase.java
+++ b/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/FloodlightTestCase.java
@@ -34,10 +34,13 @@ package org.openkilda.floodlight;
 
 import static org.easymock.EasyMock.expect;
 
+import org.openkilda.floodlight.service.FeatureDetectorService;
+
 import net.floodlightcontroller.core.FloodlightContext;
 import net.floodlightcontroller.core.IFloodlightProviderService;
 import net.floodlightcontroller.core.IOFSwitch;
 import net.floodlightcontroller.core.SwitchDescription;
+import net.floodlightcontroller.core.module.FloodlightModuleContext;
 import net.floodlightcontroller.packet.Ethernet;
 import org.easymock.EasyMock;
 import org.junit.Before;
@@ -68,6 +71,7 @@ public class FloodlightTestCase {
     protected MockSwitchManager mockSwitchManager;
     protected OFFeaturesReply swFeatures;
     protected OFFactory factory = OFFactories.getFactory(OFVersion.OF_13);
+    protected FeatureDetectorService featureDetectorService = new FeatureDetectorService();
 
     public MockFloodlightProvider getMockFloodlightProvider() {
         return mockFloodlightProvider;
@@ -103,6 +107,7 @@ public class FloodlightTestCase {
         mockFloodlightProvider = new MockFloodlightProvider();
         mockSwitchManager = new MockSwitchManager();
         swFeatures = factory.buildFeaturesReply().setNBuffers(1000).build();
+        featureDetectorService.setup(new FloodlightModuleContext());
     }
 
     public static OFPortDesc createOfPortDesc(IOFSwitch sw, String name, int number) {

--- a/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/ping/PingResponseCommandTest.java
+++ b/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/ping/PingResponseCommandTest.java
@@ -94,7 +94,7 @@ public class PingResponseCommandTest extends PingCommandTest {
         expect(pingService.unwrapData(eq(dpId), anyObject())).andReturn(null);
 
         OfInput input = createMock(OfInput.class);
-        expect(input.packetInCookieMismatch(anyObject(), anyObject())).andReturn(false);
+        expect(input.packetInCookieMismatchAll(anyObject(), anyObject())).andReturn(false);
         expect(input.getPacketInPayload()).andReturn(new Ethernet());
         expect(input.getDpId()).andReturn(dpId);
 

--- a/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/model/OfInputTest.java
+++ b/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/model/OfInputTest.java
@@ -67,7 +67,7 @@ public class OfInputTest extends EasyMockSupport {
     @Test
     public void isCookieMismatch0() {
         OfInput input = makeInput(U64.of(cookieAlpha.getValue()));
-        Assert.assertFalse(input.packetInCookieMismatch(cookieAlpha, callerLogger));
+        Assert.assertFalse(input.packetInCookieMismatchAll(callerLogger, cookieAlpha));
     }
 
     /**
@@ -76,10 +76,10 @@ public class OfInputTest extends EasyMockSupport {
     @Test
     public void isCookieMismatch1() {
         OfInput input = makeInput(U64.of(-1));
-        Assert.assertFalse(input.packetInCookieMismatch(cookieAlpha, callerLogger));
+        Assert.assertFalse(input.packetInCookieMismatchAll(callerLogger, cookieAlpha));
 
         input = makeInput(U64.ZERO);
-        Assert.assertFalse(input.packetInCookieMismatch(cookieAlpha, callerLogger));
+        Assert.assertFalse(input.packetInCookieMismatchAll(callerLogger, cookieAlpha));
     }
 
     /**
@@ -95,7 +95,7 @@ public class OfInputTest extends EasyMockSupport {
 
         FloodlightContext messageMetadata = new FloodlightContext();
         OfInput input = new OfInput(ofSwitch, message, messageMetadata);
-        Assert.assertFalse(input.packetInCookieMismatch(cookieAlpha, callerLogger));
+        Assert.assertFalse(input.packetInCookieMismatchAll(callerLogger, cookieAlpha));
     }
 
     /**
@@ -104,7 +104,7 @@ public class OfInputTest extends EasyMockSupport {
     @Test
     public void isCookieMismatch3() {
         OfInput input = makeInput(cookieAlpha);
-        Assert.assertTrue(input.packetInCookieMismatch(cookieBeta, callerLogger));
+        Assert.assertTrue(input.packetInCookieMismatchAll(callerLogger, cookieBeta));
     }
 
     private OfInput makeInput(U64 cookie) {

--- a/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/pathverification/PathVerificationPacketInTest.java
+++ b/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/pathverification/PathVerificationPacketInTest.java
@@ -34,6 +34,7 @@ import static org.openkilda.floodlight.pathverification.PathVerificationService.
 import org.openkilda.floodlight.FloodlightTestCase;
 import org.openkilda.floodlight.KildaCore;
 import org.openkilda.floodlight.service.CommandProcessorService;
+import org.openkilda.floodlight.service.FeatureDetectorService;
 import org.openkilda.floodlight.service.kafka.IKafkaProducerService;
 import org.openkilda.floodlight.service.of.InputService;
 import org.openkilda.floodlight.utils.CommandContextFactory;
@@ -240,6 +241,7 @@ public class PathVerificationPacketInTest extends FloodlightTestCase {
         fmc.addService(IOFSwitchService.class, getMockSwitchService());
         fmc.addService(InputService.class, inputService);
         fmc.addService(IKafkaProducerService.class, producerService);
+        fmc.addService(FeatureDetectorService.class, featureDetectorService);
 
         KildaCore kildaCore = EasyMock.createMock(KildaCore.class);
         fmc.addService(CommandProcessorService.class, new CommandProcessorService(kildaCore, commandContextFactory));

--- a/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/pathverification/PathVerificationPacketOutTest.java
+++ b/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/pathverification/PathVerificationPacketOutTest.java
@@ -20,6 +20,7 @@ import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertArrayEquals;
 
 import org.openkilda.floodlight.FloodlightTestCase;
+import org.openkilda.floodlight.service.FeatureDetectorService;
 
 import net.floodlightcontroller.core.IFloodlightProviderService;
 import net.floodlightcontroller.core.IOFSwitch;
@@ -52,6 +53,7 @@ public class PathVerificationPacketOutTest extends FloodlightTestCase {
         FloodlightModuleContext fmc = new FloodlightModuleContext();
         fmc.addService(IFloodlightProviderService.class, mockFloodlightProvider);
         fmc.addService(IOFSwitchService.class, getMockSwitchService());
+        fmc.addService(FeatureDetectorService.class, featureDetectorService);
         OFDescStatsReply swDescription = factory.buildDescStatsReply().build();
 
         PathVerificationServiceConfig config = EasyMock.createMock(PathVerificationServiceConfig.class);

--- a/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/service/FeatureDetectorServiceTest.java
+++ b/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/service/FeatureDetectorServiceTest.java
@@ -101,6 +101,13 @@ public class FeatureDetectorServiceTest extends EasyMockSupport {
                        ImmutableSet.of(METERS, LIMITED_BURST_SIZE));
     }
 
+    @Test
+    public void roundTripActon() {
+        discoveryCheck(makeSwitchMock("Sonus Networks Inc, 4 Technology Park Dr, Westford, MA 01886, USA",
+                "8.1.0.14", OFVersion.OF_12),
+                ImmutableSet.of(RESET_COUNTS_FLAG));
+    }
+
     private void discoveryCheck(IOFSwitch sw, Set<Feature> expectedFeatures) {
         replayAll();
 

--- a/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerTest.java
+++ b/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerTest.java
@@ -44,6 +44,7 @@ import static org.openkilda.floodlight.Constants.meterId;
 import static org.openkilda.floodlight.Constants.outputPort;
 import static org.openkilda.floodlight.Constants.outputVlanId;
 import static org.openkilda.floodlight.Constants.transitVlanId;
+import static org.openkilda.floodlight.pathverification.PathVerificationService.LATENCY_PACKET_UDP_PORT;
 import static org.openkilda.floodlight.switchmanager.ISwitchManager.OVS_MANUFACTURER;
 import static org.openkilda.floodlight.switchmanager.SwitchManager.ROUND_TRIP_LATENCY_GROUP_ID;
 import static org.openkilda.floodlight.test.standard.PushSchemeOutputCommands.ofFactory;
@@ -122,6 +123,7 @@ import org.projectfloodlight.openflow.protocol.meterband.OFMeterBandDrop;
 import org.projectfloodlight.openflow.types.DatapathId;
 import org.projectfloodlight.openflow.types.OFGroup;
 import org.projectfloodlight.openflow.types.OFPort;
+import org.projectfloodlight.openflow.types.TransportPort;
 import org.projectfloodlight.openflow.types.U64;
 
 import java.util.ArrayList;
@@ -1078,6 +1080,7 @@ public class SwitchManagerTest {
         expect(iofSwitch.getSwitchDescription()).andStubReturn(switchDescription);
         expect(iofSwitch.getId()).andStubReturn(dpid);
         expect(switchDescription.getManufacturerDescription()).andStubReturn(StringUtils.EMPTY);
+        expect(switchDescription.getSoftwareDescription()).andStubReturn(StringUtils.EMPTY);
         Capture<OFFlowMod> capture = EasyMock.newCapture();
         expect(iofSwitch.write(capture(capture))).andStubReturn(true);
         expect(featureDetectorService.detectSwitch(iofSwitch))
@@ -1229,7 +1232,8 @@ public class SwitchManagerTest {
     private void mockGetGroupsRequest(List<Integer> groupIds) throws Exception {
         List<OFGroupDescStatsEntry> meterConfigs = new ArrayList<>(groupIds.size());
         for (Integer groupId : groupIds) {
-            OFBucket bucket = mock(OFBucket.class);
+            OFBucket firstBucket = mock(OFBucket.class);
+            OFBucket secondBucket = mock(OFBucket.class);
 
             OFActionSetField setDestMacAction = ofFactory.actions()
                     .buildSetField()
@@ -1240,15 +1244,20 @@ public class SwitchManagerTest {
                     .build();
 
             OFActionOutput sendToControllerAction = ofFactory.actions().output(OFPort.CONTROLLER, 0xFFFFFFFF);
+            TransportPort udpPort = TransportPort.of(LATENCY_PACKET_UDP_PORT);
+            OFActionSetField setUdpDstAction = ofFactory.actions().setField(ofFactory.oxms().udpDst(udpPort));
+            OFActionOutput sendInPortAction = ofFactory.actions().output(OFPort.IN_PORT, 0xFFFFFFFF);
 
-            expect(bucket.getActions()).andStubReturn(
+            expect(firstBucket.getActions()).andStubReturn(
                     Lists.newArrayList(setDestMacAction, sendToControllerAction));
+            expect(secondBucket.getActions()).andStubReturn(
+                    Lists.newArrayList(setUdpDstAction, sendInPortAction));
 
             OFGroupDescStatsEntry groupEntry = mock(OFGroupDescStatsEntry.class);
             expect(groupEntry.getGroup()).andStubReturn(OFGroup.of(groupId));
-            expect(groupEntry.getBuckets()).andStubReturn(Lists.newArrayList(bucket));
+            expect(groupEntry.getBuckets()).andStubReturn(Lists.newArrayList(firstBucket, secondBucket));
 
-            replay(bucket, groupEntry);
+            replay(firstBucket,  secondBucket, groupEntry);
             meterConfigs.add(groupEntry);
         }
 

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/event/IslBaseLatency.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/event/IslBaseLatency.java
@@ -1,0 +1,55 @@
+/* Copyright 2019 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.messaging.info.event;
+
+import org.openkilda.messaging.info.InfoData;
+import org.openkilda.model.SwitchId;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class IslBaseLatency extends InfoData {
+    private static final long serialVersionUID = 2608381426921286914L;
+
+    @JsonProperty("src_switch_id")
+    private SwitchId srcSwitchId;
+
+    @JsonProperty("src_port_no")
+    private int srcPortNo;
+
+    @JsonProperty("latency_ns")
+    private long latency;
+
+    @JsonProperty("packet_id")
+    private Long packetId;
+
+    @JsonCreator
+    public IslBaseLatency(@JsonProperty("src_switch_id") SwitchId srcSwitchId,
+                          @JsonProperty("src_port_no") int srcPortNo,
+                          @JsonProperty("latency_ns") long latency,
+                          @JsonProperty("packet_id") Long packetId) {
+        this.srcSwitchId = srcSwitchId;
+        this.srcPortNo = srcPortNo;
+        this.latency = latency;
+        this.packetId = packetId;
+    }
+}

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/event/IslOneWayLatency.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/event/IslOneWayLatency.java
@@ -1,0 +1,64 @@
+/* Copyright 2019 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.messaging.info.event;
+
+import org.openkilda.model.SwitchId;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class IslOneWayLatency extends IslBaseLatency {
+    private static final long serialVersionUID = 5043236275282286971L;
+
+    @JsonProperty("dst_switch_id")
+    private SwitchId dstSwitchId;
+
+    @JsonProperty("dst_port_no")
+    private int dstPortNo;
+
+    @JsonProperty("src_switch_supports_copy_field")
+    private boolean srcSwitchSupportsCopyField;
+
+    @JsonProperty("dst_switch_supports_copy_field")
+    private boolean dstSwitchSupportsCopyField;
+
+    @JsonProperty("dst_switch_supports_groups")
+    private boolean dstSwitchSupportsGroups;
+
+    @JsonCreator
+    public IslOneWayLatency(@JsonProperty("src_switch_id") SwitchId srcSwitchId,
+                            @JsonProperty("src_port_no") int srcPortNo,
+                            @JsonProperty("dst_switch_id") SwitchId dstSwitchId,
+                            @JsonProperty("dst_port_no") int dstPortNo,
+                            @JsonProperty("latency_ns") long latency,
+                            @JsonProperty("packet_id") Long packetId,
+                            @JsonProperty("src_switch_supports_copy_field") boolean srcSwitchSupportsCopyField,
+                            @JsonProperty("dst_switch_supports_copy_field") boolean dstSwitchSupportsCopyField,
+                            @JsonProperty("dst_switch_supports_groups") boolean dstSwitchSupportsGroups) {
+        super(srcSwitchId, srcPortNo, latency, packetId);
+        this.dstSwitchId = dstSwitchId;
+        this.dstPortNo = dstPortNo;
+        this.srcSwitchSupportsCopyField = srcSwitchSupportsCopyField;
+        this.dstSwitchSupportsCopyField = dstSwitchSupportsCopyField;
+        this.dstSwitchSupportsGroups = dstSwitchSupportsGroups;
+    }
+}

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/event/IslRoundTripLatency.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/event/IslRoundTripLatency.java
@@ -1,0 +1,39 @@
+/* Copyright 2019 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.messaging.info.event;
+
+import org.openkilda.model.SwitchId;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class IslRoundTripLatency extends IslBaseLatency {
+    private static final long serialVersionUID = 4184676909685019373L;
+
+    @JsonCreator
+    public IslRoundTripLatency(@JsonProperty("src_switch_id") SwitchId srcSwitchId,
+                               @JsonProperty("src_port_no") int srcPortNo,
+                               @JsonProperty("latency_ns") long latency,
+                               @JsonProperty("packet_id") Long packetId) {
+        super(srcSwitchId, srcPortNo, latency, packetId);
+    }
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/ComponentType.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/ComponentType.java
@@ -23,6 +23,7 @@ public final class ComponentType {
     public static final String NORTHBOUND_REPLY_BOLT = "NORTHBOUND_REPLY_BOLT";
     public static final String KILDA_SWITCH_MANAGER_REPLY_BOLT = "KILDA_SWITCH_MANAGER_REPLY_BOLT";
     public static final String KILDA_STATS_REPLY_BOLT = "KILDA_STATS_REPLY_BOLT";
+    public static final String KILDA_ISL_LATENCY_REPLY_BOLT = "KILDA_ISL_LATENCY_REPLY_BOLT";
     public static final String KILDA_NB_WORKER_REPLY_BOLT = "KILDA_NB_WORKER_REPLY_BOLT";
     public static final String KILDA_TOPO_DISCO_BOLT = "KILDA_TOPO_DISCO_BOLT";
 
@@ -48,6 +49,8 @@ public final class ComponentType {
     public static final String KILDA_PING_KAFKA_BOLT = "KILDA_PING_KAFKA_BOLT";
     public static final String KILDA_STATS_KAFKA_SPOUT = "KILDA_STATS_KAFKA_SPOUT";
     public static final String KILDA_STATS_KAFKA_BOLT = "KILDA_STATS_KAFKA_BOLT";
+    public static final String KILDA_ISL_LATENCY_KAFKA_SPOUT = "KILDA_ISL_LATENCY_KAFKA_SPOUT";
+    public static final String KILDA_ISL_LATENCY_KAFKA_BOLT = "KILDA_ISL_LATENCY_KAFKA_BOLT";
     public static final String KILDA_SWITCH_MANAGER_KAFKA_BOLT = "KILDA_SWITCH_MANAGER_KAFKA_BOLT";
     public static final String KILDA_SWITCH_MANAGER_KAFKA_SPOUT = "KILDA_SWITCH_MANAGER_KAFKA_SPOUT";
     public static final String SPEAKER_DISCO_KAFKA_SPOUT = "SPEAKER_DISCO_KAFKA_SPOUT";

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/Stream.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/Stream.java
@@ -39,6 +39,7 @@ public final class Stream {
     public static final String SPEAKER_PING = "SPEAKER_PING";
     public static final String KILDA_PING = "KILDA_PING";
     public static final String KILDA_STATS = "KILDA_STATS";
+    public static final String KILDA_ISL_LATENCY = "KILDA_ISL_LATENCY";
     public static final String KILDA_SWITCH_MANAGER = "KILDA_SWITCH_MANAGER";
     public static final String SPEAKER_DISCO = "SPEAKER_DISCO";
     public static final String NORTHBOUND_REPLY = "NORTHBOUND_REPLY";


### PR DESCRIPTION
Floodlight gets RTL packet and measure round trip latency,
but does not send it to any topology (will be implemented in next commit)

DB still stores one way latency

Related-To #580

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/2471)
<!-- Reviewable:end -->
