### PR TITLE
Fix switch rules synchronization.

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/switchmanager/service/impl/ValidationServiceImpl.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/switchmanager/service/impl/ValidationServiceImpl.java
@@ -130,7 +130,7 @@ public class ValidationServiceImpl implements ValidationService {
                 }
 
                 if (defaultRule.size() > 1) {
-                    excessRules.add(expectedDefaultRule.getCookie());
+                    misconfiguredRules.add(expectedDefaultRule.getCookie());
                 }
             }
         });

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/switchmanager/service/impl/ValidationServiceImplTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/switchmanager/service/impl/ValidationServiceImplTest.java
@@ -107,10 +107,10 @@ public class ValidationServiceImplTest {
         ValidateRulesResult response =
                 validationService.validateRules(SWITCH_ID_A, flowEntries, expectedDefaultFlowEntries);
         assertEquals(ImmutableSet.of(0x8000000000000001L), new HashSet<>(response.getProperRules()));
-        assertEquals(ImmutableSet.of(0x8000000000000002L), new HashSet<>(response.getMisconfiguredRules()));
+        assertEquals(ImmutableSet.of(0x8000000000000001L, 0x8000000000000002L),
+                new HashSet<>(response.getMisconfiguredRules()));
         assertEquals(ImmutableSet.of(0x8000000000000003L), new HashSet<>(response.getMissingRules()));
-        assertEquals(ImmutableSet.of(0x8000000000000001L, 0x8000000000000002L, 0x8000000000000004L),
-                new HashSet<>(response.getExcessRules()));
+        assertEquals(ImmutableSet.of(0x8000000000000004L), new HashSet<>(response.getExcessRules()));
     }
 
     @Test


### PR DESCRIPTION
- fixed validation logic;
- fixed response when syncing default rules (closes: #2707);
- fixed default rules synchronization with `remove_excess` flag (closes: #2706).