### PR TITLE
Replaced oraclejdk8 to openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
       language: java
       sudo: false
       install: true
-      jdk: oraclejdk8
+      jdk: openjdk8
       if: fork = false
 
       addons:
@@ -49,7 +49,7 @@ jobs:
     - stage: tests
       name: "Unit"
       language: java
-      jdk: oraclejdk8
+      jdk: openjdk8
 
       before_install:
         - wget https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-linux-amd64


### PR DESCRIPTION
Replaced oracle JDK to open JDK for Travis CI