### PR TITLE
Changed 'isl.latency' to 'isl.rtt' metric in GUI

### DIFF
--- a/services/src/openkilda-gui/src/main/java/org/openkilda/constants/IConstants.java
+++ b/services/src/openkilda-gui/src/main/java/org/openkilda/constants/IConstants.java
@@ -329,7 +329,7 @@ public abstract class IConstants {
 
         FLOW_TABLEID("Flow_tableid", "flow.tableid"),
 
-        ISL_LATENCY("Isl_latency", "isl.latency"),
+        ISL_LATENCY("Isl_latency", "isl.rtt"),
 
         SWITCH_COLLISIONS("Switch_collisions", "switch.collisions"),    
 

--- a/services/src/openkilda-gui/ui/src/app/modules/isl/isl-detail/isl-detail.component.html
+++ b/services/src/openkilda-gui/ui/src/app/modules/isl/isl-detail/isl-detail.component.html
@@ -93,7 +93,7 @@
                     <!-- ISL Latency Details -->
                     <div class='row isl_sbl_details'>
                       <label class='col-sm-6 col-form-label'>Latency:</label>
-                      <p class='col-sm-6 isl_div_latency'>{{latency}}</p>
+                      <p class='col-sm-6 isl_div_latency'>{{latency}} ns</p>
                     </div>
                     <div class='row isl_sbl_details'>
                       <label id="isl_cost_lbl" class='col-sm-6 col-form-label'>Cost:</label>


### PR DESCRIPTION
'isl.latency' metric name was renamed to 'isl.rtt'. 
Also now we measure latency in nanoseconds so 'ns' was added

Part of #580