### PR TITLE
Remove obsolete section

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,13 +178,6 @@ In order to debug a topology, for example, ```OfEventWfmTopology```, we should n
 Please refer to the [Testing](https://github.com/telstra/open-kilda/wiki/Testing)
 section on our Wiki.
 
-### How to run floodlight-modules locally
-
-From the base directory run these commands:
-
-1. ```make build-floodlight```
-2. ```make run-floodlight```
-
 ### How to build / test locally without containers
 
 Start with the following


### PR DESCRIPTION
Ability to build and run floodlight modules using `make` was removed long time ago but readme still has related section. Looks like nobody need it, so I suggest remove obsolete section.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/2757)
<!-- Reviewable:end -->
