### PR TITLE
Propagate correlation id into completable future callbacks

### DIFF
--- a/services/src/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/flow/request/SpeakerFlowRequest.java
+++ b/services/src/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/flow/request/SpeakerFlowRequest.java
@@ -67,5 +67,4 @@ public abstract class SpeakerFlowRequest extends AbstractMessage {
         this.switchId = switchId;
         this.multiTable = multiTable;
     }
-
 }

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/SessionProxy.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/SessionProxy.java
@@ -16,26 +16,16 @@
 package org.openkilda.floodlight.command;
 
 import org.openkilda.floodlight.error.SwitchWriteException;
-import org.openkilda.floodlight.service.session.Session;
 import org.openkilda.floodlight.service.session.SessionService;
 import org.openkilda.messaging.MessageContext;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import net.floodlightcontroller.core.IOFSwitch;
 import org.projectfloodlight.openflow.protocol.OFMessage;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-@AllArgsConstructor
-@Getter
-@Slf4j
-public class MessageWriter implements SessionProxy {
-
-    final OFMessage ofMessage;
-
+public interface SessionProxy {
     /**
      * Sends of ofMessage to the switch.
      * @param sw target switch.
@@ -43,18 +33,8 @@ public class MessageWriter implements SessionProxy {
      * @return response.
      * @throws SwitchWriteException if error occurred.
      */
-    public CompletableFuture<Optional<OFMessage>> writeTo(
-            IOFSwitch sw, SessionService sessionService, MessageContext context)
-            throws SwitchWriteException {
-        try (Session session = sessionService.open(context, sw)) {
-            return session.write(ofMessage)
-                    .whenComplete((result, error) -> {
-                        if (error == null) {
-                            log.debug("OF command successfully executed {} on the switch {}", ofMessage, sw.getId());
-                        } else {
-                            log.error("Failed to execute OF command", error);
-                        }
-                    });
-        }
-    }
+    CompletableFuture<Optional<OFMessage>> writeTo(IOFSwitch sw, SessionService sessionService, MessageContext context)
+            throws SwitchWriteException;
+
+    OFMessage getOfMessage();
 }

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/bfd/BfdCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/bfd/BfdCommand.java
@@ -26,6 +26,7 @@ import org.openkilda.floodlight.service.kafka.KafkaUtilityService;
 import org.openkilda.floodlight.service.session.Session;
 import org.openkilda.floodlight.service.session.SessionService;
 import org.openkilda.floodlight.switchmanager.ISwitchManager;
+import org.openkilda.messaging.MessageContext;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.InfoMessage;
 import org.openkilda.model.SwitchFeature;
@@ -69,7 +70,7 @@ abstract class BfdCommand extends Command {
             IOFSwitch sw = switchManager.lookupSwitch(target);
 
             validate(sw);
-            try (Session session = sessionService.open(sw)) {
+            try (Session session = sessionService.open(new MessageContext(getContext().getCorrelationId()), sw)) {
                 handle(session);
             }
         } catch (SwitchOperationException e) {

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/FlowCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/FlowCommand.java
@@ -20,7 +20,7 @@ import static org.openkilda.model.FlowEncapsulationType.VXLAN;
 import static org.projectfloodlight.openflow.protocol.OFVersion.OF_12;
 
 import org.openkilda.floodlight.FloodlightResponse;
-import org.openkilda.floodlight.command.OfCommand;
+import org.openkilda.floodlight.command.SpeakerCommand;
 import org.openkilda.floodlight.error.SessionErrorResponseException;
 import org.openkilda.floodlight.error.SwitchNotFoundException;
 import org.openkilda.floodlight.flow.response.FlowErrorResponse;
@@ -54,7 +54,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 @Getter
-public abstract class FlowCommand extends OfCommand {
+public abstract class FlowCommand extends SpeakerCommand {
     // This is invalid VID mask - it cut of highest bit that indicate presence of VLAN tag on package. But valid mask
     // 0x1FFF lead to rule reject during install attempt on accton based switches.
     private static short OF10_VLAN_MASK = 0x0FFF;
@@ -149,7 +149,7 @@ public abstract class FlowCommand extends OfCommand {
                 .build();
 
         CompletableFuture<List<OFFlowStatsReply>> dumpFlowStatsStage =
-                new CompletableFutureAdapter<>(sw.writeStatsRequest(flowRequest));
+                new CompletableFutureAdapter<>(messageContext, sw.writeStatsRequest(flowRequest));
         return dumpFlowStatsStage.thenApply(values ->
                 values.stream()
                         .map(OFFlowStatsReply::getEntries)

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/GetRuleCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/GetRuleCommand.java
@@ -19,8 +19,8 @@ import static java.lang.String.format;
 
 import org.openkilda.floodlight.FloodlightResponse;
 import org.openkilda.floodlight.command.MessageWriter;
+import org.openkilda.floodlight.command.SessionProxy;
 import org.openkilda.floodlight.flow.response.FlowRuleResponse;
-import org.openkilda.floodlight.service.session.SessionService;
 import org.openkilda.floodlight.utils.CompletableFutureAdapter;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.Cookie;
@@ -68,10 +68,10 @@ public class GetRuleCommand extends FlowCommand {
     }
 
     @Override
-    protected CompletableFuture<Optional<OFMessage>> writeCommands(IOFSwitch sw, SessionService sessionService,
+    protected CompletableFuture<Optional<OFMessage>> writeCommands(IOFSwitch sw,
                                                                    FloodlightModuleContext moduleContext) {
         getLogger().debug("Getting rule with cookie {} from the switch {}", cookie, switchId);
-        return new CompletableFutureAdapter<>(sw.writeRequest(buildCommand(sw)))
+        return new CompletableFutureAdapter<>(messageContext, sw.writeRequest(buildCommand(sw)))
                 .thenApply(Optional::of);
     }
 
@@ -81,7 +81,7 @@ public class GetRuleCommand extends FlowCommand {
     }
 
     @Override
-    public List<MessageWriter> getCommands(IOFSwitch sw, FloodlightModuleContext moduleContext) {
+    public List<SessionProxy> getCommands(IOFSwitch sw, FloodlightModuleContext moduleContext) {
         return Collections.singletonList(new MessageWriter(buildCommand(sw)));
     }
 

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/InstallEgressRuleCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/InstallEgressRuleCommand.java
@@ -19,6 +19,7 @@ import static org.openkilda.floodlight.switchmanager.SwitchManager.convertDpIdTo
 import static org.openkilda.messaging.Utils.ETH_TYPE;
 
 import org.openkilda.floodlight.command.MessageWriter;
+import org.openkilda.floodlight.command.SessionProxy;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.Cookie;
 import org.openkilda.model.FlowEncapsulationType;
@@ -67,7 +68,7 @@ public class InstallEgressRuleCommand extends InstallTransitRuleCommand {
     }
 
     @Override
-    public List<MessageWriter> getCommands(IOFSwitch sw, FloodlightModuleContext moduleContext) {
+    public List<SessionProxy> getCommands(IOFSwitch sw, FloodlightModuleContext moduleContext) {
         List<OFAction> actionList = new ArrayList<>();
         OFFactory ofFactory = sw.getOFFactory();
 

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/InstallIngressRuleCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/InstallIngressRuleCommand.java
@@ -26,7 +26,8 @@ import static org.openkilda.messaging.Utils.ETH_TYPE;
 import static org.projectfloodlight.openflow.protocol.OFVersion.OF_15;
 
 import org.openkilda.floodlight.command.MessageWriter;
-import org.openkilda.floodlight.command.OfCommand;
+import org.openkilda.floodlight.command.SessionProxy;
+import org.openkilda.floodlight.command.SpeakerCommand;
 import org.openkilda.floodlight.command.meter.InstallMeterCommand;
 import org.openkilda.floodlight.error.SwitchOperationException;
 import org.openkilda.floodlight.error.UnsupportedSwitchOperationException;
@@ -100,9 +101,9 @@ public class InstallIngressRuleCommand extends InstallTransitRuleCommand {
     }
 
     @Override
-    public List<MessageWriter> getCommands(IOFSwitch sw, FloodlightModuleContext moduleContext)
+    public List<SessionProxy> getCommands(IOFSwitch sw, FloodlightModuleContext moduleContext)
             throws SwitchOperationException {
-        List<MessageWriter> commands = new ArrayList<>(2);
+        List<SessionProxy> commands = new ArrayList<>(2);
         FeatureDetectorService featureDetectorService = moduleContext.getServiceImpl(FeatureDetectorService.class);
 
         getMeterCommand(sw, moduleContext)
@@ -218,7 +219,7 @@ public class InstallIngressRuleCommand extends InstallTransitRuleCommand {
         return meterInstruction;
     }
 
-    private Optional<MessageWriter> getMeterCommand(IOFSwitch sw, FloodlightModuleContext moduleContext)
+    private Optional<SessionProxy> getMeterCommand(IOFSwitch sw, FloodlightModuleContext moduleContext)
             throws SwitchOperationException {
         if (meterId == null) {
             getLogger().debug("Skip meter installation. No meter required for flow {}", flowId);
@@ -226,7 +227,7 @@ public class InstallIngressRuleCommand extends InstallTransitRuleCommand {
         }
 
         try {
-            OfCommand meterCommand = new InstallMeterCommand(messageContext, switchId, meterId, bandwidth);
+            SpeakerCommand meterCommand = new InstallMeterCommand(messageContext, switchId, meterId, bandwidth);
             return meterCommand.getCommands(sw, moduleContext).stream().findFirst();
         } catch (UnsupportedSwitchOperationException e) {
             getLogger().info("Skip meter {} installation for flow {} on switch {}: {}",

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/InstallTransitRuleCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/InstallTransitRuleCommand.java
@@ -19,6 +19,7 @@ import static org.openkilda.floodlight.switchmanager.SwitchManager.convertDpIdTo
 import static org.projectfloodlight.openflow.protocol.OFVersion.OF_12;
 
 import org.openkilda.floodlight.command.MessageWriter;
+import org.openkilda.floodlight.command.SessionProxy;
 import org.openkilda.floodlight.error.SwitchOperationException;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.Cookie;
@@ -73,7 +74,7 @@ public class InstallTransitRuleCommand extends FlowInstallCommand {
     }
 
     @Override
-    public List<MessageWriter> getCommands(IOFSwitch sw, FloodlightModuleContext moduleContext)
+    public List<SessionProxy> getCommands(IOFSwitch sw, FloodlightModuleContext moduleContext)
             throws SwitchOperationException {
         OFFactory factory = sw.getOFFactory();
         List<OFAction> actionList = new ArrayList<>();

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/meter/InstallMeterCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/meter/InstallMeterCommand.java
@@ -21,7 +21,7 @@ import static org.projectfloodlight.openflow.protocol.OFVersion.OF_13;
 import org.openkilda.floodlight.FloodlightResponse;
 import org.openkilda.floodlight.command.IdempotentMessageWriter;
 import org.openkilda.floodlight.command.IdempotentMessageWriter.ErrorTypeHelper;
-import org.openkilda.floodlight.command.MessageWriter;
+import org.openkilda.floodlight.command.SessionProxy;
 import org.openkilda.floodlight.config.provider.FloodlightModuleConfigurationProvider;
 import org.openkilda.floodlight.error.InvalidMeterIdException;
 import org.openkilda.floodlight.error.SwitchOperationException;
@@ -76,7 +76,7 @@ public class InstallMeterCommand extends MeterCommand {
     }
 
     @Override
-    public List<MessageWriter> getCommands(IOFSwitch sw, FloodlightModuleContext moduleContext)
+    public List<SessionProxy> getCommands(IOFSwitch sw, FloodlightModuleContext moduleContext)
             throws SwitchOperationException {
         FeatureDetectorService featureDetectorService = moduleContext.getServiceImpl(FeatureDetectorService.class);
         FloodlightModuleConfigurationProvider provider =
@@ -86,6 +86,7 @@ public class InstallMeterCommand extends MeterCommand {
         OFMeterMod meterInstallCommand = buildMeter(switchManagerConfig, featureDetectorService, sw);
 
         return Collections.singletonList(IdempotentMessageWriter.<OFMeterConfigStatsReply>builder()
+                .context(messageContext)
                 .message(meterInstallCommand)
                 .readRequest(getMeterRequest(sw.getOFFactory()))
                 .ofEntryChecker(new MeterChecker(meterInstallCommand))

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/meter/MeterCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/meter/MeterCommand.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.floodlight.command.meter;
 
-import org.openkilda.floodlight.command.OfCommand;
+import org.openkilda.floodlight.command.SpeakerCommand;
 import org.openkilda.floodlight.error.UnsupportedSwitchOperationException;
 import org.openkilda.floodlight.service.FeatureDetectorService;
 import org.openkilda.messaging.MessageContext;
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
-abstract class MeterCommand extends OfCommand {
+abstract class MeterCommand extends SpeakerCommand {
 
     MeterId meterId;
 

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/meter/RemoveMeterCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/meter/RemoveMeterCommand.java
@@ -17,6 +17,7 @@ package org.openkilda.floodlight.command.meter;
 
 import org.openkilda.floodlight.FloodlightResponse;
 import org.openkilda.floodlight.command.MessageWriter;
+import org.openkilda.floodlight.command.SessionProxy;
 import org.openkilda.floodlight.error.UnsupportedSwitchOperationException;
 import org.openkilda.floodlight.service.FeatureDetectorService;
 import org.openkilda.messaging.MessageContext;
@@ -51,7 +52,7 @@ public class RemoveMeterCommand extends MeterCommand {
     }
 
     @Override
-    public List<MessageWriter> getCommands(IOFSwitch sw, FloodlightModuleContext moduleContext)
+    public List<SessionProxy> getCommands(IOFSwitch sw, FloodlightModuleContext moduleContext)
             throws UnsupportedSwitchOperationException {
         FeatureDetectorService featureDetector = moduleContext.getServiceImpl(FeatureDetectorService.class);
         checkSwitchSupportCommand(sw, featureDetector);

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
@@ -29,7 +29,7 @@ import static org.openkilda.model.Cookie.VERIFICATION_UNICAST_VXLAN_RULE_COOKIE;
 
 import org.openkilda.floodlight.command.Command;
 import org.openkilda.floodlight.command.CommandContext;
-import org.openkilda.floodlight.command.OfCommand;
+import org.openkilda.floodlight.command.SpeakerCommand;
 import org.openkilda.floodlight.converter.OfFlowStatsMapper;
 import org.openkilda.floodlight.converter.OfMeterConverter;
 import org.openkilda.floodlight.converter.OfPortDescConverter;
@@ -1240,7 +1240,7 @@ class RecordHandler implements Runnable {
     }
 
     private void parseRecord(ConsumerRecord<String, String> record) {
-        if (handleOfCommand()) {
+        if (handleSpeakerCommand()) {
             return;
         }
 
@@ -1273,15 +1273,15 @@ class RecordHandler implements Runnable {
         }
     }
 
-    private boolean handleOfCommand() {
+    private boolean handleSpeakerCommand() {
         try {
-            OfCommand ofCommand = MAPPER.readValue(record.value(), OfCommand.class);
+            SpeakerCommand speakerCommand = MAPPER.readValue(record.value(), SpeakerCommand.class);
 
             try (CorrelationContextClosable closable =
-                         CorrelationContext.create(ofCommand.getMessageContext().getCorrelationId())) {
+                         CorrelationContext.create(speakerCommand.getMessageContext().getCorrelationId())) {
                 KafkaTopicFactory kafkaTopicFactory = new KafkaTopicFactory(context);
 
-                ofCommand.execute(context.getModuleContext())
+                speakerCommand.execute(context.getModuleContext())
                         .whenComplete((response, error) -> {
                             if (error != null) {
                                 logger.error("Error occurred while trying to execute OF command", error.getCause());

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/session/SessionService.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/session/SessionService.java
@@ -21,6 +21,7 @@ import org.openkilda.floodlight.model.OfInput;
 import org.openkilda.floodlight.service.IService;
 import org.openkilda.floodlight.service.of.IInputTranslator;
 import org.openkilda.floodlight.service.of.InputService;
+import org.openkilda.messaging.MessageContext;
 
 import com.google.common.annotations.VisibleForTesting;
 import net.floodlightcontroller.core.IOFSwitch;
@@ -43,16 +44,14 @@ public class SessionService implements IService, IInputTranslator {
     /**
      * Create new OF communication session and register it in service.
      */
-    public Session open(IOFSwitch sw) {
-        SwitchSessions group;
-        group = sessionsByDatapath.get(sw.getId());
-
+    public Session open(MessageContext context, IOFSwitch sw) {
+        SwitchSessions group = sessionsByDatapath.get(sw.getId());
         if (group == null) {
             throw new IllegalStateException(String.format(
                     "Switch %s is not registered into %s", sw.getId(), getClass().getName()));
         }
 
-        return group.open(sw);
+        return group.open(sw, context);
     }
 
     @Override

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/session/SwitchSessions.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/session/SwitchSessions.java
@@ -15,6 +15,8 @@
 
 package org.openkilda.floodlight.service.session;
 
+import org.openkilda.messaging.MessageContext;
+
 import net.floodlightcontroller.core.IOFSwitch;
 import org.projectfloodlight.openflow.protocol.OFMessage;
 
@@ -24,8 +26,8 @@ import java.util.Map;
 class SwitchSessions {
     private final Map<Long, Session> sessionsByXid = new HashMap<>();
 
-    Session open(IOFSwitch sw) {
-        return new Session(this, sw);
+    Session open(IOFSwitch sw, MessageContext context) {
+        return new Session(this, sw, context);
     }
 
     void handleResponse(OFMessage message) {

--- a/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/service/session/SessionServiceTest.java
+++ b/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/service/session/SessionServiceTest.java
@@ -25,6 +25,7 @@ import org.openkilda.floodlight.error.SessionRevertException;
 import org.openkilda.floodlight.error.SwitchOperationException;
 import org.openkilda.floodlight.error.SwitchWriteException;
 import org.openkilda.floodlight.service.of.InputService;
+import org.openkilda.messaging.MessageContext;
 
 import net.floodlightcontroller.core.IOFSwitch;
 import net.floodlightcontroller.core.internal.IOFSwitchService;
@@ -59,6 +60,7 @@ public class SessionServiceTest extends EasyMockSupport {
     private final FloodlightModuleContext moduleContext = new FloodlightModuleContext();
 
     private final DatapathId dpId = DatapathId.of(0xfffe000000000001L);
+    private final MessageContext context = new MessageContext();
 
     private final Capture<OFMessage> swWriteMessages = EasyMock.newCapture(CaptureType.ALL);
 
@@ -98,7 +100,7 @@ public class SessionServiceTest extends EasyMockSupport {
         CompletableFuture<Optional<OFMessage>> future;
         OFPacketOut pktOut = makePacketOut(sw.getOFFactory(), 1);
 
-        try (Session session = subject.open(sw)) {
+        try (Session session = subject.open(context, sw)) {
             future = session.write(pktOut);
         }
         Assert.assertFalse(future.isDone());
@@ -128,7 +130,7 @@ public class SessionServiceTest extends EasyMockSupport {
 
         CompletableFuture<Optional<OFMessage>> pktOutFuture;
         CompletableFuture<Optional<OFMessage>> barrierFuture;
-        try (Session session = subject.open(sw)) {
+        try (Session session = subject.open(context, sw)) {
             pktOutFuture = session.write(pktOut);
             barrierFuture = session.write(barrier);
         }
@@ -162,7 +164,7 @@ public class SessionServiceTest extends EasyMockSupport {
         OFFactory ofFactory = sw.getOFFactory();
         OFPacketOut pktOut = makePacketOut(ofFactory, 1);
         CompletableFuture<Optional<OFMessage>> future;
-        try (Session session = subject.open(sw)) {
+        try (Session session = subject.open(context, sw)) {
             future = session.write(pktOut);
         }
 
@@ -191,7 +193,7 @@ public class SessionServiceTest extends EasyMockSupport {
         CompletableFuture<Optional<OFMessage>> futureAlpha = null;
         CompletableFuture<Optional<OFMessage>> futureBeta = null;
         try {
-            try (Session session = subject.open(sw)) {
+            try (Session session = subject.open(context, sw)) {
                 futureAlpha = session.write(makePacketOut(ofFactory, 1));
                 futureBeta = session.write(makePacketOut(ofFactory, 2));
             }
@@ -213,7 +215,7 @@ public class SessionServiceTest extends EasyMockSupport {
 
         CompletableFuture<Optional<OFMessage>> future = null;
         try {
-            try (Session session = subject.open(sw)) {
+            try (Session session = subject.open(context, sw)) {
                 future = session.write(makePacketOut(sw.getOFFactory(), 1));
             }
             throw new AssertionError("Expect exception to be thrown");


### PR DESCRIPTION
Wrap completable future callbacks into correlation-id context so it's
logs can be tracked by correlatiion-id.

Also some attempt to clean-up/normilize naming into FL "commands".