### PR TITLE
Fix for vxlan unicast ping rule

### DIFF
--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/ping/PingResponseCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/ping/PingResponseCommand.java
@@ -62,8 +62,8 @@ public class PingResponseCommand extends PingCommand {
     }
 
     private byte[] unwrap() {
-        if (input.packetInCookieMismatchAll(log, PingService.OF_CATCH_RULE_COOKIE)
-                && input.packetInCookieMismatchAll(log, PingService.OF_CATCH_RULE_COOKIE_VXLAN)) {
+        if (input.packetInCookieMismatchAll(log, PingService.OF_CATCH_RULE_COOKIE,
+                PingService.OF_CATCH_RULE_COOKIE_VXLAN)) {
             return null;
         }
 

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/ping/PingResponseCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/ping/PingResponseCommand.java
@@ -62,7 +62,8 @@ public class PingResponseCommand extends PingCommand {
     }
 
     private byte[] unwrap() {
-        if (input.packetInCookieMismatchAll(log, PingService.OF_CATCH_RULE_COOKIE)) {
+        if (input.packetInCookieMismatchAll(log, PingService.OF_CATCH_RULE_COOKIE)
+                && input.packetInCookieMismatchAll(log, PingService.OF_CATCH_RULE_COOKIE_VXLAN)) {
             return null;
         }
 

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/converter/OfFlowStatsMapper.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/converter/OfFlowStatsMapper.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -150,7 +151,14 @@ public abstract class OfFlowStatsMapper {
     public FlowApplyActions toFlowApplyActions(OFInstruction instruction) {
         Map<OFActionType, OFAction> actions = ((OFInstructionApplyActions) instruction).getActions()
                 .stream()
+                .filter(ofAction -> !ofAction.getType().equals(OFActionType.EXPERIMENTER))
                 .collect(Collectors.toMap(OFAction::getType, action -> action));
+        // NOTE(tdurakov): there are could be more then one action of type experimenter, better to filter them out
+        // and handle independently
+        Set<OFAction> experimenterActions = ((OFInstructionApplyActions) instruction).getActions()
+                .stream()
+                .filter(ofAction -> ofAction.getType().equals(OFActionType.EXPERIMENTER))
+                .collect(Collectors.toSet());
         return FlowApplyActions.builder()
                 .meter(Optional.ofNullable(actions.get(OFActionType.METER))
                         .map(action -> String.valueOf(((OFActionMeter) action).getMeterId()))

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
@@ -25,6 +25,7 @@ import static org.openkilda.model.Cookie.DROP_VERIFICATION_LOOP_RULE_COOKIE;
 import static org.openkilda.model.Cookie.ROUND_TRIP_LATENCY_RULE_COOKIE;
 import static org.openkilda.model.Cookie.VERIFICATION_BROADCAST_RULE_COOKIE;
 import static org.openkilda.model.Cookie.VERIFICATION_UNICAST_RULE_COOKIE;
+import static org.openkilda.model.Cookie.VERIFICATION_UNICAST_VXLAN_RULE_COOKIE;
 
 import org.openkilda.floodlight.command.Command;
 import org.openkilda.floodlight.command.CommandContext;
@@ -553,6 +554,9 @@ class RecordHandler implements Runnable {
                 // TODO: this isn't installed as well. Refactor this section
                 switchManager.installRoundTripLatencyFlow(dpid);
                 installedRules.add(ROUND_TRIP_LATENCY_RULE_COOKIE);
+            } else if (installAction == InstallRulesAction.INSTALL_UNICAST_VXLAN) {
+                switchManager.installUnicastVerificationRuleVxlan(dpid);
+                installedRules.add(VERIFICATION_UNICAST_VXLAN_RULE_COOKIE);
             } else {
                 switchManager.installDefaultRules(dpid);
                 installedRules.addAll(asList(
@@ -561,7 +565,8 @@ class RecordHandler implements Runnable {
                         VERIFICATION_UNICAST_RULE_COOKIE,
                         DROP_VERIFICATION_LOOP_RULE_COOKIE,
                         CATCH_BFD_RULE_COOKIE,
-                        ROUND_TRIP_LATENCY_RULE_COOKIE
+                        ROUND_TRIP_LATENCY_RULE_COOKIE,
+                        VERIFICATION_UNICAST_VXLAN_RULE_COOKIE
                 ));
             }
 
@@ -623,6 +628,10 @@ class RecordHandler implements Runnable {
                     case REMOVE_ROUND_TRIP_LATENCY:
                         criteria = DeleteRulesCriteria.builder()
                                 .cookie(ROUND_TRIP_LATENCY_RULE_COOKIE).build();
+                        break;
+                    case REMOVE_UNICAST_VXLAN:
+                        criteria = DeleteRulesCriteria.builder()
+                                .cookie(VERIFICATION_UNICAST_VXLAN_RULE_COOKIE).build();
                         break;
                     default:
                         logger.warn("Received unexpected delete switch rule action: {}", deleteAction);

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/ping/PingService.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/ping/PingService.java
@@ -41,6 +41,7 @@ import java.util.Map;
 
 public class PingService implements IService {
     public static final U64 OF_CATCH_RULE_COOKIE = U64.of(Cookie.VERIFICATION_UNICAST_RULE_COOKIE);
+    public static final U64 OF_CATCH_RULE_COOKIE_VXLAN = U64.of(Cookie.VERIFICATION_UNICAST_VXLAN_RULE_COOKIE);
     private static final String NET_L3_ADDRESS = "127.0.0.2";
     private static final int NET_L3_PORT = PathVerificationService.DISCOVERY_PACKET_UDP_PORT + 1;
     private static final byte NET_L3_TTL = 96;

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/ISwitchManager.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/ISwitchManager.java
@@ -66,6 +66,13 @@ public interface ISwitchManager extends IFloodlightService {
     void installDefaultRules(final DatapathId dpid) throws SwitchOperationException;
 
     /**
+     * Add default rule for install verfication rule applicable for vxlan.
+     * @param dpid datapathId of switch
+     * @throws SwitchOperationException in case of errors
+     */
+    void installUnicastVerificationRuleVxlan(final DatapathId dpid) throws SwitchOperationException;
+
+    /**
      * Installs the default verification rule, if it is allowed. One case where it isn't -
      * if the switch is an OpenFlow 1.2 switch and isBroadcast = false. In that scenario, nothing
      * happens.

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
@@ -177,6 +177,8 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
     public static final IPv4Address STUB_VXLAN_IPV4_SRC = IPv4Address.of("127.0.0.1");
     public static final IPv4Address STUB_VXLAN_IPV4_DST = IPv4Address.of("127.0.0.2");
     public static final int STUB_VXLAN_UDP_SRC = 4500;
+    public static final int INTERNAL_ETH_DEST_OFFSET = 400;
+    public static final int MAC_ADDRESS_SIZE_IN_BITS = 48;
 
 
     // This is invalid VID mask - it cut of highest bit that indicate presence of VLAN tag on package. But valid mask
@@ -1458,6 +1460,7 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
                 break;
             case VXLAN:
                 actionList.add(actionPushVxlan(ofFactory, transitTunnelId, dpIdToMac(ethSrc)));
+                actionList.add(actionVxlanEthDstCopyField(ofFactory));
                 break;
             default:
                 throw new UnsupportedOperationException(
@@ -1523,6 +1526,17 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
                 .setIpv4Src(STUB_VXLAN_IPV4_SRC)
                 .setIpv4Dst(STUB_VXLAN_IPV4_DST)
                 .setFlags((short) 0x01)
+                .build();
+    }
+
+    private OFAction actionVxlanEthDstCopyField(OFFactory ofFactory) {
+        OFOxms oxms = ofFactory.oxms();
+        return ofFactory.actions().buildNoviflowCopyField()
+                .setNBits(MAC_ADDRESS_SIZE_IN_BITS)
+                .setSrcOffset(INTERNAL_ETH_DEST_OFFSET)
+                .setDstOffset(0)
+                .setOxmSrcHeader(oxms.buildNoviflowPacketOffset().getTypeLen())
+                .setOxmDstHeader(oxms.buildNoviflowPacketOffset().getTypeLen())
                 .build();
     }
 

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
@@ -785,11 +785,12 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
     public List<Long> deleteDefaultRules(DatapathId dpid) throws SwitchOperationException {
         List<Long> deletedRules = deleteRulesWithCookie(dpid, DROP_RULE_COOKIE, VERIFICATION_BROADCAST_RULE_COOKIE,
                 VERIFICATION_UNICAST_RULE_COOKIE, DROP_VERIFICATION_LOOP_RULE_COOKIE, CATCH_BFD_RULE_COOKIE,
-                ROUND_TRIP_LATENCY_RULE_COOKIE);
+                ROUND_TRIP_LATENCY_RULE_COOKIE, VERIFICATION_UNICAST_VXLAN_RULE_COOKIE);
 
         try {
             deleteMeter(dpid, createMeterIdForDefaultRule(VERIFICATION_BROADCAST_RULE_COOKIE).getValue());
             deleteMeter(dpid, createMeterIdForDefaultRule(VERIFICATION_UNICAST_RULE_COOKIE).getValue());
+            deleteMeter(dpid, createMeterIdForDefaultRule(VERIFICATION_UNICAST_VXLAN_RULE_COOKIE).getValue());
         } catch (UnsupportedSwitchOperationException e) {
             logger.info("Skip meters deletion from switch {} due to lack of meters support", dpid);
         }
@@ -827,7 +828,7 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
             MacAddress dstMac = dpIdToMac(sw.getId());
             Builder builder = sw.getOFFactory().buildMatch();
             builder.setMasked(MatchField.ETH_DST, dstMac, MacAddress.NO_MASK);
-            builder.setExact(MatchField.UDP_SRC, TransportPort.of(4500));
+            builder.setExact(MatchField.UDP_SRC, TransportPort.of(STUB_VXLAN_UDP_SRC));
             Match match = builder.build();
             OFFlowMod flowMod = prepareFlowModBuilder(ofFactory, cookie, VERIFICATION_RULE_VXLAN_PRIORITY)
                     .setInstructions(meter != null ? ImmutableList.of(meter, actions) : ImmutableList.of(actions))

--- a/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/ping/PingResponseCommandTest.java
+++ b/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/ping/PingResponseCommandTest.java
@@ -94,7 +94,7 @@ public class PingResponseCommandTest extends PingCommandTest {
         expect(pingService.unwrapData(eq(dpId), anyObject())).andReturn(null);
 
         OfInput input = createMock(OfInput.class);
-        expect(input.packetInCookieMismatchAll(anyObject(), anyObject())).andReturn(false);
+        expect(input.packetInCookieMismatchAll(anyObject(), anyObject(), anyObject())).andReturn(false);
         expect(input.getPacketInPayload()).andReturn(new Ethernet());
         expect(input.getDpId()).andReturn(dpId);
 

--- a/services/src/kilda-core/kilda-model/src/main/java/org/openkilda/model/Cookie.java
+++ b/services/src/kilda-core/kilda-model/src/main/java/org/openkilda/model/Cookie.java
@@ -34,6 +34,7 @@ public class Cookie implements Comparable<Cookie>, Serializable {
     public static final long DROP_VERIFICATION_LOOP_RULE_COOKIE = 0x8000000000000004L;
     public static final long CATCH_BFD_RULE_COOKIE = 0x8000000000000005L;
     public static final long ROUND_TRIP_LATENCY_RULE_COOKIE = 0x8000000000000006L;
+    public static final long VERIFICATION_UNICAST_VXLAN_RULE_COOKIE = 0x8000000000000007L;
     public static final long DEFAULT_RULES_MASK = 0x8000000000000000L;
 
     public static final long FORWARD_FLOW_COOKIE_MASK = 0x4000000000000000L;

--- a/services/src/kilda-core/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/IslRepository.java
+++ b/services/src/kilda-core/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/IslRepository.java
@@ -53,12 +53,14 @@ public interface IslRepository extends Repository<Isl> {
      * bandwidth.
      * <p/>
      * ISLs must have available bandwidth to satisfy the difference between newly requested and already taken by the
-     * same flow.
+     * same flow and support requested transit encapsulation type.
      *
      * @param pathIds           list of the pathId.
      * @param requiredBandwidth required bandwidth amount that should be available on ISLs.
+     * @param flowEncapsulationType required encapsulation support
      */
-    Collection<Isl> findActiveAndOccupiedByFlowPathWithAvailableBandwidth(List<PathId> pathIds, long requiredBandwidth);
+    Collection<Isl> findActiveAndOccupiedByFlowPathWithAvailableBandwidth(List<PathId> pathIds, long requiredBandwidth,
+                                                                          FlowEncapsulationType flowEncapsulationType);
 
     /**
      * Finds all active ISLs.

--- a/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jFlowPairRepository.java
+++ b/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jFlowPairRepository.java
@@ -15,13 +15,15 @@
 
 package org.openkilda.persistence.repositories.impl;
 
+import org.openkilda.model.EncapsulationId;
 import org.openkilda.model.Flow;
+import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.FlowPair;
-import org.openkilda.model.TransitVlan;
 import org.openkilda.persistence.TransactionManager;
 import org.openkilda.persistence.repositories.FlowPairRepository;
 import org.openkilda.persistence.repositories.FlowRepository;
 import org.openkilda.persistence.repositories.TransitVlanRepository;
+import org.openkilda.persistence.repositories.VxlanRepository;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -37,10 +39,12 @@ public class Neo4jFlowPairRepository implements FlowPairRepository {
 
     private FlowRepository flowRepository;
     private TransitVlanRepository transitVlanRepository;
+    private VxlanRepository vxlanRepository;
 
     public Neo4jFlowPairRepository(Neo4jSessionFactory sessionFactory, TransactionManager transactionManager) {
         flowRepository = new Neo4jFlowRepository(sessionFactory, transactionManager);
         transitVlanRepository = new Neo4jTransitVlanRepository(sessionFactory, transactionManager);
+        vxlanRepository =  new Neo4jVxlanRepository(sessionFactory, transactionManager);
     }
 
     @Override
@@ -56,11 +60,22 @@ public class Neo4jFlowPairRepository implements FlowPairRepository {
     }
 
     private FlowPair toFlowPair(Flow flow) {
-        TransitVlan forwardTransitVlan = transitVlanRepository.findByPathId(
-                flow.getForwardPathId(), flow.getReversePathId()).stream().findAny().orElse(null);
-        TransitVlan reverseTransitVlan = transitVlanRepository.findByPathId(
-                flow.getReversePathId(), flow.getForwardPathId()).stream().findAny().orElse(null);
-
-        return new FlowPair(flow, forwardTransitVlan, reverseTransitVlan);
+        EncapsulationId forwardEncapsulationId = null;
+        EncapsulationId reverseEncapsulationId = null;
+        if (flow.getEncapsulationType() == FlowEncapsulationType.TRANSIT_VLAN) {
+            forwardEncapsulationId = transitVlanRepository.findByPathId(
+                    flow.getForwardPathId(), flow.getReversePathId()).stream().findAny().orElse(null);
+            reverseEncapsulationId = transitVlanRepository.findByPathId(
+                    flow.getReversePathId(), flow.getForwardPathId()).stream().findAny().orElse(null);
+        } else if (flow.getEncapsulationType() == FlowEncapsulationType.VXLAN) {
+            forwardEncapsulationId = vxlanRepository.findByPathId(
+                    flow.getForwardPathId(), flow.getReversePathId()).stream().findAny().orElse(null);
+            reverseEncapsulationId = vxlanRepository.findByPathId(
+                    flow.getReversePathId(), flow.getForwardPathId()).stream().findAny().orElse(null);
+        } else {
+            throw new IllegalArgumentException(String.format("Unknown encapsulation type %s",
+                    flow.getEncapsulationType()));
+        }
+        return new FlowPair(flow, forwardEncapsulationId, reverseEncapsulationId);
     }
 }

--- a/services/src/kilda-core/kilda-persistence-neo4j/src/test/java/org/openkilda/persistence/repositories/impl/Neo4jFlowRepositoryTest.java
+++ b/services/src/kilda-core/kilda-persistence-neo4j/src/test/java/org/openkilda/persistence/repositories/impl/Neo4jFlowRepositoryTest.java
@@ -118,6 +118,7 @@ public class Neo4jFlowRepositoryTest extends Neo4jBasedTest {
     public void shouldUpdateFlow() {
         Flow flow = buildTestFlow(TEST_FLOW_ID, switchA, switchB);
         flow.setBandwidth(10000);
+        flow.setEncapsulationType(FlowEncapsulationType.TRANSIT_VLAN);
         flowRepository.createOrUpdate(flow);
 
         flow.setBandwidth(100);

--- a/services/src/kilda-core/kilda-persistence-neo4j/src/test/java/org/openkilda/persistence/repositories/impl/Neo4jIslRepositoryTest.java
+++ b/services/src/kilda-core/kilda-persistence-neo4j/src/test/java/org/openkilda/persistence/repositories/impl/Neo4jIslRepositoryTest.java
@@ -270,7 +270,8 @@ public class Neo4jIslRepositoryTest extends Neo4jBasedTest {
         Flow flow = buildFlowWithPath(0, 0);
 
         List<Isl> foundIsls = Lists.newArrayList(
-                islRepository.findActiveAndOccupiedByFlowPathWithAvailableBandwidth(flow.getFlowPathIds(), 100));
+                islRepository.findActiveAndOccupiedByFlowPathWithAvailableBandwidth(flow.getFlowPathIds(), 100,
+                        FlowEncapsulationType.TRANSIT_VLAN));
         assertThat(foundIsls, Matchers.hasSize(1));
     }
 
@@ -289,7 +290,8 @@ public class Neo4jIslRepositoryTest extends Neo4jBasedTest {
         Flow flow = buildFlowWithPath(0, 0);
 
         List<Isl> foundIsls = Lists.newArrayList(
-                islRepository.findActiveAndOccupiedByFlowPathWithAvailableBandwidth(flow.getFlowPathIds(), 100));
+                islRepository.findActiveAndOccupiedByFlowPathWithAvailableBandwidth(flow.getFlowPathIds(), 100,
+                        FlowEncapsulationType.TRANSIT_VLAN));
         assertThat(foundIsls, Matchers.hasSize(0));
     }
 

--- a/services/src/kilda-pce/src/main/java/org/openkilda/pce/AvailableNetworkFactory.java
+++ b/services/src/kilda-pce/src/main/java/org/openkilda/pce/AvailableNetworkFactory.java
@@ -78,7 +78,7 @@ public class AvailableNetworkFactory {
             if (!reusePathsResources.isEmpty() && !flow.isIgnoreBandwidth()) {
                 // ISLs occupied by the flow (take the bandwidth already occupied by the flow into account).
                 Collection<Isl> flowLinks = islRepository.findActiveAndOccupiedByFlowPathWithAvailableBandwidth(
-                        reusePathsResources, flow.getBandwidth());
+                        reusePathsResources, flow.getBandwidth(), flow.getEncapsulationType());
                 flowLinks.forEach(network::addLink);
             }
         } catch (PersistenceException e) {

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/command/switches/DeleteRulesAction.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/command/switches/DeleteRulesAction.java
@@ -49,6 +49,9 @@ public enum DeleteRulesAction {
     // Remove Round Trip Latency rule
     REMOVE_ROUND_TRIP_LATENCY,
 
+    // Remove unicast verification for VXLAN
+    REMOVE_UNICAST_VXLAN,
+
     // Drop all default rules (ie a combination of the above)
     REMOVE_DEFAULTS,
 

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/command/switches/InstallRulesAction.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/command/switches/InstallRulesAction.java
@@ -34,6 +34,9 @@ public enum InstallRulesAction {
     // Install Round Trip Latency rule
     INSTALL_ROUND_TRIP_LATENCY,
 
+    // Install Unicast for VXLAN
+    INSTALL_UNICAST_VXLAN,
+
     // Install all default rules (ie a combination of the above)
     INSTALL_DEFAULTS;
 }

--- a/services/src/northbound-service/northbound/src/main/java/org/openkilda/northbound/controller/v1/SwitchController.java
+++ b/services/src/northbound-service/northbound/src/main/java/org/openkilda/northbound/controller/v1/SwitchController.java
@@ -151,7 +151,7 @@ public class SwitchController extends BaseController {
             @ApiParam(value = "default: IGNORE_DEFAULTS. Can be one of DeleteRulesAction: "
                     + "DROP_ALL,DROP_ALL_ADD_DEFAULTS,IGNORE_DEFAULTS,OVERWRITE_DEFAULTS,"
                     + "REMOVE_DROP,REMOVE_BROADCAST,REMOVE_UNICAST,REMOVE_VERIFICATION_LOOP,REMOVE_BFD_CATCH,"
-                    + "REMOVE_ROUND_TRIP_LATENCY,REMOVE_DEFAULTS,REMOVE_ADD_DEFAULTS",
+                    + "REMOVE_ROUND_TRIP_LATENCY,REMOVE_UNICAST_VXLAN,REMOVE_DEFAULTS,REMOVE_ADD_DEFAULTS",
                     required = false)
             @RequestParam(value = "delete-action", required = false) Optional<DeleteRulesAction> deleteAction,
             @RequestParam(value = "cookie", required = false) Optional<Long> cookie,
@@ -222,7 +222,7 @@ public class SwitchController extends BaseController {
             @PathVariable("switch-id") SwitchId switchId,
             @ApiParam(value = "default: INSTALL_DEFAULTS. Can be one of InstallRulesAction: "
                     + " INSTALL_DROP,INSTALL_BROADCAST,INSTALL_UNICAST,INSTALL_BFD_CATCH,INSTALL_ROUND_TRIP_LATENCY,"
-                    + "INSTALL_DEFAULTS")
+                    + "INSTALL_UNICAST_VXLAN,INSTALL_DEFAULTS")
             @RequestParam(value = "install-action", required = false) Optional<InstallRulesAction> installAction) {
         return switchService.installRules(switchId, installAction.orElse(InstallRulesAction.INSTALL_DEFAULTS));
     }

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flow/service/BaseFlowServiceTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flow/service/BaseFlowServiceTest.java
@@ -18,6 +18,7 @@ package org.openkilda.wfm.topology.flow.service;
 import static org.junit.Assert.assertTrue;
 
 import org.openkilda.model.Flow;
+import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.FlowPair;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchId;
@@ -56,6 +57,7 @@ public class BaseFlowServiceTest extends Neo4jBasedTest {
         Flow flow = new TestFlowBuilder()
                 .srcSwitch(getOrCreateSwitch(SWITCH_ID_1))
                 .destSwitch(getOrCreateSwitch(SWITCH_ID_2))
+                .encapsulationType(FlowEncapsulationType.TRANSIT_VLAN)
                 .build();
         flowRepository.createOrUpdate(flow);
 

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/nbworker/services/FlowOperationsServiceTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/nbworker/services/FlowOperationsServiceTest.java
@@ -18,6 +18,7 @@ package org.openkilda.wfm.topology.nbworker.services;
 import static org.junit.Assert.assertEquals;
 
 import org.openkilda.messaging.model.FlowDto;
+import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.FlowStatus;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchId;
@@ -69,6 +70,7 @@ public class FlowOperationsServiceTest extends Neo4jBasedTest {
                 .destSwitch(switchB)
                 .destPort(2)
                 .destVlan(11)
+                .encapsulationType(FlowEncapsulationType.TRANSIT_VLAN)
                 .buildUnidirectionalFlow();
         flow.setStatus(FlowStatus.UP);
         flowRepository.createOrUpdate(flow.getFlow());


### PR DESCRIPTION
This patch add additional action on ingress rule for
vxlan encapsulated flow. This rule copies eth_dst from original
packet to newly pushed vxlan header

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/2553)
<!-- Reviewable:end -->
