### PR TITLE
Fix flow validation for swap endpoints functionality (for default flows)

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/validation/FlowValidator.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/validation/FlowValidator.java
@@ -30,6 +30,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -74,8 +75,8 @@ public class FlowValidator {
     public void validateFowSwap(Flow firstFlow, Flow secondFlow) throws FlowValidationException {
         checkFlowForIslConflicts(firstFlow);
         checkFlowForIslConflicts(secondFlow);
-        checkFlowForEndpointConflicts(firstFlow, firstFlow.getFlowId(), secondFlow.getFlowId());
-        checkFlowForEndpointConflicts(secondFlow, firstFlow.getFlowId(), secondFlow.getFlowId());
+        checkFlowForEndpointConflicts(firstFlow, Collections.singleton(secondFlow.getFlowId()));
+        checkFlowForEndpointConflicts(secondFlow, Collections.singleton(firstFlow.getFlowId()));
         checkForEqualsEndpoints(firstFlow, secondFlow);
     }
 
@@ -118,20 +119,29 @@ public class FlowValidator {
     /**
      * Checks a flow for endpoints' conflicts.
      *
-     * @param requestedFlow a flow to be validated.
+     * @param subject a flow to be validated.
      * @throws FlowValidationException is thrown in a case when flow endpoints conflict with existing flows.
      */
     @VisibleForTesting
-    void checkFlowForEndpointConflicts(Flow requestedFlow) throws FlowValidationException {
+    void checkFlowForEndpointConflicts(Flow subject) throws FlowValidationException {
+        checkFlowForEndpointConflicts(subject, new HashSet<>());
+    }
+
+    @VisibleForTesting
+    void checkFlowForEndpointConflicts(Flow subject, Set<String> flowIdsConflictToBeIgnored)
+            throws FlowValidationException {
         // Check the source
-        Collection<Flow> conflictsOnSource = flowRepository.findByEndpoint(requestedFlow.getSrcSwitch().getSwitchId(),
-                requestedFlow.getSrcPort());
+        Collection<Flow> conflictsOnSource = flowRepository.findByEndpoint(subject.getSrcSwitch().getSwitchId(),
+                subject.getSrcPort());
+
+        Set<String> processingFlowIds = new HashSet<>(flowIdsConflictToBeIgnored);
+        processingFlowIds.add(subject.getFlowId());
 
         Optional<Flow> conflictSrcSrc = conflictsOnSource.stream()
-                .filter(flow -> !requestedFlow.getFlowId().equals(flow.getFlowId()))
-                .filter(flow -> flow.getSrcSwitch().getSwitchId().equals(requestedFlow.getSrcSwitch().getSwitchId())
-                        && flow.getSrcPort() == requestedFlow.getSrcPort()
-                        && (flow.getSrcVlan() == requestedFlow.getSrcVlan()))
+                .filter(flow -> !processingFlowIds.contains(flow.getFlowId()))
+                .filter(flow -> flow.getSrcSwitch().getSwitchId().equals(subject.getSrcSwitch().getSwitchId())
+                        && flow.getSrcPort() == subject.getSrcPort()
+                        && (flow.getSrcVlan() == subject.getSrcVlan()))
                 .findAny();
 
         if (conflictSrcSrc.isPresent()) {
@@ -139,9 +149,9 @@ public class FlowValidator {
                             + "Details: "
                             + "requested flow '%s' source: switch=%s port=%d vlan=%d, "
                             + "existing flow '%s' source: switch=%s port=%d vlan=%d",
-                    requestedFlow.getFlowId(), conflictSrcSrc.get().getFlowId(),
-                    requestedFlow.getFlowId(), requestedFlow.getSrcSwitch().getSwitchId().toString(),
-                    requestedFlow.getSrcPort(), requestedFlow.getSrcVlan(),
+                    subject.getFlowId(), conflictSrcSrc.get().getFlowId(),
+                    subject.getFlowId(), subject.getSrcSwitch().getSwitchId().toString(),
+                    subject.getSrcPort(), subject.getSrcVlan(),
                     conflictSrcSrc.get().getFlowId(),
                     conflictSrcSrc.get().getSrcSwitch().getSwitchId().toString(),
                     conflictSrcSrc.get().getSrcPort(), conflictSrcSrc.get().getSrcVlan());
@@ -149,10 +159,10 @@ public class FlowValidator {
         }
 
         Optional<Flow> conflictDstSrc = conflictsOnSource.stream()
-                .filter(flow -> !requestedFlow.getFlowId().equals(flow.getFlowId()))
-                .filter(flow -> flow.getDestSwitch().getSwitchId().equals(requestedFlow.getSrcSwitch().getSwitchId())
-                        && flow.getDestPort() == requestedFlow.getSrcPort()
-                        && (flow.getDestVlan() == requestedFlow.getSrcVlan()))
+                .filter(flow -> !processingFlowIds.contains(flow.getFlowId()))
+                .filter(flow -> flow.getDestSwitch().getSwitchId().equals(subject.getSrcSwitch().getSwitchId())
+                        && flow.getDestPort() == subject.getSrcPort()
+                        && (flow.getDestVlan() == subject.getSrcVlan()))
                 .findAny();
 
         if (conflictDstSrc.isPresent()) {
@@ -160,9 +170,9 @@ public class FlowValidator {
                             + "Details: "
                             + "requested flow '%s' source: switch=%s port=%d vlan=%d, "
                             + "existing flow '%s' destination: switch=%s port=%d vlan=%d",
-                    requestedFlow.getFlowId(), conflictDstSrc.get().getFlowId(),
-                    requestedFlow.getFlowId(), requestedFlow.getSrcSwitch().getSwitchId().toString(),
-                    requestedFlow.getSrcPort(), requestedFlow.getSrcVlan(),
+                    subject.getFlowId(), conflictDstSrc.get().getFlowId(),
+                    subject.getFlowId(), subject.getSrcSwitch().getSwitchId().toString(),
+                    subject.getSrcPort(), subject.getSrcVlan(),
                     conflictDstSrc.get().getFlowId(),
                     conflictDstSrc.get().getDestSwitch().getSwitchId().toString(),
                     conflictDstSrc.get().getDestPort(), conflictDstSrc.get().getDestVlan());
@@ -171,15 +181,15 @@ public class FlowValidator {
 
         // Check the destination
         Collection<Flow> conflictsOnDest = flowRepository.findByEndpoint(
-                requestedFlow.getDestSwitch().getSwitchId(),
-                requestedFlow.getDestPort());
+                subject.getDestSwitch().getSwitchId(),
+                subject.getDestPort());
 
 
         Optional<Flow> conflictSrcDst = conflictsOnDest.stream()
-                .filter(flow -> !requestedFlow.getFlowId().equals(flow.getFlowId()))
-                .filter(flow -> flow.getSrcSwitch().getSwitchId().equals(requestedFlow.getDestSwitch().getSwitchId())
-                        && flow.getSrcPort() == requestedFlow.getDestPort()
-                        && (flow.getSrcVlan() == requestedFlow.getDestVlan()))
+                .filter(flow -> !processingFlowIds.contains(flow.getFlowId()))
+                .filter(flow -> flow.getSrcSwitch().getSwitchId().equals(subject.getDestSwitch().getSwitchId())
+                        && flow.getSrcPort() == subject.getDestPort()
+                        && (flow.getSrcVlan() == subject.getDestVlan()))
                 .findAny();
 
         if (conflictSrcDst.isPresent()) {
@@ -187,9 +197,9 @@ public class FlowValidator {
                             + "Details: "
                             + "requested flow '%s' destination: switch=%s port=%d vlan=%d, "
                             + "existing flow '%s' source: switch=%s port=%d vlan=%d",
-                    requestedFlow.getFlowId(), conflictSrcDst.get().getFlowId(),
-                    requestedFlow.getFlowId(), requestedFlow.getDestSwitch().getSwitchId().toString(),
-                    requestedFlow.getDestPort(), requestedFlow.getDestVlan(),
+                    subject.getFlowId(), conflictSrcDst.get().getFlowId(),
+                    subject.getFlowId(), subject.getDestSwitch().getSwitchId().toString(),
+                    subject.getDestPort(), subject.getDestVlan(),
                     conflictSrcDst.get().getFlowId(),
                     conflictSrcDst.get().getSrcSwitch().getSwitchId().toString(),
                     conflictSrcDst.get().getSrcPort(), conflictSrcDst.get().getSrcVlan());
@@ -197,10 +207,10 @@ public class FlowValidator {
         }
 
         Optional<Flow> conflictDstDst = conflictsOnDest.stream()
-                .filter(flow -> !requestedFlow.getFlowId().equals(flow.getFlowId()))
-                .filter(flow -> flow.getDestSwitch().getSwitchId().equals(requestedFlow.getDestSwitch().getSwitchId())
-                        && flow.getDestPort() == requestedFlow.getDestPort()
-                        && (flow.getDestVlan() == requestedFlow.getDestVlan()))
+                .filter(flow -> !processingFlowIds.contains(flow.getFlowId()))
+                .filter(flow -> flow.getDestSwitch().getSwitchId().equals(subject.getDestSwitch().getSwitchId())
+                        && flow.getDestPort() == subject.getDestPort()
+                        && (flow.getDestVlan() == subject.getDestVlan()))
                 .findAny();
 
         if (conflictDstDst.isPresent()) {
@@ -208,89 +218,12 @@ public class FlowValidator {
                             + "Details: "
                             + "requested flow '%s' destination: switch=%s port=%d vlan=%d, "
                             + "existing flow '%s' destination: switch=%s port=%d vlan=%d",
-                    requestedFlow.getFlowId(), conflictDstDst.get().getFlowId(),
-                    requestedFlow.getFlowId(), requestedFlow.getDestSwitch().getSwitchId().toString(),
-                    requestedFlow.getDestPort(), requestedFlow.getDestVlan(),
+                    subject.getFlowId(), conflictDstDst.get().getFlowId(),
+                    subject.getFlowId(), subject.getDestSwitch().getSwitchId().toString(),
+                    subject.getDestPort(), subject.getDestVlan(),
                     conflictDstDst.get().getFlowId(),
                     conflictDstDst.get().getDestSwitch().getSwitchId().toString(),
                     conflictDstDst.get().getDestPort(), conflictDstDst.get().getDestVlan());
-            throw new FlowValidationException(errorMessage, ErrorType.ALREADY_EXISTS);
-        }
-    }
-
-    @VisibleForTesting
-    void checkFlowForEndpointConflicts(Flow checkedFlow, String firstFlowId, String secondFlowId)
-            throws FlowValidationException {
-        Collection<Flow> conflictsOnSource = flowRepository.findByEndpoint(checkedFlow.getSrcSwitch().getSwitchId(),
-                checkedFlow.getSrcPort());
-
-        Optional<Flow> conflictSrcSrc = conflictsOnSource.stream()
-                .filter(flow -> !firstFlowId.equals(flow.getFlowId()))
-                .filter(flow -> !secondFlowId.equals(flow.getFlowId()))
-                .filter(flow -> flow.getSrcSwitch().getSwitchId().equals(checkedFlow.getSrcSwitch().getSwitchId())
-                        && flow.getSrcPort() == checkedFlow.getSrcPort()
-                        && (flow.getSrcVlan() == checkedFlow.getSrcVlan()
-                        || flow.getSrcVlan() == 0 || checkedFlow.getSrcVlan() == 0))
-                .findAny();
-
-        if (conflictSrcSrc.isPresent()) {
-            String errorMessage = format("Requested source endpoint for flow '%s' conflicts with "
-                            + "existing source endpoint for flow '%s'.",
-                    checkedFlow.getFlowId(), conflictSrcSrc.get().getFlowId());
-            throw new FlowValidationException(errorMessage, ErrorType.ALREADY_EXISTS);
-        }
-
-        Optional<Flow> conflictDstSrc = conflictsOnSource.stream()
-                .filter(flow -> !firstFlowId.equals(flow.getFlowId()))
-                .filter(flow -> !secondFlowId.equals(flow.getFlowId()))
-                .filter(flow -> flow.getDestSwitch().getSwitchId().equals(checkedFlow.getSrcSwitch().getSwitchId())
-                        && flow.getDestPort() == checkedFlow.getSrcPort()
-                        && (flow.getDestVlan() == checkedFlow.getSrcVlan()
-                        || flow.getDestVlan() == 0 || checkedFlow.getSrcVlan() == 0))
-                .findAny();
-
-        if (conflictDstSrc.isPresent()) {
-            String errorMessage = format("Requested source endpoint for flow '%s' conflicts with "
-                            + "existing destination endpoint for flow '%s'.",
-                    checkedFlow.getFlowId(), conflictDstSrc.get().getFlowId());
-            throw new FlowValidationException(errorMessage, ErrorType.ALREADY_EXISTS);
-        }
-
-        // Check the destination
-        Collection<Flow> conflictsOnDest = flowRepository.findByEndpoint(
-                checkedFlow.getDestSwitch().getSwitchId(),
-                checkedFlow.getDestPort());
-
-
-        Optional<Flow> conflictSrcDst = conflictsOnDest.stream()
-                .filter(flow -> !firstFlowId.equals(flow.getFlowId()))
-                .filter(flow -> !secondFlowId.equals(flow.getFlowId()))
-                .filter(flow -> flow.getSrcSwitch().getSwitchId().equals(checkedFlow.getDestSwitch().getSwitchId())
-                        && flow.getSrcPort() == checkedFlow.getDestPort()
-                        && (flow.getSrcVlan() == checkedFlow.getDestVlan()
-                        || flow.getSrcVlan() == 0 || checkedFlow.getDestVlan() == 0))
-                .findAny();
-
-        if (conflictSrcDst.isPresent()) {
-            String errorMessage = format("Requested destination endpoint for flow '%s' conflicts with "
-                            + "existing source endpoint for flow '%s'.",
-                    checkedFlow.getFlowId(), conflictSrcDst.get().getFlowId());
-            throw new FlowValidationException(errorMessage, ErrorType.ALREADY_EXISTS);
-        }
-
-        Optional<Flow> conflictDstDst = conflictsOnDest.stream()
-                .filter(flow -> !firstFlowId.equals(flow.getFlowId()))
-                .filter(flow -> !secondFlowId.equals(flow.getFlowId()))
-                .filter(flow -> flow.getDestSwitch().getSwitchId().equals(checkedFlow.getDestSwitch().getSwitchId())
-                        && flow.getDestPort() == checkedFlow.getDestPort()
-                        && (flow.getDestVlan() == checkedFlow.getDestVlan()
-                        || flow.getDestVlan() == 0 || checkedFlow.getDestVlan() == 0))
-                .findAny();
-
-        if (conflictDstDst.isPresent()) {
-            String errorMessage = format("Requested destination endpoint for flow '%s' conflicts "
-                            + "with existing destination endpoint for flow '%s'.",
-                    checkedFlow.getFlowId(), conflictDstDst.get().getFlowId());
             throw new FlowValidationException(errorMessage, ErrorType.ALREADY_EXISTS);
         }
     }


### PR DESCRIPTION
We weren't able to swap a flow if there was a default flow already created on a port or if a flow created with vlan on the port and we are trying to swap a default flow that should use the same port of an existent flow.