### PR TITLE
Fix false-negative meter's validation

### DIFF
--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/meter/MeterVerifyCommand.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/meter/MeterVerifyCommand.java
@@ -84,7 +84,7 @@ public class MeterVerifyCommand extends AbstractMeterInstall<MeterVerifyReport> 
 
         boolean isInaccurate = getSwitchFeatures().contains(SwitchFeature.INACCURATE_METER);
         MeterSchema schema = MeterSchemaMapper.INSTANCE.map(getSw().getId(), target.get(), isInaccurate);
-        validateMeterConfig(schema);
+        validateMeterConfig(schema, isInaccurate);
 
         return schema;
     }
@@ -99,11 +99,12 @@ public class MeterVerifyCommand extends AbstractMeterInstall<MeterVerifyReport> 
         return Optional.empty();
     }
 
-    private void validateMeterConfig(MeterSchema actualSchema) {
+    private void validateMeterConfig(MeterSchema actualSchema, boolean isInaccurate) {
         DatapathId datapathId = getSw().getId();
         MeterSchema expectedSchema = MeterSchemaMapper.INSTANCE.map(datapathId, makeMeterAddMessage());
         if (! expectedSchema.equals(actualSchema)) {
-            throw maskCallbackException(new SwitchIncorrectMeterException(datapathId, meterConfig, actualSchema));
+            throw maskCallbackException(new SwitchIncorrectMeterException(
+                    datapathId, meterConfig, expectedSchema, actualSchema, isInaccurate));
         }
     }
 }

--- a/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/error/SwitchIncorrectMeterException.java
+++ b/services/src/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/error/SwitchIncorrectMeterException.java
@@ -23,12 +23,24 @@ import org.projectfloodlight.openflow.types.DatapathId;
 
 @Getter
 public class SwitchIncorrectMeterException extends SwitchOperationException {
-    private final MeterConfig expectedMeterConfig;
+    private final MeterConfig meterConfig;
+    private final MeterSchema expectedSchema;
     private final MeterSchema actualSchema;
 
-    public SwitchIncorrectMeterException(DatapathId dpId, MeterConfig meterConfig, MeterSchema actualSchema) {
-        super(dpId, String.format("Meter %d on %s have incorrect config", meterConfig.getId().getValue(), dpId));
-        this.expectedMeterConfig = meterConfig;
-        this.actualSchema = actualSchema;
+    public SwitchIncorrectMeterException(
+            DatapathId dpId, MeterConfig meterConfig, MeterSchema expected, MeterSchema actual,
+            boolean isInaccurate) {
+        super(dpId, formatMessage(dpId, meterConfig, expected, actual, isInaccurate));
+        this.meterConfig = meterConfig;
+        this.expectedSchema = expected;
+        this.actualSchema = actual;
+    }
+
+    private static String formatMessage(
+            DatapathId dpId, MeterConfig config, MeterSchema expected, MeterSchema actual, boolean isInaccurate) {
+        return String.format(
+                "Meter %d on %s have incorrect config - actual value is %s while expected value is %s "
+                        + "(is accurate %s, config %s)",
+                expected.getMeterId().getValue(), dpId, actual, expected, !isInaccurate, config);
     }
 }

--- a/services/src/kilda-core/kilda-model/src/main/java/org/openkilda/model/of/MeterSchemaBand.java
+++ b/services/src/kilda-core/kilda-model/src/main/java/org/openkilda/model/of/MeterSchemaBand.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 public class MeterSchemaBand {
     private static final float INACCURATE_RATE_DEVIATION = 0.01f;
     private static final float INACCURATE_BURST_DEVIATION = 0.01f;
+    private static final long ACCURATE_BURST_DEVIATION = 1;
 
     private final int type;
 
@@ -53,9 +54,8 @@ public class MeterSchemaBand {
                     && inaccurateEquals(rate, that.rate, INACCURATE_RATE_DEVIATION)
                     && inaccurateEquals(burstSize, that.burstSize, INACCURATE_BURST_DEVIATION);
         } else {
-            return equals.append(rate, that.rate)
-                    .append(burstSize, that.burstSize)
-                    .isEquals();
+            return equals.append(rate, that.rate).isEquals()
+                    && inaccurateEquals(burstSize, that.burstSize, ACCURATE_BURST_DEVIATION);
         }
     }
 
@@ -66,6 +66,16 @@ public class MeterSchemaBand {
                 .append(rate)
                 .append(burstSize)
                 .toHashCode();
+    }
+
+    private boolean inaccurateEquals(long left, long right, long deviation) {
+        long diff;
+        if (left < right) {
+            diff = right - left;
+        } else {
+            diff = left - right;
+        }
+        return diff <= deviation;
     }
 
     private boolean inaccurateEquals(long left, long right, float deviation) {


### PR DESCRIPTION
Existing implementation does not take into account meter burst deviation (+-1) for accurate meters. As a result it leads to false-negative flow segment validation on some subset of switches.
    
This fix adds such burst behaviour peculiarity of accurate meters.
