### PR TITLE
Fix removing of unallocated resources on neo4j failure / constraint.

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/FlowRerouteFsm.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/FlowRerouteFsm.java
@@ -99,7 +99,8 @@ public final class FlowRerouteFsm
     private FlowEncapsulationType originalEncapsulationType;
 
     private FlowEncapsulationType newEncapsulationType;
-    private Collection<FlowResources> newResources;
+    private FlowResources newPrimaryResources;
+    private FlowResources newProtectedResources;
     private PathId newPrimaryForwardPath;
     private PathId newPrimaryReversePath;
     private PathId newProtectedForwardPath;
@@ -370,13 +371,6 @@ public final class FlowRerouteFsm
                                              PathComputer pathComputer, FlowResourcesManager resourcesManager) {
         return builder(persistenceManager, pathComputer, resourcesManager)
                 .newStateMachine(state, commandContext, carrier);
-    }
-
-    public void addNewResources(FlowResources flowResources) {
-        if (newResources == null) {
-            newResources = new ArrayList<>();
-        }
-        newResources.add(flowResources);
     }
 
     public void addOldResources(FlowResources flowResources) {

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocatePrimaryResourcesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocatePrimaryResourcesAction.java
@@ -72,7 +72,7 @@ public class AllocatePrimaryResourcesAction extends BaseResourceAllocationAction
             log.debug("Allocating resources for a new primary path of flow {}", flowId);
             FlowResources flowResources = resourcesManager.allocateFlowResources(flow);
             log.debug("Resources have been allocated: {}", flowResources);
-            stateMachine.addNewResources(flowResources);
+            stateMachine.setNewPrimaryResources(flowResources);
 
             FlowPathPair paths = createFlowPathPair(flow, potentialPath, flowResources);
             log.debug("New primary path has been created: {}", paths);
@@ -87,5 +87,12 @@ public class AllocatePrimaryResourcesAction extends BaseResourceAllocationAction
         } else {
             log.debug("Found the same primary path for flow {}. Skip creating of it.", flowId);
         }
+    }
+
+    @Override
+    protected void onFailure(FlowRerouteContext context, FlowRerouteFsm stateMachine) {
+        stateMachine.setNewPrimaryResources(null);
+        stateMachine.setNewPrimaryForwardPath(null);
+        stateMachine.setNewPrimaryReversePath(null);
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocateProtectedResourcesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocateProtectedResourcesAction.java
@@ -105,7 +105,7 @@ public class AllocateProtectedResourcesAction extends BaseResourceAllocationActi
                 log.debug("Allocating resources for a new protected path of flow {}", flowId);
                 FlowResources flowResources = resourcesManager.allocateFlowResources(flow);
                 log.debug("Resources have been allocated: {}", flowResources);
-                stateMachine.addNewResources(flowResources);
+                stateMachine.setNewProtectedResources(flowResources);
 
                 FlowPathPair paths = createFlowPathPair(flow, potentialPath, flowResources);
                 log.debug("New protected path has been created: {}", paths);
@@ -121,5 +121,12 @@ public class AllocateProtectedResourcesAction extends BaseResourceAllocationActi
                 log.debug("Found the same protected path for flow {}. Skip creating of it.", flowId);
             }
         }
