### PR TITLE
Skip corrupted flow while doing periodic pings invalidation.

### DIFF
--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/FlowFetcher.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/FlowFetcher.java
@@ -35,10 +35,11 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 public class FlowFetcher extends Abstract {
     public static final String BOLT_ID = ComponentId.FLOW_FETCHER.toString();
@@ -100,9 +101,15 @@ public class FlowFetcher extends Abstract {
 
     private void refreshHeap(Tuple input, boolean emitCacheExpiry) throws PipelineException {
         log.debug("Handle periodic ping request");
-        final Set<BidirectionalFlowDto> flows = flowPairRepository.findWithPeriodicPingsEnabled().stream()
-                .map(pair -> new BidirectionalFlowDto(FlowMapper.INSTANCE.map(pair)))
-                .collect(Collectors.toSet());
+        final Set<BidirectionalFlowDto> flows = new HashSet<>();
+        Collection<FlowPair> flowPairs = flowPairRepository.findWithPeriodicPingsEnabled();
+        for (FlowPair fp : flowPairs) {
+            try {
+                flows.add(new BidirectionalFlowDto(FlowMapper.INSTANCE.map(fp)));
+            } catch (Exception e) {
+                log.info("Failed to build flow for path. Skipping. ");
+            }
+        }
         if (emitCacheExpiry) {
             final CommandContext commandContext = pullContext(input);
             emitCacheExpire(input, commandContext, flows);

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/FlowFetcher.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ping/bolt/FlowFetcher.java
@@ -107,7 +107,20 @@ public class FlowFetcher extends Abstract {
             try {
                 flows.add(new BidirectionalFlowDto(FlowMapper.INSTANCE.map(fp)));
             } catch (Exception e) {
-                log.info("Failed to build flow for path. Skipping. ");
+                String forwardPathId = null;
+                if (fp != null && fp.forward != null && fp.forward.getFlowPath() != null
+                        && fp.forward.getFlowPath().getPathId() != null) {
+                    forwardPathId = fp.forward.getFlowPath().getPathId().getId();
+                }
+                String reversePathId = null;
+                if (fp != null && fp.reverse != null && fp.reverse.getFlowPath() != null
+                        && fp.reverse.getFlowPath().getPathId() != null) {
+                    reversePathId = fp.reverse.getFlowPath().getPathId().getId();
+                }
+
+                String message = String.format("Failed to build flow from paths. Forward path id '%s', "
+                        + "reverse path id '%s'. Skipping.", forwardPathId, reversePathId);
+                log.info(message, e);
             }
         }
         if (emitCacheExpiry) {


### PR DESCRIPTION
If flow do not have any path it should be skipped during periodic
ping cache update