### PR TITLE
improve tests according to reroute on switchUp event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v1.47.1 (03/02/2020)
+
+### Bug Fixes:
+-  [#3158](https://github.com/telstra/open-kilda/pull/3158) Skip corrupted flow while doing periodic pings invalidation. [**storm-topologies**]
+-  [#3133](https://github.com/telstra/open-kilda/pull/3133) Reroute affected flows on switch up event. (Issue: [#3131](https://github.com/telstra/open-kilda/issues/3131)) [**storm-topologies**]
+-  [#3159](https://github.com/telstra/open-kilda/pull/3159) Fixed incorrect log message in case of v2 FlowDelete. [**storm-topologies**]
+
+For the complete list of changes, check out [the commit log](https://github.com/telstra/open-kilda/compare/v1.47.0...v1.47.1).
+
+### Affected Components:
+ping, reroute, network
+
+---
+
 ## v1.47.0 (29/01/2020)
 
 ### Bug Fixes:

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteV2Spec.groovy
@@ -20,7 +20,6 @@ import org.openkilda.messaging.command.switches.DeleteRulesAction
 import org.openkilda.messaging.info.event.IslChangeType
 import org.openkilda.messaging.info.event.PathNode
 import org.openkilda.messaging.info.event.SwitchChangeType
-import org.openkilda.messaging.model.system.FeatureTogglesDto
 import org.openkilda.messaging.payload.flow.FlowState
 import org.openkilda.model.SwitchId
 import org.openkilda.model.SwitchStatus
@@ -28,7 +27,6 @@ import org.openkilda.northbound.dto.v2.flows.FlowRequestV2
 import org.openkilda.testing.model.topology.TopologyDefinition.Isl
 
 import spock.lang.Narrative
-import spock.lang.Unroll
 
 import java.util.concurrent.TimeUnit
 
@@ -143,62 +141,6 @@ class AutoRerouteV2Spec extends HealthCheckSpecification {
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }
-    }
-
-    @Unroll
-    @Tags([VIRTUAL, LOW_PRIORITY])
-    //the actual reroute is caused by the ISL down event which follows the initial sw disconnect
-    def "Flow goes to 'Down' status when an intermediate switch is disconnected and there is no ability to reroute"() {
-        given: "An intermediate-switch flow without alternative paths"
-        def (flow, allFlowPaths) = intermediateSwitchFlow(0, true)
-        flowHelperV2.addFlow(flow)
-        def flowPath = PathHelper.convert(northbound.getFlowPath(flow.flowId))
-
-        def altPaths = allFlowPaths.findAll { it != flowPath && it.first().portNo != flowPath.first().portNo }
-        List<PathNode> broughtDownPorts = []
-        altPaths.unique { it.first() }.each { path ->
-            def src = path.first()
-            broughtDownPorts.add(src)
-            antiflap.portDown(src.switchId, src.portNo)
-        }
-
-        when: "The intermediate switch is disconnected"
-        lockKeeper.knockoutSwitch(findSw(flowPath[1].switchId))
-
-        then: "The flow becomes 'Down'"
-        Wrappers.wait(discoveryTimeout + rerouteDelay + WAIT_OFFSET * 2) {
-            assert northbound.getFlowStatus(flow.flowId).status == FlowState.DOWN
-        }
-
-        when: "Set flowsRerouteOnIslDiscovery=#flowsRerouteOnIslDiscovery"
-        northbound.toggleFeature(FeatureTogglesDto.builder()
-                                                  .flowsRerouteOnIslDiscoveryEnabled(flowsRerouteOnIslDiscovery)
-                                                  .build())
-
-        and: "Connect the intermediate switch back"
-        lockKeeper.reviveSwitch(findSw(flowPath[1].switchId))
-        Wrappers.wait(WAIT_OFFSET) { assert northbound.activeSwitches*.switchId.contains(flowPath[1].switchId) }
-
-        then: "The flow is #flowStatus"
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            northbound.getLinks(flowPath[1].switchId, null, null, null)
-                      .each { assert it.state == IslChangeType.DISCOVERED }
-        }
-        Wrappers.wait(WAIT_OFFSET + rerouteDelay) { assert northbound.getFlowStatus(flow.flowId).status == flowStatus }
-
-        and: "Restore topology to the original state, remove the flow, reset toggles"
-        flowHelperV2.deleteFlow(flow.flowId)
-        northbound.toggleFeature(FeatureTogglesDto.builder().flowsRerouteOnIslDiscoveryEnabled(true).build())
-        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
-        }
-        database.resetCosts()
-
-        where:
-        flowsRerouteOnIslDiscovery | flowStatus
-        true                       | FlowState.UP
-        false                      | FlowState.DOWN
     }
 
     @Tags(SMOKE)


### PR DESCRIPTION
some test is not actual anymore due to #3133 
- tested functionality in deleted tests are covered by  `def "Flow in 'Down' status is rerouted after switchUp event"()`
- add new test for testing the `flows_reroute_on_isl_discovery` feature toogle