### PR TITLE
minor improve in flowCrud specs

### DIFF
--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
@@ -177,7 +177,9 @@ class FlowCrudSpec extends HealthCheckSpecification {
                         description  : "same switch-port but vlans on src and dst are swapped",
                         getNotConflictingFlows: {
                             def (Switch srcSwitch, Switch dstSwitch) = getTopology().activeSwitches
-                            def flow1 = getFlowHelper().randomFlow(srcSwitch, dstSwitch)
+                            def flow1 = getFlowHelper().randomFlow(srcSwitch, dstSwitch).tap {
+                                it.source.vlanId == it.destination.vlanId && it.destination.vlanId--
+                            }
                             def flow2 = getFlowHelper().randomFlow(srcSwitch, dstSwitch).tap {
                                 it.source.portNumber = flow1.source.portNumber
                                 it.source.vlanId = flow1.destination.vlanId

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV2Spec.groovy
@@ -171,7 +171,9 @@ class FlowCrudV2Spec extends HealthCheckSpecification {
                         description  : "same switch-port but vlans on src and dst are swapped",
                         getNotConflictingFlows: {
                             def (Switch srcSwitch, Switch dstSwitch) = getTopology().activeSwitches
-                            def flow1 = getFlowHelperV2().randomFlow(srcSwitch, dstSwitch)
+                            def flow1 = getFlowHelperV2().randomFlow(srcSwitch, dstSwitch).tap {
+                                it.source.vlanId == it.destination.vlanId && it.destination.vlanId--
+                            }
                             def flow2 = getFlowHelperV2().randomFlow(srcSwitch, dstSwitch).tap {
                                 it.source.portNumber = flow1.source.portNumber
                                 it.source.vlanId = flow1.destination.vlanId


### PR DESCRIPTION
sometimes `Able to create a second flow if same switch-port but vlans on src and dst are swapped` is failed  due to creating flow1 with the same src/dst vlan_ids
that  PR should prevent this situation.