### PR TITLE
Fix MeterVerifyCommand to handle inaccurate meter bandwidth and burst

### DIFF
--- a/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/AbstractSpeakerCommandTest.java
+++ b/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/AbstractSpeakerCommandTest.java
@@ -39,6 +39,7 @@ import org.openkilda.model.SwitchId;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 import net.floodlightcontroller.core.IOFSwitch;
@@ -59,7 +60,6 @@ import org.projectfloodlight.openflow.types.DatapathId;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -240,13 +240,15 @@ public abstract class AbstractSpeakerCommandTest extends EasyMockSupport {
     }
 
     protected void switchFeaturesSetup(IOFSwitch target, boolean metersSupport) {
-        Set<SwitchFeature> features = new HashSet<>();
-
         if (metersSupport) {
-            features.add(SwitchFeature.METERS);
+            switchFeaturesSetup(target, SwitchFeature.METERS);
+        } else {
+            switchFeaturesSetup(target);
         }
+    }
 
-        switchFeaturesSetup(target, features);
+    protected void switchFeaturesSetup(IOFSwitch target, SwitchFeature... switchFeatures) {
+        switchFeaturesSetup(target, Sets.newHashSet(switchFeatures));
     }
 
     protected void switchFeaturesSetup(IOFSwitch target, Set<SwitchFeature> features) {

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/of/MeterSchemaBand.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/of/MeterSchemaBand.java
@@ -23,9 +23,11 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 @Value
 @Builder
 public class MeterSchemaBand {
-    private static final float INACCURATE_RATE_DEVIATION = 0.01f;
-    private static final float INACCURATE_BURST_DEVIATION = 0.01f;
-    private static final long ACCURATE_BURST_DEVIATION = 1;
+    private static final long INACCURATE_RATE_ALLOWED_DEVIATION = 1;
+    private static final long INACCURATE_BURST_ALLOWED_DEVIATION = 1;
+    private static final float INACCURATE_RATE_ALLOWED_RELATIVE_DEVIATION = 0.01f;
+    private static final float INACCURATE_BURST_ALLOWED_RELATIVE_DEVIATION = 0.01f;
+    private static final long ACCURATE_BURST_ALLOWED_DEVIATION = 1;
 
     private final int type;
 
@@ -51,11 +53,13 @@ public class MeterSchemaBand {
 
         if (inaccurate || that.inaccurate) {
             return equals.isEquals()
-                    && inaccurateEquals(rate, that.rate, INACCURATE_RATE_DEVIATION)
-                    && inaccurateEquals(burstSize, that.burstSize, INACCURATE_BURST_DEVIATION);
+                    && isEqualOrWithinDeviation(rate, that.rate, INACCURATE_RATE_ALLOWED_DEVIATION,
+                    INACCURATE_RATE_ALLOWED_RELATIVE_DEVIATION)
+                    && isEqualOrWithinDeviation(burstSize, that.burstSize, INACCURATE_BURST_ALLOWED_DEVIATION,
+                    INACCURATE_BURST_ALLOWED_RELATIVE_DEVIATION);
         } else {
             return equals.append(rate, that.rate).isEquals()
-                    && inaccurateEquals(burstSize, that.burstSize, ACCURATE_BURST_DEVIATION);
+                    && inaccurateEquals(burstSize, that.burstSize, ACCURATE_BURST_ALLOWED_DEVIATION);
         }
     }
 
@@ -66,6 +70,12 @@ public class MeterSchemaBand {
                 .append(rate)
                 .append(burstSize)
                 .toHashCode();
+    }
+
+    private boolean isEqualOrWithinDeviation(long left, long right,
+                                             long allowedDeviation, float allowedRelativeDeviation) {
+        return inaccurateEquals(left, right, allowedDeviation)
+                || inaccurateEquals(left, right, allowedRelativeDeviation);
     }
 
     private boolean inaccurateEquals(long left, long right, long deviation) {


### PR DESCRIPTION
The changes:
- Fix MeterVerifyCommand to handle inaccurate meter bandwidth and burst with absolute difference equals to 1.

Solves #3027

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/3039)
<!-- Reviewable:end -->
