### PR TITLE
Minor fixes for nb correlation id check and logging

### DIFF
--- a/services/src/northbound-service/northbound/src/main/java/org/openkilda/northbound/config/WebConfig.java
+++ b/services/src/northbound-service/northbound/src/main/java/org/openkilda/northbound/config/WebConfig.java
@@ -17,14 +17,12 @@ package org.openkilda.northbound.config;
 
 import org.openkilda.northbound.utils.ExecutionTimeInterceptor;
 import org.openkilda.northbound.utils.ExtraAuthInterceptor;
-import org.openkilda.northbound.utils.RequestCorrelationFilter;
 import org.openkilda.northbound.utils.async.CompletableFutureReturnValueHandler;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -111,10 +109,4 @@ public class WebConfig extends WebMvcConfigurerAdapter {
     public ExtraAuthInterceptor extraAuthInterceptor() {
         return new ExtraAuthInterceptor();
     }
-
-    @Bean
-    public OncePerRequestFilter requestCorrelationIdFilter() {
-        return new RequestCorrelationFilter();
-    }
-
 }

--- a/services/src/northbound-service/northbound/src/main/java/org/openkilda/northbound/utils/NorthboundExceptionHandler.java
+++ b/services/src/northbound-service/northbound/src/main/java/org/openkilda/northbound/utils/NorthboundExceptionHandler.java
@@ -23,6 +23,8 @@ import org.openkilda.messaging.error.ErrorType;
 import org.openkilda.messaging.error.MessageError;
 import org.openkilda.messaging.error.MessageException;
 
+import org.slf4j.MDC;
+import org.slf4j.MDC.MDCCloseable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -85,7 +87,9 @@ public class NorthboundExceptionHandler extends ResponseEntityExceptionHandler {
         MessageError error = new MessageError(exception.getCorrelationId(), exception.getTimestamp(),
                 exception.getErrorType().toString(), exception.getMessage(), exception.getErrorDescription());
 
-        logger.warn(format("Error %s caught.", error), exception);
+        try (MDCCloseable mdcCloseable = MDC.putCloseable(CORRELATION_ID, exception.getCorrelationId())) {
+            logger.warn(format("Error %s caught.", error), exception);
+        }
 
         return super.handleExceptionInternal(exception, error, new HttpHeaders(), status, request);
     }

--- a/services/src/northbound-service/northbound/src/main/java/org/openkilda/northbound/utils/RequestCorrelationInspectorFilter.java
+++ b/services/src/northbound-service/northbound/src/main/java/org/openkilda/northbound/utils/RequestCorrelationInspectorFilter.java
@@ -1,4 +1,4 @@
-/* Copyright 2018 Telstra Open Source
+/* Copyright 2019 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -17,14 +17,9 @@ package org.openkilda.northbound.utils;
 
 import static org.openkilda.messaging.Utils.CORRELATION_ID;
 
-import org.openkilda.northbound.utils.RequestCorrelationId.RequestCorrelationClosable;
-
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
-import org.slf4j.MDC.MDCCloseable;
+import org.springframework.core.Ordered;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
@@ -32,23 +27,22 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.UUID;
+import javax.annotation.Priority;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * Spring Web filter which initializes the correlation context with either provided "correlation_id" (HTTP header) or a
- * new one.
+ * Filter that controls existence of correlation id in the header. IT should not allow to access to any resources
+ * without correlation id (except v1 APIs).
  */
+@Priority(value = Ordered.LOWEST_PRECEDENCE - 1)
 @Component
-public class RequestCorrelationFilter extends OncePerRequestFilter {
-
-    private static final Logger logger = LoggerFactory.getLogger(RequestCorrelationFilter.class);
+public class RequestCorrelationInspectorFilter extends OncePerRequestFilter {
 
     private static final List<String> EXCLUDE_PATTERNS = ImmutableList.of(
-            "/v1/health-check"
+            "/v1/**"
     );
 
     private final PathMatcher matcher = new AntPathMatcher();
@@ -59,34 +53,15 @@ public class RequestCorrelationFilter extends OncePerRequestFilter {
                 .anyMatch(p -> matcher.match(p, request.getServletPath()));
     }
 
-    /**
-     * Generates new correlation_id and add it into passing correlation id in the header.
-     */
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         String correlationId = request.getHeader(CORRELATION_ID);
-
-        boolean emptyCorrelationId = StringUtils.isBlank(correlationId);
-        if (emptyCorrelationId) {
-            correlationId = UUID.randomUUID().toString();
+        if (StringUtils.isBlank(correlationId)) {
+            response.getWriter().write("A request header 'correlation_id' with specified value is required");
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
         } else {
-            correlationId = RequestCorrelationId.chain(UUID.randomUUID().toString(), correlationId);
-        }
-
-        try (RequestCorrelationClosable requestCorrelation = RequestCorrelationId.create(correlationId)) {
-            // Put the request's correlationId into the logger context.
-            // MDC is picked up by the %X in log4j2 formatter .. resources/log4j2.xml
-            try (MDCCloseable closable = MDC.putCloseable(CORRELATION_ID, correlationId)) {
-                if (emptyCorrelationId) {
-                    logger.warn("CorrelationId was not sent, generated one: {}", correlationId);
-                } else {
-                    logger.trace("Found correlationId in header. Chaining: {}", correlationId);
-                }
-
-                response.addHeader(CORRELATION_ID, correlationId);
-                filterChain.doFilter(request, response);
-            }
+            filterChain.doFilter(request, response);
         }
     }
 }

--- a/services/src/northbound-service/northbound/src/test/java/org/openkilda/northbound/controller/v1/SwitchControllerTest.java
+++ b/services/src/northbound-service/northbound/src/test/java/org/openkilda/northbound/controller/v1/SwitchControllerTest.java
@@ -32,6 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.openkilda.northbound.controller.NorthboundBaseTest;
 import org.openkilda.northbound.controller.TestConfig;
 import org.openkilda.northbound.utils.RequestCorrelationFilter;
+import org.openkilda.northbound.utils.RequestCorrelationInspectorFilter;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -66,7 +67,7 @@ public class SwitchControllerTest extends NorthboundBaseTest {
     @Before
     public void setUp() throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-                .addFilters(new RequestCorrelationFilter())
+                .addFilters(new RequestCorrelationInspectorFilter(), new RequestCorrelationFilter())
                 .apply(springSecurity())
                 .build();
     }


### PR DESCRIPTION
- Ignored correlation id check for health-check endpoint
- Fix logs without correlation id in MDC context
- Forbid access to v2 APIs if correlation id is not presented