### PR TITLE
Check flow response actual type before casting

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowPathSwappingFsm.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowPathSwappingFsm.java
@@ -89,4 +89,14 @@ public abstract class FlowPathSwappingFsm<T extends NbTrackableFsm<T, S, E, C>, 
     }
 
     public abstract void fireNoPathFound(String errorReason);
+
+    public void setPendingCommands(Collection<UUID> commandIds) {
+        pendingCommands.clear();
+        pendingCommands.addAll(commandIds);
+    }
+
+    public void resetFailedCommandsAndRetries() {
+        retriedCommands.clear();
+        failedCommands.clear();
+    }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/DumpIngressRulesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/DumpIngressRulesAction.java
@@ -26,6 +26,8 @@ import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteFsm.State;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collection;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -39,10 +41,11 @@ public class DumpIngressRulesAction extends HistoryRecordingAction<FlowRerouteFs
 
         dumpFlowRules.forEach(command -> stateMachine.getCarrier().sendSpeakerRequest(command));
 
-        stateMachine.getPendingCommands().addAll(dumpFlowRules.stream()
+        Set<UUID> commandIds = dumpFlowRules.stream()
                 .map(SpeakerFlowRequest::getCommandId)
-                .collect(Collectors.toSet()));
-        stateMachine.getRetriedCommands().clear();
+                .collect(Collectors.toSet());
+        stateMachine.setPendingCommands(commandIds);
+        stateMachine.resetFailedCommandsAndRetries();
 
         stateMachine.saveActionToHistory("Started validation of installed ingress rules");
     }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/DumpNonIngressRulesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/DumpNonIngressRulesAction.java
@@ -52,8 +52,8 @@ public class DumpNonIngressRulesAction extends
             Set<UUID> commandIds = dumpFlowRules.stream()
                     .map(SpeakerFlowRequest::getCommandId)
                     .collect(Collectors.toSet());
-            stateMachine.getPendingCommands().addAll(commandIds);
-            stateMachine.getRetriedCommands().clear();
+            stateMachine.setPendingCommands(commandIds);
+            stateMachine.resetFailedCommandsAndRetries();
 
             stateMachine.saveActionToHistory("Started validation of installed non ingress rules");
         }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/InstallIngressRulesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/InstallIngressRulesAction.java
@@ -75,8 +75,8 @@ public class InstallIngressRulesAction extends FlowProcessingAction<FlowRerouteF
                 .peek(command -> stateMachine.getCarrier().sendSpeakerRequest(command))
                 .map(SpeakerFlowRequest::getCommandId)
                 .collect(Collectors.toSet());
