### PR TITLE
FL: Read from the latest offset from disco topic

### DIFF
--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/KafkaMessageCollector.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/KafkaMessageCollector.java
@@ -104,9 +104,9 @@ public class KafkaMessageCollector implements IFloodlightModule {
         ExecutorService discoCommandExecutor = buildExecutorWithNoQueue(consumerConfig.getDiscoExecutorCount());
         logger.info("Kafka Consumer: disco executor threads = {}", consumerConfig.getDiscoExecutorCount());
 
-        KafkaConsumerSetup kafkaSetup = new KafkaConsumerSetup(kafkaChannel.getSpeakerDiscoTopic());
-        kafkaSetup.offsetResetStrategy(OffsetResetStrategy.LATEST);
-        launcher.launch(discoCommandExecutor, kafkaSetup);
+        launcher.launch(discoCommandExecutor, new KafkaConsumerSetup(kafkaChannel.getSpeakerDiscoTopic())
+                .withOffsetResetStrategy(OffsetResetStrategy.LATEST)
+                .withForceSeekToEnd(true));
     }
 
     protected ExecutorService buildExecutorWithNoQueue(int executorCount) {

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/pathverification/PathVerificationService.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/pathverification/PathVerificationService.java
@@ -293,13 +293,12 @@ public class PathVerificationService implements IFloodlightModule, IPathVerifica
 
     @Override
     public boolean sendDiscoveryMessage(DatapathId srcSwId, OFPort port, Long packetId) {
-        boolean result = false;
-
         try {
             IOFSwitch srcSwitch = switchService.getSwitch(srcSwId);
             if (srcSwitch != null && srcSwitch.getPort(port) != null) {
                 OFPacketOut ofPacketOut = generateDiscoveryPacket(srcSwitch, port, true, packetId);
 
+                boolean result = false;
                 if (ofPacketOut != null) {
                     logger.debug("==> Sending discovery packet out {}/{} id {}: {}", srcSwitch.getId(),
                             port.getPortNumber(),
@@ -319,12 +318,15 @@ public class PathVerificationService implements IFloodlightModule, IPathVerifica
                             "Failed to send PACKET_OUT(ISL discovery packet) via {}-{} id: {}",
                             srcSwitch.getId(), port.getPortNumber(), packetId);
                 }
+                return result;
             }
         } catch (Exception exception) {
             logger.error(String.format("Unhandled exception in %s", getClass().getName()), exception);
         }
 
-        return result;
+        // return true to make sure network topology will fail already discovered ISL's by timeout
+        // on disconnected switches
+        return true;
     }
 
     private static LLDPTLV switchTimestampTlv(byte type) {

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/kafka/KafkaConsumerSetup.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/kafka/KafkaConsumerSetup.java
@@ -17,8 +17,10 @@ package org.openkilda.floodlight.service.kafka;
 
 import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,26 +30,36 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
+@Slf4j
 public class KafkaConsumerSetup {
     private final HashSet<String> topicsSet = new HashSet<>();
 
     private final HashMap<String, String> configOverride = new HashMap<>();
+
+    private boolean forceSeekToEnd = false;
 
     public KafkaConsumerSetup(String topic, String... extraTopics) {
         topicsSet.add(topic);
         topicsSet.addAll(Arrays.asList(extraTopics));
     }
 
-    public void offsetResetStrategy(OffsetResetStrategy strategy) {
+    public KafkaConsumerSetup withOffsetResetStrategy(OffsetResetStrategy strategy) {
         configOverride.put(AUTO_OFFSET_RESET_CONFIG, strategy.toString().toLowerCase());
+        return this;
+    }
+
+    public KafkaConsumerSetup withForceSeekToEnd(boolean value) {
+        forceSeekToEnd = value;
+        return this;
     }
 
     /**
      * List of kafka-topics consumer will be subscribed to.
      */
     public List<String> getTopics() {
-        ArrayList<String> topics = new ArrayList<>(topicsSet.size());
+        ArrayList<String> topics = new ArrayList<>(topicsSet);
         Collections.sort(topics);
         return topics;
     }
@@ -67,5 +79,22 @@ public class KafkaConsumerSetup {
      */
     public void applyInstance(KafkaConsumer<?, ?> consumer) {
         consumer.subscribe(topicsSet);
+        if (forceSeekToEnd) {
+            seekToEnd(consumer);
+        }
+    }
+
+    private void seekToEnd(KafkaConsumer<?, ?> consumer) {
+        // Force partitions assignment, because this is initial read and seek to end is forced we can ignore any
+        // available now records (i.e. ignore results of .poll() call)
+        consumer.poll(0L);
+
+        // Seek to end assigned for current consumer partitions (other consumers for this consumer group will do the
+        // same) i.e. seek to the end will be applied to all partitions
+        List<TopicPartition> partitionsToSeek = new ArrayList<>(consumer.assignment());
+        log.info("Seek kafka partitions to the end: \"{}\"", partitionsToSeek.stream()
+                .map(TopicPartition::toString)
+                .collect(Collectors.joining("\", \"")));
+        consumer.seekToEnd(partitionsToSeek);
     }
 }

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/info/discovery/DiscoPacketResponse.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/info/discovery/DiscoPacketResponse.java
@@ -26,7 +26,7 @@ import lombok.Value;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
-public class DiscoPacketSendingConfirmation extends InfoData {
+public class DiscoPacketResponse extends InfoData {
 
     @JsonProperty("endpoint")
     private NetworkEndpoint endpoint;
@@ -37,10 +37,15 @@ public class DiscoPacketSendingConfirmation extends InfoData {
     @JsonProperty("packetId")
     private long packetId;
 
+    @JsonProperty("confirmed")
+    private boolean confirmed;
+
     @JsonCreator
-    public DiscoPacketSendingConfirmation(@JsonProperty("endpoint") NetworkEndpoint endpoint,
-                                          @JsonProperty("packetId") final long packetId) {
+    public DiscoPacketResponse(@JsonProperty("endpoint") NetworkEndpoint endpoint,
+                               @JsonProperty("packetId") final long packetId,
+                               @JsonProperty("confirmed") boolean confirmed) {
         this.endpoint = endpoint;
         this.packetId = packetId;
+        this.confirmed = confirmed;
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/service/NetworkWatcherService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/service/NetworkWatcherService.java
@@ -93,13 +93,18 @@ public class NetworkWatcherService {
     }
 
     /**
-     * .
+     * Process discovery packet confirmation.
      */
-    public void confirmation(Endpoint endpoint, long packetNo) {
+    public void processConfirmation(Endpoint endpoint, long packetNo, boolean confirmed) {
         log.debug("Watcher service receive SEND-confirmation for {} id:{} task:{}", endpoint, packetNo, taskId);
         Packet packet = Packet.of(endpoint, packetNo);
         if (producedPackets.remove(packet)) {
-            confirmedPackets.add(packet);
+            if (confirmed) {
+                confirmedPackets.add(packet);
+            } else {
+                log.warn("Discovery packet was rejected for {} id:{} task:{}. "
+                        + "Floodlight failed to send packet to the switch.", endpoint, packetNo, taskId);
+            }
         } else if (log.isDebugEnabled()) {
             log.debug("Can't find produced packet for {} id:{} task:{}", endpoint, packetNo, taskId);
         }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/storm/bolt/speaker/SpeakerRouter.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/storm/bolt/speaker/SpeakerRouter.java
@@ -19,7 +19,7 @@ import org.openkilda.messaging.Message;
 import org.openkilda.messaging.floodlight.response.BfdSessionResponse;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.InfoMessage;
-import org.openkilda.messaging.info.discovery.DiscoPacketSendingConfirmation;
+import org.openkilda.messaging.info.discovery.DiscoPacketResponse;
 import org.openkilda.messaging.info.discovery.InstallIslDefaultRulesResult;
 import org.openkilda.messaging.info.discovery.NetworkDumpSwitchData;
 import org.openkilda.messaging.info.discovery.RemoveIslDefaultRulesResult;
@@ -126,9 +126,9 @@ public class SpeakerRouter extends AbstractBolt {
         if (payload instanceof IslInfoData) {
             emit(STREAM_WATCHER_ID, input, makeWatcherTuple(
                     input, new WatcherSpeakerDiscoveryCommand((IslInfoData) payload)));
-        } else if (payload instanceof DiscoPacketSendingConfirmation) {
+        } else if (payload instanceof DiscoPacketResponse) {
             emit(STREAM_WATCHER_ID, input, makeWatcherTuple(
-                    input, new WatcherSpeakerSendConfirmationCommand((DiscoPacketSendingConfirmation) payload)));
+                    input, new WatcherSpeakerSendConfirmationCommand((DiscoPacketResponse) payload)));
         } else if (payload instanceof SwitchInfoData) {
             emit(input, makeDefaultTuple(input, new SwitchEventCommand((SwitchInfoData) payload)));
         } else if (payload instanceof PortInfoData) {

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/storm/bolt/watcher/WatcherHandler.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/storm/bolt/watcher/WatcherHandler.java
@@ -142,8 +142,8 @@ public class WatcherHandler extends AbstractBolt implements IWatcherCarrier {
 
     // WatcherCommand
 
-    public void processConfirmation(Endpoint endpoint, long packetId) {
-        service.confirmation(endpoint, packetId);
+    public void processConfirmation(Endpoint endpoint, long packetId, boolean confirmed) {
+        service.processConfirmation(endpoint, packetId, confirmed);
     }
 
     public void processAddWatch(Endpoint endpoint) {

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/network/storm/bolt/watcher/command/WatcherSpeakerSendConfirmationCommand.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/network/storm/bolt/watcher/command/WatcherSpeakerSendConfirmationCommand.java
@@ -15,20 +15,20 @@
 
 package org.openkilda.wfm.topology.network.storm.bolt.watcher.command;
 
-import org.openkilda.messaging.info.discovery.DiscoPacketSendingConfirmation;
+import org.openkilda.messaging.info.discovery.DiscoPacketResponse;
 import org.openkilda.wfm.share.model.Endpoint;
 import org.openkilda.wfm.topology.network.storm.bolt.watcher.WatcherHandler;
 
 public class WatcherSpeakerSendConfirmationCommand extends WatcherCommand {
-    private final DiscoPacketSendingConfirmation confirmation;
+    private final DiscoPacketResponse response;
 
-    public WatcherSpeakerSendConfirmationCommand(DiscoPacketSendingConfirmation confirmation) {
-        super(new Endpoint(confirmation.getEndpoint()));
-        this.confirmation = confirmation;
+    public WatcherSpeakerSendConfirmationCommand(DiscoPacketResponse response) {
+        super(new Endpoint(response.getEndpoint()));
+        this.response = response;
     }
 
     @Override
     public void apply(WatcherHandler handler) {
-        handler.processConfirmation(getEndpoint(), confirmation.getPacketId());
+        handler.processConfirmation(getEndpoint(), response.getPacketId(), response.isConfirmed());
     }
 }

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/floodlightrouter/bolts/DiscoReplyBoltTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/floodlightrouter/bolts/DiscoReplyBoltTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.openkilda.messaging.info.InfoMessage;
-import org.openkilda.messaging.info.discovery.DiscoPacketSendingConfirmation;
+import org.openkilda.messaging.info.discovery.DiscoPacketResponse;
 import org.openkilda.messaging.model.NetworkEndpoint;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.topology.floodlightrouter.Stream;
@@ -84,7 +84,7 @@ public class DiscoReplyBoltTest {
     @Test
     public void verifySpeakerToConsumerTupleConsistency() throws Exception {
         InfoMessage discoveryConfirmation = new InfoMessage(
-                new DiscoPacketSendingConfirmation(new NetworkEndpoint(switchAlpha, 1), 1L),
+                new DiscoPacketResponse(new NetworkEndpoint(switchAlpha, 1), 1L, true),
                 3L, "discovery-confirmation", REGION_ONE);
         Tuple tuple = mock(Tuple.class);
         when(tuple.getStringByField(FIELD_ID_KEY)).thenReturn(switchAlpha.toString());


### PR DESCRIPTION
Floodlight should skip all outdated discovery packets on startup.

To prevent ISL fails on floodlight restart network topology should not consider disco packet as confirmed if it can not be sent from floodlight to switches.

Close #2084

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/2717)
<!-- Reviewable:end -->
