### PR TITLE
Fix incorrect output port for single-switch-single-port flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.41.1 (07/11/2019)
+
+### Bug Fixes:
+-  [#2908](https://github.com/telstra/open-kilda/pull/2908) Fix incorrect output port for single-switch-single-port flows [**floodlight**]
+
+### Affected Components:
+fl
+
+---
+
 ## v1.41.0 (06/11/2019)
  
 ### Features:

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/InstallIngressRuleCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/InstallIngressRuleCommand.java
@@ -141,10 +141,6 @@ public class InstallIngressRuleCommand extends InstallTransitRuleCommand {
         }
     }
 
-    OFPort getOutputPort() {
-        return OFPort.of(outputPort);
-    }
-
     final OFFlowMod getIntermediateIngressRule(IOFSwitch sw, int port) {
         OFFactory ofFactory = sw.getOFFactory();
         Match match = ofFactory.buildMatch()

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/InstallOneSwitchRuleCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/InstallOneSwitchRuleCommand.java
@@ -59,8 +59,11 @@ public class InstallOneSwitchRuleCommand extends InstallIngressRuleCommand {
     }
 
     @Override
-    OFPort getOutputPort() {
-        return outputPort.equals(inputPort) ? OFPort.IN_PORT : OFPort.of(outputPort);
+    protected OFAction setOutputPort(OFFactory ofFactory) {
+        OFPort port = outputPort.equals(inputPort)
+                ? OFPort.IN_PORT
+                : OFPort.of(outputPort);
+        return setOutputPort(ofFactory, port);
     }
 
     @Override

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/InstallTransitRuleCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/InstallTransitRuleCommand.java
@@ -88,7 +88,7 @@ public class InstallTransitRuleCommand extends FlowInstallCommand {
         return Collections.singletonList(new MessageWriter(flowMod));
     }
 
-    final OFAction setOutputPort(OFFactory ofFactory) {
+    protected OFAction setOutputPort(OFFactory ofFactory) {
         return setOutputPort(ofFactory, OFPort.of(outputPort));
     }
 

--- a/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/FlowCommandTest.java
+++ b/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/FlowCommandTest.java
@@ -1,0 +1,57 @@
+/* Copyright 2019 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.floodlight.command.flow;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.openkilda.floodlight.test.standard.OutputCommands.ofFactory;
+import static org.openkilda.model.SwitchFeature.BFD;
+import static org.openkilda.model.SwitchFeature.GROUP_PACKET_OUT_CONTROLLER;
+import static org.openkilda.model.SwitchFeature.METERS;
+import static org.openkilda.model.SwitchFeature.NOVIFLOW_COPY_FIELD;
+import static org.openkilda.model.SwitchFeature.RESET_COUNTS_FLAG;
+
+import org.openkilda.floodlight.service.FeatureDetectorService;
+import org.openkilda.model.SwitchFeature;
+import org.openkilda.model.SwitchId;
+
+import com.google.common.collect.Sets;
+import net.floodlightcontroller.core.IOFSwitch;
+import org.junit.Before;
+
+import java.util.Set;
+
+abstract class FlowCommandTest {
+    protected static final String FLOW_ID = "test_flow";
+    protected static final SwitchId SWITCH_ID = new SwitchId(1);
+
+    protected IOFSwitch iofSwitch;
+    protected FeatureDetectorService featureDetectorService;
+
+    @Before
+    public void setUp() {
+        iofSwitch = createMock(IOFSwitch.class);
+        featureDetectorService = createMock(FeatureDetectorService.class);
+        Set<SwitchFeature> features = Sets.newHashSet(METERS, BFD, GROUP_PACKET_OUT_CONTROLLER,
+                NOVIFLOW_COPY_FIELD, RESET_COUNTS_FLAG);
+        expect(featureDetectorService.detectSwitch(iofSwitch)).andStubReturn(features);
+
+        expect(iofSwitch.getOFFactory()).andStubReturn(ofFactory);
+        replay(iofSwitch);
+        replay(featureDetectorService);
+    }
+}

--- a/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/InstallIngressRuleCommandTest.java
+++ b/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/InstallIngressRuleCommandTest.java
@@ -15,65 +15,29 @@
 
 package org.openkilda.floodlight.command.flow;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
-import static org.openkilda.floodlight.test.standard.OutputCommands.ofFactory;
 import static org.openkilda.model.FlowEncapsulationType.TRANSIT_VLAN;
 import static org.openkilda.model.FlowEncapsulationType.VXLAN;
-import static org.openkilda.model.SwitchFeature.BFD;
-import static org.openkilda.model.SwitchFeature.GROUP_PACKET_OUT_CONTROLLER;
-import static org.openkilda.model.SwitchFeature.METERS;
-import static org.openkilda.model.SwitchFeature.NOVIFLOW_COPY_FIELD;
-import static org.openkilda.model.SwitchFeature.RESET_COUNTS_FLAG;
 
 import org.openkilda.floodlight.error.SwitchOperationException;
-import org.openkilda.floodlight.service.FeatureDetectorService;
 import org.openkilda.floodlight.test.standard.OutputCommands;
 import org.openkilda.floodlight.test.standard.ReplaceSchemeOutputCommands;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.Cookie;
 import org.openkilda.model.MeterId;
 import org.openkilda.model.OutputVlanType;
-import org.openkilda.model.SwitchFeature;
 import org.openkilda.model.SwitchId;
 
-import com.google.common.collect.Sets;
-import net.floodlightcontroller.core.IOFSwitch;
-import org.easymock.Capture;
-import org.easymock.EasyMock;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.projectfloodlight.openflow.protocol.OFFlowMod;
 import org.projectfloodlight.openflow.types.DatapathId;
 
-import java.util.Set;
 import java.util.UUID;
 
-public class InstallIngressRuleCommandTest {
-
-    private static final String FLOW_ID = "test_flow";
-    private static final SwitchId SWITCH_ID = new SwitchId(1);
+public class InstallIngressRuleCommandTest extends FlowCommandTest {
     private static final SwitchId EGRESS_SWITCH_ID = new SwitchId(2);
-    private IOFSwitch iofSwitch;
-    private FeatureDetectorService featureDetectorService;
     private static final OutputCommands scheme = new ReplaceSchemeOutputCommands();
-
-    @Before
-    public void setUp() {
-        iofSwitch = createMock(IOFSwitch.class);
-        featureDetectorService = createMock(FeatureDetectorService.class);
-        Set<SwitchFeature> features = Sets.newHashSet(METERS, BFD, GROUP_PACKET_OUT_CONTROLLER,
-                    NOVIFLOW_COPY_FIELD, RESET_COUNTS_FLAG);
-        expect(featureDetectorService.detectSwitch(iofSwitch)).andStubReturn(features);
-
-        Capture<OFFlowMod> capture = EasyMock.newCapture();
-        expect(iofSwitch.getOFFactory()).andStubReturn(ofFactory);
-        replay(iofSwitch);
-        replay(featureDetectorService);
-    }
 
     @Test
     public void testGetCommandsVlanReplace() throws SwitchOperationException {

--- a/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/InstallOneSwitchRuleCommandTest.java
+++ b/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/InstallOneSwitchRuleCommandTest.java
@@ -1,0 +1,78 @@
+/* Copyright 2019 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.floodlight.command.flow;
+
+import org.openkilda.floodlight.switchmanager.SwitchManager;
+import org.openkilda.messaging.MessageContext;
+import org.openkilda.model.Cookie;
+import org.openkilda.model.MeterId;
+import org.openkilda.model.OutputVlanType;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Assert;
+import org.junit.Test;
+import org.projectfloodlight.openflow.protocol.OFFactory;
+import org.projectfloodlight.openflow.protocol.OFFlowAdd;
+import org.projectfloodlight.openflow.protocol.OFFlowMod;
+import org.projectfloodlight.openflow.protocol.OFFlowModFlags;
+import org.projectfloodlight.openflow.protocol.match.MatchField;
+import org.projectfloodlight.openflow.types.OFPort;
+import org.projectfloodlight.openflow.types.OFVlanVidMatch;
+import org.projectfloodlight.openflow.types.U64;
+
+import java.util.UUID;
+
+public class InstallOneSwitchRuleCommandTest extends FlowCommandTest {
+
+    @Test
+    public void samePort() {
+        int inOutPort = 10;
+        int inVlan = 1001;
+        int outVlan = 1002;
+        int meterId = 12;
+        int cookie = 22;
+
+        InstallOneSwitchRuleCommand command = new InstallOneSwitchRuleCommand(
+                UUID.randomUUID(), FLOW_ID, new MessageContext(), new Cookie(cookie),
+                SWITCH_ID,
+                inOutPort, inOutPort,
+                10L,
+                inVlan,
+                OutputVlanType.REPLACE,
+                new MeterId(meterId),
+                outVlan,
+                false);
+
+        OFFlowMod result = command.getInstallRuleCommand(iofSwitch, featureDetectorService);
+        OFFactory of = iofSwitch.getOFFactory();
+        OFFlowAdd expected = of.buildFlowAdd()
+                .setPriority(SwitchManager.FLOW_PRIORITY)
+                .setCookie(U64.of(command.getCookie().getValue()))
+                .setFlags(ImmutableSet.of(OFFlowModFlags.RESET_COUNTS))
+                .setMatch(of.buildMatch()
+                        .setExact(MatchField.IN_PORT, OFPort.of(inOutPort))
+                        .setExact(MatchField.VLAN_VID, OFVlanVidMatch.ofVlan(inVlan))
+                        .build())
+                .setInstructions(ImmutableList.of(
+                        of.instructions().meter(meterId),
+                        of.instructions().applyActions(ImmutableList.of(
+                                of.actions().setField(of.oxms().vlanVid(OFVlanVidMatch.ofVlan(outVlan))),
+                                of.actions().buildOutput().setPort(OFPort.IN_PORT).setMaxLen(0xFFFFFFFF).build()))))
+                .build();
+        Assert.assertEquals(expected, result);
+    }
+}


### PR DESCRIPTION
Fix `InstallOneSwitchRuleCommand` to produce correct output port value for
single-switch-sinle-port flows. For such flows special OF port called "IN_PORT"
must be used or switch will silendtly drop packets routed by this OF flow/rule.

Speaker command `InstallOneSwitchRuleCommand` is used only by APIv2 i.e. h&s
CRUD operations, so only APIv2 was affected by this issue.