### PR TITLE
Avoid reseting in progress flow status

### DIFF
--- a/services/src/kilda-core/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/FlowRepository.java
+++ b/services/src/kilda-core/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/FlowRepository.java
@@ -58,4 +58,10 @@ public interface FlowRepository extends Repository<Flow> {
     Optional<String> getOrCreateFlowGroupId(String flowId);
 
     void updateStatus(String flowId, FlowStatus flowStatus);
+
+    /**
+     * Flow in "IN_PROGRESS" status can be switched to other status only inside flow CRUD handlers topology. All other
+     * components must use this method, which guarantee safety such flows status.
+     */
+    void updateStatusSafe(String flowId, FlowStatus flowStatus);
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/reroute/service/RerouteService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/reroute/service/RerouteService.java
@@ -84,7 +84,7 @@ public class RerouteService {
 
             transactionManager.doInTransaction(() -> {
                 updateFlowPathsStateForFlow(switchId, port, flow);
-                flowRepository.updateStatus(flow.getFlowId(), flow.computeFlowStatus());
+                flowRepository.updateStatusSafe(flow.getFlowId(), flow.computeFlowStatus());
             });
 
             sender.emitRerouteCommand(correlationId, entry.getKey(), entry.getValue(),
@@ -96,7 +96,7 @@ public class RerouteService {
                 updateFlowPathsStateForFlow(switchId, port, flow);
                 if (flow.getStatus() != FlowStatus.DOWN) {
                     flowDashboardLogger.onFlowStatusUpdate(flow.getFlowId(), FlowStatus.DOWN);
-                    flowRepository.updateStatus(flow.getFlowId(), FlowStatus.DOWN);
+                    flowRepository.updateStatusSafe(flow.getFlowId(), FlowStatus.DOWN);
                 }
             });
         }
@@ -155,7 +155,7 @@ public class RerouteService {
                         flowPathRepository.updateStatus(flowPath.getPathId(), FlowPathStatus.ACTIVE);
                     }
                 }
-                flowRepository.updateStatus(flow.getFlowId(), flow.computeFlowStatus());
+                flowRepository.updateStatusSafe(flow.getFlowId(), flow.computeFlowStatus());
             });
 
             if (flow.isPinned()) {

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/reroute/service/RerouteServiceTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/reroute/service/RerouteServiceTest.java
@@ -15,6 +15,7 @@
 
 package org.openkilda.wfm.topology.reroute.service;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -177,7 +178,7 @@ public class RerouteServiceTest {
             FlowStatus status = invocation.getArgument(1);
             pinnedFlow.setStatus(status);
             return null;
-        }).when(flowRepository).updateStatus(eq(pinnedFlow.getFlowId()), any());
+        }).when(flowRepository).updateStatusSafe(eq(pinnedFlow.getFlowId()), any());
         when(repositoryFactory.createFlowRepository()).thenReturn(flowRepository);
         FlowPathRepository pathRepository = mock(FlowPathRepository.class);
         doAnswer(invocation -> {
@@ -202,9 +203,9 @@ public class RerouteServiceTest {
         RerouteService rerouteService = new RerouteService(persistenceManager);
         rerouteService.rerouteInactiveFlows(messageSender, CORRELATION_ID,
                 REROUTE_INACTIVE_FLOWS_COMMAND);
-        assertTrue(FlowStatus.UP.equals(pinnedFlow.getStatus()));
+        assertEquals(FlowStatus.UP, pinnedFlow.getStatus());
         for (FlowPath fp : pinnedFlow.getPaths()) {
-            assertTrue(FlowPathStatus.ACTIVE.equals(fp.getStatus()));
+            assertEquals(FlowPathStatus.ACTIVE, fp.getStatus());
             for (PathSegment ps : fp.getSegments()) {
                 if (ps.containsNode(SWITCH_ID_A, PORT)) {
                     assertFalse(ps.isFailed());


### PR DESCRIPTION
Flow's "in-progress" status used as "lock" that prevents simultaneous
flow CRUD operation over same flow. And this status must not be reseted
aniwhere oputside CRUD operations.