### PR TITLE
Extend local execution time for storm topologies

### DIFF
--- a/confd/templates/wfm/topology.properties.tmpl
+++ b/confd/templates/wfm/topology.properties.tmpl
@@ -64,7 +64,7 @@ message.blacklist.timeout = {{ getv "/kilda_message_blacklist_timeout" }}
 floodlight.regions = {{ getv "/kilda_floodlight_regions" }}
 
 local = no
-local.execution.time = 300
+local.execution.time = 3000
 
 pce.strategy = {{ getv "/kilda_pce_strategy" }}
 pce.network.strategy = {{ getv "/kilda_pce_network_strategy" }}

--- a/services/wfm/src/main/resources/topology.properties.example
+++ b/services/wfm/src/main/resources/topology.properties.example
@@ -79,7 +79,7 @@ discovery.db.write.repeats.time.frame = 30
 #flow.ping.fail.reset = 1800
 
 local = no
-local.execution.time = 300
+local.execution.time = 3000
 
 pce.strategy = COST
 pce.network.strategy = SYMMETRIC_COST


### PR DESCRIPTION
When you run storm locally 300 seconds is to small amount of time
for local debugging. Increase it 10 times.