### PR TITLE
Fix double network failure handling

### DIFF
--- a/services/src/checkstyle/checkstyle-header.txt
+++ b/services/src/checkstyle/checkstyle-header.txt
@@ -1,4 +1,4 @@
-^/\* Copyright 201\d Telstra Open Source
+^/\* Copyright \d{4} Telstra Open Source
 ^ \*
 ^ \*   Licensed under the Apache License, Version 2\.0 \(the "License"\);
 ^ \*   you may not use this file except in compliance with the License\.

--- a/services/wfm/src/checkstyle/checkstyle-header.txt
+++ b/services/wfm/src/checkstyle/checkstyle-header.txt
@@ -1,4 +1,4 @@
-^/\* Copyright 201\d Telstra Open Source
+^/\* Copyright \d{4} Telstra Open Source
 ^ \*
 ^ \*   Licensed under the Apache License, Version 2\.0 \(the "License"\);
 ^ \*   you may not use this file except in compliance with the License\.

--- a/services/wfm/src/main/java/org/openkilda/wfm/AbstractBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/AbstractBolt.java
@@ -19,6 +19,7 @@ import org.openkilda.wfm.error.PipelineException;
 
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.base.BaseRichBolt;
@@ -48,6 +49,7 @@ public abstract class AbstractBolt extends BaseRichBolt {
     private transient Tuple currentTuple;
 
     @Getter(AccessLevel.PROTECTED)
+    @Setter(AccessLevel.PROTECTED)
     private transient CommandContext commandContext;
 
     @Override

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/FlowRerouteHubBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/FlowRerouteHubBolt.java
@@ -15,6 +15,7 @@
 
 package org.openkilda.wfm.topology.flowhs.bolts;
 
+import static org.openkilda.messaging.Utils.CORRELATION_ID;
 import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.HUB_TO_HISTORY_BOLT;
 import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.HUB_TO_NB_RESPONSE_SENDER;
 import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.HUB_TO_SPEAKER_WORKER;
@@ -29,6 +30,7 @@ import org.openkilda.pce.PathComputer;
 import org.openkilda.pce.PathComputerConfig;
 import org.openkilda.pce.PathComputerFactory;
 import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.wfm.CommandContext;
 import org.openkilda.wfm.error.PipelineException;
 import org.openkilda.wfm.share.flow.resources.FlowResourcesConfig;
 import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
@@ -36,6 +38,7 @@ import org.openkilda.wfm.share.history.model.FlowHistoryHolder;
 import org.openkilda.wfm.share.hubandspoke.HubBolt;
 import org.openkilda.wfm.share.utils.KeyProvider;
 import org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream;
+import org.openkilda.wfm.topology.flowhs.model.FlowRerouteFact;
 import org.openkilda.wfm.topology.flowhs.service.FlowRerouteHubCarrier;
 import org.openkilda.wfm.topology.flowhs.service.FlowRerouteService;
 import org.openkilda.wfm.topology.utils.MessageKafkaTranslator;
@@ -45,6 +48,7 @@ import lombok.Getter;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
+import org.slf4j.MDC;
 
 public class FlowRerouteHubBolt extends HubBolt implements FlowRerouteHubCarrier {
 
@@ -122,6 +126,31 @@ public class FlowRerouteHubBolt extends HubBolt implements FlowRerouteHubCarrier
     @Override
     public void cancelTimeoutCallback(String key) {
         cancelCallback(key);
+    }
+
+    @Override
+    public void setupTimeoutCallback(String key) {
+        registerCallback(key);
+    }
+
+    /**
+     * "Hack" required to propagate execution context for postponed requests up to transport/carrier level.
+     */
+    @Override
+    public void injectRetry(FlowRerouteFact reroute) {
+        String originalKey = currentKey;
+        CommandContext originalCommandContext = getCommandContext();
+        try {
+            MDC.put(CORRELATION_ID, reroute.getCommandContext().getCorrelationId());
+            setCommandContext(reroute.getCommandContext());
+            currentKey = reroute.getKey();
+
+            service.handlePostponedRequest(reroute);
+        } finally {
+            currentKey = originalKey;
+            setCommandContext(originalCommandContext);
+            MDC.put(CORRELATION_ID, originalCommandContext.getCorrelationId());
+        }
     }
 
     @Override

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/model/FlowRerouteFact.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/model/FlowRerouteFact.java
@@ -1,0 +1,33 @@
+/* Copyright 2020 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.model;
+
+import org.openkilda.model.PathId;
+import org.openkilda.wfm.CommandContext;
+
+import lombok.Value;
+
+import java.util.Set;
+
+@Value
+public class FlowRerouteFact {
+    private String key;
+    private CommandContext commandContext;
+    private String flowId;
+    private Set<PathId> pathsToReroute;
+    private boolean forceReroute;
+    private String rerouteReason;
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteHubCarrier.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteHubCarrier.java
@@ -16,6 +16,7 @@
 package org.openkilda.wfm.topology.flowhs.service;
 
 import org.openkilda.messaging.Message;
+import org.openkilda.wfm.topology.flowhs.model.FlowRerouteFact;
 
 public interface FlowRerouteHubCarrier extends FlowGenericCarrier {
     /**
@@ -29,4 +30,8 @@ public interface FlowRerouteHubCarrier extends FlowGenericCarrier {
      * @param key operation identifier.
      */
     void cancelTimeoutCallback(String key);
+
+    void setupTimeoutCallback(String key);
+
+    void injectRetry(FlowRerouteFact retry);
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteService.java
@@ -28,6 +28,8 @@ import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteContext;
 import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteFsm;
 import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteFsm.Event;
 import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteFsm.State;
+import org.openkilda.wfm.topology.flowhs.model.FlowRerouteFact;
+import org.openkilda.wfm.topology.flowhs.utils.RerouteRetryManager;
 
 import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.slf4j.Slf4j;
@@ -40,6 +42,8 @@ import java.util.Set;
 public class FlowRerouteService {
     @VisibleForTesting
     final Map<String, FlowRerouteFsm> fsms = new HashMap<>();
+
+    private final RerouteRetryManager retryManager = new RerouteRetryManager();
 
     private final FlowRerouteFsm.Factory fsmFactory;
     private final FsmExecutor<FlowRerouteFsm, State, Event, FlowRerouteContext> fsmExecutor
@@ -87,24 +91,25 @@ public class FlowRerouteService {
             return;
         }
 
-        String eventKey = commandContext.getCorrelationId();
-        if (flowEventRepository.existsByTaskId(eventKey)) {
-            log.error("Attempt to reuse key {}, but there's a history record(s) for it.", eventKey);
-            return;
+        FlowRerouteFact reroute = new FlowRerouteFact(
+                key, commandContext, flowId, pathsToReroute, forceReroute, rerouteReason);
+        if (retryManager.record(reroute)) {
+            initReroute(reroute);
+        } else {
+            carrier.cancelTimeoutCallback(key);
+            log.warn("Postpone (queue/merge) reroute request for flow {} (key={}, reasod={})",
+                     flowId, key, rerouteReason);
         }
+    }
 
-        FlowRerouteFsm fsm = fsmFactory.newInstance(commandContext, flowId);
-        fsms.put(key, fsm);
-
-        FlowRerouteContext context = FlowRerouteContext.builder()
-                .flowId(flowId)
-                .pathsToReroute(pathsToReroute)
-                .forceReroute(forceReroute)
-                .rerouteReason(rerouteReason)
-                .build();
-        fsmExecutor.fire(fsm, Event.NEXT, context);
-
-        removeIfFinished(fsm, key);
+    /**
+     * Handle postponed flow reroute request.
+     */
+    public void handlePostponedRequest(FlowRerouteFact reroute) {
+        log.info("Handling postponed flow reroute request with key {} and flow ID: {}",
+                 reroute.getKey(), reroute.getFlowId());
+        carrier.setupTimeoutCallback(reroute.getKey());
+        initReroute(reroute);
     }
 
     /**
@@ -151,12 +156,54 @@ public class FlowRerouteService {
         removeIfFinished(fsm, key);
     }
 
+    private void initReroute(FlowRerouteFact reroute) {
+        final CommandContext commandContext = reroute.getCommandContext();
+
+        String eventKey = commandContext.getCorrelationId();
+        if (flowEventRepository.existsByTaskId(eventKey)) {
+            log.error("Attempt to reuse key {}, but there's a history record(s) for it.", eventKey);
+            return;
+        }
+
+        final String flowId =  reroute.getFlowId();
+        final String key = reroute.getKey();
+        FlowRerouteFsm fsm = fsmFactory.newInstance(commandContext, flowId);
+        fsms.put(key, fsm);
+
+        FlowRerouteContext context = FlowRerouteContext.builder()
+                .flowId(flowId)
+                .pathsToReroute(reroute.getPathsToReroute())
+                .forceReroute(reroute.isForceReroute())
+                .rerouteReason(reroute.getRerouteReason())
+                .build();
+        fsmExecutor.fire(fsm, Event.NEXT, context);
+
+        removeIfFinished(fsm, key);
+    }
+
     private void removeIfFinished(FlowRerouteFsm fsm, String key) {
         if (fsm.isTerminated()) {
-            log.debug("FSM with key {} is finished with state {}", key, fsm.getCurrentState());
-            fsms.remove(key);
+            performHousekeeping(fsm, key);
 
-            carrier.cancelTimeoutCallback(key);
+            // use some sort of recursion here, because iterative way require too complex scheme to clean/use retryQueue
+            retryManager.read(fsm.getFlowId()).ifPresent(carrier::injectRetry);
+        }
+    }
+
+    private void performHousekeeping(FlowRerouteFsm fsm, String key) {
+        log.debug("FSM with key {} is finished with state {}", key, fsm.getCurrentState());
+        fsms.remove(key);
+
+        carrier.cancelTimeoutCallback(key);
+
+        FlowRerouteFact reroute = retryManager.discard(fsm.getFlowId())
+                .orElseThrow(() -> new IllegalStateException(String.format(
+                        "There is no current reroute into retry queue (flow=\"%s\", key=\"%s\")",
+                        fsm.getFlowId(), key)));
+        if (! reroute.getKey().equals(key)) {
+            log.error(
+                    "Retry queue is broken, expect to remove record with key \"{}\" but got record with key=\"{}\" "
+                    + "(flowId=\"{}\")", key, reroute.getKey(), fsm.getFlowId());
         }
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/utils/RerouteRetryManager.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/utils/RerouteRetryManager.java
@@ -1,0 +1,71 @@
+/* Copyright 2020 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.utils;
+
+import org.openkilda.wfm.topology.flowhs.model.FlowRerouteFact;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+public class RerouteRetryManager {
+    private final Map<String, RerouteRetryQueue> queueByFlowId = new HashMap<>();
+
+    /**
+     * Register request in retry "queue" and check is it can be processed now. Return true if this request can be
+     * processed now.
+     */
+    public boolean record(FlowRerouteFact entity) {
+        RerouteRetryQueue queue = queueByFlowId.computeIfAbsent(
+                entity.getFlowId(), ignore -> new RerouteRetryQueue());
+        queue.add(entity);
+        log.info("Size of flow reroute queue for {} is {}", entity.getFlowId(), queue.size());
+        return queue.size() == 1;
+    }
+
+    /**
+     * Return "active" request.
+     */
+    public Optional<FlowRerouteFact> read(String flowId) {
+        RerouteRetryQueue queue = queueByFlowId.get(flowId);
+        if (queue == null) {
+            return Optional.empty();
+        }
+
+        // use method raises exception on empty queue access, because queue can't be empty by used design
+        return queue.get();
+    }
+
+    /**
+     * Remove "active" request.
+     */
+    public Optional<FlowRerouteFact> discard(String flowId) {
+        RerouteRetryQueue queue = queueByFlowId.get(flowId);
+        if (queue == null) {
+            return Optional.empty();
+        }
+
+        // use method raises exception on empty queue access, because queue can't be empty by used design
+        Optional<FlowRerouteFact> entity = queue.remove();
+        if (queue.isEmpty()) {
+            queueByFlowId.remove(flowId);
+        }
+        return entity;
+    }
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/utils/RerouteRetryQueue.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/utils/RerouteRetryQueue.java
@@ -1,0 +1,95 @@
+/* Copyright 2020 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.utils;
+
+import org.openkilda.wfm.topology.flowhs.model.FlowRerouteFact;
+
+import java.util.Collections;
+import java.util.Optional;
+
+public class RerouteRetryQueue {
+    private FlowRerouteFact active = null;
+    private FlowRerouteFact pending = null;
+
+    /**
+     * Add request into "queue".
+     */
+    public void add(FlowRerouteFact reroute) {
+        if (active == null) {
+            active = reroute;
+        } else if (pending == null) {
+            pending = reroute;
+        } else {
+            pending = mergePending(pending, reroute);
+        }
+    }
+
+    /**
+     * Return first/active queue entry.
+     */
+    public Optional<FlowRerouteFact> get() {
+        return Optional.ofNullable(active);
+    }
+
+    /**
+     * Remove and return first/active queue entry.
+     */
+    public Optional<FlowRerouteFact> remove() {
+        FlowRerouteFact result = active;
+        active = pending;
+        pending = null;
+        return Optional.ofNullable(result);
+    }
+
+    /**
+     * Return queue size.
+     */
+    public int size() {
+        if (pending != null) {
+            return 2;
+        }
+        if (active != null) {
+            return 1;
+        }
+        return 0;
+    }
+
+    public boolean isEmpty() {
+        return active == null;
+    }
+
+    private static FlowRerouteFact mergePending(FlowRerouteFact pending, FlowRerouteFact reroute) {
+        boolean isForced = pending.isForceReroute() || reroute.isForceReroute();
+        // Clean list of affected paths to force reroute of all paths related to the flow.
+        // Reroute topology fill's affected paths set from affected network segment. It know only already stored
+        // into DB paths, so it will produce reroute requests for currently stored paths. For thew first glance we can
+        // ignore requests that mention not exists any more paths. But because old and new paths can share network
+        // segments (this segments have been healthy during paths allocation) we can't ignore such request and must
+        // perform reroute for them.
+        //
+        // A --- B --- C  original-path (path1)
+        // A -x- B --- C  first network outage - emit reroute for path1
+        // A --- D --- C  path after reroute (path2 - reroute in progress)
+        // A --- D -x- C  second network outage - emit reroute for path1
+        // done reroute for path1, fetch postponed reroute request (it targeted to path1)
+        //
+        // So if this postponed request will be ignored, because path1 is not related to the flow any more
+        // we will leave flow in UP state on ISL in FAILED state.
+        return new FlowRerouteFact(
+                reroute.getKey(), reroute.getCommandContext(), reroute.getFlowId(), Collections.emptySet(),
+                isForced, reroute.getRerouteReason());
+    }
+}

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/service/AbstractFlowTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/service/AbstractFlowTest.java
@@ -107,6 +107,16 @@ public abstract class AbstractFlowTest {
         ));
     }
 
