### PR TITLE
fix pinned flow spec

### DIFF
--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PinnedFlowSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PinnedFlowSpec.groovy
@@ -35,7 +35,7 @@ class PinnedFlowSpec extends HealthCheckSpecification {
         flowHelper.addFlow(flow)
 
         def currentPath = pathHelper.convert(northbound.getFlowPath(flow.id))
-        def altPath = switchPair.paths.find { it != currentPath }
+        def altPath = switchPair.paths.findAll { it != currentPath }.min { it.size() }
         def involvedSwitches = pathHelper.getInvolvedSwitches(flow.id)
 
         when: "Make alt path more preferable than current path"


### PR DESCRIPTION
sometimes the PinnedFlowSpec fail on jenkins with an error:
```java.lang.IndexOutOfBoundsException: toIndex = 2
org.openkilda.functionaltests.spec.flows.PinnedFlowSpec.System doesn't reroute(automatically) pinned flow when flow path is partially broken(PinnedFlowSpec.groovy:67)```
