### PR TITLE
Fix flow ping ethernet header

### DIFF
--- a/confd/templates/floodlight/floodlightkilda.properties.tmpl
+++ b/confd/templates/floodlight/floodlightkilda.properties.tmpl
@@ -74,6 +74,7 @@ org.openkilda.floodlight.kafka.KafkaMessageCollector.consumer-disco-executors={{
 org.openkilda.floodlight.pathverification.PathVerificationService.isl_bandwidth_quotient=1.0
 org.openkilda.floodlight.pathverification.PathVerificationService.hmac256-secret=secret
 org.openkilda.floodlight.pathverification.PathVerificationService.verification-bcast-packet-dst={{ getv "/kilda_floodlight_broadcast_mac_address" }}
+org.openkilda.floodlight.KildaCore.flow-ping-magic-src-mac-address={{ getv "/kilda_floodlight_flow_ping_magic_src_mac_address" }}
 org.openkilda.floodlight.statistics.StatisticsService.interval=60
 org.openkilda.floodlight.switchmanager.SwitchManager.environment-naming-prefix={{ getv "/kilda_environment_naming_prefix" }}
 org.openkilda.floodlight.switchmanager.SwitchManager.connect-mode=AUTO

--- a/confd/vars/main.yaml
+++ b/confd/vars/main.yaml
@@ -38,6 +38,7 @@ kilda_floodlight_flow_meter_burst_coefficient: 1.05
 kilda_floodlight_consumer_executors: 20
 kilda_floodlight_consumer_disco_executors: 20
 kilda_floodlight_broadcast_mac_address: "00:26:E1:FF:FF:FF"
+kilda_floodlight_flow_ping_magic_src_mac_address: "00:26:E1:FF:FF:FE"
 kilda_floodlight_ovs_meters_enabled: true
 
 kilda_grpc_speaker_kafka_listener_threads: 1

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/KafkaChannel.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/KafkaChannel.java
@@ -55,7 +55,8 @@ public class KafkaChannel implements IFloodlightModule {
 
     @Override
     public Collection<Class<? extends IFloodlightService>> getModuleDependencies() {
-        return ImmutableList.of();
+        return ImmutableList.of(
+                KildaCore.class);
     }
 
     @Override

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/KildaCore.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/KildaCore.java
@@ -41,13 +41,14 @@ import java.util.Map;
  * This module is a container for all base kilda services. The main mark of such service - lack of dependencies on other
  * kilda services. I.e. they have dependencies only on base FL services.
  */
-public class KildaCore implements IFloodlightModule {
+public class KildaCore implements IFloodlightModule, IFloodlightService {
     private KildaCoreConfig config;
     private final CommandContextFactory commandContextFactory = new CommandContextFactory();
     private final Map<Class<? extends IFloodlightService>, IFloodlightService> services;
 
     public KildaCore() {
         services = ImmutableMap.<Class<? extends IFloodlightService>, IFloodlightService>builder()
+                .put(KildaCore.class, this)
                 .put(CommandProcessorService.class, new CommandProcessorService(this, commandContextFactory))
                 .put(InputService.class, new InputService(commandContextFactory))
                 .put(SessionService.class, new SessionService())

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/KildaCoreConfig.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/KildaCoreConfig.java
@@ -34,4 +34,8 @@ public interface KildaCoreConfig {
     @Key("command-processor-idle-workers-keep-alive-seconds")
     @Default("300")
     long getCommandIdleWorkersKeepAliveSeconds();
+
+    @Key("flow-ping-magic-src-mac-address")
+    @Default("00:26:E1:FF:FF:FE")
+    String getFlowPingMagicSrcMacAddress();
 }

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/ping/PingService.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/ping/PingService.java
@@ -15,6 +15,8 @@
 
 package org.openkilda.floodlight.service.ping;
 
+import org.openkilda.floodlight.KildaCore;
+import org.openkilda.floodlight.KildaCoreConfig;
 import org.openkilda.floodlight.error.InvalidSignatureConfigurationException;
 import org.openkilda.floodlight.pathverification.PathVerificationService;
 import org.openkilda.floodlight.service.IService;
@@ -48,6 +50,7 @@ public class PingService implements IService {
 
     private DataSignature signature = null;
     private ISwitchManager switchManager;
+    private MacAddress magicSourceMacAddress;
 
     /**
      * Initialize internal data structures. Called by module that own this service. Called after all dependencies have
@@ -67,6 +70,9 @@ public class PingService implements IService {
 
         InputService inputService = moduleContext.getServiceImpl(InputService.class);
         inputService.addTranslator(OFType.PACKET_IN, new PingInputTranslator());
+
+        KildaCoreConfig coreConfig = moduleContext.getServiceImpl(KildaCore.class).getConfig();
+        magicSourceMacAddress = MacAddress.of(coreConfig.getFlowPingMagicSrcMacAddress());
     }
 
     /**
@@ -90,7 +96,7 @@ public class PingService implements IService {
         l2.setPayload(l3);
         l2.setEtherType(EthType.IPv4);
 
-        l2.setSourceMACAddress(ping.getDest().getDatapath().toMacAddress());
+        l2.setSourceMACAddress(magicSourceMacAddress);
         l2.setDestinationMACAddress(ping.getDest().getDatapath().toMacAddress());
         if (null != ping.getSourceVlanId()) {
             l2.setVlanID(ping.getSourceVlanId());

--- a/services/src/floodlight-service/floodlight-modules/src/main/resources/floodlightkilda.properties.example
+++ b/services/src/floodlight-service/floodlight-modules/src/main/resources/floodlightkilda.properties.example
@@ -62,6 +62,7 @@ net.floodlightcontroller.topology.TopologyManager.maxPathsToCompute=3
 #org.openkilda.floodlight.KildaCore.command-processor-workers-limit = 32
 #org.openkilda.floodlight.KildaCore.command-processor-deferred-requests-limit = 8
 #org.openkilda.floodlight.KildaCore.command-processor-idle-workers-keep-alive-seconds = 300
+#org.openkilda.floodlight.KildaCore.flow-ping-magic-src-mac-address=00:26:E1:FF:FF:FE
 org.openkilda.floodlight.KafkaChannel.environment-naming-prefix=
 org.openkilda.floodlight.KafkaChannel.bootstrap-servers=kafka.pendev:9092
 #org.openkilda.floodlight.KafkaChannel.heart-beat-interval=1

--- a/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/ping/PingCommandTest.java
+++ b/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/ping/PingCommandTest.java
@@ -22,7 +22,10 @@ import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.newCapture;
 
 import org.openkilda.floodlight.KafkaChannel;
+import org.openkilda.floodlight.KildaCore;
+import org.openkilda.floodlight.KildaCoreConfig;
 import org.openkilda.floodlight.command.AbstractCommandTest;
+import org.openkilda.floodlight.config.provider.FloodlightModuleConfigurationProvider;
 import org.openkilda.floodlight.service.kafka.IKafkaProducerService;
 import org.openkilda.floodlight.service.kafka.KafkaUtilityService;
 import org.openkilda.floodlight.service.ping.PingService;
@@ -44,11 +47,20 @@ public abstract class PingCommandTest extends AbstractCommandTest {
     @Mock
     protected PingService pingService;
 
+    @Mock
+    protected KildaCore kildaCore;
+
     @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();
 
+        FloodlightModuleConfigurationProvider provider = FloodlightModuleConfigurationProvider.of(
+                moduleContext, KildaCore.class);
+        KildaCoreConfig coreConfig = provider.getConfiguration(KildaCoreConfig.class);
+        expect(kildaCore.getConfig()).andStubReturn(coreConfig);
+
+        moduleContext.addService(KildaCore.class, kildaCore);
         moduleContext.addService(IKafkaProducerService.class, producerService);
         moduleContext.addService(PingService.class, pingService);
 

--- a/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/service/ping/PingServiceTest.java
+++ b/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/service/ping/PingServiceTest.java
@@ -19,6 +19,9 @@ import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 
+import org.openkilda.floodlight.KildaCore;
+import org.openkilda.floodlight.KildaCoreConfig;
+import org.openkilda.floodlight.config.provider.FloodlightModuleConfigurationProvider;
 import org.openkilda.floodlight.pathverification.PathVerificationService;
 import org.openkilda.floodlight.service.of.InputService;
 import org.openkilda.floodlight.switchmanager.ISwitchManager;
@@ -30,6 +33,7 @@ import org.openkilda.model.SwitchId;
 import net.floodlightcontroller.core.internal.IOFSwitchService;
 import net.floodlightcontroller.core.module.FloodlightModuleContext;
 import net.floodlightcontroller.packet.Ethernet;
+import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.junit.Assert;
 import org.junit.Before;
@@ -48,6 +52,14 @@ public class PingServiceTest extends EasyMockSupport {
     public void setUp() {
         injectMocks(this);
 
+        KildaCore kildaCore = EasyMock.createMock(KildaCore.class);
+        FloodlightModuleConfigurationProvider provider = FloodlightModuleConfigurationProvider.of(
+                moduleContext, KildaCore.class);
+        KildaCoreConfig coreConfig = provider.getConfiguration(KildaCoreConfig.class);
+        expect(kildaCore.getConfig()).andStubReturn(coreConfig);
+        EasyMock.replay(kildaCore);
+
+        moduleContext.addService(KildaCore.class, kildaCore);
         moduleContext.addService(IOFSwitchService.class, createMock(IOFSwitchService.class));
         moduleContext.addService(InputService.class, createMock(InputService.class));
         moduleContext.addService(ISwitchManager.class, createMock(ISwitchManager.class));


### PR DESCRIPTION
Avoid producing of ethenet packets with equal l2.src and l2.dst
addresses. Because normal network is not transparent for such packets,
as result flow-ping packets can be dropped by some ISLs.

Updated flow-ping VxLAN catch rule use "magic" (defined in config) source mac
address to distinguish flow-ping packets from custormer traffic. It
have little biggere priority than existing, so during release it will
override existing rules.

During switch connect and following validate/sync operations difference 
between old and desired rules mast be detected and fixed i.e. it will
not require manual rules migration. But in any case operator must check
correctness of installed rules after upgrade.