### PR TITLE
Handles reroute failures caused by over-provisioning 

### DIFF
--- a/confd/templates/wfm/topology.properties.tmpl
+++ b/confd/templates/wfm/topology.properties.tmpl
@@ -112,6 +112,8 @@ latency.discovery.interval.multiplier = {{ getv "/kilda_latency_discovery_interv
 
 # flow(H&S) topology
 flow.hub.transaction.retries = 3
+flow.path.allocation.retries = 10
+flow.path.allocation.retry.delay = 50
 flow.create.hub.timeout.seconds = 30
 flow.create.speaker.timeout.seconds = 10
 flow.create.speaker.command.retries = {{ getv "/kilda_flow_create_command_retries" }}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/FlowHsTopology.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/FlowHsTopology.java
@@ -138,6 +138,8 @@ public class FlowHsTopology extends AbstractTopology<FlowHsTopologyConfig> {
 
         FlowUpdateConfig config = FlowUpdateConfig.flowUpdateBuilder()
                 .transactionRetriesLimit(topologyConfig.getHubTransactionRetries())
+                .pathAllocationRetriesLimit(topologyConfig.getPathAllocationRetriesLimit())
+                .pathAllocationRetryDelay(topologyConfig.getPathAllocationRetryDelay())
                 .speakerCommandRetriesLimit(topologyConfig.getUpdateSpeakerCommandRetries())
                 .autoAck(true)
                 .timeoutMs(hubTimeout)
@@ -161,6 +163,8 @@ public class FlowHsTopology extends AbstractTopology<FlowHsTopologyConfig> {
 
         FlowRerouteConfig config = FlowRerouteConfig.flowRerouteBuilder()
                 .transactionRetriesLimit(topologyConfig.getHubTransactionRetries())
+                .pathAllocationRetriesLimit(topologyConfig.getPathAllocationRetriesLimit())
+                .pathAllocationRetryDelay(topologyConfig.getPathAllocationRetryDelay())
                 .speakerCommandRetriesLimit(topologyConfig.getRerouteSpeakerCommandRetries())
                 .autoAck(true)
                 .timeoutMs(hubTimeout)

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/FlowHsTopologyConfig.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/FlowHsTopologyConfig.java
@@ -41,6 +41,14 @@ public interface FlowHsTopologyConfig extends AbstractTopologyConfig {
     @Default("3")
     int getHubTransactionRetries();
 
+    @Key("flow.path.allocation.retries")
+    @Default("10")
+    int getPathAllocationRetriesLimit();
+
+    @Key("flow.path.allocation.retry.delay")
+    @Default("50")
+    int getPathAllocationRetryDelay();
+
     @Key("flow.create.hub.timeout.seconds")
     @Default("30")
     int getCreateHubTimeoutSeconds();

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/FlowRerouteHubBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/FlowRerouteHubBolt.java
@@ -75,7 +75,8 @@ public class FlowRerouteHubBolt extends HubBolt implements FlowRerouteHubCarrier
 
         FlowResourcesManager resourcesManager = new FlowResourcesManager(persistenceManager, flowResourcesConfig);
         service = new FlowRerouteService(this, persistenceManager, pathComputer, resourcesManager,
-                config.getTransactionRetriesLimit(), config.getSpeakerCommandRetriesLimit());
+                config.getTransactionRetriesLimit(), config.getPathAllocationRetriesLimit(),
+                config.getPathAllocationRetryDelay(), config.getSpeakerCommandRetriesLimit());
     }
 
     @Override
@@ -135,13 +136,18 @@ public class FlowRerouteHubBolt extends HubBolt implements FlowRerouteHubCarrier
     @Getter
     public static class FlowRerouteConfig extends Config {
         private int transactionRetriesLimit;
+        private int pathAllocationRetriesLimit;
+        private int pathAllocationRetryDelay;
         private int speakerCommandRetriesLimit;
 
         @Builder(builderMethodName = "flowRerouteBuilder", builderClassName = "flowRerouteBuild")
         public FlowRerouteConfig(String requestSenderComponent, String workerComponent, int timeoutMs, boolean autoAck,
-                                 int transactionRetriesLimit, int speakerCommandRetriesLimit) {
+                                 int transactionRetriesLimit, int pathAllocationRetriesLimit,
+                                 int pathAllocationRetryDelay, int speakerCommandRetriesLimit) {
             super(requestSenderComponent, workerComponent, timeoutMs, autoAck);
             this.transactionRetriesLimit = transactionRetriesLimit;
+            this.pathAllocationRetriesLimit = pathAllocationRetriesLimit;
+            this.pathAllocationRetryDelay = pathAllocationRetryDelay;
             this.speakerCommandRetriesLimit = speakerCommandRetriesLimit;
         }
     }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/FlowUpdateHubBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/FlowUpdateHubBolt.java
@@ -75,7 +75,8 @@ public class FlowUpdateHubBolt extends HubBolt implements FlowUpdateHubCarrier {
 
         FlowResourcesManager resourcesManager = new FlowResourcesManager(persistenceManager, flowResourcesConfig);
         service = new FlowUpdateService(this, persistenceManager, pathComputer, resourcesManager,
-                config.getTransactionRetriesLimit(), config.getSpeakerCommandRetriesLimit());
+                config.getTransactionRetriesLimit(), config.getPathAllocationRetriesLimit(),
+                config.getPathAllocationRetryDelay(), config.getSpeakerCommandRetriesLimit());
     }
 
     @Override
@@ -134,13 +135,18 @@ public class FlowUpdateHubBolt extends HubBolt implements FlowUpdateHubCarrier {
     @Getter
     public static class FlowUpdateConfig extends Config {
         private int transactionRetriesLimit;
+        private int pathAllocationRetriesLimit;
+        private int pathAllocationRetryDelay;
         private int speakerCommandRetriesLimit;
 
         @Builder(builderMethodName = "flowUpdateBuilder", builderClassName = "flowUpdateBuild")
         public FlowUpdateConfig(String requestSenderComponent, String workerComponent, int timeoutMs, boolean autoAck,
-                                int transactionRetriesLimit, int speakerCommandRetriesLimit) {
+                                int transactionRetriesLimit, int pathAllocationRetriesLimit,
+                                int pathAllocationRetryDelay, int speakerCommandRetriesLimit) {
             super(requestSenderComponent, workerComponent, timeoutMs, autoAck);
             this.transactionRetriesLimit = transactionRetriesLimit;
+            this.pathAllocationRetriesLimit = pathAllocationRetriesLimit;
+            this.pathAllocationRetryDelay = pathAllocationRetryDelay;
             this.speakerCommandRetriesLimit = speakerCommandRetriesLimit;
         }
     }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/FlowRerouteFsm.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/FlowRerouteFsm.java
@@ -126,7 +126,8 @@ public final class FlowRerouteFsm extends FlowPathSwappingFsm<FlowRerouteFsm, St
 
         public Factory(FlowRerouteHubCarrier carrier, PersistenceManager persistenceManager,
                        PathComputer pathComputer, FlowResourcesManager resourcesManager,
-                       int transactionRetriesLimit, int speakerCommandRetriesLimit) {
+                       int transactionRetriesLimit, int pathAllocationRetriesLimit, int pathAllocationRetryDelay,
+                       int speakerCommandRetriesLimit) {
             this.carrier = carrier;
 
             builder = StateMachineBuilderFactory.create(FlowRerouteFsm.class, State.class, Event.class,
@@ -140,6 +141,7 @@ public final class FlowRerouteFsm extends FlowPathSwappingFsm<FlowRerouteFsm, St
 
             builder.transition().from(State.FLOW_VALIDATED).to(State.PRIMARY_RESOURCES_ALLOCATED).on(Event.NEXT)
                     .perform(new AllocatePrimaryResourcesAction(persistenceManager, transactionRetriesLimit,
+                            pathAllocationRetriesLimit, pathAllocationRetryDelay,
                             pathComputer, resourcesManager, dashboardLogger));
             builder.transitions().from(State.FLOW_VALIDATED)
                     .toAmong(State.REVERTING_FLOW_STATUS, State.REVERTING_FLOW_STATUS)
@@ -148,6 +150,7 @@ public final class FlowRerouteFsm extends FlowPathSwappingFsm<FlowRerouteFsm, St
             builder.transition().from(State.PRIMARY_RESOURCES_ALLOCATED).to(State.PROTECTED_RESOURCES_ALLOCATED)
                     .on(Event.NEXT)
                     .perform(new AllocateProtectedResourcesAction(persistenceManager, transactionRetriesLimit,
+                            pathAllocationRetriesLimit, pathAllocationRetryDelay,
                             pathComputer, resourcesManager, dashboardLogger));
             builder.transition().from(State.PRIMARY_RESOURCES_ALLOCATED).to(State.MARKING_FLOW_DOWN)
                     .on(Event.NO_PATH_FOUND);

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocatePrimaryResourcesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocatePrimaryResourcesAction.java
@@ -38,9 +38,11 @@ import lombok.extern.slf4j.Slf4j;
 public class AllocatePrimaryResourcesAction extends
         BaseResourceAllocationAction<FlowRerouteFsm, State, Event, FlowRerouteContext> {
     public AllocatePrimaryResourcesAction(PersistenceManager persistenceManager, int transactionRetriesLimit,
+                                          int pathAllocationRetriesLimit, int pathAllocationRetryDelay,
                                           PathComputer pathComputer, FlowResourcesManager resourcesManager,
                                           FlowOperationsDashboardLogger dashboardLogger) {
-        super(persistenceManager, transactionRetriesLimit, pathComputer, resourcesManager, dashboardLogger);
+        super(persistenceManager, transactionRetriesLimit, pathAllocationRetriesLimit, pathAllocationRetryDelay,
+                pathComputer, resourcesManager, dashboardLogger);
     }
 
     @Override

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocateProtectedResourcesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocateProtectedResourcesAction.java
@@ -43,9 +43,11 @@ import lombok.extern.slf4j.Slf4j;
 public class AllocateProtectedResourcesAction extends
         BaseResourceAllocationAction<FlowRerouteFsm, State, Event, FlowRerouteContext> {
     public AllocateProtectedResourcesAction(PersistenceManager persistenceManager, int transactionRetriesLimit,
+                                            int pathAllocationRetriesLimit, int pathAllocationRetryDelay,
                                             PathComputer pathComputer, FlowResourcesManager resourcesManager,
                                             FlowOperationsDashboardLogger dashboardLogger) {
-        super(persistenceManager, transactionRetriesLimit, pathComputer, resourcesManager, dashboardLogger);
+        super(persistenceManager, transactionRetriesLimit, pathAllocationRetriesLimit, pathAllocationRetryDelay,
+                pathComputer, resourcesManager, dashboardLogger);
     }
 
     @Override

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/FlowUpdateFsm.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/FlowUpdateFsm.java
@@ -121,7 +121,8 @@ public final class FlowUpdateFsm extends FlowPathSwappingFsm<FlowUpdateFsm, Stat
 
         public Factory(FlowUpdateHubCarrier carrier, PersistenceManager persistenceManager,
                        PathComputer pathComputer, FlowResourcesManager resourcesManager,
-                       int transactionRetriesLimit, int speakerCommandRetriesLimit) {
+                       int transactionRetriesLimit, int pathAllocationRetriesLimit, int pathAllocationRetryDelay,
+                       int speakerCommandRetriesLimit) {
             this.carrier = carrier;
 
 
@@ -142,6 +143,7 @@ public final class FlowUpdateFsm extends FlowPathSwappingFsm<FlowUpdateFsm, Stat
 
             builder.transition().from(State.FLOW_UPDATED).to(State.PRIMARY_RESOURCES_ALLOCATED).on(Event.NEXT)
                     .perform(new AllocatePrimaryResourcesAction(persistenceManager, transactionRetriesLimit,
+                            pathAllocationRetriesLimit, pathAllocationRetryDelay,
                             pathComputer, resourcesManager, dashboardLogger));
             builder.transitions().from(State.FLOW_UPDATED)
                     .toAmong(State.REVERTING_FLOW, State.REVERTING_FLOW)
@@ -150,6 +152,7 @@ public final class FlowUpdateFsm extends FlowPathSwappingFsm<FlowUpdateFsm, Stat
             builder.transition().from(State.PRIMARY_RESOURCES_ALLOCATED).to(State.PROTECTED_RESOURCES_ALLOCATED)
                     .on(Event.NEXT)
                     .perform(new AllocateProtectedResourcesAction(persistenceManager, transactionRetriesLimit,
+                            pathAllocationRetriesLimit, pathAllocationRetryDelay,
                             pathComputer, resourcesManager, dashboardLogger));
             builder.transitions().from(State.PRIMARY_RESOURCES_ALLOCATED)
                     .toAmong(State.REVERTING_ALLOCATED_RESOURCES, State.REVERTING_ALLOCATED_RESOURCES,

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocatePrimaryResourcesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocatePrimaryResourcesAction.java
@@ -38,9 +38,11 @@ import lombok.extern.slf4j.Slf4j;
 public class AllocatePrimaryResourcesAction extends
         BaseResourceAllocationAction<FlowUpdateFsm, State, Event, FlowUpdateContext> {
     public AllocatePrimaryResourcesAction(PersistenceManager persistenceManager, int transactionRetriesLimit,
+                                          int pathAllocationRetriesLimit, int pathAllocationRetryDelay,
                                           PathComputer pathComputer, FlowResourcesManager resourcesManager,
                                           FlowOperationsDashboardLogger dashboardLogger) {
-        super(persistenceManager, transactionRetriesLimit, pathComputer, resourcesManager, dashboardLogger);
+        super(persistenceManager, transactionRetriesLimit, pathAllocationRetriesLimit, pathAllocationRetryDelay,
+                pathComputer, resourcesManager, dashboardLogger);
     }
 
     @Override

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocateProtectedResourcesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocateProtectedResourcesAction.java
@@ -46,9 +46,11 @@ import java.util.stream.Stream;
 public class AllocateProtectedResourcesAction extends
         BaseResourceAllocationAction<FlowUpdateFsm, State, Event, FlowUpdateContext> {
     public AllocateProtectedResourcesAction(PersistenceManager persistenceManager, int transactionRetriesLimit,
+                                            int pathAllocationRetriesLimit, int pathAllocationRetryDelay,
                                             PathComputer pathComputer, FlowResourcesManager resourcesManager,
                                             FlowOperationsDashboardLogger dashboardLogger) {
-        super(persistenceManager, transactionRetriesLimit, pathComputer, resourcesManager, dashboardLogger);
+        super(persistenceManager, transactionRetriesLimit, pathAllocationRetriesLimit, pathAllocationRetryDelay,
+                pathComputer, resourcesManager, dashboardLogger);
     }
 
     @Override

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteService.java
@@ -55,7 +55,8 @@ public class FlowRerouteService {
 
     public FlowRerouteService(FlowRerouteHubCarrier carrier, PersistenceManager persistenceManager,
                               PathComputer pathComputer, FlowResourcesManager flowResourcesManager,
-                              int transactionRetriesLimit, int speakerCommandRetriesLimit) {
+                              int transactionRetriesLimit, int pathAllocationRetriesLimit, int pathAllocationRetryDelay,
+                              int speakerCommandRetriesLimit) {
         this.carrier = carrier;
         this.persistenceManager = persistenceManager;
         flowEventRepository = persistenceManager.getRepositoryFactory().createFlowEventRepository();
@@ -64,7 +65,8 @@ public class FlowRerouteService {
         this.transactionRetriesLimit = transactionRetriesLimit;
         this.speakerCommandRetriesLimit = speakerCommandRetriesLimit;
         fsmFactory = new FlowRerouteFsm.Factory(carrier, persistenceManager, pathComputer, flowResourcesManager,
-                transactionRetriesLimit, speakerCommandRetriesLimit);
+                transactionRetriesLimit, pathAllocationRetriesLimit, pathAllocationRetryDelay,
+                speakerCommandRetriesLimit);
     }
 
     /**

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowUpdateService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowUpdateService.java
@@ -56,7 +56,8 @@ public class FlowUpdateService {
 
     public FlowUpdateService(FlowUpdateHubCarrier carrier, PersistenceManager persistenceManager,
                              PathComputer pathComputer, FlowResourcesManager flowResourcesManager,
-                             int transactionRetriesLimit, int speakerCommandRetriesLimit) {
+                             int transactionRetriesLimit, int pathAllocationRetriesLimit, int pathAllocationRetryDelay,
+                             int speakerCommandRetriesLimit) {
         this.carrier = carrier;
         this.persistenceManager = persistenceManager;
         flowEventRepository = persistenceManager.getRepositoryFactory().createFlowEventRepository();
@@ -65,7 +66,8 @@ public class FlowUpdateService {
         this.transactionRetriesLimit = transactionRetriesLimit;
         this.speakerCommandRetriesLimit = speakerCommandRetriesLimit;
         fsmFactory = new FlowUpdateFsm.Factory(carrier, persistenceManager, pathComputer, flowResourcesManager,
-                transactionRetriesLimit, speakerCommandRetriesLimit);
+                transactionRetriesLimit, pathAllocationRetriesLimit, pathAllocationRetryDelay,
+                speakerCommandRetriesLimit);
     }
 
     /**

--- a/services/wfm/src/main/resources/topology.properties.example
+++ b/services/wfm/src/main/resources/topology.properties.example
@@ -120,6 +120,8 @@ latency.discovery.interval.multiplier = 3
 
 # flow(H&S) topology
 flow.hub.transaction.retries = 3
+flow.path.allocation.retries = 10
+flow.path.allocation.retry.delay = 50
 flow.create.hub.timeout.seconds = 30
 flow.create.speaker.timeout.seconds = 10
 flow.create.speaker.command.retries = 3

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/service/AbstractFlowTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/service/AbstractFlowTest.java
@@ -36,6 +36,7 @@ import org.openkilda.persistence.TransactionManager;
 import org.openkilda.persistence.repositories.FeatureTogglesRepository;
 import org.openkilda.persistence.repositories.FlowPathRepository;
 import org.openkilda.persistence.repositories.FlowRepository;
+import org.openkilda.persistence.repositories.IslRepository;
 import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
 
 import lombok.SneakyThrows;
@@ -64,6 +65,8 @@ public abstract class AbstractFlowTest {
     FlowResourcesManager flowResourcesManager;
     @Mock
     FeatureTogglesRepository featureTogglesRepository;
+    @Mock
+    IslRepository islRepository;
 
     final Queue<SpeakerFlowRequest> requests = new ArrayDeque<>();
     final Map<SwitchId, Map<Cookie, InstallFlowRule>> installedRules = new HashMap<>();


### PR DESCRIPTION
The changes:
- Introduce dedicated handling of over-provisioning and resource allocation failures.
- Define default retries limit for the handling.

Mitigate and in most cases completely remove rerouting failures caused by over-provisioning.

Solves #2925

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/2974)
<!-- Reviewable:end -->
