### PR TITLE
Simplify unit test exec process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,17 +60,11 @@ compile:
 	$(MAKE) -C services/wfm all-in-one
 	$(MAKE) -C services/lab-service/lab test
 
-.PHONY: unit unit-java-common unit-java-storm
-unit: update-props unit-java-common unit-java-storm
-unit-java-common:
+.PHONY: unit
+unit: update-props
 	$(MAKE) build-no-test -C services/src
 	$(MAKE) unit -C services/src
-unit-java-storm: avoid-port-conflicts
 	mvn -B -f services/wfm/pom.xml test
-
-.PHONY: avoid-port-conflicts
-avoid-port-conflicts:
-	docker-compose stop
 
 clean-test:
 	docker-compose down


### PR DESCRIPTION
Remove extra steps from `make unit` process. This step was required to
manage topology-engine tests. Now we have no TE and can get rid from
it's artifacts.