### PR TITLE
Fix rollback in flow reroute

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/OnReceivedRemoveOrRevertResponseAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/OnReceivedRemoveOrRevertResponseAction.java
@@ -76,7 +76,7 @@ public class OnReceivedRemoveOrRevertResponseAction extends
                                     + "Retrying (attempt %d)",
                             commandId, errorResponse.getSwitchId(), removeCommand.getCookie(), errorResponse, retries));
 
-                    stateMachine.getCarrier().sendSpeakerRequest(removeCommand.makeInstallRequest(commandId));
+                    stateMachine.getCarrier().sendSpeakerRequest(removeCommand.makeRemoveRequest(commandId));
                 } else {
                     stateMachine.saveErrorToHistory("Failed to re-install (revert) rule", format(
                             "Failed to install the rule: commandId %s, switch %s, cookie %s. Error %s. "

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/utils/SpeakerRequestEmitter.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/utils/SpeakerRequestEmitter.java
@@ -49,7 +49,6 @@ public abstract class SpeakerRequestEmitter {
 
         for (FlowSegmentRequestFactory factory : factories) {
             FlowSegmentRequest request = makeRequest(factory);
-            // TODO ensure no conflicts
             requestsStorage.put(request.getCommandId(), factory);
             carrier.sendSpeakerRequest(request);
         }


### PR DESCRIPTION
Flow's reroute operation have produced incorrect speaker requests during rollback phase. It produce remove request while it should produce install request.
    
Also one more issue in repeat this requests in case of errors, it convert remove request into install request.
