### PR TITLE
Fixed incorrect converting meter rate/burstsize from packets to kilobits

### DIFF
--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
@@ -174,7 +174,6 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
     public static final int FLOW_PRIORITY = FlowModUtils.PRIORITY_HIGH;
     public static final int DEFAULT_FLOW_PRIORITY = FLOW_PRIORITY - 1;
     public static final int BDF_DEFAULT_PORT = 3784;
-    public static final int MIN_RATE_IN_KBPS = 64;
     public static final int ROUND_TRIP_LATENCY_GROUP_ID = 1;
     public static final MacAddress STUB_VXLAN_ETH_DST_MAC = MacAddress.of(0xFFFFFFEDCBA2L);
     public static final IPv4Address STUB_VXLAN_IPV4_SRC = IPv4Address.of("127.0.0.1");
@@ -388,7 +387,7 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
         OFFactory ofFactory = sw.getOFFactory();
 
         // build meter instruction
-        OFInstructionMeter meter = buildMeterInstruction(meterId, sw, ofFactory, actionList);
+        OFInstructionMeter meter = buildMeterInstruction(meterId, sw, actionList);
 
         // output action based on encap scheme
         actionList.addAll(inputVlanTypeToOfActionList(ofFactory, transitTunnelId, outputVlanType,
@@ -495,7 +494,7 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
 
 
         // build meter instruction
-        OFInstructionMeter meter = buildMeterInstruction(meterId, sw, ofFactory, actionList);
+        OFInstructionMeter meter = buildMeterInstruction(meterId, sw, actionList);
 
         // output action based on encap scheme
         actionList.addAll(pushSchemeOutputVlanTypeToOfActionList(ofFactory, outputVlanId, outputVlanType));
@@ -571,7 +570,7 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
 
     private OFInstructionMeter buildMeterInstructionForBroadcastRule(IOFSwitch sw, ArrayList<OFAction> actionList) {
         return buildMeterInstruction(createMeterIdForDefaultRule(VERIFICATION_BROADCAST_RULE_COOKIE).getValue(),
-                sw, sw.getOFFactory(), actionList);
+                sw, actionList);
     }
 
     private ArrayList<OFAction> prepareActionListForUnicastRule(IOFSwitch sw) {
@@ -582,12 +581,12 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
 
     private OFInstructionMeter buildMeterInstructionForUnicastRule(IOFSwitch sw, ArrayList<OFAction> actionList) {
         return buildMeterInstruction(createMeterIdForDefaultRule(VERIFICATION_UNICAST_RULE_COOKIE).getValue(),
-                sw, sw.getOFFactory(), actionList);
+                sw, actionList);
     }
 
     private OFInstructionMeter buildMeterInstructionForUnicastVxlanRule(IOFSwitch sw, ArrayList<OFAction> actionList) {
         return buildMeterInstruction(createMeterIdForDefaultRule(VERIFICATION_UNICAST_VXLAN_RULE_COOKIE).getValue(),
-                sw, sw.getOFFactory(), actionList);
+                sw, actionList);
     }
 
     /**
@@ -707,7 +706,7 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
                     .collect(Collectors.toSet());
             installMeter(sw, flags, bandwidth, burstSize, meterId);
         } else {
-            throw new InvalidMeterIdException(dpid, "Meter id must be positive.");
+            throw new InvalidMeterIdException(dpid, format("Meter id must be greater than %d.", MIN_FLOW_METER_ID));
         }
     }
 
@@ -1853,7 +1852,14 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
 
     @VisibleForTesting
     OFInstructionMeter installMeterForDefaultRule(IOFSwitch sw, long meterId, long ratePkts,
-                                                  ArrayList<OFAction> actionList) {
+                                                  List<OFAction> actionList) {
+        return installOrReinstallMeter(sw, meterId, ratePkts, config.getDiscoPacketSize(),
+                config.getSystemMeterBurstSizeInPackets(), actionList);
+    }
+
+    private OFInstructionMeter installOrReinstallMeter(IOFSwitch sw, long meterId, long rateInPackets,
+                                                       long packetSizeInBytes, long burstSizeInPackets,
+                                                       List<OFAction> actionList) {
         OFMeterConfig meterConfig;
         try {
             meterConfig = getMeter(sw.getId(), meterId);
@@ -1876,19 +1882,19 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
             if (featureDetectorService.detectSwitch(sw).contains(Feature.PKTPS_FLAG)) {
                 flags = ImmutableSet.of(OFMeterFlags.PKTPS, OFMeterFlags.STATS, OFMeterFlags.BURST);
                 // With PKTPS flag rate and burst size is in packets
-                rate = ratePkts;
-                burstSize = config.getSystemMeterBurstSizeInPackets();
+                rate = rateInPackets;
+                burstSize = burstSizeInPackets;
             } else {
                 flags = ImmutableSet.of(OFMeterFlags.KBPS, OFMeterFlags.STATS, OFMeterFlags.BURST);
                 // With KBPS flag rate and burst size is in Kbits
-                rate = Math.max(MIN_RATE_IN_KBPS, (ratePkts * config.getDiscoPacketSize()) / 1024L);
-                burstSize = config.getSystemMeterBurstSizeInPackets() * config.getDiscoPacketSize() / 1024L;
+                rate = Meter.convertRateToKiloBits(rateInPackets, packetSizeInBytes);
+                burstSize = Meter.convertBurstSizeToKiloBits(burstSizeInPackets, packetSizeInBytes);
             }
 
             if (meterBandDrop != null && meterBandDrop.getRate() == rate
                     && CollectionUtils.isEqualCollection(meterConfig.getFlags(), flags)) {
                 logger.debug("Meter {} won't be reinstalled on switch {}. It already exists", meterId, sw.getId());
-                return buildMeterInstruction(meterId, sw, sw.getOFFactory(), actionList);
+                return buildMeterInstruction(meterId, sw, actionList);
             }
 
             if (meterBandDrop != null) {
@@ -1904,7 +1910,7 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
             return null;
         }
 
-        return buildMeterInstruction(meterId, sw, sw.getOFFactory(), actionList);
+        return buildMeterInstruction(meterId, sw, actionList);
     }
 
     /**
@@ -1912,12 +1918,11 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
      *
      * @param meterId meter to be installed.
      * @param sw switch information.
-     * @param ofFactory OF factory for the switch.
      * @param actionList actions for the flow.
      * @return built {@link OFInstructionMeter} for OF 1.3 and 1.4, otherwise returns null.
      */
