### PR TITLE
Partially revert PR2212 - deduplicate port event notifications

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/controller/port/PortFsm.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/controller/port/PortFsm.java
@@ -24,7 +24,6 @@ import org.openkilda.wfm.topology.network.controller.port.PortFsm.PortFsmContext
 import org.openkilda.wfm.topology.network.controller.port.PortFsm.PortFsmEvent;
 import org.openkilda.wfm.topology.network.controller.port.PortFsm.PortFsmState;
 import org.openkilda.wfm.topology.network.model.Endpoint;
-import org.openkilda.wfm.topology.network.model.LinkStatus;
 import org.openkilda.wfm.topology.network.service.IPortCarrier;
 
 import lombok.Builder;
@@ -42,7 +41,6 @@ public final class PortFsm extends AbstractBaseFsm<PortFsm, PortFsmState, PortFs
     private final PortReportFsm reportFsm;
 
     private static final StateMachineBuilder<PortFsm, PortFsmState, PortFsmEvent, PortFsmContext> builder;
-    private final NetworkTopologyDashboardLogger logWrapper = new NetworkTopologyDashboardLogger(log);
 
     static {
         builder = StateMachineBuilderFactory.create(
@@ -127,7 +125,6 @@ public final class PortFsm extends AbstractBaseFsm<PortFsm, PortFsmState, PortFs
     }
 
     public void upEnter(PortFsmState from, PortFsmState to, PortFsmEvent event, PortFsmContext context) {
-        logWrapper.onUpdatePortStatus(endpoint, LinkStatus.UP);
         reportFsm.fire(PortFsmEvent.PORT_UP);
         context.getOutput().enableDiscoveryPoll(endpoint);
     }
@@ -141,8 +138,6 @@ public final class PortFsm extends AbstractBaseFsm<PortFsm, PortFsmState, PortFs
     }
 
     public void downEnter(PortFsmState from, PortFsmState to, PortFsmEvent event, PortFsmContext context) {
-        logWrapper.onUpdatePortStatus(endpoint, LinkStatus.DOWN);
-
         reportFsm.fire(PortFsmEvent.PORT_DOWN);
         IPortCarrier output = context.getOutput();
         output.disableDiscoveryPoll(endpoint);


### PR DESCRIPTION
Revert duplication of port's event logging. #2212 add extra(incorrect)
point of port events logging.