### PR TITLE
add and refactor existing tests according to ISL cost manipulation in DB

### DIFF
--- a/services/src/functional-tests/kilda.properties.example
+++ b/services/src/functional-tests/kilda.properties.example
@@ -44,6 +44,7 @@ antiflap.cooldown=5
 
 isl.cost.when.port.down=10000
 isl.cost.when.under.maintenance=10000
+isl.unstable.timeout.sec=7200
 
 burst.coefficient=1.05
 

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkMaintenanceSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkMaintenanceSpec.groovy
@@ -2,6 +2,7 @@ package org.openkilda.functionaltests.spec.links
 
 import static org.junit.Assume.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
+import static org.openkilda.testing.Constants.DEFAULT_COST
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
@@ -11,18 +12,8 @@ import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.info.event.IslChangeType
 import org.openkilda.messaging.info.event.PathNode
 import org.openkilda.messaging.payload.flow.FlowState
-import org.openkilda.testing.Constants
-
-import org.springframework.beans.factory.annotation.Value
 
 class LinkMaintenanceSpec extends HealthCheckSpecification {
-
-    @Value('${isl.cost.when.under.maintenance}')
-    int islCostWhenUnderMaintenance
-
-    def setupOnce() {
-        database.resetCosts()  // set default cost on all links before tests
-    }
 
     @Tags(SMOKE)
     def "Maintenance mode can be set/unset for a particular link"() {
@@ -35,9 +26,9 @@ class LinkMaintenanceSpec extends HealthCheckSpecification {
         then: "Maintenance flag for forward and reverse ISLs is really set"
         response.each { assert it.underMaintenance }
 
-        and: "Cost for ISLs is changed respectively"
-        database.getIslCost(isl) == islCostWhenUnderMaintenance + Constants.DEFAULT_COST
-        database.getIslCost(isl.reversed) == islCostWhenUnderMaintenance + Constants.DEFAULT_COST
+        and: "Cost for ISLs is not changed"
+        database.getIslCost(isl) == DEFAULT_COST
+        database.getIslCost(isl.reversed) == DEFAULT_COST
 
         when: "Unset maintenance mode from the link"
         response = northbound.setLinkMaintenance(islUtils.toLinkUnderMaintenance(isl, false, false))
@@ -46,8 +37,8 @@ class LinkMaintenanceSpec extends HealthCheckSpecification {
         response.each { assert !it.underMaintenance }
 
         and: "Cost for ISLs is changed to the default value"
-        database.getIslCost(isl) == Constants.DEFAULT_COST
-        database.getIslCost(isl.reversed) == Constants.DEFAULT_COST
+        database.getIslCost(isl) == DEFAULT_COST
+        database.getIslCost(isl.reversed) == DEFAULT_COST
     }
 
     def "Flows can be evacuated (rerouted) from a particular link when setting maintenance mode for it"() {

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
@@ -140,7 +140,7 @@ class SwitchFailuresSpec extends HealthCheckSpecification {
         and: "Rules are valid on the knocked out switch"
         verifySwitchRules(uniqueSwitch.dpId)
 
-        and: "Remove the flow and reset costs"
+        and: "Remove the flow and delete link props"
         flowHelper.deleteFlow(flow.id)
         northbound.deleteLinkProps(northbound.getAllLinkProps())
     }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchMaintenanceSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchMaintenanceSpec.groovy
@@ -15,18 +15,10 @@ import org.openkilda.messaging.info.event.IslChangeType
 import org.openkilda.messaging.info.event.SwitchChangeType
 import org.openkilda.messaging.payload.flow.FlowState
 
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.client.HttpClientErrorException
 import spock.lang.Ignore
 
 class SwitchMaintenanceSpec extends HealthCheckSpecification {
-
-    @Value('${isl.cost.when.under.maintenance}')
-    int islCostWhenUnderMaintenance
-
-    def setupOnce() {
-        database.resetCosts()  // set default cost on all links before tests
-    }
 
     @Tags(SMOKE)
     def "Maintenance mode can be set/unset for a particular switch"() {
@@ -45,10 +37,10 @@ class SwitchMaintenanceSpec extends HealthCheckSpecification {
             assert it.underMaintenance
         }
 
-        and: "Cost for ISLs is changed respectively"
+        and: "Cost for ISLs is not changed"
         topology.islsForActiveSwitches.findAll { sw.dpId in [it.srcSwitch, it.dstSwitch]*.dpId }.each {
-            assert database.getIslCost(it) == islCostWhenUnderMaintenance + DEFAULT_COST
-            assert database.getIslCost(it.reversed) == islCostWhenUnderMaintenance + DEFAULT_COST
+            assert database.getIslCost(it) == DEFAULT_COST
+            assert database.getIslCost(it.reversed) == DEFAULT_COST
         }
 
         when: "Unset maintenance mode from the switch"
@@ -63,7 +55,7 @@ class SwitchMaintenanceSpec extends HealthCheckSpecification {
             assert !it.underMaintenance
         }
 
-        and: "Cost for ISLs is changed to the default value"
+        and: "Cost for ISLs is not changed"
         topology.islsForActiveSwitches.findAll { sw.dpId in [it.srcSwitch, it.dstSwitch]*.dpId }.each {
             assert database.getIslCost(it) == DEFAULT_COST
             assert database.getIslCost(it.reversed) == DEFAULT_COST

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
@@ -197,6 +197,5 @@ class SwitchesSpec extends HealthCheckSpecification {
             assert northbound.getSwitch(switchToDisconnect.dpId).state == SwitchChangeType.ACTIVATED
         }
         [simpleFlow, singleFlow].each { flowHelper.deleteFlow(it.id) }
-        database.resetCosts()
     }
 }

--- a/services/src/test-library/src/main/java/org/openkilda/testing/service/database/DatabaseSupportImpl.java
+++ b/services/src/test-library/src/main/java/org/openkilda/testing/service/database/DatabaseSupportImpl.java
@@ -222,7 +222,7 @@ public class DatabaseSupportImpl implements Database {
     @Override
     public boolean resetCosts() {
         Session session = ((Neo4jSessionFactory) transactionManager).getSession();
-        String query = "MATCH ()-[i:isl]->() SET i.cost=$cost";
+        String query = "MATCH ()-[i:isl]->() SET i.cost=$cost, i.time_unstable=null";
         Result result = session.query(query, ImmutableMap.of("cost", DEFAULT_COST));
         return result.queryStatistics().getPropertiesSet() > 0;
     }


### PR DESCRIPTION
- refactor tests according to ISL cost manipulation in DB
- add test for checking that system takes into account the `time_unstable` field while creating a flow