+    }
+
+    @Override
+    protected void onFailure(FlowRerouteContext context, FlowRerouteFsm stateMachine) {
+        stateMachine.setNewProtectedResources(null);
+        stateMachine.setNewProtectedForwardPath(null);
+        stateMachine.setNewProtectedReversePath(null);
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/HandleNotRevertedResourceAllocationAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/HandleNotRevertedResourceAllocationAction.java
@@ -22,8 +22,6 @@ import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteFsm;
 import lombok.extern.slf4j.Slf4j;
 import org.squirrelframework.foundation.fsm.AnonymousAction;
 
-import java.util.Collection;
-
 @Slf4j
 public class HandleNotRevertedResourceAllocationAction
         extends AnonymousAction<FlowRerouteFsm, FlowRerouteFsm.State, FlowRerouteFsm.Event, FlowRerouteContext> {
@@ -31,9 +29,14 @@ public class HandleNotRevertedResourceAllocationAction
     @Override
     public void execute(FlowRerouteFsm.State from, FlowRerouteFsm.State to,
                         FlowRerouteFsm.Event event, FlowRerouteContext context, FlowRerouteFsm stateMachine) {
-        Collection<FlowResources> newResources = stateMachine.getNewResources();
-        if (newResources != null) {
-            newResources.forEach(flowResources -> log.warn("Failed to revert resource allocation: {}", flowResources));
+        FlowResources newPrimaryResources = stateMachine.getNewPrimaryResources();
+        if (newPrimaryResources != null) {
+            log.warn("Failed to revert resource allocation: {}", newPrimaryResources);
+        }
+
+        FlowResources newProtectedResources = stateMachine.getNewProtectedResources();
+        if (newProtectedResources != null) {
+            log.warn("Failed to revert resource allocation: {}", newProtectedResources);
         }
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/RevertResourceAllocationAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/RevertResourceAllocationAction.java
@@ -36,7 +36,6 @@ import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteFsm.State;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Instant;
-import java.util.Collection;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -58,16 +57,18 @@ public class RevertResourceAllocationAction extends BaseFlowPathRemovalAction {
         transactionManager.doInTransaction(() -> {
             Flow flow = getFlow(stateMachine.getFlowId(), FetchStrategy.DIRECT_RELATIONS);
 
-            Collection<FlowResources> newResources = stateMachine.getNewResources();
-            log.debug("Reverting resource allocation {}.", newResources);
-            if (newResources != null) {
-                newResources.forEach(flowResources -> {
-                    resourcesManager.deallocatePathResources(flowResources);
+            FlowResources newPrimaryResources = stateMachine.getNewPrimaryResources();
+            if (newPrimaryResources != null) {
+                resourcesManager.deallocatePathResources(newPrimaryResources);
+                log.debug("Resources has been de-allocated: {}", newPrimaryResources);
+                saveHistory(stateMachine, flow, newPrimaryResources);
+            }
 
-                    log.debug("Resources has been de-allocated: {}", flowResources);
-
-                    saveHistory(stateMachine, flow, flowResources);
-                });
+            FlowResources newProtectedResources = stateMachine.getNewProtectedResources();
+            if (newProtectedResources != null) {
+                resourcesManager.deallocatePathResources(newProtectedResources);
+                log.debug("Resources has been de-allocated: {}", newProtectedResources);
+                saveHistory(stateMachine, flow, newProtectedResources);
             }
 
             FlowPath newPrimaryForward = null;
@@ -103,6 +104,9 @@ public class RevertResourceAllocationAction extends BaseFlowPathRemovalAction {
                 saveHistory(stateMachine, flow.getFlowId(), newProtectedForward, newProtectedReverse);
             }
         });
+
+        stateMachine.setNewPrimaryResources(null);
+        stateMachine.setNewProtectedResources(null);
     }
 
     private void saveHistory(FlowRerouteFsm stateMachine, Flow flow, FlowResources resources) {

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteServiceTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteServiceTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -163,6 +164,23 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         verify(flowResourcesManager, times(4)).allocateFlowResources(any());
         verify(carrier, never()).sendSpeakerRequest(any());
         verify(carrier, times(1)).sendNorthboundResponse(any());
+    }
+
+    @Test
+    public void shouldFailRerouteFlowOnResourcesAllocationConstraint()
+            throws RecoverableException, UnroutableFlowException, ResourceAllocationException {
+        Flow flow = build2SwitchFlow();
+        when(pathComputer.getPath(any(), any())).thenReturn(build2SwitchPathPair(2, 3));
+        buildFlowResources();
+        doThrow(new RuntimeException("Must fail")).when(flowPathRepository).lockInvolvedSwitches(any(), any());
+
+        FlowRerouteService rerouteService = new FlowRerouteService(carrier, persistenceManager,
+                pathComputer, flowResourcesManager);
+
+        rerouteService.handleRequest("test_key", commandContext, FLOW_ID, null);
+
+        verify(flowResourcesManager, times(0)).deallocatePathResources(any());
+        verify(flowResourcesManager, times(0)).deallocatePathResources(any(), anyLong(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
The purpose of these changes is to avoid removing of unallocated resources by H&S reroute operations in a case of Neo4j transaction rollback (due to failure / constraint violation).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/2766)
<!-- Reviewable:end -->
