### PR TITLE
Added condition to skip cost reduction when link goes from state under maintenance and cost less than isl.cost.when.under.maintenance.

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/services/LinkOperationsService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/services/LinkOperationsService.java
@@ -85,9 +85,13 @@ public class LinkOperationsService {
             if (underMaintenance) {
                 isl.setCost(isl.getCost() + islCostWhenUnderMaintenance);
                 reverceIsl.setCost(reverceIsl.getCost() + islCostWhenUnderMaintenance);
-            } else {
+            } else if (isl.getCost() >= islCostWhenUnderMaintenance
+                    && reverceIsl.getCost() >= islCostWhenUnderMaintenance) {
                 isl.setCost(isl.getCost() - islCostWhenUnderMaintenance);
                 reverceIsl.setCost(reverceIsl.getCost() - islCostWhenUnderMaintenance);
+            } else {
+                log.warn("Skipped updating cost for ISL {}_{} - {}_{} because cost will be negative after update.",
+                        srcSwitchId, srcPort, dstSwitchId, dstPort);
             }
 
             islRepository.createOrUpdate(isl);


### PR DESCRIPTION
Closes: #2319.