### PR TITLE
[Network topo] Change logging level for port state events.

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/service/NetworkSwitchService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/service/NetworkSwitchService.java
@@ -149,14 +149,9 @@ public class NetworkSwitchService {
                 event = SwitchFsmEvent.PORT_DOWN;
                 break;
 
-            case OTHER_UPDATE:
-            case CACHED:
-                log.error("Invalid port event {} for {}_{} - incomplete or deprecated",
-                          payload.getState(), payload.getSwitchId(), payload.getPortNo());
-                break;
-
             default:
-                log.info("Ignore port event {}_{} (no need to handle it)", payload.getSwitchId(), payload.getPortNo());
+                log.info("Ignore port event {} for {}_{} (no need to handle it)",
+                        payload.getState(), payload.getSwitchId(), payload.getPortNo());
         }
 
         if (event != null) {


### PR DESCRIPTION
Other update and cached are not an error and will be logged as info.