### PR TITLE
Allow to use traffexam on python-3.5.2

### DIFF
--- a/services/lab-service/traffexam/kilda/traffexam/__init__.py
+++ b/services/lab-service/traffexam/kilda/traffexam/__init__.py
@@ -13,4 +13,4 @@
 #   limitations under the License.
 #
 
-__version__ = '0.1.dev13'
+__version__ = '0.1.dev14'

--- a/services/lab-service/traffexam/kilda/traffexam/context.py
+++ b/services/lab-service/traffexam/kilda/traffexam/context.py
@@ -71,7 +71,7 @@ class Context(object):
     def set_root(self, root):
         self.root = pathlib.Path(root)
         if not self._init_done:
-            self.root.mkdir(parents=True, exist_ok=True)
+            os.makedirs(str(self.root), exist_ok=True)
         return self
 
     def set_default_logging(self):


### PR DESCRIPTION
Avoid usage of merthod `Path.mkdir(mode=0o777, parents=False,
exist_ok=False)` of pathlib module due to lack of `exists_ok` argument
in python-3.5.2.