### PR TITLE
Do not treat all speaker as unavailable on floodlightrouter start

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/AliveMarker.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/AliveMarker.java
@@ -1,4 +1,4 @@
-/* Copyright 2018 Telstra Open Source
+/* Copyright 2019 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -15,20 +15,16 @@
 
 package org.openkilda.wfm.topology.floodlightrouter.service;
 
-import lombok.Data;
+import lombok.Value;
 
-@Data
-public class FloodlightInstance {
-    private String region;
-    private long aliveTimeout;
-    private long lastAliveResponse;
-    private int missedAliveResponses;
-    private boolean alive;
-    private boolean requireUnmanagedNotification;
+import java.time.Duration;
+import java.time.Instant;
 
-    public FloodlightInstance(String region) {
-        this.region = region;
-    }
+@Value
+public class AliveMarker {
+    private Instant lastSeenActivity;
+    private Instant nextAliveRequestAt;
+    private Instant aliveExpireAt;
 
-
+    private Duration remoteOffsetMillis;
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/AliveSetup.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/AliveSetup.java
@@ -1,0 +1,65 @@
+/* Copyright 2019 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.floodlightrouter.service;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+public class AliveSetup {
+    private final Clock localClock;
+    private final Clock aliveExpireClock;
+    private final Clock aliveIntervalClock;
+
+    public AliveSetup(long aliveTimeout, long aliveInterval) {
+        this(Clock.systemUTC(), aliveTimeout, aliveInterval);
+    }
+
+    AliveSetup(Clock systemClock, long aliveTimeout, long aliveInterval) {
+        localClock = systemClock;
+        aliveExpireClock = Clock.offset(localClock, Duration.ofSeconds(aliveTimeout));
+        aliveIntervalClock = Clock.offset(localClock, Duration.ofSeconds(aliveInterval));
+    }
+
+    public boolean isAlive(AliveMarker marker) {
+        return marker.getAliveExpireAt().isAfter(localClock.instant());
+    }
+
+    public boolean isAliveRequestRequired(AliveMarker marker) {
+        return marker.getNextAliveRequestAt().isBefore(localClock.instant());
+    }
+
+    public Duration timeFromLastSeen(AliveMarker marker) {
+        return Duration.between(marker.getLastSeenActivity(), localClock.instant());
+    }
+
+    public AliveMarker makeZeroMarker() {
+        Instant timeNow = localClock.instant();
+        return new AliveMarker(timeNow, timeNow, aliveExpireClock.instant(), null);
+    }
+
+    public AliveMarker makeMarker(Long remoteTimeMillis) {
+        return new AliveMarker(localClock.instant(), aliveIntervalClock.instant(), aliveExpireClock.instant(),
+                               measureRemoteOffset(remoteTimeMillis));
+    }
+
+    private Duration measureRemoteOffset(Long remoteTimeMillis) {
+        if (remoteTimeMillis != null) {
+            return Duration.ofMillis(localClock.instant().toEpochMilli() - remoteTimeMillis);
+        }
+        return null;
+    }
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/MessageSender.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/MessageSender.java
@@ -16,10 +16,15 @@
 package org.openkilda.wfm.topology.floodlightrouter.service;
 
 import org.openkilda.messaging.Message;
-import org.openkilda.wfm.CommandContext;
-
+import org.openkilda.model.SwitchId;
 
 public interface MessageSender {
+    void emitSpeakerAliveRequest(String region);
+
+    void emitSwitchUnmanagedNotification(SwitchId sw);
+
+    void emitNetworkDumpRequest(String region);
+
     void emitSpeakerMessage(Message message, String region);
 
     void emitSpeakerMessage(String key, Message message, String region);
@@ -28,5 +33,5 @@ public interface MessageSender {
 
     void emitControllerMessage(String key, Message message);
 
-    void emitRegionNotification(SwitchMapping mapping, CommandContext context);
+    void emitRegionNotification(SwitchMapping mapping);
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/RouterService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/RouterService.java
@@ -15,12 +15,8 @@
 
 package org.openkilda.wfm.topology.floodlightrouter.service;
 
-import org.openkilda.messaging.AliveRequest;
 import org.openkilda.messaging.AliveResponse;
-import org.openkilda.messaging.Destination;
 import org.openkilda.messaging.Message;
-import org.openkilda.messaging.command.CommandMessage;
-import org.openkilda.messaging.command.discovery.NetworkCommandData;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.InfoMessage;
 import org.openkilda.messaging.info.discovery.NetworkDumpSwitchData;
@@ -28,11 +24,8 @@ import org.openkilda.messaging.info.event.IslInfoData;
 import org.openkilda.messaging.info.event.PortInfoData;
 import org.openkilda.messaging.info.event.SwitchInfoData;
 import org.openkilda.model.SwitchId;
-import org.openkilda.wfm.CommandContext;
 
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.UUID;
 
 @Slf4j
 public class RouterService {
@@ -48,14 +41,8 @@ public class RouterService {
      * @param routerMessageSender callback to be used for message sending
      */
     public void doPeriodicProcessing(MessageSender routerMessageSender) {
-        for (String region : floodlightTracker.getRegionsForAliveRequest()) {
-            AliveRequest request = new AliveRequest();
-            CommandMessage message = new CommandMessage(request, System.currentTimeMillis(), UUID.randomUUID()
-                    .toString());
-            routerMessageSender.emitSpeakerMessage(message.getCorrelationId(), message, region);
-        }
-        floodlightTracker.checkTimeouts();
-        floodlightTracker.handleUnmanagedSwitches(routerMessageSender);
+        emitAliveRequests(routerMessageSender);
+        floodlightTracker.handleAliveExpiration(routerMessageSender);
     }
 
     /**
@@ -63,8 +50,7 @@ public class RouterService {
      * @param routerMessageSender callback to be used for message sending
      * @param message message to be handled and resend
      */
