### PR TITLE
Fixed unit test for multi table

### DIFF
--- a/src-java/kilda-persistence-neo4j/src/test/java/org/openkilda/persistence/repositories/impl/Neo4jFlowRepositoryTest.java
+++ b/src-java/kilda-persistence-neo4j/src/test/java/org/openkilda/persistence/repositories/impl/Neo4jFlowRepositoryTest.java
@@ -288,13 +288,17 @@ public class Neo4jFlowRepositoryTest extends Neo4jBasedTest {
 
     @Test
     public void shouldFindFlowBySwitchEndpointWithMultiTable() {
-        Flow flow = buildTestFlow(TEST_FLOW_ID, switchA, switchB);
-        flow.setSrcWithMultiTable(true);
-        flowRepository.createOrUpdate(flow);
+        Flow firstFlow = buildTestFlow(TEST_FLOW_ID, switchA, switchB);
+        firstFlow.setSrcWithMultiTable(true);
+        flowRepository.createOrUpdate(firstFlow);
+
+        Flow secondFlow = buildTestFlow(TEST_FLOW_ID_2, switchA, switchB);
+        secondFlow.setSrcWithMultiTable(false);
+        flowRepository.createOrUpdate(secondFlow);
 
         Collection<Flow> foundFlows = flowRepository.findByEndpointSwitchWithMultiTableSupport(TEST_SWITCH_A_ID);
-        Set<String> foundFlowIds = foundFlows.stream().map(foundFlow -> flow.getFlowId()).collect(Collectors.toSet());
-        assertThat(foundFlowIds, Matchers.hasSize(1));
+        Set<String> foundFlowIds = foundFlows.stream().map(Flow::getFlowId).collect(Collectors.toSet());
+        assertEquals(Collections.singleton(firstFlow.getFlowId()), foundFlowIds);
     }
 
     @Test


### PR DESCRIPTION
Test has incorrect mapping in lambda expression.
It always map found flows to target flow id.
Also test was improved