### PR TITLE
Use hs auto-reroutes by default. Update waiters for path allocation

### DIFF
--- a/confd/templates/atdd-staging/kilda.properties.tmpl
+++ b/confd/templates/atdd-staging/kilda.properties.tmpl
@@ -58,7 +58,7 @@ grpc.password={{ getv "/kilda_grpc_password" }}
 grpc.remote.log.server.ip={{ getv "/kilda_grpc_remote_log_server_ip" }}
 grpc.remote.log.server.port={{ getv "/kilda_grpc_remote_log_server_port" }}
 
-use.hs=false
+use.hs=true
 
 # round trip latency
 latency.update.interval = {{ getv "/kilda_latency_update_interval" }}

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MultiRerouteSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MultiRerouteSpec.groovy
@@ -1,6 +1,7 @@
 package org.openkilda.functionaltests.spec.flows
 
 import static org.junit.Assume.assumeTrue
+import static org.openkilda.testing.Constants.PATH_INSTALLATION_TIME
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
@@ -46,9 +47,7 @@ class MultiRerouteSpec extends HealthCheckSpecification {
         TimeUnit.SECONDS.sleep(rerouteDelay - 1)
 
         then: "Both flows change their paths (or go Down if no path)"
-        //TODO: new H&S reroute requires more time to complete because of switch rule validation.
-        // Revise and fix the test appropriately.
-        Wrappers.wait(WAIT_OFFSET * 2) {
+        Wrappers.wait(PATH_INSTALLATION_TIME) {
             flows.each {
                 def status = northbound.getFlowStatus(it.id).status
                 assert status != FlowState.IN_PROGRESS

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
@@ -5,6 +5,7 @@ import static org.junit.Assume.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.model.MeterId.MAX_SYSTEM_RULE_METER_ID
 import static org.openkilda.testing.Constants.NON_EXISTENT_FLOW_ID
+import static org.openkilda.testing.Constants.PROTECTED_PATH_INSTALLATION_TIME
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
@@ -20,7 +21,6 @@ import org.openkilda.testing.service.traffexam.TraffExamService
 import org.openkilda.testing.tools.FlowTrafficExamBuilder
 
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.client.HttpClientErrorException
 import spock.lang.Ignore
 import spock.lang.Narrative
@@ -219,9 +219,7 @@ class ProtectedPathSpec extends HealthCheckSpecification {
         northbound.portDown(islToBreak.srcSwitch.dpId, islToBreak.srcPort)
 
         then: "Flow is switched to protected path"
-        //TODO: new H&S reroute requires more time to complete because of switch rule validation.
-        // Revise and fix the test appropriately.
-        Wrappers.wait(WAIT_OFFSET * 2) {
+        Wrappers.wait(PROTECTED_PATH_INSTALLATION_TIME) {
             assert northbound.getFlowStatus(flow.id).status == FlowState.UP
             def flowPathInfoAfterRerouting = northbound.getFlowPath(flow.id)
 
@@ -336,9 +334,7 @@ class ProtectedPathSpec extends HealthCheckSpecification {
         northbound.portDown(islToBreak.srcSwitch.dpId, islToBreak.srcPort)
 
         then: "Flow is switched to protected path"
-        //TODO: new H&S reroute requires more time to complete because of switch rule validation.
-        // Revise and fix the test appropriately.
-        Wrappers.wait(WAIT_OFFSET * 2) {
+        Wrappers.wait(PROTECTED_PATH_INSTALLATION_TIME) {
             def newPathInfo = northbound.getFlowPath(flow.id)
             def newCurrentPath = pathHelper.convert(newPathInfo)
             assert northbound.getFlowStatus(flow.id).status == FlowState.UP
@@ -528,9 +524,7 @@ class ProtectedPathSpec extends HealthCheckSpecification {
 
         then: "Protected path is recalculated"
         def newProtectedPath
-        //TODO: new H&S reroute requires more time to complete because of switch rule validation.
-        // Revise and fix the test appropriately.
-        Wrappers.wait(WAIT_OFFSET * 2) {
+        Wrappers.wait(PROTECTED_PATH_INSTALLATION_TIME) {
             newProtectedPath = pathHelper.convert(northbound.getFlowPath(flow.id).protectedPath)
             assert newProtectedPath != currentProtectedPath
             assert northbound.getFlowStatus(flow.id).status == FlowState.UP
@@ -540,11 +534,8 @@ class ProtectedPathSpec extends HealthCheckSpecification {
         currentPath == pathHelper.convert(northbound.getFlowPath(flow.id))
 
         and: "Bandwidth is reserved for new protected path on involved ISLs"
-
         def allLinks
-        //TODO: new H&S reroute requires more time to complete because of switch rule validation.
-        // Revise and fix the test appropriately.
-        Wrappers.wait(WAIT_OFFSET * 2) {
+        Wrappers.wait(PROTECTED_PATH_INSTALLATION_TIME) {
             def newProtectedIsls = pathHelper.getInvolvedIsls(newProtectedPath)
             allLinks = northbound.getAllLinks()
             def newProtectedIslsInfo = newProtectedIsls.collect { islUtils.getIslInfo(allLinks, it).get() }
@@ -929,9 +920,7 @@ class ProtectedPathSpec extends HealthCheckSpecification {
 
         //TODO (andriidovhan) FlowState should be DEGRADED and mainFlowPathStatus should be "Up" when pr2430 is merged
         then: "Flow state is still DEGRADED"
-        //TODO: new H&S reroute requires more time to complete because of switch rule validation.
-        // Revise and fix the test appropriately.
-        Wrappers.wait(WAIT_OFFSET * 2) {
+        Wrappers.wait(PROTECTED_PATH_INSTALLATION_TIME) {
             assert northbound.getFlowStatus(flow.id).status == FlowState.DEGRADED
             with(northbound.getFlow(flow.id).flowStatusDetails) {
                 mainFlowPathStatus == "Up"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkMaintenanceSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkMaintenanceSpec.groovy
@@ -2,6 +2,7 @@ package org.openkilda.functionaltests.spec.links
 
 import static org.junit.Assume.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
+import static org.openkilda.testing.Constants.PATH_INSTALLATION_TIME
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
@@ -79,9 +80,7 @@ class LinkMaintenanceSpec extends HealthCheckSpecification {
 
         then: "Flows are evacuated (rerouted)"
         def flow1PathUpdated, flow2PathUpdated
-        //TODO: new H&S reroute requires more time to complete because of switch rule validation.
-        // Revise and fix the test appropriately.
-        Wrappers.wait(WAIT_OFFSET * 2) {
+        Wrappers.wait(PATH_INSTALLATION_TIME) {
             [flow1, flow2].each { assert northbound.getFlowStatus(it.id).status == FlowState.UP }
 
             flow1PathUpdated = PathHelper.convert(northbound.getFlowPath(flow1.id))

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
@@ -5,6 +5,7 @@ import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.VIRTUAL
 import static org.openkilda.testing.Constants.NON_EXISTENT_SWITCH_ID
+import static org.openkilda.testing.Constants.PATH_INSTALLATION_TIME
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
@@ -171,9 +172,7 @@ class LinkSpec extends HealthCheckSpecification {
         broughtDownPorts.each { northbound.portUp(it.switchId, it.portNo) }
 
         then: "All flows go to 'Up' status"
-        //TODO: new H&S reroute requires more time to complete because of switch rule validation.
-        // Revise and fix the test appropriately.
-        Wrappers.wait(rerouteDelay + discoveryInterval + WAIT_OFFSET * 2) {
+        Wrappers.wait(rerouteDelay + discoveryInterval + PATH_INSTALLATION_TIME) {
             [flow1, flow2, flow3, flow4].each { assert northbound.getFlowStatus(it.id).status == FlowState.UP }
         }
 
@@ -366,10 +365,7 @@ class LinkSpec extends HealthCheckSpecification {
 
         then: "Flows are rerouted"
         response.containsAll([flow1, flow2]*.id)
-
-        //TODO: new H&S reroute requires more time to complete because of switch rule validation.
-        // Revise and fix the test appropriately.
-        Wrappers.wait(WAIT_OFFSET * 2) {
+        Wrappers.wait(PATH_INSTALLATION_TIME) {
             [flow1, flow2].each { assert northbound.getFlowStatus(it.id).status == FlowState.UP }
             assert PathHelper.convert(northbound.getFlowPath(flow1.id)) != flow1Path
             assert PathHelper.convert(northbound.getFlowPath(flow2.id)) != flow2Path

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/ChaosSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/ChaosSpec.groovy
@@ -1,6 +1,7 @@
 package org.openkilda.functionaltests.spec.resilience
 
 import static org.openkilda.model.MeterId.MAX_SYSTEM_RULE_METER_ID
+import static org.openkilda.testing.Constants.PATH_INSTALLATION_TIME
 import static org.openkilda.testing.Constants.RULES_DELETION_TIME
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
@@ -57,9 +58,8 @@ class ChaosSpec extends HealthCheckSpecification {
             northbound.getAllLinks().findAll { it.state == IslChangeType.FAILED }.empty
         }
         TimeUnit.SECONDS.sleep(rerouteDelay) //all throttled reroutes should start executing
-        //TODO: new H&S reroute requires more time to complete because of switch rule validation.
-        // Revise and fix the test appropriately.
-        Wrappers.wait(WAIT_OFFSET * 5 + flowsAmount) {
+
+        Wrappers.wait(PATH_INSTALLATION_TIME * 3 + flowsAmount) {
             flows.each { flow ->
                 assert northbound.getFlowStatus(flow.id).status == FlowState.UP
                 northbound.validateFlow(flow.id).each { direction -> assert direction.asExpected }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchMaintenanceSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchMaintenanceSpec.groovy
@@ -4,6 +4,7 @@ import static org.junit.Assume.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.VIRTUAL
 import static org.openkilda.testing.Constants.DEFAULT_COST
+import static org.openkilda.testing.Constants.PATH_INSTALLATION_TIME
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
@@ -100,9 +101,7 @@ class SwitchMaintenanceSpec extends HealthCheckSpecification {
 
         then: "Flows are evacuated (rerouted)"
         def flow1PathUpdated, flow2PathUpdated
-        //TODO: new H&S reroute requires more time to complete because of switch rule validation.
-        // Revise and fix the test appropriately.
-        Wrappers.wait(WAIT_OFFSET * 2) {
+        Wrappers.wait(PATH_INSTALLATION_TIME) {
             [flow1, flow2].each { assert northbound.getFlowStatus(it.id).status == FlowState.UP }
 
             flow1PathUpdated = PathHelper.convert(northbound.getFlowPath(flow1.id))

--- a/services/src/test-library/src/main/java/org/openkilda/testing/Constants.java
+++ b/services/src/test-library/src/main/java/org/openkilda/testing/Constants.java
@@ -23,6 +23,8 @@ import java.util.UUID;
 public final class Constants {
     public static final Integer DEFAULT_COST = 700;
     public static final Integer WAIT_OFFSET = 10;
+    public static final Integer PROTECTED_PATH_INSTALLATION_TIME = 20;
+    public static final Integer PATH_INSTALLATION_TIME = 15;
     public static final Integer TOPOLOGY_DISCOVERING_TIME = 120;
     public static final Integer SWITCHES_ACTIVATION_TIME = 10;
     public static final Integer RULES_DELETION_TIME = 7;

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/FlowHsTopology.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/FlowHsTopology.java
@@ -19,6 +19,7 @@ import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.ROUTER_TO_
 import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.ROUTER_TO_FLOW_REROUTE_HUB;
 import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.SPEAKER_WORKER_TO_HUB_CREATE;
 import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.SPEAKER_WORKER_TO_HUB_REROUTE;
+import static org.openkilda.wfm.topology.flowhs.bolts.RouterBolt.FLOW_ID_FIELD;
 
 import org.openkilda.messaging.AbstractMessage;
 import org.openkilda.messaging.Message;
@@ -42,10 +43,12 @@ import org.apache.storm.generated.StormTopology;
 import org.apache.storm.kafka.bolt.KafkaBolt;
 import org.apache.storm.kafka.spout.KafkaSpout;
 import org.apache.storm.topology.TopologyBuilder;
+import org.apache.storm.tuple.Fields;
 
 import java.util.concurrent.TimeUnit;
 
 public class FlowHsTopology extends AbstractTopology<FlowHsTopologyConfig> {
+    private static final Fields FLOW_FIELD = new Fields(FLOW_ID_FIELD);
 
     private int parallelism;
 
@@ -110,7 +113,7 @@ public class FlowHsTopology extends AbstractTopology<FlowHsTopologyConfig> {
         FlowCreateHubBolt hubBolt =
                 new FlowCreateHubBolt(config, persistenceManager, pathComputerConfig, flowResourcesConfig);
         topologyBuilder.setBolt(ComponentId.FLOW_CREATE_HUB.name(), hubBolt, parallelism)
-                .fieldsGrouping(ComponentId.FLOW_ROUTER_BOLT.name(), ROUTER_TO_FLOW_CREATE_HUB.name(), FIELDS_KEY)
+                .fieldsGrouping(ComponentId.FLOW_ROUTER_BOLT.name(), ROUTER_TO_FLOW_CREATE_HUB.name(), FLOW_FIELD)
                 .directGrouping(ComponentId.FLOW_CREATE_SPEAKER_WORKER.name(),
                         Stream.SPEAKER_WORKER_TO_HUB_CREATE.name())
                 .directGrouping(CoordinatorBolt.ID);
@@ -124,7 +127,7 @@ public class FlowHsTopology extends AbstractTopology<FlowHsTopologyConfig> {
                 ComponentId.FLOW_REROUTE_SPEAKER_WORKER.name(), hubTimeout, true,
                 persistenceManager, pathComputerConfig, flowResourcesConfig);
         topologyBuilder.setBolt(ComponentId.FLOW_REROUTE_HUB.name(), hubBolt, parallelism)
-                .fieldsGrouping(ComponentId.FLOW_ROUTER_BOLT.name(), ROUTER_TO_FLOW_REROUTE_HUB.name(), FIELDS_KEY)
+                .fieldsGrouping(ComponentId.FLOW_ROUTER_BOLT.name(), ROUTER_TO_FLOW_REROUTE_HUB.name(), FLOW_FIELD)
                 .directGrouping(ComponentId.FLOW_REROUTE_SPEAKER_WORKER.name(),
                         Stream.SPEAKER_WORKER_TO_HUB_REROUTE.name())
                 .directGrouping(CoordinatorBolt.ID);

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/RouterBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/RouterBolt.java
@@ -18,26 +18,32 @@ package org.openkilda.wfm.topology.flowhs.bolts;
 import static java.lang.String.format;
 import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.ROUTER_TO_FLOW_CREATE_HUB;
 import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.ROUTER_TO_FLOW_REROUTE_HUB;
+import static org.openkilda.wfm.topology.utils.KafkaRecordTranslator.FIELD_ID_KEY;
+import static org.openkilda.wfm.topology.utils.KafkaRecordTranslator.FIELD_ID_PAYLOAD;
 
 import org.openkilda.messaging.MessageData;
 import org.openkilda.messaging.command.CommandMessage;
 import org.openkilda.messaging.command.flow.FlowRequest;
 import org.openkilda.messaging.command.flow.FlowRerouteRequest;
 import org.openkilda.wfm.AbstractBolt;
-import org.openkilda.wfm.topology.utils.MessageTranslator;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 
 @Slf4j
 public class RouterBolt extends AbstractBolt {
 
+    public static final String FLOW_ID_FIELD = "flow-id";
+    private static final Fields STREAM_FIELDS =
+            new Fields(FIELD_ID_KEY, FLOW_ID_FIELD, FIELD_ID_PAYLOAD, FIELD_ID_CONTEXT);
+
     @Override
     protected void handleInput(Tuple input) {
-        String key = input.getStringByField(MessageTranslator.FIELD_ID_KEY);
+        String key = input.getStringByField(FIELD_ID_KEY);
         if (StringUtils.isBlank(key)) {
             //TODO: the key must be unique, but the correlationId comes in from outside and we can't guarantee that.
             //IMPORTANT: Storm may initiate reprocessing of the same tuple (e.g. in the case of timeout) and
@@ -46,15 +52,16 @@ public class RouterBolt extends AbstractBolt {
             key = getCommandContext().getCorrelationId();
         }
 
-        CommandMessage message = (CommandMessage) input.getValueByField(MessageTranslator.FIELD_ID_PAYLOAD);
+        CommandMessage message = (CommandMessage) input.getValueByField(FIELD_ID_PAYLOAD);
         MessageData data = message.getData();
 
         if (data instanceof FlowRequest) {
             FlowRequest request = (FlowRequest) data;
             log.debug("Received request {} with key {}", request, key);
+            Values values = new Values(key, request.getFlowId(), request);
             switch (request.getType()) {
                 case CREATE:
-                    emitWithContext(ROUTER_TO_FLOW_CREATE_HUB.name(), input, new Values(key, request));
+                    emitWithContext(ROUTER_TO_FLOW_CREATE_HUB.name(), input, values);
                     break;
                 default:
                     throw new UnsupportedOperationException(format("Flow operation %s is not supported",
@@ -64,7 +71,8 @@ public class RouterBolt extends AbstractBolt {
             FlowRerouteRequest rerouteRequest = (FlowRerouteRequest) data;
             log.debug("Received a reroute request {}/{} with key {}. MessageId {}", rerouteRequest.getFlowId(),
                     rerouteRequest.getPathIds(), key, input.getMessageId());
-            emitWithContext(ROUTER_TO_FLOW_REROUTE_HUB.name(), input, new Values(key, data));
+            Values values = new Values(key, rerouteRequest.getFlowId(), data);
+            emitWithContext(ROUTER_TO_FLOW_REROUTE_HUB.name(), input, values);
         } else {
             unhandledInput(input);
         }
@@ -72,7 +80,7 @@ public class RouterBolt extends AbstractBolt {
 
     @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
-        declarer.declareStream(ROUTER_TO_FLOW_CREATE_HUB.name(), MessageTranslator.STREAM_FIELDS);
-        declarer.declareStream(ROUTER_TO_FLOW_REROUTE_HUB.name(), MessageTranslator.STREAM_FIELDS);
+        declarer.declareStream(ROUTER_TO_FLOW_CREATE_HUB.name(), STREAM_FIELDS);
+        declarer.declareStream(ROUTER_TO_FLOW_REROUTE_HUB.name(), STREAM_FIELDS);
     }
 }


### PR DESCRIPTION
Due to h&s nature, it now takes longer to change flow status to UP state during path manipulations.
Also, now 'flows_reroute_via_flowhs' feature toggle is turned 'on' by default