-    private OFInstructionMeter buildMeterInstruction(long meterId, IOFSwitch sw, OFFactory ofFactory,
-                                                     List<OFAction> actionList) {
+    private OFInstructionMeter buildMeterInstruction(long meterId, IOFSwitch sw, List<OFAction> actionList) {
+        OFFactory ofFactory = sw.getOFFactory();
         OFInstructionMeter meterInstruction = null;
         if (meterId != 0L && (config.isOvsMetersEnabled() || !isOvs(sw))) {
             if (ofFactory.getVersion().compareTo(OF_12) <= 0) {

--- a/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerTest.java
+++ b/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/switchmanager/SwitchManagerTest.java
@@ -1183,7 +1183,7 @@ public class SwitchManagerTest {
                 contains(OFMeterFlags.KBPS, OFMeterFlags.STATS, OFMeterFlags.BURST))));
         for (OFMeterMod mod : actual) {
             long expectedBurstSize =
-                    config.getSystemMeterBurstSizeInPackets() * config.getDiscoPacketSize() / 1024L;
+                    config.getSystemMeterBurstSizeInPackets() * config.getDiscoPacketSize() * 8 / 1024L;
             assertThat(mod.getMeters(), everyItem(hasProperty("burstSize", is(expectedBurstSize))));
         }
     }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/MetersSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/MetersSpec.groovy
@@ -121,10 +121,10 @@ class MetersSpec extends HealthCheckSpecification {
         def meters = northbound.getAllMeters(sw.dpId)
         assert meters.meterEntries.size() == 2
         assert meters.meterEntries.each {
-            assert it.rate == Math.max((long) (DISCO_PKT_RATE * DISCO_PKT_SIZE / 1024L), MIN_RATE_KBPS)
+            assert it.rate == Math.max((long) (DISCO_PKT_RATE * DISCO_PKT_SIZE * 8 / 1024L), MIN_RATE_KBPS)
         }
         //unable to use #getExpectedBurst. For Centects there's special burst due to KBPS
-        assert meters.meterEntries.every { it.burstSize == (long) ((DISCO_PKT_BURST * DISCO_PKT_SIZE) / 1024) }
+        assert meters.meterEntries.every { it.burstSize == (long) ((DISCO_PKT_BURST * DISCO_PKT_SIZE * 8) / 1024) }
         assert meters.meterEntries.every(defaultMeters)
         assert meters.meterEntries.every { ["KBPS", "BURST", "STATS"].containsAll(it.flags) }
         assert meters.meterEntries.every { it.flags.size() == 3 }

--- a/services/src/kilda-core/kilda-model/src/main/java/org/openkilda/model/Meter.java
+++ b/services/src/kilda-core/kilda-model/src/main/java/org/openkilda/model/Meter.java
@@ -26,6 +26,7 @@ public final class Meter implements Serializable {
     private static final double MAX_NOVIFLOW_BURST_COEFFICIENT = 1.005;
     private static final long MIN_CENTEC_SWITCH_BURST_SIZE = 1024L;
     private static final long MAX_CENTEC_SWITCH_BURST_SIZE = 32000L;
+    public static final int MIN_RATE_IN_KBPS = 64;
 
     private static final String[] METER_FLAGS = {"KBPS", "BURST", "STATS"};
 
@@ -62,6 +63,20 @@ public final class Meter implements Serializable {
         }
 
         return Math.round(bandwidth * burstCoefficient);
+    }
+
+    /**
+     * Convert rate from packets to kilobits.
+     */
+    public static long convertRateToKiloBits(long rateInPackets, long packetSizeInBytes) {
+        return Math.max(MIN_RATE_IN_KBPS, (rateInPackets * packetSizeInBytes * 8) / 1024L);
+    }
+
+    /**
+     * Convert burst size from packets to kilobits.
+     */
+    public static long convertBurstSizeToKiloBits(long burstSizeInPackets, long packetSizeInBytes) {
+        return (burstSizeInPackets * packetSizeInBytes * 8) / 1024L;
     }
 
     /**

--- a/services/src/kilda-core/kilda-model/src/test/java/org/openkilda/model/MeterTest.java
+++ b/services/src/kilda-core/kilda-model/src/test/java/org/openkilda/model/MeterTest.java
@@ -29,4 +29,17 @@ public class MeterTest {
         assertEquals(1105500, Meter.calculateBurstSize(1100000L, 1024L, 1.005, "NW000.0.0"));
         assertEquals(1105500, Meter.calculateBurstSize(1100000L, 1024L, 1.05, "NW000.0.0"));
     }
+
+    @Test
+    public void convertRateToKiloBitsTest() {
+        assertEquals(800, Meter.convertRateToKiloBits(100, 1024));
+        assertEquals(64, Meter.convertRateToKiloBits(1, 1));
+        assertEquals(64, Meter.convertRateToKiloBits(8, 16));
+    }
+
+    @Test
+    public void convertBurstSizeToKiloBitsTest() {
+        assertEquals(800, Meter.convertBurstSizeToKiloBits(100, 1024));
+        assertEquals(1, Meter.convertBurstSizeToKiloBits(8, 16));
+    }
 }


### PR DESCRIPTION
We converted packets to kilobytes, not to kilobits.
It causes incorrect meters on Centec and E switches