### PR TITLE
Limit traffexam bandwidth when examing in parallel

### DIFF
--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/DefaultFlowSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/DefaultFlowSpec.groovy
@@ -87,7 +87,7 @@ class DefaultFlowSpec extends HealthCheckSpecification {
         }
 
         and: "System allows traffic on the default flow"
-        def exam2 = new FlowTrafficExamBuilder(topology, traffExam).buildBidirectionalExam(defaultFlow, 0)
+        def exam2 = new FlowTrafficExamBuilder(topology, traffExam).buildBidirectionalExam(defaultFlow, 1000)
         withPool {
             [exam2.forward, exam2.reverse].eachParallel { direction ->
                 def resources = traffExam.startExam(direction)
@@ -115,7 +115,7 @@ class DefaultFlowSpec extends HealthCheckSpecification {
 
         then: "System allows tagged traffic on the default flow"
         def traffExam = traffExamProvider.get()
-        def exam = new FlowTrafficExamBuilder(topology, traffExam).buildBidirectionalExam(flow, 0)
+        def exam = new FlowTrafficExamBuilder(topology, traffExam).buildBidirectionalExam(flow, 1000)
         withPool {
             [exam.forward, exam.reverse].eachParallel { direction ->
                 def resources = traffExam.startExam(direction)
@@ -149,7 +149,7 @@ class DefaultFlowSpec extends HealthCheckSpecification {
 
         then: "System doesn't allow to send traffic in these directions"
         def traffExam = traffExamProvider.get()
-        def exam = new FlowTrafficExamBuilder(topology, traffExam).buildBidirectionalExam(flow, 0)
+        def exam = new FlowTrafficExamBuilder(topology, traffExam).buildBidirectionalExam(flow, 1000)
         [exam.forward, exam.reverse].each { direction ->
             def resources = traffExam.startExam(direction)
             direction.setResources(resources)

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
@@ -76,7 +76,7 @@ class FlowCrudSpec extends HealthCheckSpecification {
 
         and: "The flow allows traffic (only applicable flows are checked)"
         try {
-            def exam = new FlowTrafficExamBuilder(topology, traffExam).buildBidirectionalExam(flow, 0)
+            def exam = new FlowTrafficExamBuilder(topology, traffExam).buildBidirectionalExam(flow, 1000)
             withPool {
                 [exam.forward, exam.reverse].eachParallel { direction ->
                     def resources = traffExam.startExam(direction)

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV2Spec.groovy
@@ -84,7 +84,7 @@ class FlowCrudV2Spec extends HealthCheckSpecification {
 
         and: "The flow allows traffic (only applicable flows are checked)"
         try {
-            def exam = new FlowTrafficExamBuilder(topology, traffExam).buildBidirectionalExam(toFlowPayload(flow), 0)
+            def exam = new FlowTrafficExamBuilder(topology, traffExam).buildBidirectionalExam(toFlowPayload(flow), 1000)
             withPool {
                 [exam.forward, exam.reverse].eachParallel { direction ->
                     def resources = traffExam.startExam(direction)

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
@@ -731,7 +731,7 @@ class ProtectedPathSpec extends HealthCheckSpecification {
 
         and: "The flow allows traffic(on the main path)"
         def traffExam = traffExamProvider.get()
-        def exam = new FlowTrafficExamBuilder(topology, traffExam).buildBidirectionalExam(flow, 0)
+        def exam = new FlowTrafficExamBuilder(topology, traffExam).buildBidirectionalExam(flow, 1000)
         withPool {
             [exam.forward, exam.reverse].eachParallel { direction ->
                 def resources = traffExam.startExam(direction)


### PR DESCRIPTION
This fixes occasional failures on stage when one direction exam would
consume most resources and leave no room for parallel reversed exam.