### PR TITLE
Fix occasionally failing SwapEndpoint test

### DIFF
--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
@@ -237,8 +237,8 @@ switches"() {
         validateFlows(flow1, flow2)
 
         and: "Switch validation doesn't show any missing/excess rules and meters"
-        validateSwitches(flow1SwitchPair)
-        validateSwitches(flow2SwitchPair)
+        validateSwitches(switchPairs[0])
+        validateSwitches(switchPairs[1])
 
         and: "Delete flows"
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
@@ -246,10 +246,14 @@ switches"() {
         where:
         endpointsPart << ["vlans", "ports", "switches"]
         description << ["src1 <-> dst2, dst1 <-> src2"] * 3
-        flow1SwitchPair << [getTopologyHelper().getNotNeighboringSwitchPair()] * 3
-        flow2SwitchPair << [getHalfDifferentNotNeighboringSwitchPair(flow1SwitchPair, "dst")] * 3
-        flow1 << [getFirstFlow(flow1SwitchPair, flow2SwitchPair)] * 3
-        flow2 << [getSecondFlow(flow1SwitchPair, flow2SwitchPair, flow1)] * 3
+        switchPairs << [getTopologyHelper().getAllNotNeighboringSwitchPairs().inject(null) { result, switchPair ->
+            if (result) return result
+            def halfDifferent = getHalfDifferentNotNeighboringSwitchPair(switchPair, "dst")
+            if (halfDifferent) result = [switchPair, halfDifferent]
+            return result
+        }] * 3
+        flow1 << [getFirstFlow(switchPairs[0], switchPairs[1])] * 3
+        flow2 << [getSecondFlow(switchPairs[0], switchPairs[1], flow1)] * 3
         [flow1Src, flow1Dst, flow2Src, flow2Dst] << [
                 [changePropertyValue(flow1.source, "vlanId", flow2.destination.vlanId),
                  changePropertyValue(flow1.destination, "vlanId", flow2.source.vlanId),


### PR DESCRIPTION
Used to sometimes fail with 
```
2019-06-28 19:38:03.978 java.lang.NullPointerException: Cannot get property 'src' on null object
2019-06-28 19:38:03.978 	at org.openkilda.functionaltests.spec.flows.SwapEndpointSpec.getFirstFlow(SwapEndpointSpec.groovy:1066)
```
I assume this was because sometimes we randomly picked such a `flow1SwitchPair` that it didn't have a proper `getHalfDifferentNotNeighboringSwitchPair(flow1SwitchPair, "dst")`