### PR TITLE
Fix double network failure handling

### DIFF
--- a/services/src/checkstyle/checkstyle-header.txt
+++ b/services/src/checkstyle/checkstyle-header.txt
@@ -1,4 +1,4 @@
-^/\* Copyright 201\d Telstra Open Source
+^/\* Copyright \d{4} Telstra Open Source
 ^ \*
 ^ \*   Licensed under the Apache License, Version 2\.0 \(the "License"\);
 ^ \*   you may not use this file except in compliance with the License\.

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathV2Spec.groovy
@@ -191,6 +191,7 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
         def switchPair = topologyHelper.getAllNotNeighboringSwitchPairs().find {
             it.paths.unique(false) { a, b -> a.intersect(b) == [] ? 1 : 0 }.size() >= 3
         } ?: assumeTrue("No suiting switches found", false)
+        def uniquePathCount = switchPair.paths.unique(false) { a, b -> a.intersect(b) == [] ? 1 : 0 }.size()
 
         when: "Create flow with protected path"
         def flow = flowHelperV2.randomFlow(switchPair)
@@ -230,8 +231,10 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
             def flowPathInfoAfterRerouting = northbound.getFlowPath(flow.flowId)
 
             assert pathHelper.convert(flowPathInfoAfterRerouting) == currentProtectedPath
-            assert pathHelper.convert(flowPathInfoAfterRerouting.protectedPath) != currentPath
-            assert pathHelper.convert(flowPathInfoAfterRerouting.protectedPath) != currentProtectedPath
+            if (4 <= uniquePathCount) {
+                assert pathHelper.convert(flowPathInfoAfterRerouting.protectedPath) != currentPath
+                assert pathHelper.convert(flowPathInfoAfterRerouting.protectedPath) != currentProtectedPath
+            }
         }
 
         when: "Restore port status"
@@ -320,6 +323,8 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
             it.paths.unique(false) { a, b -> a.intersect(b) == [] ? 1 : 0 }.size() >= 3
         } ?: assumeTrue("No suiting switches found", false)
 
+        def uniquePathCount = switchPair.paths.unique(false) { a, b -> a.intersect(b) == [] ? 1 : 0 }.size()
+
         and: "A flow with protected path"
         def flow = flowHelperV2.randomFlow(switchPair)
         flow.maximumBandwidth = bandwidth
@@ -352,8 +357,10 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
 
             def newCurrentProtectedPath = pathHelper.convert(newPathInfo.protectedPath)
             assert newCurrentPath == currentProtectedPath
-            assert newCurrentProtectedPath != currentPath
-            assert newCurrentProtectedPath != currentProtectedPath
+            if (4 <= uniquePathCount) {
+                assert newCurrentProtectedPath != currentPath
+                assert newCurrentProtectedPath != currentProtectedPath
+            }
         }
 
         when: "Restore port status"

--- a/services/src/messaging/src/main/java/org/openkilda/messaging/command/flow/FlowRerouteRequest.java
+++ b/services/src/messaging/src/main/java/org/openkilda/messaging/command/flow/FlowRerouteRequest.java
@@ -16,7 +16,7 @@
 package org.openkilda.messaging.command.flow;
 
 import org.openkilda.messaging.command.CommandData;
-import org.openkilda.model.PathId;
+import org.openkilda.model.IslEndpoint;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -41,7 +41,7 @@ public class FlowRerouteRequest extends CommandData {
     protected String flowId;
 
     @JsonProperty("path_ids")
-    protected Set<PathId> pathIds;
+    protected Set<IslEndpoint> affectedIsl;
 
     /**
      * Update flow even if path will not be changed.
@@ -49,21 +49,29 @@ public class FlowRerouteRequest extends CommandData {
     @JsonProperty("force")
     private boolean force;
 
+    @JsonProperty("effectively_down")
+    private boolean effectivelyDown;
+
     @JsonProperty("reason")
     private String reason;
 
+    /**
+     * Create Simplified request usable only for northbound API.
+     */
     public FlowRerouteRequest(String flowId, boolean force, String reason) {
-        this(flowId, force, Collections.emptySet(), reason);
+        this(flowId, force, false, Collections.emptySet(), reason);
     }
 
     @JsonCreator
     public FlowRerouteRequest(@NonNull @JsonProperty("flowid") String flowId,
                               @JsonProperty("force") boolean force,
-                              @NonNull @JsonProperty("path_ids") Set<PathId> pathIds,
+                              @JsonProperty("effectively_down")  boolean effectivelyDown,
+                              @NonNull @JsonProperty("path_ids") Set<IslEndpoint> affectedIsl,
                               @JsonProperty("reason") String reason) {
         this.flowId = flowId;
         this.force = force;
-        this.pathIds = pathIds;
+        this.effectivelyDown = effectivelyDown;
+        this.affectedIsl = affectedIsl;
         this.reason = reason;
     }
 }

--- a/services/src/messaging/src/test/java/org/openkilda/messaging/command/flow/AbstractSerializerTest.java
+++ b/services/src/messaging/src/test/java/org/openkilda/messaging/command/flow/AbstractSerializerTest.java
@@ -50,8 +50,8 @@ import org.openkilda.messaging.model.SpeakerSwitchView;
 import org.openkilda.messaging.payload.flow.FlowIdStatusPayload;
 import org.openkilda.messaging.payload.flow.FlowState;
 import org.openkilda.model.FlowEncapsulationType;
+import org.openkilda.model.IslEndpoint;
 import org.openkilda.model.OutputVlanType;
-import org.openkilda.model.PathId;
 import org.openkilda.model.SwitchId;
 
 import org.junit.Ignore;
