### PR TITLE
Fixed flow ping for VXLAN flows

### DIFF
--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
@@ -1182,6 +1182,7 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
         MacAddress srcMac = MacAddress.of(kildaCore.getConfig().getFlowPingMagicSrcMacAddress());
         Builder builder = sw.getOFFactory().buildMatch();
         builder.setMasked(MatchField.ETH_SRC, srcMac, MacAddress.NO_MASK);
+        builder.setMasked(MatchField.ETH_DST, dpIdToMac(sw.getId()), MacAddress.NO_MASK);
         builder.setExact(MatchField.ETH_TYPE, EthType.IPv4);
         builder.setExact(MatchField.IP_PROTO, IpProtocol.UDP);
         builder.setExact(MatchField.UDP_SRC, TransportPort.of(STUB_VXLAN_UDP_SRC));

--- a/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/test/standard/OutputCommands.java
+++ b/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/test/standard/OutputCommands.java
@@ -660,6 +660,7 @@ public interface OutputCommands {
     default OFFlowAdd installUnicastVerificationRuleVxlan(DatapathId dpid) {
         Match match = ofFactory.buildMatch()
                 .setMasked(MatchField.ETH_SRC, FLOW_PING_MAGIC_SRC_MAC_ADDRESS, MacAddress.NO_MASK)
+                .setMasked(MatchField.ETH_DST, MacAddress.of(dpid), MacAddress.NO_MASK)
                 .setExact(MatchField.ETH_TYPE, EthType.IPv4)
                 .setExact(MatchField.IP_PROTO, IpProtocol.UDP)
                 .setExact(MatchField.UDP_SRC, TransportPort.of(4500))


### PR DESCRIPTION
Ping rule for VXLAN doesn't match ping packet by dst mac. That is why ping packet will be sent to controller from first transit switch