-    public void processSpeakerDiscoResponse(MessageSender routerMessageSender,
-                                            Message message, CommandContext context) {
+    public void processSpeakerDiscoResponse(MessageSender routerMessageSender, Message message) {
         if (message instanceof InfoMessage) {
             InfoMessage infoMessage = (InfoMessage) message;
             InfoData infoData = infoMessage.getData();
@@ -74,7 +60,7 @@ public class RouterService {
             if (infoData instanceof AliveResponse) {
                 AliveResponse aliveResponse = (AliveResponse) infoData;
                 if (aliveResponse.getFailedMessages() > 0) {
-                    sendNetworkRequest(routerMessageSender, region);
+                    routerMessageSender.emitNetworkDumpRequest(region);
                 }
                 return;
             } else if (infoData instanceof IslInfoData) {
@@ -90,7 +76,7 @@ public class RouterService {
 
             // NOTE(tdurakov): need to notify of a mapping update
             if (switchId != null && region != null && floodlightTracker.updateSwitchRegion(switchId, region)) {
-                routerMessageSender.emitRegionNotification(new SwitchMapping(switchId, region), context);
+                routerMessageSender.emitRegionNotification(new SwitchMapping(switchId, region));
             }
         }
         routerMessageSender.emitControllerMessage(message);
@@ -115,27 +101,17 @@ public class RouterService {
         }
     }
 
-    private void handleResponseFromSpeaker(MessageSender routerMessageSender, String region,
-                                           long timestamp) {
+    private void handleResponseFromSpeaker(MessageSender routerMessageSender, String region, long timestamp) {
         boolean requireSync = floodlightTracker.handleAliveResponse(region, timestamp);
         if (requireSync) {
             log.info("Region {} requires sync", region);
-            sendNetworkRequest(routerMessageSender, region);
+            routerMessageSender.emitNetworkDumpRequest(region);
         }
     }
 
-    /**
-     * Send network dump requests for target region.
-     * @param routerMessageSender sender
-     * @param region target
-     */
-    public void sendNetworkRequest(MessageSender routerMessageSender, String region) {
-        String correlationId = UUID.randomUUID().toString();
-        CommandMessage command = new CommandMessage(new NetworkCommandData(),
-                System.currentTimeMillis(), correlationId,
-                Destination.CONTROLLER);
-
-        log.info("Send network dump request (correlation-id: {})", correlationId);
-        routerMessageSender.emitSpeakerMessage(correlationId, command, region);
+    private void emitAliveRequests(MessageSender messageSender) {
+        for (String region : floodlightTracker.getRegionsForAliveRequest()) {
+            messageSender.emitSpeakerAliveRequest(region);
+        }
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/SpeakerStatus.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/SpeakerStatus.java
@@ -1,0 +1,71 @@
+/* Copyright 2019 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.floodlightrouter.service;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+
+@Slf4j
+@Data
+public class SpeakerStatus {
+    private final String region;
+    private final Duration remoteOffsetInfo;
+    private final Duration remoteOffsetWarn;
+
+    private AliveMarker aliveMarker;
+    private boolean active = true;
+
+    public SpeakerStatus(String region, Duration aliveTimeout, AliveMarker aliveMarker) {
+        this.region = region;
+        this.remoteOffsetWarn = aliveTimeout;
+        this.remoteOffsetInfo = Duration.ofMillis((long) (aliveTimeout.toMillis() * .7));
+        this.aliveMarker = aliveMarker;
+    }
+
+    /**
+     * Remove inactive marker from current speaker.
+     */
+    public void markActive(AliveMarker marker) {
+        active = true;
+        aliveMarker = marker;
+        if (aliveMarker.getRemoteOffsetMillis() != null) {
+            reportRemoteOffset(aliveMarker.getRemoteOffsetMillis());
+        }
+    }
+
+    /**
+     * Put inactive marker on current speaker.
+     */
+    public boolean markInactive() {
+        boolean isActiveChanged = active;
+        active = false;
+        return isActiveChanged;
+    }
+
+    private void reportRemoteOffset(Duration remoteOffset) {
+        String message = String.format("Time offset between SPEAKER and router is %s (region %s)", remoteOffset,
+                                       region);
+        if (remoteOffsetWarn.compareTo(remoteOffset) < 0) {
+            log.warn(message);
+        } else if (remoteOffsetInfo.compareTo(remoteOffset) < 0) {
+            log.info(message);
+        } else {
+            log.debug(message);
+        }
+    }
+}

--- a/services/wfm/src/test/java/org/openkilda/wfm/share/utils/ManualClock.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/share/utils/ManualClock.java
@@ -1,0 +1,61 @@
+/* Copyright 2019 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.share.utils;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.TemporalAmount;
+
+/**
+ * Main goal of {@link ManualClock} is to be used in test code.Unlike {@link java.time.Clock.FixedClock} value
+ * produced by this "clock" can be adjusted. So test code can track how test subject handle time flow.
+ */
+public class ManualClock extends Clock {
+    private Instant instant;
+    private final ZoneId zone;
+
+    public ManualClock(Instant timeNow, ZoneId zone) {
+        this.instant = timeNow;
+        this.zone = zone;
+    }
+
+    @Override
+    public ZoneId getZone() {
+        return zone;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+        if (zone.equals(this.zone)) {
+            return this;
+        }
+        return new ManualClock(instant, zone);
+    }
+
+    @Override
+    public Instant instant() {
+        return instant;
+    }
+
+    public void set(Instant timeNow) {
+        instant = timeNow;
+    }
+
+    public void adjust(TemporalAmount offset) {
+        instant = instant.plus(offset);
+    }
+}

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/floodlightrouter/service/RouterServiceTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/floodlightrouter/service/RouterServiceTest.java
@@ -1,0 +1,128 @@
+/* Copyright 2019 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.floodlightrouter.service;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.openkilda.messaging.AliveResponse;
+import org.openkilda.messaging.Message;
+import org.openkilda.messaging.info.InfoData;
+import org.openkilda.messaging.info.InfoMessage;
+import org.openkilda.messaging.info.event.PortChangeType;
+import org.openkilda.messaging.info.event.PortInfoData;
+import org.openkilda.model.SwitchId;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.internal.util.Collections;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RouterServiceTest {
+    private static final String REGION_ONE = "one";
+    private static final String REGION_TWO = "two";
+
+    private RouterService service;
+
+    @Mock
+    private FloodlightTracker speakerTracker;
+
+    @Mock
+    private MessageSender carrier;
+
+    @Before
+    public void setUp() {
+        service = new RouterService(speakerTracker);
+    }
+
+    @Test
+    public void testPeriodicProcessing() {
+        when(speakerTracker.getRegionsForAliveRequest()).thenReturn(Collections.asSet(REGION_ONE, REGION_TWO));
+
+        service.doPeriodicProcessing(carrier);
+
+        verify(speakerTracker).handleAliveExpiration(carrier);
+        verify(speakerTracker).getRegionsForAliveRequest();
+        verifyNoMoreInteractions(speakerTracker);
+
+        verify(carrier).emitSpeakerAliveRequest(REGION_ONE);
+        verify(carrier).emitSpeakerAliveRequest(REGION_TWO);
+        verifyNoMoreInteractions(carrier);
+    }
+
+    @Test
+    public void testSpeakerResponse() {
+        long remoteTimestamp = 1000L;
+        final SwitchId switchId = new SwitchId(1001);
+        InfoData payload = new PortInfoData(switchId, 1, PortChangeType.UP);
+        Message message = new InfoMessage(payload, remoteTimestamp, "unit-test", REGION_ONE);
+
+        when(speakerTracker.updateSwitchRegion(switchId, REGION_ONE)).thenReturn(true);
+        when(speakerTracker.handleAliveResponse(REGION_ONE, remoteTimestamp)).thenReturn(true);
+
+        service.processSpeakerDiscoResponse(carrier, message);
+
+        verify(speakerTracker).handleAliveResponse(REGION_ONE, remoteTimestamp);
+        verify(speakerTracker).updateSwitchRegion(switchId, REGION_ONE);
+        verifyNoMoreInteractions(speakerTracker);
+
+        verify(carrier).emitRegionNotification(Mockito.eq(new SwitchMapping(switchId, REGION_ONE)));
+        verify(carrier).emitNetworkDumpRequest(REGION_ONE);
+        verify(carrier).emitControllerMessage(Mockito.eq(message));
+        verifyNoMoreInteractions(carrier);
+    }
+
+    @Test
+    public void testConsecutiveSpeakerResponse() {
+        long remoteTimestamp = 1000L;
+        final SwitchId switchId = new SwitchId(1001);
+        InfoData payload = new PortInfoData(switchId, 1, PortChangeType.UP);
+        Message message = new InfoMessage(payload, remoteTimestamp, "unit-test", REGION_ONE);
+
+        when(speakerTracker.updateSwitchRegion(switchId, REGION_ONE)).thenReturn(false);
+        when(speakerTracker.handleAliveResponse(REGION_ONE, remoteTimestamp)).thenReturn(false);
+
+        service.processSpeakerDiscoResponse(carrier, message);
+
+        verify(speakerTracker).handleAliveResponse(REGION_ONE, remoteTimestamp);
+        verify(speakerTracker).updateSwitchRegion(switchId, REGION_ONE);
+        verifyNoMoreInteractions(speakerTracker);
+
+        verify(carrier).emitControllerMessage(Mockito.eq(message));
+        verifyNoMoreInteractions(carrier);
+    }
+
+    @Test
+    public void testAliveResponseWithErrorMarker() {
+        long remoteTimestamp = 1000L;
+        InfoData payload = new AliveResponse(REGION_ONE, 1);
+        Message message = new InfoMessage(payload, remoteTimestamp, "unit-test", REGION_ONE);
+
+        when(speakerTracker.handleAliveResponse(REGION_ONE, remoteTimestamp)).thenReturn(false);
+
+        service.processSpeakerDiscoResponse(carrier, message);
+        verify(speakerTracker).handleAliveResponse(REGION_ONE, remoteTimestamp);
+        verifyNoMoreInteractions(speakerTracker);
+
+        verify(carrier).emitNetworkDumpRequest(REGION_ONE);
+        verifyNoMoreInteractions(carrier);
+    }
+}


### PR DESCRIPTION
Treat all speaker regions as avaibable untill available timeout is
reached. It removes "region unavailable errors" with huge (number of
seconds from EPOCH) timeouts. Also it eliminate possibility to mark all
existing switches as "unmanaged" (it don't happens now, because switches
mapping list is empty on topology start).

To avoid time difference influence between speaker and controller hosts,
replace usage of timestamps from proxied message with local time.

Also add time offset calculation between local clock and remote(speaker)
clock.

Issue #2456

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/2476)
<!-- Reviewable:end -->