-        stateMachine.getPendingCommands().addAll(commandIds);
-        stateMachine.getRetriedCommands().clear();
+        stateMachine.setPendingCommands(commandIds);
+        stateMachine.resetFailedCommandsAndRetries();
 
         if (commands.isEmpty()) {
             stateMachine.saveActionToHistory("No need to install ingress rules");

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/InstallNonIngressRulesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/InstallNonIngressRulesAction.java
@@ -80,7 +80,8 @@ public class InstallNonIngressRulesAction extends
                 .peek(command -> stateMachine.getCarrier().sendSpeakerRequest(command))
                 .map(SpeakerFlowRequest::getCommandId)
                 .collect(Collectors.toSet());
-        stateMachine.getPendingCommands().addAll(commandIds);
+        stateMachine.setPendingCommands(commandIds);
+        stateMachine.resetFailedCommandsAndRetries();
 
         if (commands.isEmpty()) {
             stateMachine.saveActionToHistory("No need to install non ingress rules");

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/RemoveOldRulesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/RemoveOldRulesAction.java
@@ -80,8 +80,8 @@ public class RemoveOldRulesAction extends FlowProcessingAction<FlowRerouteFsm, S
                 .peek(command -> stateMachine.getCarrier().sendSpeakerRequest(command))
                 .map(SpeakerFlowRequest::getCommandId)
                 .collect(Collectors.toSet());
-        stateMachine.getPendingCommands().addAll(commandIds);
-        stateMachine.getRetriedCommands().clear();
+        stateMachine.setPendingCommands(commandIds);
+        stateMachine.resetFailedCommandsAndRetries();
 
         stateMachine.saveActionToHistory("Remove commands for old rules have been sent");
     }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/RevertNewRulesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/RevertNewRulesAction.java
@@ -95,8 +95,8 @@ public class RevertNewRulesAction extends FlowProcessingAction<FlowRerouteFsm, S
                 .peek(command -> stateMachine.getCarrier().sendSpeakerRequest(command))
                 .map(SpeakerFlowRequest::getCommandId)
                 .collect(Collectors.toSet());
-        stateMachine.getPendingCommands().addAll(commandIds);
-        stateMachine.getRetriedCommands().clear();
+        stateMachine.setPendingCommands(commandIds);
+        stateMachine.resetFailedCommandsAndRetries();
 
         stateMachine.saveActionToHistory(
                 "Commands for removing new rules and re-installing original ingress rule have been sent");

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/ValidateIngressRulesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/ValidateIngressRulesAction.java
@@ -17,6 +17,7 @@ package org.openkilda.wfm.topology.flowhs.fsm.reroute.actions;
 
 import static java.lang.String.format;
 
+import org.openkilda.floodlight.flow.request.GetInstalledRule;
 import org.openkilda.floodlight.flow.request.InstallIngressRule;
 import org.openkilda.floodlight.flow.response.FlowResponse;
 import org.openkilda.floodlight.flow.response.FlowRuleResponse;
@@ -86,7 +87,10 @@ public class ValidateIngressRulesAction extends
                                 + "Retrying (attempt %d)",
                         commandId, response.getSwitchId(), command.getCookie(), response, retries));
 
-                stateMachine.getCarrier().sendSpeakerRequest(command);
+                GetInstalledRule dumpFlowRule = new GetInstalledRule(command.getMessageContext(),
+                        command.getCommandId(), command.getFlowId(), command.getSwitchId(), command.getCookie(), false);
+
+                stateMachine.getCarrier().sendSpeakerRequest(dumpFlowRule);
             } else {
                 stateMachine.getPendingCommands().remove(commandId);
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/ValidateIngressRulesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/ValidateIngressRulesAction.java
@@ -18,7 +18,6 @@ package org.openkilda.wfm.topology.flowhs.fsm.reroute.actions;
 import static java.lang.String.format;
 
 import org.openkilda.floodlight.flow.request.InstallIngressRule;
-import org.openkilda.floodlight.flow.response.FlowErrorResponse;
 import org.openkilda.floodlight.flow.response.FlowResponse;
 import org.openkilda.floodlight.flow.response.FlowRuleResponse;
 import org.openkilda.model.Switch;
@@ -57,7 +56,7 @@ public class ValidateIngressRulesAction extends
             return;
         }
 
