### PR TITLE
Produce LLDP packets by traffexam

### DIFF
--- a/services/lab-service/lab/api/api.py
+++ b/services/lab-service/lab/api/api.py
@@ -181,7 +181,7 @@ def lockkeeper_proxy(lab_id, to_path):
         return Response(str(ex), status=500)
 
 
-@app.route('/api/<int:lab_id>/traffgen/<tg_name>/<path:to_path>', methods=['GET', 'HEAD', 'POST', 'DELETE'])
+@app.route('/api/<int:lab_id>/traffgen/<tg_name>/<path:to_path>', methods=['GET', 'HEAD', 'POST', 'PUT', 'DELETE'])
 def traffgen_proxy(lab_id, tg_name, to_path):
     try:
         if lab_id not in labs:

--- a/services/lab-service/traffexam/kilda/traffexam/__init__.py
+++ b/services/lab-service/traffexam/kilda/traffexam/__init__.py
@@ -13,4 +13,4 @@
 #   limitations under the License.
 #
 
-__version__ = '0.1.dev12'
+__version__ = '0.1.dev13'

--- a/services/lab-service/traffexam/kilda/traffexam/action.py
+++ b/services/lab-service/traffexam/kilda/traffexam/action.py
@@ -1,0 +1,61 @@
+# Copyright 2017 Telstra Open Source
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import functools
+import pathlib
+import operator
+
+import nsenter
+from scapy.all import Ether, sendp
+from scapy.contrib import lldp
+
+from kilda.traffexam import context as context_module
+
+
+class Abstract(context_module.ContextConsumer):
+    def __call__(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class LLDPPush(Abstract):
+    ns_fs_location = pathlib.Path('/var/run/netns')
+    lldp_bcast_mac = '01:80:c2:00:00:0e'
+
+    def __call__(self, iface, push_entry):
+        pkt = self._encode(push_entry)
+
+        ns_name = self.context.make_network_namespace_name()
+        ns_fd = self.ns_fs_location / ns_name
+        with nsenter.Namespace(str(ns_fd), 'net'):
+            sendp(pkt, iface=iface.name, verbose=False, promisc=False)
+
+    def _encode(self, entry):
+        entries = (
+            lldp.LLDPDUChassisID(
+                subtype=lldp.LLDPDUChassisID.SUBTYPE_MAC_ADDRESS,
+                id=entry.mac_address),
+            lldp.LLDPDUPortID(
+                subtype=lldp.LLDPDUPortID.SUBTYPE_LOCALLY_ASSIGNED,
+                id=entry.port_number),
+            lldp.LLDPDUTimeToLive(ttl=entry.time_to_live),
+            lldp.LLDPDUEndOfLLDPDU())
+        payload = functools.reduce(operator.truediv, entries)
+
+        return Ether(src=entry.mac_address, dst=self.lldp_bcast_mac) / payload
+
+
+class Adapter(object):
+    def __init__(self, context):
+        self.lldp_push = LLDPPush(context)

--- a/services/lab-service/traffexam/kilda/traffexam/context.py
+++ b/services/lab-service/traffexam/kilda/traffexam/context.py
@@ -27,6 +27,7 @@ class Context(object):
 
     root = os.path.join(os.sep, 'var', 'run', const.PROJECT_NAME)
     service = None
+    action = None
     _init_done = False
 
     def __init__(self, iface, rest_bind):
@@ -96,6 +97,10 @@ class Context(object):
 
     def set_service_adapter(self, adapter):
         self.service = adapter
+        return self
+
+    def set_action_adapter(self, adapter):
+        self.action = adapter
         return self
 
 

--- a/services/lab-service/traffexam/kilda/traffexam/core.py
+++ b/services/lab-service/traffexam/kilda/traffexam/core.py
@@ -19,6 +19,7 @@ import sys
 
 import click
 
+from kilda.traffexam import action
 from kilda.traffexam import common
 from kilda.traffexam import const
 from kilda.traffexam import context as context_module
@@ -63,6 +64,7 @@ def main(iface, bind, **args):
                 setup_environment(context)
 
                 context.set_service_adapter(service.Adapter(context))
+                context.set_action_adapter(action.Adapter(context))
                 SigCHLD(context.children)
 
                 rest.init(bind, context)

--- a/services/lab-service/traffexam/kilda/traffexam/exc.py
+++ b/services/lab-service/traffexam/kilda/traffexam/exc.py
@@ -164,3 +164,12 @@ class SystemResourceDamagedError(SystemResourceError):
     def __str__(self):
         return 'Can\'t operate with resource kind={0} name={1!r}: {2}'.format(
                 *self.args)
+
+
+class SystemCompatibilityError(SystemResourceError):
+    def __init__(self, kind, name, details):
+        super().__init__(kind, name, details)
+
+    def __str__(self):
+        return ('Unable to configure system resource kind={0} name={1!r}'
+                ' - {2}').format(*self.args)

--- a/services/lab-service/traffexam/kilda/traffexam/model.py
+++ b/services/lab-service/traffexam/kilda/traffexam/model.py
@@ -335,6 +335,15 @@ class PortQueue(collections.Iterator):
         self.released.add(item)
 
 
+class LLDPPush(Abstract):
+    time_to_live = Default(120)
+
+    def __init__(self, mac_address, port_number, **fields):
+        super().__init__(**fields)
+        self.mac_address = mac_address
+        self.port_number = port_number
+
+
 class JSONEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, Abstract):

--- a/services/lab-service/traffexam/requirements.txt
+++ b/services/lab-service/traffexam/requirements.txt
@@ -1,3 +1,5 @@
 click==7.0
 bottle==0.12.16
 pyroute2==0.5.5
+nsenter==0.2
+scapy>=2.4.2,<2.4.3


### PR DESCRIPTION
New REST endpoint aimed to push LLDP packets via some existing
interface(so it can be VLAN tagged if interface have VLAN
assignment).

Endpoint:

PUT /address/<idnr>/lldp

{
  "mac_address": "02:00:00:00:00:01",
  "port_number": "5",
  "time_to_live": 60
}

Norwal response:

{
  "lldp_push": {
    "sent_packets": 1
  }
}

Be aware with used mac addressed - avoid 1 in less significant bit of
first byte. This bit identify "group"/broadcast recipient and filtered
out on any bridge. And because traffexam are attached to target
interface via linux bridge, such packets will never reach recipient.

Close #2661