@@ -69,7 +69,6 @@ import java.util.UUID;
 @Ignore
 public abstract class AbstractSerializerTest implements AbstractSerializer {
     private static final String FLOW_NAME = "test_flow";
-    private static final PathId PATH_ID = new PathId("path_name");
     private static final SwitchId SWITCH_ID = new SwitchId("00:00:00:00:00:00:00:00");
     private static final SwitchId EGRESS_SWITCH_ID = new SwitchId("00:00:00:00:00:00:00:00");
     private static final String CORRELATION_ID = UUID.randomUUID().toString();
@@ -563,7 +562,8 @@ public abstract class AbstractSerializerTest implements AbstractSerializer {
 
     @Test
     public void flowRerouteCommandTest() throws IOException, ClassNotFoundException {
-        FlowRerouteRequest data = new FlowRerouteRequest(FLOW_NAME, false, Collections.singleton(PATH_ID), null);
+        FlowRerouteRequest data = new FlowRerouteRequest(
+                FLOW_NAME, false, false, Collections.singleton(new IslEndpoint(SWITCH_ID, 1)), null);
         System.out.println(data);
 
         CommandMessage command = new CommandMessage(data, System.currentTimeMillis(), CORRELATION_ID, DESTINATION);

--- a/services/wfm/src/checkstyle/checkstyle-header.txt
+++ b/services/wfm/src/checkstyle/checkstyle-header.txt
@@ -1,4 +1,4 @@
-^/\* Copyright 201\d Telstra Open Source
+^/\* Copyright \d{4} Telstra Open Source
 ^ \*
 ^ \*   Licensed under the Apache License, Version 2\.0 \(the "License"\);
 ^ \*   you may not use this file except in compliance with the License\.

--- a/services/wfm/src/main/java/org/openkilda/wfm/AbstractBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/AbstractBolt.java
@@ -19,6 +19,7 @@ import org.openkilda.wfm.error.PipelineException;
 
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.base.BaseRichBolt;
@@ -48,6 +49,7 @@ public abstract class AbstractBolt extends BaseRichBolt {
     private transient Tuple currentTuple;
 
     @Getter(AccessLevel.PROTECTED)
+    @Setter(AccessLevel.PROTECTED)
     private transient CommandContext commandContext;
 
     @Override

--- a/services/wfm/src/main/java/org/openkilda/wfm/share/logger/FlowOperationsDashboardLogger.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/share/logger/FlowOperationsDashboardLogger.java
@@ -17,7 +17,7 @@ package org.openkilda.wfm.share.logger;
 
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowStatus;
-import org.openkilda.model.PathId;
+import org.openkilda.model.IslEndpoint;
 import org.openkilda.model.SwitchId;
 import org.openkilda.reporting.AbstractDashboardLogger;
 
@@ -312,13 +312,13 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
     /**
      * Log a flow-paths-reroute event.
      */
-    public void onFlowPathReroute(String flowId, Collection<PathId> pathIds, boolean forceToReroute) {
+    public void onFlowPathReroute(String flowId, Collection<IslEndpoint> affectedIsl, boolean forceToReroute) {
         Map<String, String> data = new HashMap<>();
         data.put(TAG, "flow-paths-reroute");
         data.put(FLOW_ID, flowId);
         data.put(EVENT_TYPE, REROUTE_EVENT);
         data.put("forced_reroute", Boolean.toString(forceToReroute));
-        invokeLogger(Level.INFO, String.format("Reroute paths %s of the flow %s", pathIds, flowId), data);
+        invokeLogger(Level.INFO, String.format("Reroute due to failure on %s ISLs flow %s", affectedIsl, flowId), data);
     }
 
     /**

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/CrudBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/bolts/CrudBolt.java
@@ -111,6 +111,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -544,7 +545,7 @@ public class CrudBolt extends BaseRichBolt implements ICtrlBolt {
 
         try {
             ReroutedFlowPaths reroutedFlowPaths = flowService.rerouteFlow(
-                    flowId, request.isForce(), request.getPathIds(),
+                    flowId, request.isForce(), request.getAffectedIsl(),
                     new FlowCommandSenderImpl(message.getCorrelationId(), tuple, StreamType.UPDATE));
 
             logger.warn("Rerouted flow with new path: {}", reroutedFlowPaths.getNewFlowPaths());
@@ -553,7 +554,7 @@ public class CrudBolt extends BaseRichBolt implements ICtrlBolt {
             throw new MessageException(message.getCorrelationId(), System.currentTimeMillis(),
                     ErrorType.NOT_FOUND, errorType, e.getMessage());
         } catch (UnroutableFlowException e) {
-            flowService.updateFlowStatus(flowId, FlowStatus.DOWN, request.getPathIds());
+            flowService.updateFlowStatus(flowId, FlowStatus.DOWN, Collections.emptySet());
             throw new MessageException(message.getCorrelationId(), System.currentTimeMillis(),
                     ErrorType.NOT_FOUND, errorType, "Path was not found. " + e.getMessage());
         } catch (Exception e) {

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/service/FlowService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flow/service/FlowService.java
@@ -37,6 +37,7 @@ import org.openkilda.model.FlowPair;
 import org.openkilda.model.FlowPath;
 import org.openkilda.model.FlowPathStatus;
 import org.openkilda.model.FlowStatus;
+import org.openkilda.model.IslEndpoint;
 import org.openkilda.model.LldpResources;
 import org.openkilda.model.PathId;
 import org.openkilda.model.PathSegment;
@@ -97,6 +98,7 @@ import org.neo4j.driver.v1.exceptions.TransientException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -509,17 +511,28 @@ public class FlowService extends BaseFlowService {
      *
      * @param flowId the flow to be rerouted.
      * @param forceToReroute if true the flow will be recreated even there's no better path found.
-     * @param pathIds the set of path if to reroute.
+     * @param affectedIsl the set of path if to reroute.
      * @param sender the command sender for flow rules installation and deletion.
      */
-    public ReroutedFlowPaths rerouteFlow(String flowId, boolean forceToReroute, Set<PathId> pathIds,
+    public ReroutedFlowPaths rerouteFlow(String flowId, boolean forceToReroute, Set<IslEndpoint> affectedIsl,
                                          FlowCommandSender sender) throws RecoverableException, UnroutableFlowException,
             FlowNotFoundException, ResourceAllocationException {
-        dashboardLogger.onFlowPathReroute(flowId, pathIds, forceToReroute);
+        // due to completely switch on H&S flow's CRUD implementation goal new features are not backported
+        // into old/this implementation, including reroute targeting based on affected ISL set
+        if (affectedIsl != null && ! affectedIsl.isEmpty()) {
+            log.warn("Pre H&S reroute implementation do not support reroute flow path targeting based on affected ISLs "
+                            + "set, provided set of affected ISLs {} are ignored, all path(s) belongs to flows {} will "
+                            + "be rerouted",
+                    affectedIsl.stream().map(IslEndpoint::toString).collect(Collectors.joining(", ")),
+                    flowId);
+        }
+        Set<PathId> affectedPaths = Collections.emptySet();
+
+        dashboardLogger.onFlowPathReroute(flowId, affectedIsl, forceToReroute);
 
         RerouteResult result;
         try {
-            result = doRerouteWithRetries(flowId, forceToReroute, pathIds);
+            result = doRerouteWithRetries(flowId, forceToReroute, affectedPaths);
         } catch (UnroutableFlowException e) {
             dashboardLogger.onFailedFlowReroute(flowId, "Path was not found. " + e.getMessage());
             throw e;

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/FlowRerouteHubBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/FlowRerouteHubBolt.java
@@ -15,6 +15,7 @@
 
 package org.openkilda.wfm.topology.flowhs.bolts;
 
+import static org.openkilda.messaging.Utils.CORRELATION_ID;
 import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.HUB_TO_HISTORY_BOLT;
 import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.HUB_TO_NB_RESPONSE_SENDER;
 import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.HUB_TO_SPEAKER_WORKER;
@@ -29,6 +30,7 @@ import org.openkilda.pce.PathComputer;
 import org.openkilda.pce.PathComputerConfig;
 import org.openkilda.pce.PathComputerFactory;
 import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.wfm.CommandContext;
 import org.openkilda.wfm.error.PipelineException;
 import org.openkilda.wfm.share.flow.resources.FlowResourcesConfig;
 import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
@@ -36,6 +38,7 @@ import org.openkilda.wfm.share.history.model.FlowHistoryHolder;
 import org.openkilda.wfm.share.hubandspoke.HubBolt;
 import org.openkilda.wfm.share.utils.KeyProvider;
 import org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream;
+import org.openkilda.wfm.topology.flowhs.model.FlowRerouteFact;
 import org.openkilda.wfm.topology.flowhs.service.FlowRerouteHubCarrier;
 import org.openkilda.wfm.topology.flowhs.service.FlowRerouteService;
 import org.openkilda.wfm.topology.utils.MessageKafkaTranslator;
@@ -45,6 +48,7 @@ import lombok.Getter;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
+import org.slf4j.MDC;
 
 public class FlowRerouteHubBolt extends HubBolt implements FlowRerouteHubCarrier {
 
@@ -83,8 +87,10 @@ public class FlowRerouteHubBolt extends HubBolt implements FlowRerouteHubCarrier
     protected void onRequest(Tuple input) throws PipelineException {
         currentKey = pullKey(input);
         FlowRerouteRequest request = pullValue(input, FIELD_ID_PAYLOAD, FlowRerouteRequest.class);
-        service.handleRequest(currentKey, pullContext(input), request.getFlowId(), request.getPathIds(),
-                request.isForce(), request.getReason());
+        FlowRerouteFact reroute = new FlowRerouteFact(
+                currentKey, getCommandContext(), request.getFlowId(), request.getAffectedIsl(), request.isForce(),
+                request.isEffectivelyDown(), request.getReason());
+        service.handleRequest(reroute);
     }
 
     @Override
@@ -122,6 +128,31 @@ public class FlowRerouteHubBolt extends HubBolt implements FlowRerouteHubCarrier
     @Override
     public void cancelTimeoutCallback(String key) {
         cancelCallback(key);
+    }
+
+    @Override
+    public void setupTimeoutCallback(String key) {
+        registerCallback(key);
+    }
+
+    /**
+     * "Hack" required to propagate execution context for postponed requests up to transport/carrier level.
+     */
+    @Override
+    public void injectRetry(FlowRerouteFact reroute) {
+        String originalKey = currentKey;
+        CommandContext originalCommandContext = getCommandContext();
+        try {
+            MDC.put(CORRELATION_ID, reroute.getCommandContext().getCorrelationId());
+            setCommandContext(reroute.getCommandContext());
+            currentKey = reroute.getKey();
+
+            service.handlePostponedRequest(reroute);
+        } finally {
+            currentKey = originalKey;
+            setCommandContext(originalCommandContext);
+            MDC.put(CORRELATION_ID, originalCommandContext.getCorrelationId());
+        }
     }
 
     @Override

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/RouterBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/RouterBolt.java
@@ -76,7 +76,7 @@ public class RouterBolt extends AbstractBolt {
         } else if (data instanceof FlowRerouteRequest) {
             FlowRerouteRequest rerouteRequest = (FlowRerouteRequest) data;
             log.debug("Received a reroute request {}/{} with key {}. MessageId {}", rerouteRequest.getFlowId(),
-                    rerouteRequest.getPathIds(), key, input.getMessageId());
+                    rerouteRequest.getAffectedIsl(), key, input.getMessageId());
             Values values = new Values(key, rerouteRequest.getFlowId(), data);
             emitWithContext(ROUTER_TO_FLOW_REROUTE_HUB.name(), input, values);
         } else if (data instanceof FlowDeleteRequest) {

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowContext.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowContext.java
@@ -18,9 +18,9 @@ package org.openkilda.wfm.topology.flowhs.fsm.common;
 import org.openkilda.floodlight.api.response.SpeakerFlowSegmentResponse;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 @AllArgsConstructor
 public abstract class FlowContext {
     private SpeakerFlowSegmentResponse speakerFlowResponse;

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/FlowRerouteFsm.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/FlowRerouteFsm.java
@@ -77,6 +77,7 @@ public final class FlowRerouteFsm extends FlowPathSwappingFsm<FlowRerouteFsm, St
     private boolean recreateIfSamePath;
     private boolean reroutePrimary;
     private boolean rerouteProtected;
+    private boolean effectivelyDown;
 
     private FlowStatus originalFlowStatus;
     private FlowEncapsulationType originalEncapsulationType;

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/PostResourceAllocationAction.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/PostResourceAllocationAction.java
@@ -21,6 +21,7 @@ import org.openkilda.messaging.info.event.PathInfoData;
 import org.openkilda.messaging.info.flow.FlowRerouteResponse;
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowPath;
+import org.openkilda.model.FlowStatus;
 import org.openkilda.model.PathId;
 import org.openkilda.persistence.FetchStrategy;
 import org.openkilda.persistence.PersistenceManager;
@@ -71,6 +72,10 @@ public class PostResourceAllocationAction extends
                 && stateMachine.getNewProtectedForwardPath() == null
                 && stateMachine.getNewProtectedReversePath() == null) {
             stateMachine.fireRerouteIsSkipped("Reroute is unsuccessful. Couldn't find new path(s)");
+        } else if (stateMachine.isEffectivelyDown()) {
+            log.warn("Flow {} is mentioned as effectively DOWN, so it will be forced to DOWN state if reroute fail",
+                     flowId);
+            stateMachine.setOriginalFlowStatus(FlowStatus.DOWN);
         }
 
         return Optional.of(buildRerouteResponseMessage(currentForwardPath, newForwardPath,

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/model/FlowRerouteFact.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/model/FlowRerouteFact.java
@@ -1,4 +1,4 @@
-/* Copyright 2019 Telstra Open Source
+/* Copyright 2020 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -13,34 +13,39 @@
  *   limitations under the License.
  */
 
-package org.openkilda.wfm.topology.flowhs.fsm.reroute;
+package org.openkilda.wfm.topology.flowhs.model;
 
-import org.openkilda.floodlight.api.response.SpeakerFlowSegmentResponse;
 import org.openkilda.model.IslEndpoint;
-import org.openkilda.wfm.topology.flowhs.fsm.common.FlowContext;
+import org.openkilda.wfm.CommandContext;
 
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.Value;
 
+import java.util.Collections;
 import java.util.Set;
 
-@Getter
-@EqualsAndHashCode(callSuper = true)
-public class FlowRerouteContext extends FlowContext {
+@Value
+public class FlowRerouteFact {
+    private String key;
+    private CommandContext commandContext;
     private String flowId;
     private Set<IslEndpoint> affectedIsl;
     private boolean forceReroute;
     private boolean effectivelyDown;
     private String rerouteReason;
 
-    @Builder
-    public FlowRerouteContext(
-            SpeakerFlowSegmentResponse speakerFlowResponse, String flowId, Set<IslEndpoint> affectedIsl,
+    public FlowRerouteFact(
+            String key, CommandContext commandContext, String flowId, Set<IslEndpoint> affectedIsl,
             boolean forceReroute, boolean effectivelyDown, String rerouteReason) {
-        super(speakerFlowResponse);
+        this.key = key;
+        this.commandContext = commandContext;
         this.flowId = flowId;
-        this.affectedIsl = affectedIsl;
+
+        if (affectedIsl == null) {
+            this.affectedIsl = Collections.emptySet();
+        } else {
+            this.affectedIsl = affectedIsl;
+        }
+
         this.forceReroute = forceReroute;
         this.effectivelyDown = effectivelyDown;
         this.rerouteReason = rerouteReason;

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteHubCarrier.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteHubCarrier.java
@@ -16,6 +16,7 @@
 package org.openkilda.wfm.topology.flowhs.service;
 
 import org.openkilda.messaging.Message;
+import org.openkilda.wfm.topology.flowhs.model.FlowRerouteFact;
 
 public interface FlowRerouteHubCarrier extends FlowGenericCarrier {
     /**
@@ -29,4 +30,8 @@ public interface FlowRerouteHubCarrier extends FlowGenericCarrier {
      * @param key operation identifier.
      */
     void cancelTimeoutCallback(String key);
+
+    void setupTimeoutCallback(String key);
+
+    void injectRetry(FlowRerouteFact retry);
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteService.java
@@ -17,9 +17,11 @@ package org.openkilda.wfm.topology.flowhs.service;
 
 import org.openkilda.floodlight.api.response.SpeakerFlowSegmentResponse;
 import org.openkilda.floodlight.flow.response.FlowErrorResponse;
-import org.openkilda.model.PathId;
+import org.openkilda.model.FlowStatus;
 import org.openkilda.pce.PathComputer;
 import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.persistence.repositories.FlowRepository;
+import org.openkilda.persistence.repositories.RepositoryFactory;
 import org.openkilda.persistence.repositories.history.FlowEventRepository;
 import org.openkilda.wfm.CommandContext;
 import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
@@ -28,18 +30,21 @@ import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteContext;
 import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteFsm;
 import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteFsm.Event;
 import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteFsm.State;
+import org.openkilda.wfm.topology.flowhs.model.FlowRerouteFact;
+import org.openkilda.wfm.topology.flowhs.utils.RerouteRetryManager;
 
 import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 @Slf4j
 public class FlowRerouteService {
     @VisibleForTesting
     final Map<String, FlowRerouteFsm> fsms = new HashMap<>();
+
+    private final RerouteRetryManager retryManager = new RerouteRetryManager();
 
     private final FlowRerouteFsm.Factory fsmFactory;
     private final FsmExecutor<FlowRerouteFsm, State, Event, FlowRerouteContext> fsmExecutor
@@ -48,6 +53,7 @@ public class FlowRerouteService {
     private final FlowRerouteHubCarrier carrier;
     private final PersistenceManager persistenceManager;
     private final FlowEventRepository flowEventRepository;
+    private final FlowRepository flowRepository;
     private final PathComputer pathComputer;
     private final FlowResourcesManager flowResourcesManager;
     private final int transactionRetriesLimit;
@@ -59,7 +65,11 @@ public class FlowRerouteService {
                               int speakerCommandRetriesLimit) {
         this.carrier = carrier;
         this.persistenceManager = persistenceManager;
-        flowEventRepository = persistenceManager.getRepositoryFactory().createFlowEventRepository();
+
+        final RepositoryFactory repositoryFactory = persistenceManager.getRepositoryFactory();
+        this.flowRepository = repositoryFactory.createFlowRepository();
+        this.flowEventRepository = repositoryFactory.createFlowEventRepository();
+
         this.pathComputer = pathComputer;
         this.flowResourcesManager = flowResourcesManager;
         this.transactionRetriesLimit = transactionRetriesLimit;
@@ -71,40 +81,29 @@ public class FlowRerouteService {
 
     /**
      * Handles request for flow reroute.
-     *
-     * @param key command identifier.
-     * @param flowId the flow to reroute.
-     * @param pathsToReroute the flow paths to reroute.
-     * @param forceReroute indicates that reroute must re-install paths even if they're the same.
-     * @param rerouteReason the reroute for auto-initiated reroute
      */
-    public void handleRequest(String key, CommandContext commandContext, String flowId, Set<PathId> pathsToReroute,
-                              boolean forceReroute, String rerouteReason) {
+    public void handleRequest(FlowRerouteFact reroute) {
+        final String key = reroute.getKey();
+        final String flowId = reroute.getFlowId();
         log.debug("Handling flow reroute request with key {} and flow ID: {}", key, flowId);
 
-        if (fsms.containsKey(key)) {
-            log.error("Attempt to create a FSM with key {}, while there's another active FSM with the same key.", key);
-            return;
+        if (retryManager.record(reroute)) {
+            initReroute(reroute);
+        } else {
+            carrier.cancelTimeoutCallback(key);
+            log.warn("Postpone (queue/merge) reroute request for flow {} (key={}, reasod={})",
+                     flowId, key, reroute.getRerouteReason());
         }
+    }
 
-        String eventKey = commandContext.getCorrelationId();
-        if (flowEventRepository.existsByTaskId(eventKey)) {
-            log.error("Attempt to reuse key {}, but there's a history record(s) for it.", eventKey);
-            return;
-        }
-
-        FlowRerouteFsm fsm = fsmFactory.newInstance(commandContext, flowId);
-        fsms.put(key, fsm);
-
-        FlowRerouteContext context = FlowRerouteContext.builder()
-                .flowId(flowId)
-                .pathsToReroute(pathsToReroute)
-                .forceReroute(forceReroute)
-                .rerouteReason(rerouteReason)
-                .build();
-        fsmExecutor.fire(fsm, Event.NEXT, context);
-
-        removeIfFinished(fsm, key);
+    /**
+     * Handle postponed flow reroute request.
+     */
+    public void handlePostponedRequest(FlowRerouteFact reroute) {
+        log.info("Handling postponed flow reroute request with key {} and flow ID: {}",
+                 reroute.getKey(), reroute.getFlowId());
+        carrier.setupTimeoutCallback(reroute.getKey());
+        initReroute(reroute);
     }
 
     /**
@@ -151,12 +150,78 @@ public class FlowRerouteService {
         removeIfFinished(fsm, key);
     }
 
+    private void initReroute(FlowRerouteFact reroute) {
+        final CommandContext commandContext = reroute.getCommandContext();
+
+        try {
+            checkRequestsCollision(reroute);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            performHousekeeping(reroute.getFlowId(), reroute.getKey());
+            fixFlowStatus(reroute);
+            return;
+        }
+
+        final String flowId =  reroute.getFlowId();
+        final String key = reroute.getKey();
+        FlowRerouteFsm fsm = fsmFactory.newInstance(commandContext, flowId);
+        fsms.put(key, fsm);
+
+        FlowRerouteContext context = FlowRerouteContext.builder()
+                .flowId(flowId)
+                .affectedIsl(reroute.getAffectedIsl())
+                .forceReroute(reroute.isForceReroute())
+                .effectivelyDown(reroute.isEffectivelyDown())
+                .rerouteReason(reroute.getRerouteReason())
+                .build();
+        fsmExecutor.fire(fsm, Event.NEXT, context);
+
+        removeIfFinished(fsm, key);
+    }
+
+    private void checkRequestsCollision(FlowRerouteFact reroute) {
+        if (fsms.containsKey(reroute.getKey())) {
+            throw new IllegalStateException(String.format(
+                    "Attempt to create a FSM with key %s, while there's another active FSM with the same key "
+                            + "(flowId=\"%s\")", reroute.getKey(), reroute.getFlowId()));
+        }
+
+        String eventKey = reroute.getCommandContext().getCorrelationId();
+        if (flowEventRepository.existsByTaskId(eventKey)) {
+            throw new IllegalStateException(String.format(
+                    "Attempt to reuse history key %s, but there's a history record(s) for it (flowId=\"%s\")",
+                    eventKey, reroute.getFlowId()));
+        }
+    }
+
     private void removeIfFinished(FlowRerouteFsm fsm, String key) {
         if (fsm.isTerminated()) {
             log.debug("FSM with key {} is finished with state {}", key, fsm.getCurrentState());
-            fsms.remove(key);
+            performHousekeeping(fsm.getFlowId(), key);
 
-            carrier.cancelTimeoutCallback(key);
+            // use some sort of recursion here, because iterative way require too complex scheme to clean/use retryQueue
+            retryManager.read(fsm.getFlowId()).ifPresent(carrier::injectRetry);
+        }
+    }
+
+    private void performHousekeeping(String flowId, String key) {
+        fsms.remove(key);
+        carrier.cancelTimeoutCallback(key);
+
+        FlowRerouteFact reroute = retryManager.discard(flowId)
+                .orElseThrow(() -> new IllegalStateException(String.format(
+                        "There is no current reroute into retry queue (flow=\"%s\", key=\"%s\")",
+                        flowId, key)));
+        if (! reroute.getKey().equals(key)) {
+            log.error(
+                    "Retry queue is broken, expect to remove record with key \"{}\" but got record with key=\"{}\" "
+                    + "(flowId=\"{}\")", key, reroute.getKey(), flowId);
+        }
+    }
+
+    private void fixFlowStatus(FlowRerouteFact reroute) {
+        if (reroute.isEffectivelyDown()) {
+            flowRepository.updateStatusSafe(reroute.getFlowId(), FlowStatus.DOWN);
         }
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/utils/RerouteRetryManager.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/utils/RerouteRetryManager.java
@@ -1,0 +1,71 @@
+/* Copyright 2020 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.utils;
+
+import org.openkilda.wfm.topology.flowhs.model.FlowRerouteFact;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+public class RerouteRetryManager {
+    private final Map<String, RerouteRetryQueue> queueByFlowId = new HashMap<>();
+
+    /**
+     * Register request in retry "queue" and check is it can be processed now. Return true if this request can be
+     * processed now.
+     */
+    public boolean record(FlowRerouteFact entity) {
+        RerouteRetryQueue queue = queueByFlowId.computeIfAbsent(
+                entity.getFlowId(), ignore -> new RerouteRetryQueue());
+        queue.add(entity);
+        log.info("Size of flow reroute queue for {} is {}", entity.getFlowId(), queue.size());
+        return queue.size() == 1;
+    }
+
+    /**
+     * Return "active" request.
+     */
+    public Optional<FlowRerouteFact> read(String flowId) {
+        RerouteRetryQueue queue = queueByFlowId.get(flowId);
+        if (queue == null) {
+            return Optional.empty();
+        }
+
+        // use method raises exception on empty queue access, because queue can't be empty by used design
+        return queue.get();
+    }
+
+    /**
+     * Remove "active" request.
+     */
+    public Optional<FlowRerouteFact> discard(String flowId) {
+        RerouteRetryQueue queue = queueByFlowId.get(flowId);
+        if (queue == null) {
+            return Optional.empty();
+        }
+
+        // use method raises exception on empty queue access, because queue can't be empty by used design
+        Optional<FlowRerouteFact> entity = queue.remove();
+        if (queue.isEmpty()) {
+            queueByFlowId.remove(flowId);
+        }
+        return entity;
+    }
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/utils/RerouteRetryQueue.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/flowhs/utils/RerouteRetryQueue.java
@@ -1,0 +1,87 @@
+/* Copyright 2020 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.utils;
+
+import org.openkilda.model.IslEndpoint;
+import org.openkilda.wfm.topology.flowhs.model.FlowRerouteFact;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+public class RerouteRetryQueue {
+    private FlowRerouteFact active = null;
+    private FlowRerouteFact pending = null;
+
+    /**
+     * Add request into "queue".
+     */
+    public void add(FlowRerouteFact reroute) {
+        if (active == null) {
+            active = reroute;
+        } else if (pending == null) {
+            pending = reroute;
+        } else {
+            pending = mergePending(pending, reroute);
+        }
+    }
+
+    /**
+     * Return first/active queue entry.
+     */
+    public Optional<FlowRerouteFact> get() {
+        return Optional.ofNullable(active);
+    }
+
+    /**
+     * Remove and return first/active queue entry.
+     */
+    public Optional<FlowRerouteFact> remove() {
+        FlowRerouteFact result = active;
+        active = pending;
+        pending = null;
+        return Optional.ofNullable(result);
+    }
+
+    /**
+     * Return queue size.
+     */
+    public int size() {
+        if (pending != null) {
+            return 2;
+        }
+        if (active != null) {
+            return 1;
+        }
+        return 0;
+    }
+
+    public boolean isEmpty() {
+        return active == null;
+    }
+
+    private static FlowRerouteFact mergePending(FlowRerouteFact pending, FlowRerouteFact reroute) {
+        boolean isForced = pending.isForceReroute() || reroute.isForceReroute();
+        boolean isEffectivelyDown = pending.isEffectivelyDown() || reroute.isEffectivelyDown();
+
+        Set<IslEndpoint> affectedIsl = new HashSet<>(pending.getAffectedIsl());
+        affectedIsl.addAll(reroute.getAffectedIsl());
+
+        return new FlowRerouteFact(
+                reroute.getKey(), reroute.getCommandContext(), reroute.getFlowId(), affectedIsl,
+                isForced, isEffectivelyDown, reroute.getRerouteReason());
+    }
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/services/FlowOperationsService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/services/FlowOperationsService.java
@@ -17,6 +17,7 @@ package org.openkilda.wfm.topology.nbworker.services;
 
 import static org.apache.commons.collections4.ListUtils.union;
 
+import org.openkilda.messaging.command.flow.FlowRerouteRequest;
 import org.openkilda.messaging.model.FlowDto;
 import org.openkilda.messaging.model.FlowPathDto;
 import org.openkilda.messaging.model.FlowPathDto.FlowPathDtoBuilder;
@@ -26,7 +27,7 @@ import org.openkilda.model.ConnectedDevice;
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowPair;
 import org.openkilda.model.FlowPath;
-import org.openkilda.model.PathId;
+import org.openkilda.model.IslEndpoint;
 import org.openkilda.model.SwitchId;
 import org.openkilda.model.UnidirectionalFlow;
 import org.openkilda.persistence.TransactionManager;
@@ -49,8 +50,8 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -135,18 +136,6 @@ public class FlowOperationsService {
             return flowPaths;
         }
 
-    }
-
-    /**
-     * Groups passed flow paths by flow id.
-     *
-     * @param paths the flow paths for grouping.
-     * @return map with grouped grouped flow paths.
-     */
-    public Map<String, Set<PathId>> groupFlowIdWithPathIdsForRerouting(Collection<FlowPath> paths) {
-        return paths.stream()
-                .collect(Collectors.groupingBy(path -> path.getFlow().getFlowId(),
-                        Collectors.mapping(FlowPath::getPathId, Collectors.toSet())));
     }
 
     public Optional<FlowPair> getFlowPairById(String flowId) {
@@ -298,5 +287,24 @@ public class FlowOperationsService {
 
             return connectedDeviceRepository.findByFlowId(flowId);
         });
+    }
+
+    /**
+     * Produce reroute request for all affected paths/flows.
+     */
+    public List<FlowRerouteRequest> makeRerouteRequests(
+            Collection<FlowPath> targetPaths, Set<IslEndpoint> affectedIslEndpoints, String reason) {
+        List<FlowRerouteRequest> results = new ArrayList<>();
+        Set<String> processed = new HashSet<>();
+        for (FlowPath entry : targetPaths) {
+            Flow flow = entry.getFlow();
+            if (processed.add(flow.getFlowId())) {
+                FlowRerouteRequest request = new FlowRerouteRequest(
+                        flow.getFlowId(), false, false, affectedIslEndpoints, reason);
+                results.add(request);
+            }
+        }
+
+        return results;
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/services/SwitchOperationsService.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/nbworker/services/SwitchOperationsService.java
@@ -22,6 +22,7 @@ import org.openkilda.messaging.nbtopology.response.GetSwitchResponse;
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowPath;
 import org.openkilda.model.Isl;
+import org.openkilda.model.IslEndpoint;
 import org.openkilda.model.IslStatus;
 import org.openkilda.model.PortProperties;
 import org.openkilda.model.Switch;
@@ -308,5 +309,14 @@ public class SwitchOperationsService implements ILinkOperationsServiceCarrier {
                                 .orElseThrow(() -> new SwitchNotFoundException(switchId)))
                         .port(port)
                         .build());
+    }
+
+    /**
+     * Find and return all {@code IslEndpoint} for all ISL detected for this switch.
+     */
+    public List<IslEndpoint> getSwitchIslEndpoints(SwitchId switchId) {
+        return islRepository.findBySrcSwitch(switchId).stream()
+                .map(isl -> new IslEndpoint(switchId, isl.getSrcPort()))
+                .collect(Collectors.toList());
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/reroute/bolts/FlowThrottlingBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/reroute/bolts/FlowThrottlingBolt.java
@@ -70,8 +70,8 @@ public class FlowThrottlingBolt extends AbstractTickStatefulBolt<InMemoryKeyValu
             FlowThrottlingData throttlingData = entry.getValue();
             CommandContext forkedContext = new CommandContext(throttlingData.getCorrelationId()).fork(flowId);
 
-            FlowRerouteRequest request = new FlowRerouteRequest(flowId, false, throttlingData.getPathIdSet(),
-                    "initiated by Reroute topology");
+            FlowRerouteRequest request = new FlowRerouteRequest(
+                    flowId, false, true, throttlingData.getAffectedIsl(), "initiated by Reroute topology");
             outputCollector.emit(flowsRerouteViaFlowHs ? STREAM_FLOWHS_ID : STREAM_FLOW_ID,
                     tuple, new Values(forkedContext.getCorrelationId(),
                             new CommandMessage(request, System.currentTimeMillis(), forkedContext.getCorrelationId())));

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/reroute/bolts/MessageSender.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/reroute/bolts/MessageSender.java
@@ -17,12 +17,12 @@ package org.openkilda.wfm.topology.reroute.bolts;
 
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowPath;
-import org.openkilda.model.PathId;
+import org.openkilda.model.IslEndpoint;
 
 import java.util.Set;
 
 public interface MessageSender {
-    void emitRerouteCommand(String correlationId, Flow flow, Set<PathId> paths, String reason);
+    void emitRerouteCommand(String correlationId, Flow flow, Set<IslEndpoint> affectedIsl, String reason);
 
     void emitPathSwapCommand(String correlationId, FlowPath path, String reason);
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/reroute/bolts/RerouteBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/reroute/bolts/RerouteBolt.java
@@ -22,7 +22,7 @@ import org.openkilda.messaging.command.reroute.RerouteAffectedFlows;
 import org.openkilda.messaging.command.reroute.RerouteInactiveFlows;
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowPath;
-import org.openkilda.model.PathId;
+import org.openkilda.model.IslEndpoint;
 import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.wfm.AbstractBolt;
 import org.openkilda.wfm.error.PipelineException;
@@ -88,12 +88,12 @@ public class RerouteBolt extends AbstractBolt implements MessageSender {
      * Emit reroute command for consumer.
      * @param correlationId correlation id to pass through
      * @param flow affected flow
-     * @param paths affected paths
+     * @param affectedIsl affected paths
      * @param reason inital reason of reroute
      */
-    public void emitRerouteCommand(String correlationId, Flow flow, Set<PathId> paths, String reason) {
+    public void emitRerouteCommand(String correlationId, Flow flow, Set<IslEndpoint> affectedIsl, String reason) {
         getOutput().emit(getCurrentTuple(), new Values(flow.getFlowId(),
-                new FlowThrottlingData(correlationId, flow.getPriority(), flow.getTimeCreate(), paths)));
+                new FlowThrottlingData(correlationId, flow.getPriority(), flow.getTimeCreate(), affectedIsl)));
 
         log.warn("Flow {} reroute command message sent with correlationId {}, reason \"{}\"",
                 flow.getFlowId(), correlationId, reason);

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/reroute/model/FlowThrottlingData.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/reroute/model/FlowThrottlingData.java
@@ -15,29 +15,37 @@
 
 package org.openkilda.wfm.topology.reroute.model;
 
-import org.openkilda.model.PathId;
+import org.openkilda.model.IslEndpoint;
 
 import com.google.common.annotations.VisibleForTesting;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 @Data
-@AllArgsConstructor
 public class FlowThrottlingData implements Serializable {
     private String correlationId;
     private Integer priority;
     private Instant timeCreate;
-    private Set<PathId> pathIdSet;
+    private Set<IslEndpoint> affectedIsl;
 
     @VisibleForTesting
     public FlowThrottlingData(String correlationId, Integer priority) {
+        this(correlationId, priority, Instant.now(), Collections.emptySet());
+    }
+
+    public FlowThrottlingData(
+            String correlationId, Integer priority, Instant timeCreate, Set<IslEndpoint> affectedIsl) {
         this.correlationId = correlationId;
         this.priority = priority;
-        pathIdSet = Collections.emptySet();
+        this.timeCreate = timeCreate;
+
+        // FIXME(surabujin): this field treats as mutable set by object owners
+        //  org.openkilda.wfm.topology.reroute.service.ReroutesThrottling.putRequest
+        this.affectedIsl = new HashSet<>(affectedIsl);
     }
 }

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/reroute/service/ReroutesThrottling.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/reroute/service/ReroutesThrottling.java
@@ -60,7 +60,7 @@ public class ReroutesThrottling {
         log.info("Puts flow {} with correlationId {}", flowId, throttlingData.getCorrelationId());
         FlowThrottlingData prevThrottlingData = reroutes.put(flowId, throttlingData);
         if (prevThrottlingData != null) {
-            throttlingData.getPathIdSet().addAll(prevThrottlingData.getPathIdSet());
+            throttlingData.getAffectedIsl().addAll(prevThrottlingData.getAffectedIsl());
 
             log.info("Previous flow {} with correlationId {} was dropped.",
                     flowId, prevThrottlingData.getCorrelationId());

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/service/AbstractFlowTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/service/AbstractFlowTest.java
@@ -107,6 +107,16 @@ public abstract class AbstractFlowTest {
         ));
     }
 
+    protected SpeakerFlowSegmentResponse buildSpeakerResponse(FlowSegmentRequest flowRequest) {
+        return SpeakerFlowSegmentResponse.builder()
+                        .messageContext(flowRequest.getMessageContext())
+                        .commandId(flowRequest.getCommandId())
+                        .metadata(flowRequest.getMetadata())
+                        .switchId(flowRequest.getSwitchId())
+                        .success(true)
+                        .build();
+    }
+
     Answer getSpeakerCommandsAnswer() {
         return invocation -> {
             FlowSegmentRequest request = invocation.getArgument(0);

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteServiceTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteServiceTest.java
@@ -18,6 +18,8 @@ package org.openkilda.wfm.topology.flowhs.service;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -26,6 +28,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,6 +45,7 @@ import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.FlowPath;
 import org.openkilda.model.FlowPathStatus;
 import org.openkilda.model.FlowStatus;
+import org.openkilda.model.IslEndpoint;
 import org.openkilda.model.MeterId;
 import org.openkilda.model.PathId;
 import org.openkilda.model.PathSegment;
@@ -59,10 +63,12 @@ import org.openkilda.persistence.repositories.SwitchPropertiesRepository;
 import org.openkilda.persistence.repositories.SwitchRepository;
 import org.openkilda.persistence.repositories.history.FlowEventRepository;
 import org.openkilda.wfm.CommandContext;
+import org.openkilda.wfm.share.flow.resources.EncapsulationResources;
 import org.openkilda.wfm.share.flow.resources.FlowResources;
 import org.openkilda.wfm.share.flow.resources.FlowResources.PathResources;
 import org.openkilda.wfm.share.flow.resources.ResourceAllocationException;
 import org.openkilda.wfm.share.flow.resources.transitvlan.TransitVlanEncapsulation;
+import org.openkilda.wfm.topology.flowhs.model.FlowRerouteFact;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -70,7 +76,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -82,6 +92,7 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
     private static final String FLOW_ID = "TEST_FLOW";
     private static final SwitchId SWITCH_1 = new SwitchId(1);
     private static final SwitchId SWITCH_2 = new SwitchId(2);
+    private static final SwitchId SWITCH_3 = new SwitchId(3);
     private static final PathId OLD_FORWARD_FLOW_PATH = new PathId(FLOW_ID + "_forward_old");
     private static final PathId OLD_REVERSE_FLOW_PATH = new PathId(FLOW_ID + "_reverse_old");
     private static final PathId NEW_FORWARD_FLOW_PATH = new PathId(FLOW_ID + "_forward_new");
@@ -91,8 +102,14 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
     private FlowRerouteHubCarrier carrier;
     @Mock
     private CommandContext commandContext;
+    @Mock
+    private FlowEventRepository flowEventRepository;
 
     private FlowRerouteService rerouteService;
+
+    private String currentRequestKey;
+
+    private Map<SwitchId, Switch> swMap = new HashMap<>();
 
     @Before
     public void setUp() {
@@ -116,7 +133,6 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
                         .build()));
         when(repositoryFactory.createSwitchPropertiesRepository()).thenReturn(switchPropertiesRepository);
 
-        FlowEventRepository flowEventRepository = mock(FlowEventRepository.class);
         when(flowEventRepository.existsByTaskId(any())).thenReturn(false);
         when(repositoryFactory.createFlowEventRepository()).thenReturn(flowEventRepository);
 
@@ -124,9 +140,24 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
 
         doAnswer(getSpeakerCommandsAnswer()).when(carrier).sendSpeakerRequest(any());
 
+        doAnswer(invocation -> {
+            FlowRerouteFact retry = invocation.getArgument(0);
+            currentRequestKey = retry.getKey();
+            rerouteService.handlePostponedRequest(retry);
+            return null;
+        }).when(carrier).injectRetry(any());
+
         rerouteService = new FlowRerouteService(carrier, persistenceManager,
                 pathComputer, flowResourcesManager, TRANSACTION_RETRIES_LIMIT,
                 PATH_ALLOCATION_RETRIES_LIMIT, PATH_ALLOCATION_RETRY_DELAY, SPEAKER_COMMAND_RETRIES_LIMIT);
+
+        currentRequestKey = "test-key";
+
+        for (SwitchId id : new SwitchId[] {SWITCH_1, SWITCH_2, SWITCH_3}) {
+            Switch entry = makeSwitch(id);
+            swMap.put(id, entry);
+            when(switchRepository.findById(eq(id))).thenReturn(Optional.of(entry));
+        }
     }
 
     @Test
@@ -136,7 +167,8 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         when(pathComputer.getPath(any(), any())).thenThrow(new UnroutableFlowException("No path found"));
         buildFlowResources();
 
-        rerouteService.handleRequest("test_key", commandContext, FLOW_ID, null, false, null);
+        rerouteService.handleRequest(new FlowRerouteFact(
+                "test_key", commandContext, FLOW_ID, null, false, false, null));
 
         assertEquals(FlowStatus.DOWN, flow.getStatus());
         assertEquals(OLD_FORWARD_FLOW_PATH, flow.getForwardPathId());
@@ -154,7 +186,8 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         when(pathComputer.getPath(any(), any())).thenThrow(new RecoverableException("PCE error"));
         buildFlowResources();
 
-        rerouteService.handleRequest("test_key", commandContext, FLOW_ID, null, false, null);
+        rerouteService.handleRequest(new FlowRerouteFact(
+                "test_key", commandContext, FLOW_ID, null, false, false, null));
 
         assertEquals(FlowStatus.UP, flow.getStatus());
         assertEquals(OLD_FORWARD_FLOW_PATH, flow.getForwardPathId());
@@ -175,7 +208,8 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         when(islRepository.updateAvailableBandwidth(any(), anyInt(), any(), anyInt(), anyLong()))
                 .thenThrow(ResourceAllocationException.class);
 
-        rerouteService.handleRequest("test_key", commandContext, FLOW_ID, null, false, null);
+        rerouteService.handleRequest(new FlowRerouteFact(
+                "test_key", commandContext, FLOW_ID, null, false, false, null));
 
         assertEquals(FlowStatus.UP, flow.getStatus());
         assertEquals(OLD_FORWARD_FLOW_PATH, flow.getForwardPathId());
@@ -196,7 +230,8 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         when(flowResourcesManager.allocateFlowResources(any()))
                 .thenThrow(new ResourceAllocationException("No resources"));
 
-        rerouteService.handleRequest("test_key", commandContext, FLOW_ID, null, false, null);
+        rerouteService.handleRequest(new FlowRerouteFact(
+                "test_key", commandContext, FLOW_ID, null, false, false, null));
 
         assertEquals(FlowStatus.UP, flow.getStatus());
         assertEquals(OLD_FORWARD_FLOW_PATH, flow.getForwardPathId());
@@ -215,7 +250,8 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         buildFlowResources();
         doThrow(new RuntimeException("Must fail")).when(flowPathRepository).lockInvolvedSwitches(any(), any());
 
-        rerouteService.handleRequest("test_key", commandContext, FLOW_ID, null, false, null);
+        rerouteService.handleRequest(new FlowRerouteFact(
+                "test_key", commandContext, FLOW_ID, null, false, false, null));
 
         verify(flowResourcesManager, times(0)).deallocatePathResources(any());
         verify(flowResourcesManager, times(0)).deallocatePathResources(any(), anyLong(), any(), any());
@@ -228,7 +264,8 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         when(pathComputer.getPath(any(), any())).thenReturn(build2SwitchPathPair());
         buildFlowResources();
 
-        rerouteService.handleRequest("test_key", commandContext, FLOW_ID, null, false, null);
+        rerouteService.handleRequest(new FlowRerouteFact(
+                "test_key", commandContext, FLOW_ID, null, false, false, null));
 
         assertEquals(FlowStatus.UP, flow.getStatus());
         assertEquals(OLD_FORWARD_FLOW_PATH, flow.getForwardPathId());
@@ -244,7 +281,8 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         when(pathComputer.getPath(any(), any())).thenReturn(build2SwitchPathPair(2, 3));
         buildFlowResources();
 
-        rerouteService.handleRequest("test_key", commandContext, FLOW_ID, null, false, null);
+        rerouteService.handleRequest(new FlowRerouteFact(
+                "test_key", commandContext, FLOW_ID, null, false, false, null));
 
         assertEquals(FlowStatus.IN_PROGRESS, flow.getStatus());
         verify(carrier, times(1)).sendNorthboundResponse(any());
@@ -283,7 +321,8 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         when(pathComputer.getPath(any(), any())).thenReturn(build2SwitchPathPair(2, 3));
         buildFlowResources();
 
-        rerouteService.handleRequest("test_key", commandContext, FLOW_ID, null, false, null);
+        rerouteService.handleRequest(new FlowRerouteFact(
+                "test_key", commandContext, FLOW_ID, null, false, false, null));
 
         assertEquals(FlowStatus.IN_PROGRESS, flow.getStatus());
         verify(carrier, times(1)).sendNorthboundResponse(any());
@@ -292,15 +331,7 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
 
         FlowSegmentRequest request;
         while ((request = requests.poll()) != null) {
-            if (request.isRemoveRequest()) {
-                rerouteService.handleAsyncResponse("test_key", SpeakerFlowSegmentResponse.builder()
-                        .messageContext(request.getMessageContext())
-                        .commandId(request.getCommandId())
-                        .metadata(request.getMetadata())
-                        .switchId(request.getSwitchId())
-                        .success(true)
-                        .build());
-            }
+            produceAsyncResponse("test_key", request);
         }
 
         assertEquals(FlowStatus.UP, flow.getStatus());
@@ -315,7 +346,8 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         when(pathComputer.getPath(any(), any())).thenReturn(build2SwitchPathPair(2, 3));
         buildFlowResources();
 
-        rerouteService.handleRequest("test_key", commandContext, FLOW_ID, null, false, null);
+        rerouteService.handleRequest(new FlowRerouteFact(
+                "test_key", commandContext, FLOW_ID, null, false, false, null));
 
         assertEquals(FlowStatus.IN_PROGRESS, flow.getStatus());
         verify(carrier, times(1)).sendNorthboundResponse(any());
@@ -354,7 +386,8 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         when(pathComputer.getPath(any(), any())).thenReturn(build2SwitchPathPair(2, 3));
         buildFlowResources();
 
-        rerouteService.handleRequest("test_key", commandContext, FLOW_ID, null, false, null);
+        rerouteService.handleRequest(new FlowRerouteFact(
+                "test_key", commandContext, FLOW_ID, null, false, false, null));
 
         assertEquals(FlowStatus.IN_PROGRESS, flow.getStatus());
         verify(carrier, times(1)).sendNorthboundResponse(any());
@@ -386,7 +419,8 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         when(pathComputer.getPath(any(), any())).thenReturn(build2SwitchPathPair(2, 3));
         buildFlowResources();
 
-        rerouteService.handleRequest("test_key", commandContext, FLOW_ID, null, false, null);
+        rerouteService.handleRequest(new FlowRerouteFact(
+                "test_key", commandContext, FLOW_ID, null, false, false, null));
 
         assertEquals(FlowStatus.IN_PROGRESS, flow.getStatus());
         verify(carrier, times(1)).sendNorthboundResponse(any());
@@ -434,7 +468,8 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         when(pathComputer.getPath(any(), any())).thenReturn(build2SwitchPathPair(2, 3));
         buildFlowResources();
 
-        rerouteService.handleRequest("test_key", commandContext, FLOW_ID, null, false, null);
+        rerouteService.handleRequest(new FlowRerouteFact(
+                "test_key", commandContext, FLOW_ID, null, false, false, null));
 
         assertEquals(FlowStatus.IN_PROGRESS, flow.getStatus());
         verify(carrier, times(1)).sendNorthboundResponse(any());
@@ -474,7 +509,8 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         when(pathComputer.getPath(any(), any())).thenReturn(build2SwitchPathPair(2, 3));
         buildFlowResources();
 
-        rerouteService.handleRequest("test_key", commandContext, FLOW_ID, null, false, null);
+        rerouteService.handleRequest(new FlowRerouteFact(
+                "test_key", commandContext, FLOW_ID, null, false, false, null));
 
         assertEquals(FlowStatus.IN_PROGRESS, flow.getStatus());
         verify(carrier, times(1)).sendNorthboundResponse(any());
@@ -485,17 +521,7 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
 
         FlowSegmentRequest request;
         while ((request = requests.poll()) != null) {
-            if (request.isVerifyRequest()) {
-                rerouteService.handleAsyncResponse("test_key", buildResponseOnVerifyRequest(request));
-            } else {
-                rerouteService.handleAsyncResponse("test_key", SpeakerFlowSegmentResponse.builder()
-                        .messageContext(request.getMessageContext())
-                        .commandId(request.getCommandId())
-                        .metadata(request.getMetadata())
-                        .switchId(request.getSwitchId())
-                        .success(true)
-                        .build());
-            }
+            produceAsyncResponse("test_key", request);
         }
 
         assertEquals(FlowStatus.UP, flow.getStatus());
@@ -510,7 +536,8 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         when(pathComputer.getPath(any(), any())).thenReturn(build2SwitchPathPair(2, 3));
         buildFlowResources();
 
-        rerouteService.handleRequest("test_key", commandContext, FLOW_ID, null, false, null);
+        rerouteService.handleRequest(new FlowRerouteFact(
+                "test_key", commandContext, FLOW_ID, null, false, false, null));
 
         assertEquals(FlowStatus.IN_PROGRESS, flow.getStatus());
         verify(carrier, times(1)).sendNorthboundResponse(any());
@@ -546,27 +573,20 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         Flow flow = build2SwitchFlow();
         flow.setStatus(FlowStatus.DOWN);
 
-        when(pathComputer.getPath(any(), any())).thenReturn(build2SwitchPathPair(2, 3));
+        when(pathComputer.getPath(any(), any()))
+                .thenReturn(build2SwitchPathPair(2, 3))
+                .thenReturn(build3SwitchPathPair());
         buildFlowResources();
 
-        rerouteService.handleRequest("test_key", commandContext, FLOW_ID, null, false, null);
+        rerouteService.handleRequest(new FlowRerouteFact(
+                "test_key", commandContext, FLOW_ID, null, false, false, null));
 
         assertEquals(FlowStatus.IN_PROGRESS, flow.getStatus());
         verify(carrier, times(1)).sendNorthboundResponse(any());
 
         FlowSegmentRequest request;
         while ((request = requests.poll()) != null) {
-            if (request.isVerifyRequest()) {
-                rerouteService.handleAsyncResponse("test_key", buildResponseOnVerifyRequest(request));
-            } else {
-                rerouteService.handleAsyncResponse("test_key", SpeakerFlowSegmentResponse.builder()
-                        .messageContext(request.getMessageContext())
-                        .commandId(request.getCommandId())
-                        .metadata(request.getMetadata())
-                        .switchId(request.getSwitchId())
-                        .success(true)
-                        .build());
-            }
+            produceAsyncResponse("test_key", request);
         }
 
         assertEquals(FlowStatus.UP, flow.getStatus());
@@ -574,36 +594,166 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         assertEquals(NEW_REVERSE_FLOW_PATH, flow.getReversePathId());
     }
 
-    private PathPair build2SwitchPathPair() {
-        return build2SwitchPathPair(1, 2);
+    @Test
+    public void shouldSuccessfullyHandleOverlappingRequests()
+            throws RecoverableException, UnroutableFlowException, ResourceAllocationException {
+        Flow flow = build2SwitchFlow();
+        flow.setStatus(FlowStatus.DOWN);
+
+        when(pathComputer.getPath(any(), any()))
+                .thenReturn(build2SwitchPathPair(2, 3))
+                .thenReturn(build3SwitchPathPair());
+
+        FlowResources resourcesOrigin = makeFlowResources(
+                flow.getFlowId(), flow.getForwardPathId(), flow.getReversePathId());
+
+        PathId pathForwardFirst = new PathId(flow.getFlowId() + "_forward_first");
+        PathId pathReverseFirst = new PathId(flow.getFlowId() + "_reverse_first");
+        FlowResources resourcesFirst = makeFlowResources(
+                flow.getFlowId(), pathForwardFirst, pathReverseFirst, resourcesOrigin);
+
+        PathId pathForwardSecond = new PathId(flow.getFlowId() + "_forward_second");
+        PathId pathReverseSecond = new PathId(flow.getFlowId() + "_reverse_second");
+        FlowResources resourcesSecond = makeFlowResources(
+                flow.getFlowId(), pathForwardSecond, pathReverseSecond, resourcesFirst);
+
+        when(flowResourcesManager.allocateFlowResources(any()))
+                .thenReturn(resourcesFirst)
+                .thenReturn(resourcesSecond);
+
+        rerouteService.handleRequest(new FlowRerouteFact(
+                currentRequestKey, commandContext, flow.getFlowId(), null, false, false, null));
+        assertEquals(FlowStatus.IN_PROGRESS, flow.getStatus());
+
+        rerouteService.handleRequest(new FlowRerouteFact(
+                "test_key2", commandContext, flow.getFlowId(), null, false, false, null));
+        assertEquals(FlowStatus.IN_PROGRESS, flow.getStatus());
+
+        FlowSegmentRequest request;
+        while ((request = requests.poll()) != null) {
+            produceAsyncResponse(currentRequestKey, request);
+        }
+
+        assertEquals(FlowStatus.UP, flow.getStatus());
+        assertEquals(pathForwardSecond, flow.getForwardPathId());
+        assertEquals(pathReverseSecond, flow.getReversePathId());
     }
 
-    private PathPair build2SwitchPathPair(int srcPort, int destPort) {
-        return PathPair.builder()
-                .forward(Path.builder()
-                        .srcSwitchId(SWITCH_1).destSwitchId(SWITCH_2)
-                        .segments(Collections.singletonList(Segment.builder()
-                                .srcSwitchId(SWITCH_1)
-                                .srcPort(srcPort)
-                                .destSwitchId(SWITCH_2)
-                                .destPort(destPort)
-                                .build()))
-                        .build())
-                .reverse(Path.builder()
-                        .srcSwitchId(SWITCH_2).destSwitchId(SWITCH_1)
-                        .segments(Collections.singletonList(Segment.builder()
-                                .srcSwitchId(SWITCH_2)
-                                .srcPort(destPort)
-                                .destSwitchId(SWITCH_1)
-                                .destPort(srcPort)
-                                .build()))
-                        .build())
-                .build();
+    @Test
+    public void shouldFixFlowStatusOnRequestConflict() {
+        Flow flow = build2SwitchFlow();
+        flow.setStatus(FlowStatus.UP);
+
+        reset(flowEventRepository);
+        when(flowEventRepository.existsByTaskId(any()))
+                .thenReturn(true)
+                .thenReturn(true);
+
+        rerouteService.handleRequest(new FlowRerouteFact(
+                currentRequestKey, commandContext, flow.getFlowId(), null, false, false, null));
+        FlowSegmentRequest request;
+        while ((request = requests.poll()) != null) {
+            produceAsyncResponse(currentRequestKey, request);
+        }
+        assertEquals(FlowStatus.UP, flow.getStatus());
+
+        rerouteService.handleRequest(new FlowRerouteFact(
+                currentRequestKey, commandContext, flow.getFlowId(), null, false, true, null));
+        while ((request = requests.poll()) != null) {
+            produceAsyncResponse(currentRequestKey, request);
+        }
+        assertEquals(FlowStatus.DOWN, flow.getStatus());
+    }
+
+    @Test
+    public void shouldMakeFlowDontOnTimeoutIfEffectivelyDown()
+            throws RecoverableException, UnroutableFlowException, ResourceAllocationException {
+        Flow flow = build2SwitchFlow();
+        when(pathComputer.getPath(any(), any())).thenReturn(build2SwitchPathPair(2, 3));
+        buildFlowResources();
+
+        rerouteService.handleRequest(new FlowRerouteFact(
+                currentRequestKey, commandContext, FLOW_ID, null, false, true, null));
+
+        assertEquals(FlowStatus.IN_PROGRESS, flow.getStatus());
+        verify(carrier, times(1)).sendNorthboundResponse(any());
+
+        rerouteService.handleTimeout(currentRequestKey);
+
+        FlowSegmentRequest request;
+        while ((request = requests.poll()) != null) {
+            produceAsyncResponse(currentRequestKey, request);
+        }
+
+        assertEquals(FlowStatus.DOWN, flow.getStatus());
+        assertEquals(OLD_FORWARD_FLOW_PATH, flow.getForwardPathId());
+        assertEquals(OLD_REVERSE_FLOW_PATH, flow.getReversePathId());
+    }
+
+    @Test
+    public void shouldIgnoreEffectivelyDownStateIfSamePaths() throws RecoverableException, UnroutableFlowException {
+        Flow flow = build2SwitchFlow();
+        when(pathComputer.getPath(any(), any())).thenReturn(build2SwitchPathPair());
+
+        rerouteService.handleRequest(new FlowRerouteFact(
+                currentRequestKey, commandContext, FLOW_ID, null, false, true, null));
+
+        FlowSegmentRequest request;
+        while ((request = requests.poll()) != null) {
+            produceAsyncResponse(currentRequestKey, request);
+        }
+
+        assertEquals(FlowStatus.UP, flow.getStatus());
+        assertEquals(OLD_FORWARD_FLOW_PATH, flow.getForwardPathId());
+        assertEquals(OLD_REVERSE_FLOW_PATH, flow.getReversePathId());
+    }
+
+    @Test
+    public void shouldProcessRerouteForValidRequest()
+            throws RecoverableException, UnroutableFlowException, ResourceAllocationException {
+        Flow flow = build2SwitchFlow();
+        when(pathComputer.getPath(any(), any())).thenReturn(build2SwitchPathPair(2, 3));
+        buildFlowResources();
+
+        IslEndpoint affectedEndpoint = extractIslEndpoint(flow);
+        rerouteService.handleRequest(new FlowRerouteFact(
+                currentRequestKey, commandContext, FLOW_ID, Collections.singleton(affectedEndpoint), false, true,
+                null));
+        assertEquals(FlowStatus.IN_PROGRESS, flow.getStatus());
+
+        FlowSegmentRequest request;
+        while ((request = requests.poll()) != null) {
+            produceAsyncResponse(currentRequestKey, request);
+        }
+
+        assertEquals(FlowStatus.UP, flow.getStatus());
+        assertEquals(NEW_FORWARD_FLOW_PATH, flow.getForwardPathId());
+        assertEquals(NEW_REVERSE_FLOW_PATH, flow.getReversePathId());
+    }
+
+    @Test
+    public void shouldSkipRerouteOnOutdatedRequest() {
+        Flow flow = build2SwitchFlow();
+
+        IslEndpoint affectedEndpoint = extractIslEndpoint(flow);
+        IslEndpoint notAffectedEndpoint = new IslEndpoint(
+                affectedEndpoint.getSwitchId(), affectedEndpoint.getPortNumber() + 1);
+        rerouteService.handleRequest(new FlowRerouteFact(
+                currentRequestKey, commandContext, FLOW_ID, Collections.singleton(notAffectedEndpoint), false, true,
+                null));
+
+        assertEquals(FlowStatus.UP, flow.getStatus());
+        assertEquals(OLD_FORWARD_FLOW_PATH, flow.getForwardPathId());
+        assertEquals(OLD_REVERSE_FLOW_PATH, flow.getReversePathId());
+    }
+
+    protected void produceAsyncResponse(String key, FlowSegmentRequest flowRequest) {
+        rerouteService.handleAsyncResponse(key, buildSpeakerResponse(flowRequest));
     }
 
     private Flow build2SwitchFlow() {
-        Switch src = Switch.builder().switchId(SWITCH_1).build();
-        Switch dst = Switch.builder().switchId(SWITCH_2).build();
+        Switch src = swMap.get(SWITCH_1);
+        Switch dst = swMap.get(SWITCH_2);
 
         Flow flow = Flow.builder().flowId(FLOW_ID)
                 .srcSwitch(src).destSwitch(dst)
@@ -641,14 +791,21 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
                 .build()));
         flow.setReversePath(oldReversePath);
 
-        when(flowRepository.findById(any())).thenReturn(Optional.of(flow));
-        when(flowRepository.findById(any(), any())).thenReturn(Optional.of(flow));
+        when(flowRepository.findById(eq(flow.getFlowId()))).thenReturn(Optional.of(flow));
+        when(flowRepository.findById(eq(flow.getFlowId()), any())).thenReturn(Optional.of(flow));
 
         doAnswer(invocation -> {
             FlowStatus status = invocation.getArgument(1);
             flow.setStatus(status);
             return null;
-        }).when(flowRepository).updateStatus(any(), any());
+        }).when(flowRepository).updateStatus(eq(flow.getFlowId()), any());
+        doAnswer(invocation -> {
+            FlowStatus status = invocation.getArgument(1);
+            if (FlowStatus.IN_PROGRESS != flow.getStatus()) {
+                flow.setStatus(status);
+            }
+            return null;
+        }).when(flowRepository).updateStatusSafe(eq(flow.getFlowId()), any());
 
         doAnswer(invocation -> {
             PathId pathId = invocation.getArgument(0);
@@ -658,50 +815,165 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         doAnswer(invocation -> {
             PathId pathId = invocation.getArgument(0);
             FlowPathStatus status = invocation.getArgument(1);
-            flow.getPath(pathId).get().setStatus(status);
+            flow.getPath(pathId).ifPresent(entity -> entity.setStatus(status));
             return null;
         }).when(flowPathRepository).updateStatus(any(), any());
 
         return flow;
     }
 
-    private FlowResources buildFlowResources() throws ResourceAllocationException {
-        FlowResources flowResources = FlowResources.builder()
-                .unmaskedCookie(1)
-                .forward(PathResources.builder()
-                        .pathId(NEW_FORWARD_FLOW_PATH)
-                        .meterId(new MeterId(MeterId.MIN_FLOW_METER_ID + 1))
+    private PathPair build2SwitchPathPair() {
+        return build2SwitchPathPair(1, 2);
+    }
+
+    private PathPair build2SwitchPathPair(int srcPort, int destPort) {
+        List<Segment> forwardSegments = Collections.singletonList(
+                Segment.builder()
+                        .srcSwitchId(SWITCH_1).srcPort(srcPort).destSwitchId(SWITCH_2).destPort(destPort).build());
+        List<Segment> reverseSegments = Collections.singletonList(
+                Segment.builder()
+                        .srcSwitchId(SWITCH_2).srcPort(destPort).destSwitchId(SWITCH_1).destPort(srcPort).build());
+        return buildPcePathPair(forwardSegments, reverseSegments);
+    }
+
+    private PathPair build3SwitchPathPair() {
+        return build3SwitchPathPair(3, 4);
+    }
+
+    private PathPair build3SwitchPathPair(int srcPort, int destPort) {
+        List<Segment> forwardSegments = new ArrayList<>();
+        forwardSegments.add(
+                Segment.builder()
+                        .srcSwitchId(SWITCH_1).srcPort(srcPort).destPort(destPort).destSwitchId(SWITCH_3).build());
+        forwardSegments.add(
+                Segment.builder()
+                        .srcSwitchId(SWITCH_3).srcPort(srcPort).destPort(destPort).destSwitchId(SWITCH_2).build());
+
+        List<Segment> reverseSegments = new ArrayList<>();
+        reverseSegments.add(
+                Segment.builder()
+                        .srcSwitchId(SWITCH_2).srcPort(destPort).destPort(srcPort).destSwitchId(SWITCH_3).build());
+        reverseSegments.add(
+                Segment.builder()
+                        .srcSwitchId(SWITCH_3).srcPort(destPort).destPort(srcPort).destSwitchId(SWITCH_1).build());
+
+        return buildPcePathPair(forwardSegments, reverseSegments);
+    }
+
+    private PathPair buildPcePathPair(List<Segment> forwardSegments, List<Segment> reverseSegments) {
+        return PathPair.builder()
+                .forward(Path.builder()
+                        .srcSwitchId(SWITCH_1).destSwitchId(SWITCH_2)
+                        .segments(forwardSegments)
                         .build())
-                .reverse(PathResources.builder()
-                        .pathId(NEW_REVERSE_FLOW_PATH)
-                        .meterId(new MeterId(MeterId.MIN_FLOW_METER_ID + 2))
+                .reverse(Path.builder()
+                        .srcSwitchId(SWITCH_2).destSwitchId(SWITCH_1)
+                        .segments(reverseSegments)
                         .build())
                 .build();
+    }
 
-        when(flowResourcesManager.allocateFlowResources(any())).thenReturn(flowResources);
+    private FlowResources buildFlowResources() throws ResourceAllocationException {
+        FlowResources original = makeFlowResources(FLOW_ID, OLD_FORWARD_FLOW_PATH, OLD_REVERSE_FLOW_PATH);
+        FlowResources target = makeFlowResources(FLOW_ID, NEW_FORWARD_FLOW_PATH, NEW_REVERSE_FLOW_PATH, original);
 
-        when(flowResourcesManager.getEncapsulationResources(eq(NEW_FORWARD_FLOW_PATH), eq(NEW_REVERSE_FLOW_PATH),
-                eq(FlowEncapsulationType.TRANSIT_VLAN)))
-                .thenReturn(Optional.of(TransitVlanEncapsulation.builder().transitVlan(
-                        TransitVlan.builder().flowId(FLOW_ID).pathId(NEW_FORWARD_FLOW_PATH).vlan(101).build())
-                        .build()));
-        when(flowResourcesManager.getEncapsulationResources(eq(NEW_REVERSE_FLOW_PATH), eq(NEW_FORWARD_FLOW_PATH),
-                eq(FlowEncapsulationType.TRANSIT_VLAN)))
-                .thenReturn(Optional.of(TransitVlanEncapsulation.builder().transitVlan(
-                        TransitVlan.builder().flowId(FLOW_ID).pathId(NEW_REVERSE_FLOW_PATH).vlan(102).build())
-                        .build()));
+        when(flowResourcesManager.allocateFlowResources(any())).thenReturn(target);
 
-        when(flowResourcesManager.getEncapsulationResources(eq(OLD_FORWARD_FLOW_PATH), eq(OLD_REVERSE_FLOW_PATH),
-                eq(FlowEncapsulationType.TRANSIT_VLAN)))
-                .thenReturn(Optional.of(TransitVlanEncapsulation.builder().transitVlan(
-                        TransitVlan.builder().flowId(FLOW_ID).pathId(NEW_FORWARD_FLOW_PATH).vlan(201).build())
-                        .build()));
-        when(flowResourcesManager.getEncapsulationResources(eq(OLD_REVERSE_FLOW_PATH), eq(OLD_FORWARD_FLOW_PATH),
-                eq(FlowEncapsulationType.TRANSIT_VLAN)))
-                .thenReturn(Optional.of(TransitVlanEncapsulation.builder().transitVlan(
-                        TransitVlan.builder().flowId(FLOW_ID).pathId(NEW_REVERSE_FLOW_PATH).vlan(202).build())
-                        .build()));
+        return target;
+    }
 
-        return flowResources;
+    private Switch makeSwitch(SwitchId id) {
+        return Switch.builder().switchId(id).build();
+    }
+
+    private FlowResources makeFlowResources(String flowId, PathId forward, PathId reverse) {
+        return makeFlowResources(flowId, forward, reverse, null);
+    }
+
+    private FlowResources makeFlowResources(
+            String flowId, PathId forward, PathId reverse, FlowResources lastAllocated) {
+        FlowResources resources = FlowResources.builder()
+                .unmaskedCookie(extractLastAllocatedCookie(lastAllocated).getValue())
+                .forward(PathResources.builder()
+                                 .pathId(forward)
+                                 .meterId(allocateForwardMeterId(lastAllocated))
+                                 .encapsulationResources(
+                                         makeTransitVlanResources(flowId, forward,
+                                                                  allocateForwardTransitVlanId(lastAllocated)))
+                                 .build())
+                .reverse(PathResources.builder()
+                                 .pathId(reverse)
+                                 .meterId(allocateReverseMeterId(lastAllocated))
+                                 .encapsulationResources(
+                                         makeTransitVlanResources(flowId, reverse,
+                                                                  allocateReverseTransitVlanId(lastAllocated)))
+                                 .build())
+                .build();
+
+        when(flowResourcesManager.getEncapsulationResources(
+                eq(forward), eq(reverse), eq(FlowEncapsulationType.TRANSIT_VLAN)))
+                .thenReturn(Optional.of(resources.getForward().getEncapsulationResources()));
+        when(flowResourcesManager.getEncapsulationResources(
+                eq(reverse), eq(forward), eq(FlowEncapsulationType.TRANSIT_VLAN)))
+                .thenReturn(Optional.of(resources.getReverse().getEncapsulationResources()));
+
+        return resources;
+    }
+
+    private EncapsulationResources makeTransitVlanResources(String flowId, PathId pathId, int vlanId) {
+        TransitVlan entity = TransitVlan.builder()
+                .flowId(flowId).pathId(pathId)
+                .vlan(vlanId)
+                .build();
+        return TransitVlanEncapsulation.builder()
+                .transitVlan(entity)
+                .build();
+    }
+
+    private MeterId allocateForwardMeterId(FlowResources lastAllocated) {
+        return new MeterId(extractLastAllocatedMeterId(lastAllocated).getValue() + 1);
+    }
+
+    private MeterId allocateReverseMeterId(FlowResources lastAllocated) {
+        return new MeterId(extractLastAllocatedMeterId(lastAllocated).getValue() + 2);
+    }
+
+    private int allocateForwardTransitVlanId(FlowResources lastAllocated) {
+        return extractLastAllocatedVlanId(lastAllocated) + 1;
+    }
+
+    private int allocateReverseTransitVlanId(FlowResources lastAllocated) {
+        return extractLastAllocatedVlanId(lastAllocated) + 2;
+    }
+
+    private Cookie extractLastAllocatedCookie(FlowResources resources) {
+        if (resources == null) {
+            return new Cookie(1);
+        }
+        return new Cookie(resources.getUnmaskedCookie());
+    }
+
+    private MeterId extractLastAllocatedMeterId(FlowResources resources) {
+        if (resources == null) {
+            return new MeterId(MeterId.MIN_FLOW_METER_ID);
+        }
+        return resources.getForward().getMeterId();
+    }
+
+    private int extractLastAllocatedVlanId(FlowResources resources) {
+        if (resources == null) {
+            return 100;
+        }
+        return resources.getForward().getEncapsulationResources().getTransitEncapsulationId();
+    }
+
+    private IslEndpoint extractIslEndpoint(Flow flow) {
+        FlowPath forwardPath = flow.getForwardPath();
+        assertNotNull(forwardPath);
+        List<PathSegment> forwardSegments = forwardPath.getSegments();
+        assertFalse(forwardSegments.isEmpty());
+        PathSegment firstSegment = forwardSegments.get(0);
+
+        return new IslEndpoint(firstSegment.getSrcSwitch().getSwitchId(), firstSegment.getSrcPort());
     }
 }

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/utils/RerouteRetryQueueTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/flowhs/utils/RerouteRetryQueueTest.java
@@ -1,0 +1,166 @@
+/* Copyright 2020 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.utils;
+
+import org.openkilda.model.IslEndpoint;
+import org.openkilda.model.SwitchId;
+import org.openkilda.wfm.CommandContext;
+import org.openkilda.wfm.topology.flowhs.model.FlowRerouteFact;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+public class RerouteRetryQueueTest {
+    private final CommandContext context = new CommandContext();
+    private final SwitchId switchId = new SwitchId(1);
+
+    private final String flowId = "flowA";
+    private final FlowRerouteFact rerouteEmpty = new FlowRerouteFact(
+            "empty", context, flowId, null, false, false, "reason 1");
+    private final FlowRerouteFact reroutePathA = new FlowRerouteFact(
+            "pathA", context, flowId, Collections.singleton(new IslEndpoint(switchId, 1)), false, false, "reason 2");
+    private final FlowRerouteFact reroutePathB = new FlowRerouteFact(
+            "pathB", context, flowId, Collections.singleton(new IslEndpoint(switchId, 2)), false, false, "reason 3");
+    private final FlowRerouteFact rerouteForced = new FlowRerouteFact(
+            "forced", context, flowId, null, true, true, "reason 4");
+
+    @Test
+    public void addAndSizeOperations() {
+        RerouteRetryQueue queue = new RerouteRetryQueue();
+
+        Assert.assertEquals(0, queue.size());
+        Assert.assertTrue(queue.isEmpty());
+
+        queue.add(rerouteEmpty);
+        Assert.assertEquals(1, queue.size());
+        Assert.assertFalse(queue.isEmpty());
+
+        queue.add(reroutePathA);
+        Assert.assertEquals(2, queue.size());
+        Assert.assertFalse(queue.isEmpty());
+
+        queue.add(reroutePathB);
+        Assert.assertEquals(2, queue.size());
+        Assert.assertFalse(queue.isEmpty());
+    }
+
+    @Test
+    public void removeAndSizeOperations() {
+        RerouteRetryQueue queue = new RerouteRetryQueue();
+
+        // empty
+        Assert.assertFalse(queue.remove().isPresent());
+
+        Optional<FlowRerouteFact> reroute;
+
+        // one entry
+        queue.add(rerouteEmpty);
+        reroute = queue.remove();
+        Assert.assertTrue(reroute.isPresent());
+        Assert.assertSame(rerouteEmpty, reroute.get());
+        Assert.assertFalse(queue.remove().isPresent());
+        Assert.assertEquals(0, queue.size());
+
+        // two entry
+        queue.add(rerouteEmpty);
+        queue.add(reroutePathA);
+        reroute = queue.remove();
+        Assert.assertTrue(reroute.isPresent());
+        Assert.assertSame(rerouteEmpty, reroute.get());
+        Assert.assertEquals(1, queue.size());
+
+        reroute = queue.remove();
+        Assert.assertTrue(reroute.isPresent());
+        Assert.assertSame(reroutePathA, reroute.get());
+        Assert.assertFalse(queue.remove().isPresent());
+        Assert.assertEquals(0, queue.size());
+
+        Assert.assertFalse(queue.remove().isPresent());
+
+        // more than 2 entry
+        queue.add(rerouteEmpty);
+        queue.add(reroutePathA);
+        queue.add(reroutePathB);
+
+        reroute = queue.remove();
+        Assert.assertTrue(reroute.isPresent());
+        Assert.assertSame(rerouteEmpty, reroute.get());
+        Assert.assertEquals(1, queue.size());
+
+        reroute = queue.remove();
+        Assert.assertTrue(reroute.isPresent());
+        Assert.assertNotEquals(reroutePathA, reroute.get());  // merged entry
+        Assert.assertNotEquals(reroutePathB, reroute.get());  // merged entry
+        Assert.assertFalse(queue.remove().isPresent());
+        Assert.assertEquals(0, queue.size());
+
+        Assert.assertFalse(queue.remove().isPresent());
+    }
+
+    @Test
+    public void getOperations() {
+        RerouteRetryQueue queue = new RerouteRetryQueue();
+        Assert.assertFalse(queue.get().isPresent());
+
+        Optional<FlowRerouteFact> reroute;
+        queue.add(rerouteEmpty);
+        reroute = queue.get();
+        Assert.assertTrue(reroute.isPresent());
+        Assert.assertSame(rerouteEmpty, reroute.get());
+
+        queue.add(reroutePathA);
+        reroute = queue.get();
+        Assert.assertTrue(reroute.isPresent());
+        Assert.assertSame(rerouteEmpty, reroute.get());
+
+        queue.remove();
+        reroute = queue.get();
+        Assert.assertTrue(reroute.isPresent());
+        Assert.assertSame(reroutePathA, reroute.get());
+    }
+
+    @Test
+    public void mergeOperation() {
+        RerouteRetryQueue queue = new RerouteRetryQueue();
+        queue.add(rerouteEmpty);
+        queue.add(reroutePathA);
+        queue.add(rerouteForced);
+        queue.add(reroutePathB);
+
+        Optional<FlowRerouteFact> potential;
+        queue.remove();
+        potential = queue.get();
+        Assert.assertTrue(potential.isPresent());
+
+        FlowRerouteFact reroute = potential.get();
+        Assert.assertEquals(reroutePathB.getKey(), reroute.getKey());
+        Assert.assertSame(reroutePathB.getCommandContext(), reroute.getCommandContext());
+        Assert.assertEquals(reroutePathB.getFlowId(), reroute.getFlowId());
+
+        Set<IslEndpoint> expectedIslEndpoints = new HashSet<>();
+        expectedIslEndpoints.addAll(reroutePathA.getAffectedIsl());
+        expectedIslEndpoints.addAll(reroutePathB.getAffectedIsl());
+
+        Assert.assertEquals(expectedIslEndpoints, reroute.getAffectedIsl());
+        Assert.assertTrue(reroute.isForceReroute());
+        Assert.assertEquals(reroutePathB.getRerouteReason(), reroute.getRerouteReason());
+    }
+}

--- a/services/wfm/src/test/java/org/openkilda/wfm/topology/reroute/service/RerouteServiceTest.java
+++ b/services/wfm/src/test/java/org/openkilda/wfm/topology/reroute/service/RerouteServiceTest.java
@@ -21,7 +21,10 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.openkilda.messaging.command.reroute.RerouteAffectedFlows;
@@ -32,10 +35,12 @@ import org.openkilda.model.Flow;
 import org.openkilda.model.FlowPath;
 import org.openkilda.model.FlowPathStatus;
 import org.openkilda.model.FlowStatus;
+import org.openkilda.model.IslEndpoint;
 import org.openkilda.model.PathId;
 import org.openkilda.model.PathSegment;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchId;
+import org.openkilda.persistence.PersistenceException;
 import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.persistence.TransactionCallbackWithoutResult;
 import org.openkilda.persistence.TransactionManager;
@@ -47,12 +52,17 @@ import org.openkilda.wfm.topology.reroute.bolts.MessageSender;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+@RunWith(MockitoJUnitRunner.class)
 public class RerouteServiceTest {
 
     private static final SwitchId SWITCH_ID_A = new SwitchId(1L);
@@ -74,11 +84,23 @@ public class RerouteServiceTest {
     private static final String FLOW_ID = "TEST_FLOW";
     private static final String CORRELATION_ID = "CORRELATION_ID";
 
+    private Flow regularFlow;
     private Flow pinnedFlow;
-    private Flow unpinnedFlow;
+
+    @Mock
+    private TransactionManager transactionManager;
+
+    @Mock
+    MessageSender carrier;
 
     @Before
-    public void setup() {
+    public void setup() throws Throwable {
+        doAnswer(invocation -> {
+            TransactionCallbackWithoutResult<?> arg = invocation.getArgument(0);
+            arg.doInTransaction();
+            return null;
+        }).when(transactionManager).doInTransaction(Mockito.<TransactionCallbackWithoutResult<?>>any());
+
         pinnedFlow = Flow.builder().flowId(FLOW_ID).srcSwitch(SWITCH_A)
                 .destSwitch(SWITCH_C).pinned(true).build();
         FlowPath pinnedFlowForwardPath = FlowPath.builder().pathId(new PathId("1"))
@@ -117,10 +139,11 @@ public class RerouteServiceTest {
         pinnedFlow.setForwardPath(pinnedFlowForwardPath);
         pinnedFlow.setReversePath(pinnedFlowReversePath);
 
-        unpinnedFlow = Flow.builder().flowId(FLOW_ID).srcSwitch(SWITCH_A)
+        regularFlow = Flow.builder().flowId(FLOW_ID).srcSwitch(SWITCH_A)
                 .destSwitch(SWITCH_C).pinned(false).build();
-        FlowPath unpinnedFlowForwardPath = FlowPath.builder().pathId(new PathId("3"))
-                .flow(unpinnedFlow).srcSwitch(SWITCH_A).destSwitch(SWITCH_C).cookie(Cookie.buildForwardCookie(3))
+        FlowPath regularFlowForwardPath = FlowPath.builder().pathId(new PathId("3"))
+                .flow(regularFlow).srcSwitch(SWITCH_A).destSwitch(SWITCH_C).cookie(Cookie.buildForwardCookie(3))
+                .status(FlowPathStatus.ACTIVE)
                 .build();
         List<PathSegment> unpinnedFlowForwardSegments = new ArrayList<>();
         unpinnedFlowForwardSegments.add(PathSegment.builder()
@@ -135,10 +158,11 @@ public class RerouteServiceTest {
                 .destSwitch(SWITCH_C)
                 .destPort(1)
                 .build());
-        unpinnedFlowForwardPath.setSegments(unpinnedFlowForwardSegments);
+        regularFlowForwardPath.setSegments(unpinnedFlowForwardSegments);
 
-        FlowPath unpinnedFlowReversePath = FlowPath.builder().pathId(new PathId("4"))
-                .flow(unpinnedFlow).srcSwitch(SWITCH_C).destSwitch(SWITCH_A).cookie(Cookie.buildReverseCookie(3))
+        FlowPath regularFlowReversePath = FlowPath.builder().pathId(new PathId("4"))
+                .flow(regularFlow).srcSwitch(SWITCH_C).destSwitch(SWITCH_A).cookie(Cookie.buildReverseCookie(3))
+                .status(FlowPathStatus.ACTIVE)
                 .build();
         List<PathSegment> unpinnedFlowReverseSegments = new ArrayList<>();
         unpinnedFlowReverseSegments.add(PathSegment.builder()
@@ -153,9 +177,9 @@ public class RerouteServiceTest {
                 .destSwitch(SWITCH_A)
                 .destPort(1)
                 .build());
-        unpinnedFlowReversePath.setSegments(unpinnedFlowReverseSegments);
-        unpinnedFlow.setForwardPath(unpinnedFlowForwardPath);
-        unpinnedFlow.setReversePath(unpinnedFlowReversePath);
+        regularFlowReversePath.setSegments(unpinnedFlowReverseSegments);
+        regularFlow.setForwardPath(regularFlowForwardPath);
+        regularFlow.setReversePath(regularFlowReversePath);
     }
 
 
@@ -229,28 +253,19 @@ public class RerouteServiceTest {
                 .thenReturn(Collections.singletonList(pinnedFlow));
         when(repositoryFactory.createFlowRepository()).thenReturn(flowRepository);
         FlowPathRepository pathRepository = mock(FlowPathRepository.class);
-        doAnswer(invocation -> {
-            PathId pathId = invocation.getArgument(0);
-            FlowPathStatus status = invocation.getArgument(1);
-            pinnedFlow.getPath(pathId).get().setStatus(status);
-            return null;
-        }).when(pathRepository).updateStatus(any(), any());
         when(repositoryFactory.createFlowPathRepository()).thenReturn(pathRepository);
         PathSegmentRepository pathSegmentRepository = mock(PathSegmentRepository.class);
         when(repositoryFactory.createPathSegmentRepository()).thenReturn(pathSegmentRepository);
         MessageSender messageSender = mock(MessageSender.class);
         PersistenceManager persistenceManager = mock(PersistenceManager.class);
         when(persistenceManager.getRepositoryFactory()).thenReturn(repositoryFactory);
-        TransactionManager transactionManager = mock(TransactionManager.class);
-        doAnswer(invocation -> {
-            TransactionCallbackWithoutResult arg = invocation.getArgument(0);
-            arg.doInTransaction();
-            return null;
-        }).when(transactionManager).doInTransaction(Mockito.<TransactionCallbackWithoutResult>any());
+
         when(persistenceManager.getTransactionManager()).thenReturn(transactionManager);
         RerouteService rerouteService = new RerouteService(persistenceManager);
         rerouteService.rerouteInactiveFlows(messageSender, CORRELATION_ID,
                 REROUTE_INACTIVE_FLOWS_COMMAND);
+
+        verify(pathRepository, times(0)).updateStatus(any(), any());
         assertTrue(FlowStatus.DOWN.equals(pinnedFlow.getStatus()));
         for (FlowPath fp : pinnedFlow.getPaths()) {
             assertTrue(FlowPathStatus.INACTIVE.equals(fp.getStatus()));
@@ -262,6 +277,42 @@ public class RerouteServiceTest {
                 }
             }
         }
+    }
 
+    @Test
+    public void handlePathNoFoundException() {
+        PathNode islSide = new PathNode(SWITCH_A.getSwitchId(), 1, 0);
+
+        FlowPathRepository pathRepository = mock(FlowPathRepository.class);
+        when(pathRepository.findBySegmentEndpoint(eq(islSide.getSwitchId()), eq(islSide.getPortNo())))
+                .thenReturn(Arrays.asList(regularFlow.getForwardPath(), regularFlow.getReversePath()));
+
+        FlowRepository flowRepository = mock(FlowRepository.class);
+
+        RepositoryFactory repositoryFactory = mock(RepositoryFactory.class);
+        when(repositoryFactory.createPathSegmentRepository())
+                .thenReturn(mock(PathSegmentRepository.class));
+        when(repositoryFactory.createFlowPathRepository())
+                .thenReturn(pathRepository);
+        when(repositoryFactory.createFlowRepository())
+                .thenReturn(flowRepository);
+
+        PersistenceManager persistenceManager = mock(PersistenceManager.class);
+        when(persistenceManager.getRepositoryFactory()).thenReturn(repositoryFactory);
+        when(persistenceManager.getTransactionManager()).thenReturn(transactionManager);
+
+        doThrow(new PersistenceException("Path not found exception (dummy)"))
+                .when(pathRepository).updateStatus(eq(regularFlow.getForwardPath().getPathId()), any());
+
+        RerouteService rerouteService = new RerouteService(persistenceManager);
+
+        RerouteAffectedFlows request = new RerouteAffectedFlows(islSide, "dummy-reason - unittest");
+        rerouteService.rerouteAffectedFlows(carrier, CORRELATION_ID, request);
+
+        verify(flowRepository).updateStatusSafe(eq(regularFlow.getFlowId()), eq(FlowStatus.DOWN));
+        verify(carrier).emitRerouteCommand(
+                eq(CORRELATION_ID), eq(regularFlow),
+                eq(Collections.singleton(new IslEndpoint(islSide.getSwitchId(), islSide.getPortNo()))),
+                any(String.class));
     }
 }


### PR DESCRIPTION
Add queue in front of reroute "handler" so if reroute for the flow is
going and new reroute request for this flow received (double network
failure case) second request will be postponed.

At the end of reroute request processing "handler" check presence of
postponed request and handle them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/telstra/open-kilda/3108)
<!-- Reviewable:end -->
