### PR TITLE
Fix for single switch flow

### DIFF
--- a/services/src/kilda-core/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/FlowRepository.java
+++ b/services/src/kilda-core/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/FlowRepository.java
@@ -51,6 +51,8 @@ public interface FlowRepository extends Repository<Flow> {
 
     Collection<Flow> findByEndpointSwitch(SwitchId switchId);
 
+    Collection<Flow> findByEndpointSwitchWithMultiTableSupport(SwitchId switchId);
+
     Collection<Flow> findDownFlows();
 
     Optional<String> getOrCreateFlowGroupId(String flowId);

--- a/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jFlowRepository.java
+++ b/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jFlowRepository.java
@@ -170,6 +170,19 @@ public class Neo4jFlowRepository extends Neo4jGenericRepository<Flow> implements
     }
 
     @Override
+    public Collection<Flow> findByEndpointSwitchWithMultiTableSupport(SwitchId switchId) {
+        Filter srcSwitchFilter = createSrcSwitchFilter(switchId);
+        Filter srcMultiTableFilter = new Filter(SRC_MULTI_TABLE_PROPERTY_NAME, ComparisonOperator.IS_TRUE);
+        Filter dstSwitchFilter = createDstSwitchFilter(switchId);
+        Filter dstMultiTableFilter = new Filter(DST_MULTI_TABLE_PROPERTY_NAME, ComparisonOperator.IS_TRUE);
+
+        return Stream.concat(
+                loadAll(srcSwitchFilter.and(srcMultiTableFilter)).stream(),
+                loadAll(dstSwitchFilter.and(dstMultiTableFilter)).stream())
+                .collect(Collectors.toList());
+    }
+
+    @Override
     public Collection<Flow> findDownFlows() {
         Filter flowStatusDown = new Filter(STATUS_PROPERTY_NAME, ComparisonOperator.EQUALS, FlowStatus.DOWN);
         Filter flowStatusDegraded = new Filter(STATUS_PROPERTY_NAME, ComparisonOperator.EQUALS, FlowStatus.DEGRADED);

--- a/services/src/kilda-core/kilda-persistence-neo4j/src/test/java/org/openkilda/persistence/repositories/impl/Neo4jFlowRepositoryTest.java
+++ b/services/src/kilda-core/kilda-persistence-neo4j/src/test/java/org/openkilda/persistence/repositories/impl/Neo4jFlowRepositoryTest.java
@@ -219,6 +219,17 @@ public class Neo4jFlowRepositoryTest extends Neo4jBasedTest {
     }
 
     @Test
+    public void shouldFindFlowBySwitchEndpointWithMultiTable() {
+        Flow flow = buildTestFlow(TEST_FLOW_ID, switchA, switchB);
+        flow.setSrcWithMultiTable(true);
+        flowRepository.createOrUpdate(flow);
+
+        Collection<Flow> foundFlows = flowRepository.findByEndpointSwitchWithMultiTableSupport(TEST_SWITCH_A_ID);
+        Set<String> foundFlowIds = foundFlows.stream().map(foundFlow -> flow.getFlowId()).collect(Collectors.toSet());
+        assertThat(foundFlowIds, Matchers.hasSize(1));
+    }
+
+    @Test
     public void shouldFindDownFlowIdsByEndpoint() {
         Flow flow = buildTestFlow(TEST_FLOW_ID, switchA, switchB);
         flow.setStatus(FlowStatus.DOWN);

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/switchmanager/fsm/SwitchValidateFsm.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/switchmanager/fsm/SwitchValidateFsm.java
@@ -49,6 +49,7 @@ import org.openkilda.model.Isl;
 import org.openkilda.model.SwitchId;
 import org.openkilda.model.SwitchProperties;
 import org.openkilda.persistence.repositories.FlowPathRepository;
+import org.openkilda.persistence.repositories.FlowRepository;
 import org.openkilda.persistence.repositories.IslRepository;
 import org.openkilda.persistence.repositories.RepositoryFactory;
 import org.openkilda.persistence.repositories.SwitchPropertiesRepository;
@@ -104,6 +105,7 @@ public class SwitchValidateFsm
         this.switchId = request.getSwitchId();
         this.flowPorts = new ArrayList<>();
         FlowPathRepository flowPathRepository = repositoryFactory.createFlowPathRepository();
+        FlowRepository flowRepository = repositoryFactory.createFlowRepository();
         Collection<FlowPath> flowPaths = flowPathRepository.findBySrcSwitch(switchId);
         for (FlowPath flowPath : flowPaths) {
             if (flowPath.isForward() && flowPath.getFlow().isSrcWithMultiTable()) {
@@ -113,7 +115,8 @@ public class SwitchValidateFsm
             }
         }
 
-        hasMultiTableFlows = !flowPathRepository.findBySegmentSwitchWithMultiTable(switchId, true).isEmpty();
+        hasMultiTableFlows = !flowPathRepository.findBySegmentSwitchWithMultiTable(switchId, true).isEmpty()
+                             || !flowRepository.findByEndpointSwitchWithMultiTableSupport(switchId).isEmpty();
 
         SwitchPropertiesRepository switchPropertiesRepository = repositoryFactory.createSwitchPropertiesRepository();
         this.switchProperties = switchPropertiesRepository.findBySwitchId(switchId).orElse(null);

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/switchmanager/service/impl/SwitchValidateServiceImplTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/switchmanager/service/impl/SwitchValidateServiceImplTest.java
@@ -46,6 +46,7 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.model.SwitchProperties;
 import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.persistence.repositories.FlowPathRepository;
+import org.openkilda.persistence.repositories.FlowRepository;
 import org.openkilda.persistence.repositories.IslRepository;
 import org.openkilda.persistence.repositories.RepositoryFactory;
 import org.openkilda.persistence.repositories.SwitchPropertiesRepository;
@@ -97,6 +98,7 @@ public class SwitchValidateServiceImplTest {
         when(carrier.getTopologyConfig()).thenReturn(topologyConfig);
         RepositoryFactory repositoryFactory = Mockito.mock(RepositoryFactory.class);
         FlowPathRepository flowPathRepository = Mockito.mock(FlowPathRepository.class);
+        FlowRepository flowRepository = Mockito.mock(FlowRepository.class);
         SwitchPropertiesRepository switchPropertiesRepository = mock(SwitchPropertiesRepository.class);
         when(switchPropertiesRepository.findBySwitchId(any(SwitchId.class))).thenAnswer((invocation) ->
                 Optional.of(SwitchProperties.builder()
@@ -109,6 +111,7 @@ public class SwitchValidateServiceImplTest {
                 Collections.emptyList());
         when(repositoryFactory.createIslRepository()).thenReturn(islRepository);
         when(repositoryFactory.createFlowPathRepository()).thenReturn(flowPathRepository);
+        when(repositoryFactory.createFlowRepository()).thenReturn(flowRepository);
         when(persistenceManager.getRepositoryFactory()).thenReturn(repositoryFactory);
 
         service = new SwitchValidateServiceImpl(carrier, persistenceManager);


### PR DESCRIPTION
rolling back switch from multi-table mode to single-table mode
hasn't take into account single-switch flows. This patch fixes it.

Closes: #2947