+    protected SpeakerFlowSegmentResponse buildSpeakerResponse(FlowSegmentRequest flowRequest) {
+        return SpeakerFlowSegmentResponse.builder()
+                        .messageContext(flowRequest.getMessageContext())
+                        .commandId(flowRequest.getCommandId())
+                        .metadata(flowRequest.getMetadata())
+                        .switchId(flowRequest.getSwitchId())
+                        .success(true)
+                        .build();
+    }
+
     Answer getSpeakerCommandsAnswer() {
         return invocation -> {
             FlowSegmentRequest request = invocation.getArgument(0);

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteServiceTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteServiceTest.java
@@ -59,10 +59,12 @@ import org.openkilda.persistence.repositories.SwitchPropertiesRepository;
 import org.openkilda.persistence.repositories.SwitchRepository;
 import org.openkilda.persistence.repositories.history.FlowEventRepository;
 import org.openkilda.wfm.CommandContext;
+import org.openkilda.wfm.share.flow.resources.EncapsulationResources;
 import org.openkilda.wfm.share.flow.resources.FlowResources;
 import org.openkilda.wfm.share.flow.resources.FlowResources.PathResources;
 import org.openkilda.wfm.share.flow.resources.ResourceAllocationException;
 import org.openkilda.wfm.share.flow.resources.transitvlan.TransitVlanEncapsulation;
+import org.openkilda.wfm.topology.flowhs.model.FlowRerouteFact;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -70,7 +72,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -82,6 +88,7 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
     private static final String FLOW_ID = "TEST_FLOW";
     private static final SwitchId SWITCH_1 = new SwitchId(1);
     private static final SwitchId SWITCH_2 = new SwitchId(2);
+    private static final SwitchId SWITCH_3 = new SwitchId(3);
     private static final PathId OLD_FORWARD_FLOW_PATH = new PathId(FLOW_ID + "_forward_old");
     private static final PathId OLD_REVERSE_FLOW_PATH = new PathId(FLOW_ID + "_reverse_old");
     private static final PathId NEW_FORWARD_FLOW_PATH = new PathId(FLOW_ID + "_forward_new");
@@ -93,6 +100,10 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
     private CommandContext commandContext;
 
     private FlowRerouteService rerouteService;
+
+    private String currentRequestKey;
+
+    private Map<SwitchId, Switch> swMap = new HashMap<>();
 
     @Before
     public void setUp() {
@@ -124,9 +135,24 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
 
         doAnswer(getSpeakerCommandsAnswer()).when(carrier).sendSpeakerRequest(any());
 
+        doAnswer(invocation -> {
+            FlowRerouteFact retry = invocation.getArgument(0);
+            currentRequestKey = retry.getKey();
+            rerouteService.handlePostponedRequest(retry);
+            return null;
+        }).when(carrier).injectRetry(any());
+
         rerouteService = new FlowRerouteService(carrier, persistenceManager,
                 pathComputer, flowResourcesManager, TRANSACTION_RETRIES_LIMIT,
                 PATH_ALLOCATION_RETRIES_LIMIT, PATH_ALLOCATION_RETRY_DELAY, SPEAKER_COMMAND_RETRIES_LIMIT);
+
+        currentRequestKey = "test-key";
+
+        for (SwitchId id : new SwitchId[] {SWITCH_1, SWITCH_2, SWITCH_3}) {
+            Switch entry = makeSwitch(id);
+            swMap.put(id, entry);
+            when(switchRepository.findById(eq(id))).thenReturn(Optional.of(entry));
+        }
     }
 
     @Test
@@ -292,15 +318,7 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
 
         FlowSegmentRequest request;
         while ((request = requests.poll()) != null) {
-            if (request.isRemoveRequest()) {
-                rerouteService.handleAsyncResponse("test_key", SpeakerFlowSegmentResponse.builder()
-                        .messageContext(request.getMessageContext())
-                        .commandId(request.getCommandId())
-                        .metadata(request.getMetadata())
-                        .switchId(request.getSwitchId())
-                        .success(true)
-                        .build());
-            }
+            produceAsyncResponse("test_key", request);
         }
 
         assertEquals(FlowStatus.UP, flow.getStatus());
@@ -485,17 +503,7 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
 
         FlowSegmentRequest request;
         while ((request = requests.poll()) != null) {
-            if (request.isVerifyRequest()) {
-                rerouteService.handleAsyncResponse("test_key", buildResponseOnVerifyRequest(request));
-            } else {
-                rerouteService.handleAsyncResponse("test_key", SpeakerFlowSegmentResponse.builder()
-                        .messageContext(request.getMessageContext())
-                        .commandId(request.getCommandId())
-                        .metadata(request.getMetadata())
-                        .switchId(request.getSwitchId())
-                        .success(true)
-                        .build());
-            }
+            produceAsyncResponse("test_key", request);
         }
 
         assertEquals(FlowStatus.UP, flow.getStatus());
@@ -546,7 +554,9 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         Flow flow = build2SwitchFlow();
         flow.setStatus(FlowStatus.DOWN);
 
-        when(pathComputer.getPath(any(), any())).thenReturn(build2SwitchPathPair(2, 3));
+        when(pathComputer.getPath(any(), any()))
+                .thenReturn(build2SwitchPathPair(2, 3))
+                .thenReturn(build3SwitchPathPair());
         buildFlowResources();
 
         rerouteService.handleRequest("test_key", commandContext, FLOW_ID, null, false, null);
@@ -556,17 +566,7 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
 
         FlowSegmentRequest request;
         while ((request = requests.poll()) != null) {
-            if (request.isVerifyRequest()) {
-                rerouteService.handleAsyncResponse("test_key", buildResponseOnVerifyRequest(request));
-            } else {
-                rerouteService.handleAsyncResponse("test_key", SpeakerFlowSegmentResponse.builder()
-                        .messageContext(request.getMessageContext())
-                        .commandId(request.getCommandId())
-                        .metadata(request.getMetadata())
-                        .switchId(request.getSwitchId())
-                        .success(true)
-                        .build());
-            }
+            produceAsyncResponse("test_key", request);
         }
 
         assertEquals(FlowStatus.UP, flow.getStatus());
@@ -574,36 +574,56 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         assertEquals(NEW_REVERSE_FLOW_PATH, flow.getReversePathId());
     }
 
-    private PathPair build2SwitchPathPair() {
-        return build2SwitchPathPair(1, 2);
+    @Test
+    public void shouldSuccessfullyHandleOverlappingRequests()
+            throws RecoverableException, UnroutableFlowException, ResourceAllocationException {
+        Flow flow = build2SwitchFlow();
+        flow.setStatus(FlowStatus.DOWN);
+
+        when(pathComputer.getPath(any(), any()))
+                .thenReturn(build2SwitchPathPair(2, 3))
+                .thenReturn(build3SwitchPathPair());
+
+        FlowResources resourcesOrigin = makeFlowResources(
+                flow.getFlowId(), flow.getForwardPathId(), flow.getReversePathId());
+
+        PathId pathForwardFirst = new PathId(flow.getFlowId() + "_forward_first");
+        PathId pathReverseFirst = new PathId(flow.getFlowId() + "_reverse_first");
+        FlowResources resourcesFirst = makeFlowResources(
+                flow.getFlowId(), pathForwardFirst, pathReverseFirst, resourcesOrigin);
+
+        PathId pathForwardSecond = new PathId(flow.getFlowId() + "_forward_second");
+        PathId pathReverseSecond = new PathId(flow.getFlowId() + "_reverse_second");
+        FlowResources resourcesSecond = makeFlowResources(
+                flow.getFlowId(), pathForwardSecond, pathReverseSecond, resourcesFirst);
+
+        when(flowResourcesManager.allocateFlowResources(any()))
+                .thenReturn(resourcesFirst)
+                .thenReturn(resourcesSecond);
+
+        rerouteService.handleRequest(currentRequestKey, commandContext, flow.getFlowId(), null, false, null);
+        assertEquals(FlowStatus.IN_PROGRESS, flow.getStatus());
+
+        rerouteService.handleRequest("test_key2", commandContext, flow.getFlowId(), null, false, null);
+        assertEquals(FlowStatus.IN_PROGRESS, flow.getStatus());
+
+        FlowSegmentRequest request;
+        while ((request = requests.poll()) != null) {
+            produceAsyncResponse(currentRequestKey, request);
+        }
+
+        assertEquals(FlowStatus.UP, flow.getStatus());
+        assertEquals(pathForwardSecond, flow.getForwardPathId());
+        assertEquals(pathReverseSecond, flow.getReversePathId());
     }
 
-    private PathPair build2SwitchPathPair(int srcPort, int destPort) {
-        return PathPair.builder()
-                .forward(Path.builder()
-                        .srcSwitchId(SWITCH_1).destSwitchId(SWITCH_2)
-                        .segments(Collections.singletonList(Segment.builder()
-                                .srcSwitchId(SWITCH_1)
-                                .srcPort(srcPort)
-                                .destSwitchId(SWITCH_2)
-                                .destPort(destPort)
-                                .build()))
-                        .build())
-                .reverse(Path.builder()
-                        .srcSwitchId(SWITCH_2).destSwitchId(SWITCH_1)
-                        .segments(Collections.singletonList(Segment.builder()
-                                .srcSwitchId(SWITCH_2)
-                                .srcPort(destPort)
-                                .destSwitchId(SWITCH_1)
-                                .destPort(srcPort)
-                                .build()))
-                        .build())
-                .build();
+    protected void produceAsyncResponse(String key, FlowSegmentRequest flowRequest) {
+        rerouteService.handleAsyncResponse(key, buildSpeakerResponse(flowRequest));
     }
 
     private Flow build2SwitchFlow() {
-        Switch src = Switch.builder().switchId(SWITCH_1).build();
-        Switch dst = Switch.builder().switchId(SWITCH_2).build();
+        Switch src = swMap.get(SWITCH_1);
+        Switch dst = swMap.get(SWITCH_2);
 
         Flow flow = Flow.builder().flowId(FLOW_ID)
                 .srcSwitch(src).destSwitch(dst)
@@ -641,14 +661,14 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
                 .build()));
         flow.setReversePath(oldReversePath);
 
-        when(flowRepository.findById(any())).thenReturn(Optional.of(flow));
-        when(flowRepository.findById(any(), any())).thenReturn(Optional.of(flow));
+        when(flowRepository.findById(eq(flow.getFlowId()))).thenReturn(Optional.of(flow));
+        when(flowRepository.findById(eq(flow.getFlowId()), any())).thenReturn(Optional.of(flow));
 
         doAnswer(invocation -> {
             FlowStatus status = invocation.getArgument(1);
             flow.setStatus(status);
             return null;
-        }).when(flowRepository).updateStatus(any(), any());
+        }).when(flowRepository).updateStatus(eq(flow.getFlowId()), any());
 
         doAnswer(invocation -> {
             PathId pathId = invocation.getArgument(0);
@@ -658,50 +678,155 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         doAnswer(invocation -> {
             PathId pathId = invocation.getArgument(0);
             FlowPathStatus status = invocation.getArgument(1);
-            flow.getPath(pathId).get().setStatus(status);
+            flow.getPath(pathId).ifPresent(entity -> entity.setStatus(status));
             return null;
         }).when(flowPathRepository).updateStatus(any(), any());
 
         return flow;
     }
 
-    private FlowResources buildFlowResources() throws ResourceAllocationException {
-        FlowResources flowResources = FlowResources.builder()
-                .unmaskedCookie(1)
-                .forward(PathResources.builder()
-                        .pathId(NEW_FORWARD_FLOW_PATH)
-                        .meterId(new MeterId(MeterId.MIN_FLOW_METER_ID + 1))
+    private PathPair build2SwitchPathPair() {
+        return build2SwitchPathPair(1, 2);
+    }
+
+    private PathPair build2SwitchPathPair(int srcPort, int destPort) {
+        List<Segment> forwardSegments = Collections.singletonList(
+                Segment.builder()
+                        .srcSwitchId(SWITCH_1).srcPort(srcPort).destSwitchId(SWITCH_2).destPort(destPort).build());
+        List<Segment> reverseSegments = Collections.singletonList(
+                Segment.builder()
+                        .srcSwitchId(SWITCH_2).srcPort(destPort).destSwitchId(SWITCH_1).destPort(srcPort).build());
+        return buildPcePathPair(forwardSegments, reverseSegments);
+    }
+
+    private PathPair build3SwitchPathPair() {
+        return build3SwitchPathPair(3, 4);
+    }
+
+    private PathPair build3SwitchPathPair(int srcPort, int destPort) {
+        List<Segment> forwardSegments = new ArrayList<>();
+        forwardSegments.add(
+                Segment.builder()
+                        .srcSwitchId(SWITCH_1).srcPort(srcPort).destPort(destPort).destSwitchId(SWITCH_3).build());
+        forwardSegments.add(
+                Segment.builder()
+                        .srcSwitchId(SWITCH_3).srcPort(srcPort).destPort(destPort).destSwitchId(SWITCH_2).build());
+
+        List<Segment> reverseSegments = new ArrayList<>();
+        reverseSegments.add(
+                Segment.builder()
+                        .srcSwitchId(SWITCH_2).srcPort(destPort).destPort(srcPort).destSwitchId(SWITCH_3).build());
+        reverseSegments.add(
+                Segment.builder()
+                        .srcSwitchId(SWITCH_3).srcPort(destPort).destPort(srcPort).destSwitchId(SWITCH_1).build());
+
+        return buildPcePathPair(forwardSegments, reverseSegments);
+    }
+
+    private PathPair buildPcePathPair(List<Segment> forwardSegments, List<Segment> reverseSegments) {
+        return PathPair.builder()
+                .forward(Path.builder()
+                        .srcSwitchId(SWITCH_1).destSwitchId(SWITCH_2)
+                        .segments(forwardSegments)
                         .build())
-                .reverse(PathResources.builder()
-                        .pathId(NEW_REVERSE_FLOW_PATH)
-                        .meterId(new MeterId(MeterId.MIN_FLOW_METER_ID + 2))
+                .reverse(Path.builder()
+                        .srcSwitchId(SWITCH_2).destSwitchId(SWITCH_1)
+                        .segments(reverseSegments)
                         .build())
                 .build();
+    }
 
-        when(flowResourcesManager.allocateFlowResources(any())).thenReturn(flowResources);
+    private FlowResources buildFlowResources() throws ResourceAllocationException {
+        FlowResources original = makeFlowResources(FLOW_ID, OLD_FORWARD_FLOW_PATH, OLD_REVERSE_FLOW_PATH);
+        FlowResources target = makeFlowResources(FLOW_ID, NEW_FORWARD_FLOW_PATH, NEW_REVERSE_FLOW_PATH, original);
 
-        when(flowResourcesManager.getEncapsulationResources(eq(NEW_FORWARD_FLOW_PATH), eq(NEW_REVERSE_FLOW_PATH),
-                eq(FlowEncapsulationType.TRANSIT_VLAN)))
-                .thenReturn(Optional.of(TransitVlanEncapsulation.builder().transitVlan(
-                        TransitVlan.builder().flowId(FLOW_ID).pathId(NEW_FORWARD_FLOW_PATH).vlan(101).build())
-                        .build()));
-        when(flowResourcesManager.getEncapsulationResources(eq(NEW_REVERSE_FLOW_PATH), eq(NEW_FORWARD_FLOW_PATH),
-                eq(FlowEncapsulationType.TRANSIT_VLAN)))
-                .thenReturn(Optional.of(TransitVlanEncapsulation.builder().transitVlan(
-                        TransitVlan.builder().flowId(FLOW_ID).pathId(NEW_REVERSE_FLOW_PATH).vlan(102).build())
-                        .build()));
+        when(flowResourcesManager.allocateFlowResources(any())).thenReturn(target);
 
-        when(flowResourcesManager.getEncapsulationResources(eq(OLD_FORWARD_FLOW_PATH), eq(OLD_REVERSE_FLOW_PATH),
-                eq(FlowEncapsulationType.TRANSIT_VLAN)))
-                .thenReturn(Optional.of(TransitVlanEncapsulation.builder().transitVlan(
-                        TransitVlan.builder().flowId(FLOW_ID).pathId(NEW_FORWARD_FLOW_PATH).vlan(201).build())
-                        .build()));
-        when(flowResourcesManager.getEncapsulationResources(eq(OLD_REVERSE_FLOW_PATH), eq(OLD_FORWARD_FLOW_PATH),
-                eq(FlowEncapsulationType.TRANSIT_VLAN)))
-                .thenReturn(Optional.of(TransitVlanEncapsulation.builder().transitVlan(
-                        TransitVlan.builder().flowId(FLOW_ID).pathId(NEW_REVERSE_FLOW_PATH).vlan(202).build())
-                        .build()));
+        return target;
+    }
 
-        return flowResources;
+    private Switch makeSwitch(SwitchId id) {
+        return Switch.builder().switchId(id).build();
+    }
+
+    private FlowResources makeFlowResources(String flowId, PathId forward, PathId reverse) {
+        return makeFlowResources(flowId, forward, reverse, null);
+    }
+
+    private FlowResources makeFlowResources(
+            String flowId, PathId forward, PathId reverse, FlowResources lastAllocated) {
+        FlowResources resources = FlowResources.builder()
+                .unmaskedCookie(extractLastAllocatedCookie(lastAllocated).getValue())
+                .forward(PathResources.builder()
+                                 .pathId(forward)
+                                 .meterId(allocateForwardMeterId(lastAllocated))
+                                 .encapsulationResources(
+                                         makeTransitVlanResources(flowId, forward,
+                                                                  allocateForwardTransitVlanId(lastAllocated)))
+                                 .build())
+                .reverse(PathResources.builder()
+                                 .pathId(reverse)
+                                 .meterId(allocateReverseMeterId(lastAllocated))
+                                 .encapsulationResources(
+                                         makeTransitVlanResources(flowId, reverse,
+                                                                  allocateReverseTransitVlanId(lastAllocated)))
+                                 .build())
+                .build();
+
+        when(flowResourcesManager.getEncapsulationResources(
+                eq(forward), eq(reverse), eq(FlowEncapsulationType.TRANSIT_VLAN)))
+                .thenReturn(Optional.of(resources.getForward().getEncapsulationResources()));
+        when(flowResourcesManager.getEncapsulationResources(
+                eq(reverse), eq(forward), eq(FlowEncapsulationType.TRANSIT_VLAN)))
+                .thenReturn(Optional.of(resources.getReverse().getEncapsulationResources()));
+
+        return resources;
+    }
+
+    private EncapsulationResources makeTransitVlanResources(String flowId, PathId pathId, int vlanId) {
+        TransitVlan entity = TransitVlan.builder()
+                .flowId(flowId).pathId(pathId)
+                .vlan(vlanId)
+                .build();
+        return TransitVlanEncapsulation.builder()
+                .transitVlan(entity)
+                .build();
+    }
+
+    private MeterId allocateForwardMeterId(FlowResources lastAllocated) {
+        return new MeterId(extractLastAllocatedMeterId(lastAllocated).getValue() + 1);
+    }
+
+    private MeterId allocateReverseMeterId(FlowResources lastAllocated) {
+        return new MeterId(extractLastAllocatedMeterId(lastAllocated).getValue() + 2);
+    }
+
+    private int allocateForwardTransitVlanId(FlowResources lastAllocated) {
+        return extractLastAllocatedVlanId(lastAllocated) + 1;
+    }
+
+    private int allocateReverseTransitVlanId(FlowResources lastAllocated) {
+        return extractLastAllocatedVlanId(lastAllocated) + 2;
+    }
+
+    private Cookie extractLastAllocatedCookie(FlowResources resources) {
+        if (resources == null) {
+            return new Cookie(1);
+        }
+        return new Cookie(resources.getUnmaskedCookie());
+    }
+
+    private MeterId extractLastAllocatedMeterId(FlowResources resources) {
+        if (resources == null) {
+            return new MeterId(MeterId.MIN_FLOW_METER_ID);
+        }
+        return resources.getForward().getMeterId();
+    }
+
+    private int extractLastAllocatedVlanId(FlowResources resources) {
+        if (resources == null) {
+            return 100;
+        }
+        return resources.getForward().getEncapsulationResources().getTransitEncapsulationId();
     }
 }

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/utils/RerouteRetryQueueTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/utils/RerouteRetryQueueTest.java
@@ -1,0 +1,159 @@
+/* Copyright 2020 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.utils;
+
+import org.openkilda.model.PathId;
+import org.openkilda.wfm.CommandContext;
+import org.openkilda.wfm.topology.flowhs.model.FlowRerouteFact;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+public class RerouteRetryQueueTest {
+    private final CommandContext context = new CommandContext();
+    private final String flowId = "flowA";
+    private final FlowRerouteFact rerouteEmpty = new FlowRerouteFact(
+            "empty", context, flowId, null, false, "reason 1");
+    private final FlowRerouteFact reroutePathA = new FlowRerouteFact(
+            "pathA", context, flowId, Collections.singleton(new PathId("flowA-pathA")), false, "reason 2");
+    private final FlowRerouteFact reroutePathB = new FlowRerouteFact(
+            "pathB", context, flowId, Collections.singleton(new PathId("flowA-pathB")), false, "reason 3");
+    private final FlowRerouteFact rerouteForced = new FlowRerouteFact(
+            "forced", context, flowId, null, true, "reason 4");
+
+    @Test
+    public void addAndSizeOperations() {
+        RerouteRetryQueue queue = new RerouteRetryQueue();
+
+        Assert.assertEquals(0, queue.size());
+        Assert.assertTrue(queue.isEmpty());
+
+        queue.add(rerouteEmpty);
+        Assert.assertEquals(1, queue.size());
+        Assert.assertFalse(queue.isEmpty());
+
+        queue.add(reroutePathA);
+        Assert.assertEquals(2, queue.size());
+        Assert.assertFalse(queue.isEmpty());
+
+        queue.add(reroutePathB);
+        Assert.assertEquals(2, queue.size());
+        Assert.assertFalse(queue.isEmpty());
+    }
+
+    @Test
+    public void removeAndSizeOperations() {
+        RerouteRetryQueue queue = new RerouteRetryQueue();
+
+        // empty
+        Assert.assertFalse(queue.remove().isPresent());
+
+        Optional<FlowRerouteFact> reroute;
+
+        // one entry
+        queue.add(rerouteEmpty);
+        reroute = queue.remove();
+        Assert.assertTrue(reroute.isPresent());
+        Assert.assertSame(rerouteEmpty, reroute.get());
+        Assert.assertFalse(queue.remove().isPresent());
+        Assert.assertEquals(0, queue.size());
+
+        // two entry
+        queue.add(rerouteEmpty);
+        queue.add(reroutePathA);
+        reroute = queue.remove();
+        Assert.assertTrue(reroute.isPresent());
+        Assert.assertSame(rerouteEmpty, reroute.get());
+        Assert.assertEquals(1, queue.size());
+
+        reroute = queue.remove();
+        Assert.assertTrue(reroute.isPresent());
+        Assert.assertSame(reroutePathA, reroute.get());
+        Assert.assertFalse(queue.remove().isPresent());
+        Assert.assertEquals(0, queue.size());
+
+        Assert.assertFalse(queue.remove().isPresent());
+
+        // more than 2 entry
+        queue.add(rerouteEmpty);
+        queue.add(reroutePathA);
+        queue.add(reroutePathB);
+
+        reroute = queue.remove();
+        Assert.assertTrue(reroute.isPresent());
+        Assert.assertSame(rerouteEmpty, reroute.get());
+        Assert.assertEquals(1, queue.size());
+
+        reroute = queue.remove();
+        Assert.assertTrue(reroute.isPresent());
+        Assert.assertNotEquals(reroutePathA, reroute.get());  // merged entry
+        Assert.assertNotEquals(reroutePathB, reroute.get());  // merged entry
+        Assert.assertFalse(queue.remove().isPresent());
+        Assert.assertEquals(0, queue.size());
+
+        Assert.assertFalse(queue.remove().isPresent());
+    }
+
+    @Test
+    public void getOperations() {
+        RerouteRetryQueue queue = new RerouteRetryQueue();
+        Assert.assertFalse(queue.get().isPresent());
+
+        Optional<FlowRerouteFact> reroute;
+        queue.add(rerouteEmpty);
+        reroute = queue.get();
+        Assert.assertTrue(reroute.isPresent());
+        Assert.assertSame(rerouteEmpty, reroute.get());
+
+        queue.add(reroutePathA);
+        reroute = queue.get();
+        Assert.assertTrue(reroute.isPresent());
+        Assert.assertSame(rerouteEmpty, reroute.get());
+
+        queue.remove();
+        reroute = queue.get();
+        Assert.assertTrue(reroute.isPresent());
+        Assert.assertSame(reroutePathA, reroute.get());
+    }
+
+    @Test
+    public void mergeOperation() {
+        RerouteRetryQueue queue = new RerouteRetryQueue();
+        queue.add(rerouteEmpty);
+        queue.add(reroutePathA);
+        queue.add(rerouteForced);
+        queue.add(reroutePathB);
+
+        Optional<FlowRerouteFact> potential;
+        queue.remove();
+        potential = queue.get();
+        Assert.assertTrue(potential.isPresent());
+
+        FlowRerouteFact reroute = potential.get();
+        Assert.assertEquals(reroutePathB.getKey(), reroute.getKey());
+        Assert.assertSame(reroutePathB.getCommandContext(), reroute.getCommandContext());
+        Assert.assertEquals(reroutePathB.getFlowId(), reroute.getFlowId());
+
+        Set<PathId> expectedPaths = Collections.emptySet();
+        Assert.assertEquals(expectedPaths, reroute.getPathsToReroute());
+        Assert.assertTrue(reroute.isForceReroute());
+        Assert.assertEquals(reroutePathB.getRerouteReason(), reroute.getRerouteReason());
+    }
+}


### PR DESCRIPTION
Add queue in front of reroute "handler" so if reroute for the flow is
going and new reroute request for this flow received (double network
failure case) second request will be postponed.

At the end of reroute request processing, "handler" check the presence of
postponed request and handle them.

Related to #3087

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/3097)
<!-- Reviewable:end -->
