### PR TITLE
Do not emit reroute commands for path, where edge switches are inactive

### DIFF
--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/ValidateFlowAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/ValidateFlowAction.java
@@ -77,6 +77,15 @@ public class ValidateFlowAction extends NbTrackableAction<FlowRerouteFsm, State,
                         format("Flow %s is in progress now", flowId));
             }
 
+            if (!foundFlow.getSrcSwitch().isActive()) {
+                throw new FlowProcessingException(ErrorType.UNPROCESSABLE_REQUEST,
+                        format("Flow's %s src switch is not active", flowId));
+            }
+            if (!foundFlow.getDestSwitch().isActive()) {
+                throw new FlowProcessingException(ErrorType.UNPROCESSABLE_REQUEST,
+                        format("Flow's %s dest switch is not active", flowId));
+            }
+
             stateMachine.setOriginalFlowStatus(foundFlow.getStatus());
             stateMachine.setOriginalEncapsulationType(foundFlow.getEncapsulationType());
             stateMachine.setOriginalPathComputationStrategy(foundFlow.getPathComputationStrategy());


### PR DESCRIPTION
patch adds extra check to validate flow terminating endpoints are
in active state before emiting re-route to flow h&s