-        if (response.isSuccess()) {
+        if (response.isSuccess() && response instanceof FlowRuleResponse) {
             stateMachine.getPendingCommands().remove(commandId);
 
             Switch switchObj = switchRepository.findById(command.getSwitchId())
@@ -78,8 +77,6 @@ public class ValidateIngressRulesAction extends
                 stateMachine.getFailedValidationResponses().put(commandId, response);
             }
         } else {
-            FlowErrorResponse errorResponse = (FlowErrorResponse) response;
-
             int retries = stateMachine.getRetriedCommands().getOrDefault(commandId, 0);
             if (retries < speakerCommandRetriesLimit) {
                 stateMachine.getRetriedCommands().put(commandId, ++retries);
@@ -87,7 +84,7 @@ public class ValidateIngressRulesAction extends
                 stateMachine.saveErrorToHistory("Rule validation failed", format(
                         "Failed to validate the ingress rule: commandId %s, switch %s, cookie %s. Error %s. "
                                 + "Retrying (attempt %d)",
-                        commandId, errorResponse.getSwitchId(), command.getCookie(), errorResponse, retries));
+                        commandId, response.getSwitchId(), command.getCookie(), response, retries));
 
                 stateMachine.getCarrier().sendSpeakerRequest(command);
             } else {
@@ -95,7 +92,7 @@ public class ValidateIngressRulesAction extends
 
                 stateMachine.saveErrorToHistory("Rule validation failed",
                         format("Failed to validate the ingress rule: commandId %s, switch %s, cookie %s. Error %s",
-                                commandId, errorResponse.getSwitchId(), command.getCookie(), errorResponse));
+                                commandId, response.getSwitchId(), command.getCookie(), response));
 
                 stateMachine.getFailedValidationResponses().put(commandId, response);
             }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/ValidateNonIngressRulesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/ValidateNonIngressRulesAction.java
@@ -17,6 +17,7 @@ package org.openkilda.wfm.topology.flowhs.fsm.reroute.actions;
 
 import static java.lang.String.format;
 
+import org.openkilda.floodlight.flow.request.GetInstalledRule;
 import org.openkilda.floodlight.flow.request.InstallTransitRule;
 import org.openkilda.floodlight.flow.response.FlowResponse;
 import org.openkilda.floodlight.flow.response.FlowRuleResponse;
@@ -76,7 +77,10 @@ public class ValidateNonIngressRulesAction extends
                                 + "Retrying (attempt %d)",
                         commandId, response.getSwitchId(), command.getCookie(), response, retries));
 
-                stateMachine.getCarrier().sendSpeakerRequest(command);
+                GetInstalledRule dumpFlowRule = new GetInstalledRule(command.getMessageContext(),
+                        command.getCommandId(), command.getFlowId(), command.getSwitchId(), command.getCookie(), false);
+
+                stateMachine.getCarrier().sendSpeakerRequest(dumpFlowRule);
             } else {
                 stateMachine.getPendingCommands().remove(commandId);
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/DumpIngressRulesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/DumpIngressRulesAction.java
@@ -26,6 +26,8 @@ import org.openkilda.wfm.topology.flowhs.fsm.update.FlowUpdateFsm.State;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collection;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -39,10 +41,11 @@ public class DumpIngressRulesAction extends HistoryRecordingAction<FlowUpdateFsm
 
         dumpFlowRules.forEach(command -> stateMachine.getCarrier().sendSpeakerRequest(command));
 
-        stateMachine.getPendingCommands().addAll(dumpFlowRules.stream()
+        Set<UUID> commandIds = dumpFlowRules.stream()
                 .map(SpeakerFlowRequest::getCommandId)
-                .collect(Collectors.toSet()));
-        stateMachine.getRetriedCommands().clear();
+                .collect(Collectors.toSet());
+        stateMachine.setPendingCommands(commandIds);
+        stateMachine.resetFailedCommandsAndRetries();
 
         stateMachine.saveActionToHistory("Started validation of installed ingress rules");
     }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/DumpNonIngressRulesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/DumpNonIngressRulesAction.java
@@ -51,8 +51,8 @@ public class DumpNonIngressRulesAction extends HistoryRecordingAction<FlowUpdate
             Set<UUID> commandIds = dumpFlowRules.stream()
                     .map(SpeakerFlowRequest::getCommandId)
                     .collect(Collectors.toSet());
-            stateMachine.getPendingCommands().addAll(commandIds);
-            stateMachine.getRetriedCommands().clear();
+            stateMachine.setPendingCommands(commandIds);
+            stateMachine.resetFailedCommandsAndRetries();
 
             stateMachine.saveActionToHistory("Started validation of installed non ingress rules");
         }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/InstallIngressRulesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/InstallIngressRulesAction.java
