### PR TITLE
Fix flow segment verify issue on OF1.2 switches

### DIFF
--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/feature/ResetCountsFlagFeature.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/feature/ResetCountsFlagFeature.java
@@ -21,12 +21,20 @@ import org.openkilda.model.SwitchFeature;
 
 import net.floodlightcontroller.core.IOFSwitch;
 import org.apache.commons.lang3.StringUtils;
+import org.projectfloodlight.openflow.protocol.OFVersion;
 
 import java.util.Optional;
 
 public class ResetCountsFlagFeature extends AbstractFeature {
     @Override
     public Optional<SwitchFeature> discover(IOFSwitch sw) {
+        // TODO(surabujin) recheck and fix detection or feature handling
+        if (sw.getOFFactory().getVersion().compareTo(OFVersion.OF_12) <= 0) {
+            // acton switches do not report RESET_COUNT flags into flows stats response, we can suppose it
+            // do not support (or do not keep it in flow record).
+            return Optional.empty();
+        }
+
         if (StringUtils.contains(sw.getSwitchDescription().getManufacturerDescription(), CENTEC_MANUFACTURED)) {
             return Optional.empty();
         } else {

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/utils/OfFlowPresenceVerifier.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/utils/OfFlowPresenceVerifier.java
@@ -99,7 +99,7 @@ public class OfFlowPresenceVerifier {
                     iter.remove();
                     break;
                 } else {
-                    log.debug("On {} mismatch {} vs {}", swId, tableEntry, expectedEntry);
+                    log.debug("On {} mismatch {} vs expected {}", swId, tableEntry, expectedEntry);
                 }
             }
         } else {

--- a/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/service/FeatureDetectorServiceTest.java
+++ b/services/src/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/service/FeatureDetectorServiceTest.java
@@ -71,7 +71,7 @@ public class FeatureDetectorServiceTest extends EasyMockSupport {
     @Test
     public void metersOf12() {
         discoveryCheck(makeSwitchMock("Common Inc", "Soft123", "Hard123", OFVersion.OF_12, 1),
-                       ImmutableSet.of(GROUP_PACKET_OUT_CONTROLLER, RESET_COUNTS_FLAG, PKTPS_FLAG, MATCH_UDP_PORT));
+                       ImmutableSet.of(GROUP_PACKET_OUT_CONTROLLER, PKTPS_FLAG, MATCH_UDP_PORT));
     }
 
     @Test
@@ -128,7 +128,7 @@ public class FeatureDetectorServiceTest extends EasyMockSupport {
     public void roundTripActon() {
         discoveryCheck(makeSwitchMock("Sonus Networks Inc, 4 Technology Park Dr, Westford, MA 01886, USA",
                 "8.1.0.14", "VX3048", OFVersion.OF_12, 2),
-                ImmutableSet.of(RESET_COUNTS_FLAG, PKTPS_FLAG, MATCH_UDP_PORT, MULTI_TABLE));
+                ImmutableSet.of(PKTPS_FLAG, MATCH_UDP_PORT, MULTI_TABLE));
     }
 
     @Test


### PR DESCRIPTION
OF1.2 switches(at least awailable in our test lab) do not return
OFPFF_RESET_COUNTS flag onto flow-stats request. As result our flow
segment verify code reports missing OF flow - one of it's match
criteria is matching of OF flow's flags.

As a soluttion - exclude OF1.2 switches from list of switches that
support SwitchFeature.RESET_COUNTS_FLAS. So OFPFF_RESET_COUNTS will not
be sent to such switches, also it will not be expected to present on
OF flow during validation.