### PR TITLE
Fix northbound logging after update log4j to 2.11.0

### DIFF
--- a/confd/templates/northbound/log4j2.xml.tmpl
+++ b/confd/templates/northbound/log4j2.xml.tmpl
@@ -14,6 +14,7 @@ Do not change this file, all changes will be lost. Change corresponding template
                  filePattern="{{ getv "/kilda_logging_logfile_path" }}/northbound.log.json.%i.gz">
            <JsonLayout compact="true" eventEol="true" properties="true">
                 <KeyValuePair key="correlation_id" value="${ctx:correlation_id}"/>
+                <KeyValuePair key="timeMillis" value="$${timeMillis:}"/>
            </JsonLayout>
            <Policies>
             <SizeBasedTriggeringPolicy size="100 MB"/> <!-- Or every 100 MB -->
@@ -25,6 +26,7 @@ Do not change this file, all changes will be lost. Change corresponding template
         <Socket name="LOGSTASH" host="{{ getv "/kilda_logging_logstash_host" }}" port="{{ getv "/kilda_logging_port_northbound" }}">
            <JsonLayout compact="true" eventEol="true" properties="true">
                 <KeyValuePair key="correlation_id" value="${ctx:correlation_id}"/>
+                <KeyValuePair key="timeMillis" value="$${timeMillis:}"/>
            </JsonLayout>
         </Socket>
 {{- end }}

--- a/services/src/northbound-service/northbound/src/main/java/org/openkilda/northbound/utils/Log4j2TimeMillisLookup.java
+++ b/services/src/northbound-service/northbound/src/main/java/org/openkilda/northbound/utils/Log4j2TimeMillisLookup.java
@@ -1,0 +1,32 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.northbound.utils;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.lookup.StrLookup;
+
+@Plugin(name = "timeMillis", category = StrLookup.CATEGORY)
+public class Log4j2TimeMillisLookup implements StrLookup {
+
+    public String lookup(String key) {
+        return String.valueOf(System.currentTimeMillis());
+    }
+
+    public String lookup(LogEvent event, String key) {
+        return String.valueOf(System.currentTimeMillis());
+    }
+}

--- a/services/src/northbound-service/northbound/src/main/resources/log4j2.xml.example
+++ b/services/src/northbound-service/northbound/src/main/resources/log4j2.xml.example
@@ -7,6 +7,7 @@
         <Socket name="LOGSTASH" host="logstash.pendev" port="5005">
             <JsonLayout compact="true" eventEol="true">
                 <KeyValuePair key="correlation_id" value="${ctx:correlation_id}"/>
+                <KeyValuePair key="timeMillis" value="$${timeMillis:}"/>
             </JsonLayout>
         </Socket>
         <RollingFile name="ROLLINGFILE" fileName="/var/logs/northbound/app.log"


### PR DESCRIPTION
The update containing breaking change. They removed field timeMillis
from JsonLayout.
https://issues.apache.org/jira/browse/LOG4J2-1883#comment-16342097