@@ -72,8 +72,8 @@ public class InstallIngressRulesAction extends FlowProcessingAction<FlowUpdateFs
                 .peek(command -> stateMachine.getCarrier().sendSpeakerRequest(command))
                 .map(SpeakerFlowRequest::getCommandId)
                 .collect(Collectors.toSet());
-        stateMachine.getPendingCommands().addAll(commandIds);
-        stateMachine.getRetriedCommands().clear();
+        stateMachine.setPendingCommands(commandIds);
+        stateMachine.resetFailedCommandsAndRetries();
 
         if (commands.isEmpty()) {
             stateMachine.saveActionToHistory("No need to install ingress rules");

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/InstallNonIngressRulesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/InstallNonIngressRulesAction.java
@@ -78,7 +78,8 @@ public class InstallNonIngressRulesAction extends FlowProcessingAction<FlowUpdat
                 .peek(command -> stateMachine.getCarrier().sendSpeakerRequest(command))
                 .map(SpeakerFlowRequest::getCommandId)
                 .collect(Collectors.toSet());
-        stateMachine.getPendingCommands().addAll(commandIds);
+        stateMachine.setPendingCommands(commandIds);
+        stateMachine.resetFailedCommandsAndRetries();
 
         if (commands.isEmpty()) {
             stateMachine.saveActionToHistory("No need to install non ingress rules");

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RemoveOldRulesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RemoveOldRulesAction.java
@@ -77,8 +77,8 @@ public class RemoveOldRulesAction extends FlowProcessingAction<FlowUpdateFsm, St
                 .peek(command -> stateMachine.getCarrier().sendSpeakerRequest(command))
                 .map(SpeakerFlowRequest::getCommandId)
                 .collect(Collectors.toSet());
-        stateMachine.getPendingCommands().addAll(commandIds);
-        stateMachine.getRetriedCommands().clear();
+        stateMachine.setPendingCommands(commandIds);
+        stateMachine.resetFailedCommandsAndRetries();
 
         stateMachine.saveActionToHistory("Remove commands for old rules have been sent");
     }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RevertNewRulesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RevertNewRulesAction.java
@@ -95,8 +95,8 @@ public class RevertNewRulesAction extends FlowProcessingAction<FlowUpdateFsm, St
                 .peek(command -> stateMachine.getCarrier().sendSpeakerRequest(command))
                 .map(SpeakerFlowRequest::getCommandId)
                 .collect(Collectors.toSet());
-        stateMachine.getPendingCommands().addAll(commandIds);
-        stateMachine.getRetriedCommands().clear();
+        stateMachine.setPendingCommands(commandIds);
+        stateMachine.resetFailedCommandsAndRetries();
 
         stateMachine.saveActionToHistory(
                 "Commands for removing new rules and re-installing original ingress rule have been sent");

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/ValidateIngressRulesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/ValidateIngressRulesAction.java
@@ -17,6 +17,7 @@ package org.openkilda.wfm.topology.flowhs.fsm.update.actions;
 
 import static java.lang.String.format;
 
+import org.openkilda.floodlight.flow.request.GetInstalledRule;
 import org.openkilda.floodlight.flow.request.InstallIngressRule;
 import org.openkilda.floodlight.flow.response.FlowResponse;
 import org.openkilda.floodlight.flow.response.FlowRuleResponse;
@@ -86,7 +87,10 @@ public class ValidateIngressRulesAction extends
                                 + "Retrying (attempt %d)",
                         commandId, response.getSwitchId(), command.getCookie(), response, retries));
 
