### PR TITLE
small improvements for tests

### DIFF
--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowDiversitySpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowDiversitySpec.groovy
@@ -399,24 +399,20 @@ class FlowDiversitySpec extends HealthCheckSpecification {
     void verifySegmentsStats(List<FlowPathPayload> flowPaths, Map expectedValuesMap) {
         flowPaths.each { flow ->
             with(flow.diverseGroupPayload) { diverseGroup ->
-                with(diverseGroup.overlappingSegments) {
-                    verifyAll {
-                        islCount == expectedValuesMap["diverseGroup"][flow.id]["islCount"]
-                        switchCount == expectedValuesMap["diverseGroup"][flow.id]["switchCount"]
-                        islPercent == expectedValuesMap["diverseGroup"][flow.id]["islPercent"]
-                        switchPercent == expectedValuesMap["diverseGroup"][flow.id]["switchPercent"]
-                    }
+                verifyAll(diverseGroup.overlappingSegments) {
+                    islCount == expectedValuesMap["diverseGroup"][flow.id]["islCount"]
+                    switchCount == expectedValuesMap["diverseGroup"][flow.id]["switchCount"]
+                    islPercent == expectedValuesMap["diverseGroup"][flow.id]["islPercent"]
+                    switchPercent == expectedValuesMap["diverseGroup"][flow.id]["switchPercent"]
                 }
                 with(diverseGroup.otherFlows) { otherFlows ->
                     assert (flowPaths*.id - flow.id).containsAll(otherFlows*.id)
                     otherFlows.each { otherFlow ->
-                        with(otherFlow.segmentsStats) {
-                            verifyAll {
-                                islCount == expectedValuesMap["otherFlows"][flow.id][otherFlow.id]["islCount"]
-                                switchCount == expectedValuesMap["otherFlows"][flow.id][otherFlow.id]["switchCount"]
-                                islPercent == expectedValuesMap["otherFlows"][flow.id][otherFlow.id]["islPercent"]
-                                switchPercent == expectedValuesMap["otherFlows"][flow.id][otherFlow.id]["switchPercent"]
-                            }
+                        verifyAll(otherFlow.segmentsStats) {
+                            islCount == expectedValuesMap["otherFlows"][flow.id][otherFlow.id]["islCount"]
+                            switchCount == expectedValuesMap["otherFlows"][flow.id][otherFlow.id]["switchCount"]
+                            islPercent == expectedValuesMap["otherFlows"][flow.id][otherFlow.id]["islPercent"]
+                            switchPercent == expectedValuesMap["otherFlows"][flow.id][otherFlow.id]["switchPercent"]
                         }
                     }
                 }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowPingSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowPingSpec.groovy
@@ -223,7 +223,7 @@ class FlowPingSpec extends HealthCheckSpecification {
         def response = northbound.pingFlow(wrongFlowId, new PingInput())
 
         then: "Receive error response"
-        with(response) {
+        verifyAll(response) {
             flowId == wrongFlowId
             !forward
             !reverse

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
@@ -892,7 +892,7 @@ class ProtectedPathSpec extends HealthCheckSpecification {
 
         then: "Flow state is changed to DEGRADED"
         Wrappers.wait(WAIT_OFFSET) { assert northbound.getFlowStatus(flow.id).status == FlowState.DEGRADED }
-        with(northbound.getFlow(flow.id).flowStatusDetails) {
+        verifyAll(northbound.getFlow(flow.id).flowStatusDetails) {
             mainFlowPathStatus == "Up"
             protectedFlowPathStatus == "Down"
         }
@@ -902,7 +902,7 @@ class ProtectedPathSpec extends HealthCheckSpecification {
 
         then: "Flow state is changed to DOWN"
         Wrappers.wait(WAIT_OFFSET) { assert northbound.getFlowStatus(flow.id).status == FlowState.DOWN }
-        with(northbound.getFlow(flow.id).flowStatusDetails) {
+        verifyAll(northbound.getFlow(flow.id).flowStatusDetails) {
             mainFlowPathStatus == "Down"
             protectedFlowPathStatus == "Down"
         }
@@ -924,7 +924,7 @@ class ProtectedPathSpec extends HealthCheckSpecification {
         then: "Flow state is still DEGRADED"
         Wrappers.wait(PROTECTED_PATH_INSTALLATION_TIME) {
             assert northbound.getFlowStatus(flow.id).status == FlowState.DEGRADED
-            with(northbound.getFlow(flow.id).flowStatusDetails) {
+            verifyAll(northbound.getFlow(flow.id).flowStatusDetails) {
                 mainFlowPathStatus == "Up"
                 protectedFlowPathStatus == "Down"
             }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/VxlanFlowV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/VxlanFlowV2Spec.groovy
@@ -73,20 +73,20 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
         def flowInfoFromDb = database.getFlow(flow.flowId)
         // ingressRule should contain "pushVxlan"
         // egressRule should contain "tunnel-id"
-        with(northbound.getSwitchRules(switchPair.src.dpId).flowEntries) { rules ->
-            assert rules.find {
+        verifyAll(northbound.getSwitchRules(switchPair.src.dpId).flowEntries) { rules ->
+            rules.find {
                 it.cookie == flowInfoFromDb.forwardPath.cookie.value
             }.instructions.applyActions.pushVxlan as boolean == vxlanRule
-            assert rules.find {
+            rules.find {
                 it.cookie == flowInfoFromDb.reversePath.cookie.value
             }.match.tunnelId as boolean == vxlanRule
         }
 
-        with(northbound.getSwitchRules(switchPair.dst.dpId).flowEntries) { rules ->
-            assert rules.find {
+        verifyAll(northbound.getSwitchRules(switchPair.dst.dpId).flowEntries) { rules ->
+            rules.find {
                 it.cookie == flowInfoFromDb.forwardPath.cookie.value
             }.match.tunnelId as boolean == vxlanRule
-            assert rules.find {
+            rules.find {
                 it.cookie == flowInfoFromDb.reversePath.cookie.value
             }.instructions.applyActions.pushVxlan as boolean == vxlanRule
         }
@@ -106,9 +106,9 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
         }
 
         and: "Flow is pingable"
-        with(northbound.pingFlow(flow.flowId, new PingInput())) {
-            assert it.forward.pingSuccess
-            assert it.reverse.pingSuccess
+        verifyAll(northbound.pingFlow(flow.flowId, new PingInput())) {
+            forward.pingSuccess
+            reverse.pingSuccess
         }
 
         when: "Try to update the encapsulation type to #encapsulationUpdate.toString()"
@@ -131,9 +131,9 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
         }
 
         and: "Flow is pingable"
-        with(northbound.pingFlow(flow.flowId, new PingInput())) {
-            assert it.forward.pingSuccess
-            assert it.reverse.pingSuccess
+        verifyAll(northbound.pingFlow(flow.flowId, new PingInput())) {
+            forward.pingSuccess
+            reverse.pingSuccess
         }
 
         and: "Rules are recreated"
@@ -142,20 +142,20 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
                 [flowInfoFromDb2.forwardPath.cookie.value, flowInfoFromDb2.reversePath.cookie.value].sort()
 
         and: "New rules are installed correctly"
-        with(northbound.getSwitchRules(switchPair.src.dpId).flowEntries) { rules ->
-            assert rules.find {
+        verifyAll(northbound.getSwitchRules(switchPair.src.dpId).flowEntries) { rules ->
+            rules.find {
                 it.cookie == flowInfoFromDb2.forwardPath.cookie.value
             }.instructions.applyActions.pushVxlan as boolean == !vxlanRule
-            assert rules.find {
+            rules.find {
                 it.cookie == flowInfoFromDb2.reversePath.cookie.value
             }.match.tunnelId as boolean == !vxlanRule
         }
 
-        with(northbound.getSwitchRules(switchPair.dst.dpId).flowEntries) { rules ->
-            assert rules.find {
+        verifyAll(northbound.getSwitchRules(switchPair.dst.dpId).flowEntries) { rules ->
+            rules.find {
                 it.cookie == flowInfoFromDb2.forwardPath.cookie.value
             }.match.tunnelId as boolean == !vxlanRule
-            assert rules.find {
+            rules.find {
                 it.cookie == flowInfoFromDb2.reversePath.cookie.value
             }.instructions.applyActions.pushVxlan as boolean == !vxlanRule
         }
@@ -229,26 +229,26 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
         // protected path creates engressRule
         def protectedForwardCookie = flowInfoFromDb.protectedForwardPath.cookie.value
         def protectedReverseCookie = flowInfoFromDb.protectedReversePath.cookie.value
-        with(northbound.getSwitchRules(switchPair.src.dpId).flowEntries) { rules ->
-            assert rules.find {
+        verifyAll(northbound.getSwitchRules(switchPair.src.dpId).flowEntries) { rules ->
+            rules.find {
                 it.cookie == flowInfoFromDb.forwardPath.cookie.value
             }.instructions.applyActions.pushVxlan
-            assert rules.find {
+            rules.find {
                 it.cookie == flowInfoFromDb.reversePath.cookie.value
             }.match.tunnelId
-            assert rules.find {
+            rules.find {
                 it.cookie == flowInfoFromDb.protectedReversePath.cookie.value
             }.match.tunnelId
         }
 
-        with(northbound.getSwitchRules(switchPair.dst.dpId).flowEntries) { rules ->
-            assert rules.find {
+        verifyAll(northbound.getSwitchRules(switchPair.dst.dpId).flowEntries) { rules ->
+            rules.find {
                 it.cookie == flowInfoFromDb.forwardPath.cookie.value
             }.match.tunnelId
-            assert rules.find {
+            rules.find {
                 it.cookie == flowInfoFromDb.reversePath.cookie.value
             }.instructions.applyActions.pushVxlan
-            assert rules.find {
+            rules.find {
                 it.cookie == flowInfoFromDb.protectedForwardPath.cookie.value
             }.match.tunnelId
         }
@@ -282,20 +282,20 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
         [flowInfoFromDb.forwardPath.cookie.value, flowInfoFromDb.reversePath.cookie.value].sort() !=
                 [flowInfoFromDb2.forwardPath.cookie.value, flowInfoFromDb2.reversePath.cookie.value].sort()
 
-        with(northbound.getSwitchRules(switchPair.src.dpId).flowEntries) { rules ->
-            assert rules.find {
+        verifyAll(northbound.getSwitchRules(switchPair.src.dpId).flowEntries) { rules ->
+            rules.find {
                 it.cookie == flowInfoFromDb2.forwardPath.cookie.value
             }.instructions.applyActions.pushVxlan
-            assert rules.find {
+            rules.find {
                 it.cookie == flowInfoFromDb2.reversePath.cookie.value
             }.match.tunnelId
         }
 
-        with(northbound.getSwitchRules(switchPair.dst.dpId).flowEntries) { rules ->
-            assert rules.find {
+        verifyAll(northbound.getSwitchRules(switchPair.dst.dpId).flowEntries) { rules ->
+            rules.find {
                 it.cookie == flowInfoFromDb2.forwardPath.cookie.value
             }.match.tunnelId
-            assert rules.find {
+            rules.find {
                 it.cookie == flowInfoFromDb2.reversePath.cookie.value
             }.instructions.applyActions.pushVxlan
         }
@@ -448,11 +448,11 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
         and: "Correct rules are installed"
         def flowInfoFromDb = database.getFlow(flow.flowId)
         // vxlan rules are not creating for a one-switch flow
-        with(northbound.getSwitchRules(sw.dpId).flowEntries) { rules ->
-            assert !rules.find {
+        verifyAll(northbound.getSwitchRules(sw.dpId).flowEntries) { rules ->
+            !rules.find {
                 it.cookie == flowInfoFromDb.forwardPath.cookie.value
             }.instructions.applyActions.pushVxlan
-            assert !rules.find {
+            !rules.find {
                 it.cookie == flowInfoFromDb.reversePath.cookie.value
             }.match.tunnelId
         }
@@ -461,9 +461,9 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         and: "Flow is pingable"
-        with(northbound.pingFlow(flow.flowId, new PingInput())) {
-            assert it.forward.pingSuccess
-            assert it.reverse.pingSuccess
+        verifyAll(northbound.pingFlow(flow.flowId, new PingInput())) {
+            forward.pingSuccess
+            reverse.pingSuccess
         }
 
         when: "Try to update the encapsulation type to #encapsulationUpdate.toString()"
@@ -477,9 +477,9 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         and: "Flow is pingable"
-        with(northbound.pingFlow(flow.flowId, new PingInput())) {
-            assert it.forward.pingSuccess
-            assert it.reverse.pingSuccess
+        verifyAll(northbound.pingFlow(flow.flowId, new PingInput())) {
+            forward.pingSuccess
+            reverse.pingSuccess
         }
 
         and: "Rules are recreated"
@@ -488,11 +488,11 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
                 [flowInfoFromDb2.forwardPath.cookie.value, flowInfoFromDb2.reversePath.cookie.value].sort()
 
         and: "New rules are installed correctly"
-        with(northbound.getSwitchRules(sw.dpId).flowEntries) { rules ->
-            assert !rules.find {
+        verifyAll(northbound.getSwitchRules(sw.dpId).flowEntries) { rules ->
+            !rules.find {
                 it.cookie == flowInfoFromDb2.forwardPath.cookie.value
             }.instructions.applyActions.pushVxlan
-            assert !rules.find {
+            !rules.find {
                 it.cookie == flowInfoFromDb2.reversePath.cookie.value
             }.match.tunnelId
         }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/ContentionSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/ContentionSpec.groovy
@@ -75,7 +75,7 @@ class ContentionSpec extends BaseSpecification {
 
         then: "Available bandwidth on all related isls is reverted back to normal"
         relatedIsls.each {
-            with(northbound.getLink(it)) {
+            verifyAll(northbound.getLink(it)) {
                 availableBandwidth == maxBandwidth
                 maxBandwidth == speed
             }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/ContentionV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/ContentionV2Spec.groovy
@@ -86,7 +86,7 @@ class ContentionV2Spec extends BaseSpecification {
 
         then: "Available bandwidth on all related isls is reverted back to normal"
         relatedIsls.each {
-            with(northbound.getLink(it)) {
+            verifyAll(northbound.getLink(it)) {
                 availableBandwidth == maxBandwidth
                 maxBandwidth == speed
             }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesSpec.groovy
@@ -177,12 +177,12 @@ class DefaultRulesSpec extends HealthCheckSpecification {
         }
 
         and: "Switch and rules validation shows that corresponding default rule is missing"
-        with(northbound.validateSwitchRules(sw.dpId)) {
+        verifyAll(northbound.validateSwitchRules(sw.dpId)) {
             missingRules == deletedRules
             excessRules.empty
             properRules == sw.defaultCookies.findAll { it != data.cookie }
         }
-        with(northbound.validateSwitch(sw.dpId)) {
+        verifyAll(northbound.validateSwitch(sw.dpId)) {
             rules.missing == deletedRules
             rules.misconfigured.empty
             rules.excess.empty

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesValidationSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesValidationSpec.groovy
@@ -25,14 +25,14 @@ class DefaultRulesValidationSpec extends HealthCheckSpecification {
     def "Switch and rule validation can properly detect default rules to 'proper' section (#sw.name)"() {
         given: "Clean switch without customer flows"
         expect: "Switch validation shows all expected default rules in 'proper' section"
-        with(northbound.validateSwitchRules(sw.dpId)) {
+        verifyAll(northbound.validateSwitchRules(sw.dpId)) {
             missingRules.empty
             excessRules.empty
             properRules == sw.defaultCookies
         }
 
         and: "Rule validation shows all expected default rules in 'proper' section"
-        with(northbound.validateSwitch(sw.dpId)) {
+        verifyAll(northbound.validateSwitch(sw.dpId)) {
             rules.missing.empty
             rules.misconfigured.empty
             rules.excess.empty

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/FlowRulesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/FlowRulesSpec.groovy
@@ -459,12 +459,10 @@ class FlowRulesSpec extends HealthCheckSpecification {
 
         and: "No missing rules were found after rules validation"
         involvedSwitches.each { switchId ->
-            with(northbound.validateSwitchRules(switchId)) {
-                verifyAll {
-                    properRules.findAll { !Cookie.isDefaultRule(it) }.size() == flowRulesCount
-                    missingRules.empty
-                    excessRules.empty
-                }
+            verifyAll(northbound.validateSwitchRules(switchId)) {
+                properRules.findAll { !Cookie.isDefaultRule(it) }.size() == flowRulesCount
+                missingRules.empty
+                excessRules.empty
             }
         }
 
@@ -659,12 +657,10 @@ class FlowRulesSpec extends HealthCheckSpecification {
 
         and: "No missing rules were found after rules validation"
         involvedSwitches.each { switchId ->
-            with(northbound.validateSwitchRules(switchId)) {
-                verifyAll {
-                    properRules.size() == flowRulesCount
-                    missingRules.empty
-                    excessRules.empty
-                }
+            verifyAll(northbound.validateSwitchRules(switchId)) {
+                properRules.size() == flowRulesCount
+                missingRules.empty
+                excessRules.empty
             }
         }
 


### PR DESCRIPTION
- use `eachParallel` instead of `each` in flowHelpers (v1/2);
- replace `with` by `verifyAll` for all tests. Sometimes it can be helpful to collect failures before failing the test to have more information.