### PR TITLE
Fix fails of PacketServiceTest

### DIFF
--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/connecteddevices/service/PacketServiceTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/connecteddevices/service/PacketServiceTest.java
@@ -342,13 +342,15 @@ public class PacketServiceTest extends Neo4jBasedTest {
     }
 
     private void runHandleSwitchLldpWithUpdatedDevice(SwitchLldpInfoData updatedData) throws InterruptedException {
-        // Need to have a different timestamp in 'data' and 'updatedData' messages.
-        Thread.sleep(10);
         SwitchLldpInfoData data = createSwitchLldpInfoData();
         packetService.handleSwitchLldpData(data);
         Collection<SwitchConnectedDevice> oldDevices = switchConnectedDeviceRepository.findAll();
         assertEquals(1, oldDevices.size());
         assertSwitchLldpInfoDataEqualsSwitchConnectedDevice(data, oldDevices.iterator().next());
+
+        // Need to have a different timestamp in 'data' and 'updatedData' messages.
+        // More info https://github.com/telstra/open-kilda/issues/3064
+        updatedData.setTimestamp(data.getTimestamp() + 1000);
 
         // we must update old device
         packetService.handleSwitchLldpData(updatedData);


### PR DESCRIPTION
In some cases Neo4j OGM doesn't update objects in database

This fix makes created device and updated device "more different" by increasing of timeLastSeen.
We got hash collisions in OGM if timeLastSeen in created and updated objects are very close to each other.

More information https://github.com/telstra/open-kilda/issues/3064