-                stateMachine.getCarrier().sendSpeakerRequest(command);
+                GetInstalledRule dumpFlowRule = new GetInstalledRule(command.getMessageContext(),
+                        command.getCommandId(), command.getFlowId(), command.getSwitchId(), command.getCookie(), false);
+
+                stateMachine.getCarrier().sendSpeakerRequest(dumpFlowRule);
             } else {
                 stateMachine.getPendingCommands().remove(commandId);
 

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/ValidateNonIngressRulesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/ValidateNonIngressRulesAction.java
@@ -18,7 +18,6 @@ package org.openkilda.wfm.topology.flowhs.fsm.update.actions;
 import static java.lang.String.format;
 
 import org.openkilda.floodlight.flow.request.InstallTransitRule;
-import org.openkilda.floodlight.flow.response.FlowErrorResponse;
 import org.openkilda.floodlight.flow.response.FlowResponse;
 import org.openkilda.floodlight.flow.response.FlowRuleResponse;
 import org.openkilda.wfm.topology.flowhs.fsm.common.actions.HistoryRecordingAction;
@@ -52,7 +51,7 @@ public class ValidateNonIngressRulesAction extends
             return;
         }
 
-        if (response.isSuccess()) {
+        if (response.isSuccess() && response instanceof FlowRuleResponse) {
             stateMachine.getPendingCommands().remove(commandId);
 
             RulesValidator validator = new NonIngressRulesValidator(command, (FlowRuleResponse) response);
@@ -68,8 +67,6 @@ public class ValidateNonIngressRulesAction extends
                 stateMachine.getFailedValidationResponses().put(commandId, response);
             }
         } else {
-            FlowErrorResponse errorResponse = (FlowErrorResponse) response;
-
             int retries = stateMachine.getRetriedCommands().getOrDefault(commandId, 0);
             if (retries < speakerCommandRetriesLimit) {
                 stateMachine.getRetriedCommands().put(commandId, ++retries);
@@ -77,7 +74,7 @@ public class ValidateNonIngressRulesAction extends
                 stateMachine.saveErrorToHistory("Rule validation failed", format(
                         "Failed to validate non ingress rule: commandId %s, switch %s, cookie %s. Error %s. "
                                 + "Retrying (attempt %d)",
-                        commandId, errorResponse.getSwitchId(), command.getCookie(), errorResponse, retries));
+                        commandId, response.getSwitchId(), command.getCookie(), response, retries));
 
                 stateMachine.getCarrier().sendSpeakerRequest(command);
             } else {
@@ -85,7 +82,7 @@ public class ValidateNonIngressRulesAction extends
 
                 stateMachine.saveErrorToHistory("Rule validation failed",
                         format("Failed to validate non ingress rule: commandId %s, switch %s, cookie %s. Error %s",
-                                commandId, errorResponse.getSwitchId(), command.getCookie(), errorResponse));
+                                commandId, response.getSwitchId(), command.getCookie(), response));
 
                 stateMachine.getFailedValidationResponses().put(commandId, response);
             }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/ValidateNonIngressRulesAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/ValidateNonIngressRulesAction.java
@@ -17,6 +17,7 @@ package org.openkilda.wfm.topology.flowhs.fsm.update.actions;
 
 import static java.lang.String.format;
 
+import org.openkilda.floodlight.flow.request.GetInstalledRule;
 import org.openkilda.floodlight.flow.request.InstallTransitRule;
 import org.openkilda.floodlight.flow.response.FlowResponse;
 import org.openkilda.floodlight.flow.response.FlowRuleResponse;
@@ -76,7 +77,10 @@ public class ValidateNonIngressRulesAction extends
                                 + "Retrying (attempt %d)",
                         commandId, response.getSwitchId(), command.getCookie(), response, retries));
 
-                stateMachine.getCarrier().sendSpeakerRequest(command);
+                GetInstalledRule dumpFlowRule = new GetInstalledRule(command.getMessageContext(),
+                        command.getCommandId(), command.getFlowId(), command.getSwitchId(), command.getCookie(), false);
+
+                stateMachine.getCarrier().sendSpeakerRequest(dumpFlowRule);
             } else {
                 stateMachine.getPendingCommands().remove(commandId);
 


### PR DESCRIPTION
this patch will mitigate errors caused by class cast errors in
RuleValidationAction during the H&S re-route