### PR TITLE
Fix for parse error in switch props update

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/SwitchOperationsBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/SwitchOperationsBolt.java
@@ -49,6 +49,7 @@ import org.openkilda.wfm.error.IllegalSwitchStateException;
 import org.openkilda.wfm.error.SwitchNotFoundException;
 import org.openkilda.wfm.error.SwitchPropertiesNotFoundException;
 import org.openkilda.wfm.share.mappers.PortMapper;
+import org.openkilda.wfm.share.utils.KeyProvider;
 import org.openkilda.wfm.topology.nbworker.StreamType;
 import org.openkilda.wfm.topology.nbworker.services.FlowOperationsService;
 import org.openkilda.wfm.topology.nbworker.services.ILinkOperationsServiceCarrier;
@@ -229,7 +230,7 @@ public class SwitchOperationsBolt extends PersistenceOperationsBolt implements I
                 .removeExcess(true)
                 .build();
         getOutput().emit(StreamType.TO_SWITCH_MANAGER.toString(), getCurrentTuple(),
-                new Values(data, getCorrelationId()));
+                new Values(data, KeyProvider.generateChainedKey(getCorrelationId())));
     }
 
     @Override


### PR DESCRIPTION
In rare cases switch props update could fail with parse error
in nb. The root cause of the issue is that update props shares
the same correlation id as an original request. Since switch manager
sends replies to nb topic that could be received faster than expected
responses from nbworker. This patch fixes the issues by wrapping the
correlation id with chained value from KeyProvider

Closes: #2957