### PR TITLE
test fixes and improvements

### DIFF
--- a/services/src/functional-tests/README.md
+++ b/services/src/functional-tests/README.md
@@ -27,13 +27,15 @@ connected to controller, allows to change ISLs between switches) or controlling 
 switches (bring ports down to fail certain ISLs).
 It is required to bring the topology to the original state afterwards.
 
-### Failfast with no cleanup
-We do not do a 'finally' cleanup. Any cleanup steps are usually part of the test itself and they
-are **not** run if the test fails somewhere in the middle.  
-In case of failure, any subsequent tests are skipped. This allows to diagnose the 'broken' system state when the test failed.  
-The drawback is that the engineer will have to manually bring the system/topology back to its original
-state after analysing the test failure (usually not an issue for virtual topology since it is
-recreated at the start of the test run).  
+### Test execution may be aborted due to 'uncleanupable contamination'
+Due to the fact that we use single topology for the whole suite, sometimes it is very difficult to
+compile a comprehensive cleanup code for the test that will cover any failure scenario (especially for long, complex 
+test cases). Such tests
+are __not__ marked as `@Tidy`, failure of such tests will abort further execution of any subsequent tests
+ because at this point system is considered as contaminated.
+On the other hand, if the test is supplied with a bullet-proof cleanup code, then it should have a
+`@Tidy` annotation above it, meaning that in case of failure no 'failfast' policy should be applied, allowing
+execution of subsequent tests.
 
 # How to run
 ### Virtual (local Kilda)

--- a/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/StatsHelper.groovy
+++ b/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/StatsHelper.groovy
@@ -46,9 +46,9 @@ class StatsHelper {
         Wrappers.wait(STATS_INTERVAL) {
             def dps = otsdb.query(from, metricPrefix + "flow.raw.bytes", [flowid: flowId]).dps
             if(expectTraffic) {
-                assert dps.values().any { it > 0 }
+                assert dps.values().any { it > 0 }, flowId
             } else {
-                assert dps.size() > 0
+                assert dps.size() > 0, flowId
             }
         }
     }

--- a/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/StatsHelper.groovy
+++ b/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/StatsHelper.groovy
@@ -36,16 +36,16 @@ class StatsHelper {
         soft.verify()
     }
 
-    void verifyFlowWritesStats(String flowId, boolean mustHaveTraffic = true) {
+    void verifyFlowWritesStats(String flowId, boolean pingFlow = true) {
         def beforePing = new Date()
-        mustHaveTraffic && northbound.pingFlow(flowId, new PingInput())
-        verifyFlowWritesStats(flowId, beforePing, mustHaveTraffic)
+        pingFlow && northbound.pingFlow(flowId, new PingInput())
+        verifyFlowWritesStats(flowId, beforePing, pingFlow)
     }
 
-    void verifyFlowWritesStats(String flowId, Date from, boolean mustHaveTraffic) {
+    void verifyFlowWritesStats(String flowId, Date from, boolean expectTraffic) {
         Wrappers.wait(STATS_INTERVAL) {
             def dps = otsdb.query(from, metricPrefix + "flow.raw.bytes", [flowid: flowId]).dps
-            if(mustHaveTraffic) {
+            if(expectTraffic) {
                 assert dps.values().any { it > 0 }
             } else {
                 assert dps.size() > 0

--- a/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/StatsHelper.groovy
+++ b/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/StatsHelper.groovy
@@ -28,7 +28,7 @@ class StatsHelper {
 
     void verifyFlowsWriteStats(List<String> flowIds) {
         def soft = new SoftAssertions()
-        withPool(flowIds.size()) {
+        withPool(Math.min(flowIds.size(), 15)) {
             flowIds.eachParallel { String flowId ->
                 soft.checkSucceeds { verifyFlowWritesStats(flowId) }
             }

--- a/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/TopologyHelper.groovy
+++ b/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/TopologyHelper.groovy
@@ -2,6 +2,7 @@ package org.openkilda.functionaltests.helpers
 
 import org.openkilda.functionaltests.helpers.model.SwitchPair
 import org.openkilda.messaging.info.event.SwitchChangeType
+import org.openkilda.model.SwitchId
 import org.openkilda.testing.model.topology.TopologyDefinition
 import org.openkilda.testing.model.topology.TopologyDefinition.Isl
 import org.openkilda.testing.model.topology.TopologyDefinition.Status
@@ -81,6 +82,10 @@ class TopologyHelper {
         //get deep copy
         def mapper = new ObjectMapper()
         return mapper.readValue(mapper.writeValueAsString(getSwitchPairsCached()), SwitchPair[]).toList()
+    }
+
+    Switch findSwitch(SwitchId swId) {
+        topology.switches.find { it.dpId == swId }
     }
 
     TopologyDefinition readCurrentTopology() {

--- a/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/TopologyHelper.groovy
+++ b/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/TopologyHelper.groovy
@@ -72,6 +72,11 @@ class TopologyHelper {
         }
     }
 
+    def traffgenEnabled = { SwitchPair swPair ->
+        def tgSwitches = topology.activeTraffGens*.switchConnected
+        swPair.src in tgSwitches && swPair.dst in tgSwitches
+    }
+
     List<SwitchPair> getSwitchPairs() {
         //get deep copy
         def mapper = new ObjectMapper()

--- a/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/thread/FlowHistoryConstants.groovy
+++ b/services/src/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/thread/FlowHistoryConstants.groovy
@@ -1,0 +1,9 @@
+package org.openkilda.functionaltests.helpers.thread
+
+class FlowHistoryConstants {
+    public static String CREATE_ACTION = "Flow creating"
+    public static String UPDATE_ACTION = "Flow updating"
+    public static String UPDATE_SUCCESS = "Flow was updated successfully"
+    public static String CREATE_SUCCESS = "Flow was created successfully"
+    public static String REROUTE_FAIL = "Failed to reroute the flow"
+}

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/configuration/ConfigurationSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/configuration/ConfigurationSpec.groovy
@@ -7,6 +7,7 @@ import static org.openkilda.testing.Constants.RULES_INSTALLATION_TIME
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.error.MessageError
@@ -33,6 +34,7 @@ class ConfigurationSpec extends HealthCheckSpecification {
     @Value('${use.multitable}')
     boolean useMultitable
 
+    @Tidy
     @Tags(HARDWARE)
     def "System takes into account default flow encapsulation type while creating a flow"() {
         when: "Create a flow without encapsulation type"
@@ -71,6 +73,7 @@ class ConfigurationSpec extends HealthCheckSpecification {
         [flow1.flowId, flow2.flowId].each { flowHelper.deleteFlow(it) }
     }
 
+    @Tidy
     @Tags(LOW_PRIORITY)
     def "System doesn't allow to update kilda configuration with wrong flow encapsulation type"() {
         when: "Try to set wrong flow encapsulation type"
@@ -82,10 +85,9 @@ class ConfigurationSpec extends HealthCheckSpecification {
         e.statusCode == HttpStatus.BAD_REQUEST
         e.responseBodyAsString.to(MessageError).errorMessage ==
                 "No enum constant org.openkilda.model.FlowEncapsulationType.$incorrectValue"
-        def testIsCompleted = true
 
         cleanup: "Restore default configuration"
-        if (!testIsCompleted) {
+        if (!e) {
             northbound.updateKildaConfiguration(
                     new KildaConfigurationDto(flowEncapsulationType: defaultEncapsulationType))
         }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
@@ -58,6 +58,7 @@ class AutoRerouteSpec extends HealthCheckSpecification {
         database.resetCosts()
     }
 
+    @Tidy
     @Tags(SMOKE)
     def "Flow goes to 'Down' status when one of the flow ISLs fails and there is no ability to reroute"() {
         given: "A flow without alternative paths"
@@ -91,7 +92,7 @@ class AutoRerouteSpec extends HealthCheckSpecification {
             assert northbound.getFlowStatus(flow.id).status == FlowState.UP
         }
 
-        and: "Restore topology to the original state, remove the flow"
+        cleanup: "Restore topology to the original state, remove the flow"
         portDown && !portUp && antiflap.portUp(isl.dstSwitch.dpId, isl.dstPort)
         broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         flowHelper.deleteFlow(flow.id)

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ConnectedDevicesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ConnectedDevicesSpec.groovy
@@ -240,7 +240,7 @@ srcLldpDevices=#newSrcEnabled, dstLldpDevices=#newDstEnabled"() {
             }
         }
 
-        cleanup: "Cleanup: delete the flow"
+        cleanup: "Delete the flow"
         flowHelper.deleteFlow(updatedFlow.flowId)
 
         and: "Restore initial switch properties"
@@ -360,7 +360,7 @@ srcLldpDevices=#newSrcEnabled, dstLldpDevices=#newDstEnabled"() {
             }
         }
 
-        cleanup: "Cleanup: delete the flow"
+        cleanup: "Delete the flow"
         flowHelper.deleteFlow(swappedFlow.flowId)
         [flow.source.datapath, flow.destination.datapath].each { database.removeConnectedDevices(it) }
 
@@ -802,7 +802,7 @@ srcLldpDevices=#newSrcEnabled, dstLldpDevices=#newDstEnabled"() {
             verifyEquals(it[0].lldp.first(), dstData)
         }
 
-        cleanup: "Cleanup: delete the flow"
+        cleanup: "Delete the flow"
         flowHelper.deleteFlow(flow.id)
 
         and: "Restore initial switch properties"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ConnectedDevicesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ConnectedDevicesSpec.groovy
@@ -2,6 +2,10 @@ package org.openkilda.functionaltests.spec.flows
 
 import static groovyx.gpars.GParsPool.withPool
 import static org.junit.Assume.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
+import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
+import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE_SWITCHES
+import static org.openkilda.functionaltests.extension.tags.Tag.TOPOLOGY_DEPENDENT
 import static org.openkilda.model.Cookie.LLDP_INGRESS_COOKIE
 import static org.openkilda.model.Cookie.LLDP_INPUT_PRE_DROP_COOKIE
 import static org.openkilda.model.Cookie.LLDP_POST_INGRESS_COOKIE
@@ -17,7 +21,6 @@ import org.openkilda.functionaltests.HealthCheckSpecification
 import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.functionaltests.extension.tags.IterationTag
 import org.openkilda.functionaltests.extension.tags.IterationTags
-import org.openkilda.functionaltests.extension.tags.Tag
 import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.SwitchHelper
 import org.openkilda.functionaltests.helpers.Wrappers
@@ -70,10 +73,10 @@ class ConnectedDevicesSpec extends HealthCheckSpecification {
     Provider<TraffExamService> traffExamProvider
 
     @Unroll
-    @Tags([Tag.TOPOLOGY_DEPENDENT])
+    @Tags([TOPOLOGY_DEPENDENT])
     @IterationTags([
-            @IterationTag(tags = [Tag.SMOKE], iterationNameRegex = /srcLldp=true and dstLldp=true/),
-            @IterationTag(tags = [Tag.HARDWARE], iterationNameRegex = /VXLAN/)
+            @IterationTag(tags = [SMOKE, SMOKE_SWITCHES], iterationNameRegex = /srcLldp=true and dstLldp=true/),
+            @IterationTag(tags = [HARDWARE], iterationNameRegex = /VXLAN/)
     ])
     def "Able to create a #flowDescr flow with srcLldp=#data.srcEnabled and dstLldp=#data.dstEnabled"() {
         given: "A flow with enabled or disabled connected devices"
@@ -268,6 +271,7 @@ srcLldpDevices=#newSrcEnabled, dstLldpDevices=#newDstEnabled"() {
     /**
      * This is an edge case. Other tests for 'oneSwitch' only test single-switch single-port scenarios
      */
+    @Tags([SMOKE_SWITCHES])
     def "Able to detect devices on a single-switch different-port flow"() {
         given: "A flow between different ports on the same switch"
         def sw = topology.activeTraffGens*.switchConnected.first()

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/DefaultFlowV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/DefaultFlowV2Spec.groovy
@@ -2,8 +2,10 @@ package org.openkilda.functionaltests.spec.flows
 
 import static groovyx.gpars.GParsPool.withPool
 import static org.junit.Assume.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE_SWITCHES
 
 import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.messaging.error.MessageError
 import org.openkilda.testing.model.topology.TopologyDefinition.Switch
@@ -25,6 +27,7 @@ class DefaultFlowV2Spec extends HealthCheckSpecification {
     Provider<TraffExamService> traffExamProvider
 
     @Tidy
+    @Tags([SMOKE_SWITCHES])
     def "Systems allows to pass traffic via default and vlan flow when they are on the same port"() {
         given: "At least 3 traffGen switches"
         def allTraffGenSwitches = topology.activeTraffGens*.switchConnected

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV2Spec.groovy
@@ -1252,6 +1252,54 @@ class FlowCrudV2Spec extends HealthCheckSpecification {
         }
     }
 
+    @Ignore("https://github.com/telstra/open-kilda/issues/3077")
+    @Tidy
+    def "Flow is healthy when assigned transit vlan matches the flow endpoint vlan"() {
+        given: "We know what the next transit vlan will be"
+        //Transit vlans are simply picked incrementally, so create a flow to see what is the current transit vlan
+        //and assume that the next will be 'current + 1'
+        def helperFlow = flowHelperV2.randomFlow(topologyHelper.notNeighboringSwitchPair)
+        flowHelperV2.addFlow(helperFlow)
+        def helperFlowInfo = database.getFlow(helperFlow.flowId)
+        def nextTransitVlan = database.getTransitVlan(helperFlowInfo.forwardPath.pathId).get().vlan + 1
+
+        when: "Create flow over traffgen switches with endpoint vlans matching the next transit vlan"
+        def flow = flowHelperV2.randomFlow(topologyHelper.switchPairs.find(topologyHelper.traffgenEnabled)).tap {
+            it.source.vlanId = nextTransitVlan
+            it.destination.vlanId = nextTransitVlan
+        }
+        flowHelperV2.addFlow(flow)
+        //verify that our 'nextTransitVlan' assumption was correct
+        assert database.getTransitVlan(database.getFlow(flow.flowId).forwardPath.pathId).get().vlan == nextTransitVlan
+
+        then: "Flow allows traffic"
+        def traffExam = traffExamProvider.get()
+        def exam = new FlowTrafficExamBuilder(topology, traffExam).buildBidirectionalExam(toFlowPayload(flow),
+                flow.maximumBandwidth as int, 5)
+        withPool {
+            [exam.forward, exam.reverse].eachParallel { direction ->
+                def resources = traffExam.startExam(direction)
+                direction.setResources(resources)
+                assert traffExam.waitExam(direction).hasTraffic()
+            }
+        }
+
+        and: "Flow passes flow validation"
+        northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
+
+        and: "Involved switches pass switch validation"
+        pathHelper.getInvolvedSwitches(flow.flowId).each {
+            with(northbound.validateSwitch(it.dpId)) { validation ->
+                validation.verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
+                validation.verifyMeterSectionsAreEmpty(["missing", "misconfigured", "excess"])
+            }
+        }
+
+        cleanup: "Remove flows"
+        helperFlow && flowHelperV2.deleteFlow(helperFlow.flowId)
+        flow && flowHelperV2.deleteFlow(flow.flowId)
+    }
+
     @Shared
     def errorDescription = { String operation, FlowRequestV2 flow, String endpoint, FlowRequestV2 conflictingFlow,
                              String conflictingEndpoint ->

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV2Spec.groovy
@@ -110,8 +110,7 @@ class FlowCrudV2Spec extends HealthCheckSpecification {
         }
 
         and: "Flow writes stats"
-        def isSingleSwitch = flow.source.switchId == flow.destination.switchId
-        statsHelper.verifyFlowWritesStats(flow.flowId, !isSingleSwitch)
+        statsHelper.verifyFlowWritesStats(flow.flowId, isFlowPingable(flow))
 
         when: "Remove the flow"
         flowHelperV2.deleteFlow(flow.flowId)
@@ -1410,6 +1409,17 @@ class FlowCrudV2Spec extends HealthCheckSpecification {
                     }
             ]
             r
+        }
+    }
+
+    boolean isFlowPingable(FlowRequestV2 flow) {
+        if (flow.source.switchId == flow.destination.switchId) {
+            return false
+        } else if (topologyHelper.findSwitch(flow.source.switchId).ofVersion == "OF_12" ||
+                topologyHelper.findSwitch(flow.destination.switchId).ofVersion == "OF_12") {
+            return false
+        } else {
+            return true
         }
     }
 

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowDiversityV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowDiversityV2Spec.groovy
@@ -5,6 +5,7 @@ import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.PathHelper
 import org.openkilda.functionaltests.helpers.Wrappers
@@ -42,6 +43,7 @@ class FlowDiversityV2Spec extends HealthCheckSpecification {
     @Value('${diversity.switch.cost}')
     int diversitySwitchCost
 
+    @Tidy
     @Tags(SMOKE)
     def "Able to create diverse flows"() {
         given: "Two active neighboring switches with three not overlapping paths at least"
@@ -64,10 +66,11 @@ class FlowDiversityV2Spec extends HealthCheckSpecification {
         }
         allInvolvedIsls.unique(false) == allInvolvedIsls
 
-        and: "Delete flows"
+        cleanup: "Delete flows"
         [flow1, flow2, flow3].each { flowHelperV2.deleteFlow(it.flowId) }
     }
 
+    @Tidy
     def "Able to update flows to become diverse"() {
         given: "Two active neighboring switches with three not overlapping paths at least"
         def switchPair = getSwitchPair(3)
@@ -107,10 +110,11 @@ class FlowDiversityV2Spec extends HealthCheckSpecification {
         }
         allInvolvedIsls.unique(false) == allInvolvedIsls
 
-        and: "Delete flows"
+        cleanup: "Delete flows"
         [flow1, flow2, flow3].each { flowHelperV2.deleteFlow(it.flowId) }
     }
 
+    @Tidy
     @Tags(SMOKE)
     def "Able to update flows to become not diverse"() {
         given: "Two active neighboring switches with three not overlapping paths at least"
@@ -150,10 +154,11 @@ class FlowDiversityV2Spec extends HealthCheckSpecification {
         and: "The 'diverse_with' field is removed"
         !northbound.getFlow(flow3.flowId).diverseWith
 
-        and: "Delete flows"
+        cleanup: "Delete flows"
         [flow1, flow2, flow3].each { flowHelperV2.deleteFlow(it.flowId) }
     }
 
+    @Tidy
     @Tags(SMOKE)
     def "Diverse flows are built through the same path if there are no alternative paths available"() {
         given: "Two active neighboring switches with two not overlapping paths at least"
@@ -185,8 +190,8 @@ class FlowDiversityV2Spec extends HealthCheckSpecification {
         then: "The second flow is built through the same path as the first flow"
         flow2Path == flow1Path
 
-        and: "Restore topology, delete flows and reset costs"
-        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
+        cleanup: "Restore topology, delete flows and reset costs"
+        broughtDownPorts.each { antiflap.portUp(it.switchId, it.portNo) }
         [flow1, flow2].each { flowHelperV2.deleteFlow(it.flowId) }
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
@@ -194,6 +199,7 @@ class FlowDiversityV2Spec extends HealthCheckSpecification {
         database.resetCosts()
     }
 
+    @Tidy
     @Tags(SMOKE)
     def "Links and switches get extra cost that is considered while calculating diverse flow paths"() {
         given: "Two active neighboring switches with three not overlapping paths at least"
@@ -238,11 +244,12 @@ class FlowDiversityV2Spec extends HealthCheckSpecification {
         flow3Path != flow2Path
         involvedIsls.unique(false) == involvedIsls
 
-        and: "Delete flows and link props"
+        cleanup: "Delete flows and link props"
         [flow1, flow2, flow3].each { flowHelperV2.deleteFlow(it.flowId) }
         northbound.deleteLinkProps(northbound.getAllLinkProps())
     }
 
+    @Tidy
     def "Able to get flow paths with correct overlapping segments stats (casual flows)"() {
         given: "Two active neighboring switches with three not overlapping paths at least"
         def switchPair = getSwitchPair(3)
@@ -288,7 +295,7 @@ class FlowDiversityV2Spec extends HealthCheckSpecification {
         ]
         verifySegmentsStats([flow1Path, flow2Path, flow3Path], expectedValuesMap)
 
-        and: "Delete flows"
+        cleanup: "Delete flows"
         [flow1, flow2, flow3].each { flowHelperV2.deleteFlow(it.flowId) }
     }
 

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowHistoryV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowHistoryV2Spec.groovy
@@ -1,6 +1,10 @@
 package org.openkilda.functionaltests.spec.flows
 
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
+import static org.openkilda.functionaltests.helpers.thread.FlowHistoryConstants.CREATE_ACTION
+import static org.openkilda.functionaltests.helpers.thread.FlowHistoryConstants.CREATE_SUCCESS
+import static org.openkilda.functionaltests.helpers.thread.FlowHistoryConstants.UPDATE_SUCCESS
+import static org.openkilda.functionaltests.helpers.thread.FlowHistoryConstants.UPDATE_ACTION
 import static org.openkilda.testing.Constants.NON_EXISTENT_FLOW_ID
 
 import org.openkilda.functionaltests.HealthCheckSpecification
@@ -17,11 +21,6 @@ import java.util.concurrent.TimeUnit
 @Narrative("""Verify that history records are created for the create/update actions.
 History record is created in case the create/update action is completed successfully.""")
 class FlowHistoryV2Spec extends HealthCheckSpecification {
-    String createAction = "Flow creating"
-    String updateAction = "Flow updating"
-    String updateHistoryAction = "Flow was updated successfully"
-    String createHistoryActionV2 = "Flow was created successfully"
-
     @Shared
     Long timestampBefore
 
@@ -197,14 +196,14 @@ class FlowHistoryV2Spec extends HealthCheckSpecification {
     }
 
     void checkHistoryCreateV2Action(FlowEventPayload flowHistory, String flowId) {
-        assert flowHistory.action == createAction
-        assert flowHistory.histories.action[-1] == createHistoryActionV2
+        assert flowHistory.action == CREATE_ACTION
+        assert flowHistory.histories.action[-1] == CREATE_SUCCESS
         checkHistoryCommonStuff(flowHistory, flowId)
     }
 
     void checkHistoryUpdateAction(FlowEventPayload flowHistory, String flowId) {
-        assert flowHistory.action == updateAction
-        assert flowHistory.histories.action[-1] == updateHistoryAction
+        assert flowHistory.action == UPDATE_ACTION
+        assert flowHistory.histories.action[-1] == UPDATE_SUCCESS
         checkHistoryCommonStuff(flowHistory, flowId)
     }
 

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowHistoryV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowHistoryV2Spec.groovy
@@ -1,7 +1,6 @@
 package org.openkilda.functionaltests.spec.flows
 
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
-import static org.openkilda.functionaltests.extension.tags.Tag.VIRTUAL
 import static org.openkilda.testing.Constants.NON_EXISTENT_FLOW_ID
 
 import org.openkilda.functionaltests.HealthCheckSpecification
@@ -29,7 +28,6 @@ class FlowHistoryV2Spec extends HealthCheckSpecification {
         timestampBefore = System.currentTimeSeconds() - 5
     }
 
-    @Tags([VIRTUAL]) // can't run it on stage env; mapping(v1->v2) is enabled, so flow is always created via V2
     def "History records are created for the create/update actions using custom timeline"() {
         when: "Create a flow"
         def (Switch srcSwitch, Switch dstSwitch) = topology.activeSwitches

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowSyncV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowSyncV2Spec.groovy
@@ -7,6 +7,7 @@ import static org.openkilda.testing.Constants.RULES_INSTALLATION_TIME
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.PathHelper
 import org.openkilda.functionaltests.helpers.Wrappers
@@ -22,6 +23,7 @@ class FlowSyncV2Spec extends HealthCheckSpecification {
     @Shared
     int flowRulesCount = 2
 
+    @Tidy
     @Tags(SMOKE)
     def "Able to synchronize a flow (install missing flow rules, reinstall existing) without rerouting"() {
         given: "An intermediate-switch flow with deleted rules on src switch"
@@ -66,10 +68,11 @@ class FlowSyncV2Spec extends HealthCheckSpecification {
         and: "Flow is valid"
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
-        and: "Delete the flow"
+        cleanup: "Delete the flow"
         flowHelperV2.deleteFlow(flow.flowId)
     }
 
+    @Tidy
     def "Able to synchronize a flow (install missing flow rules, reinstall existing) with rerouting"() {
         given: "An intermediate-switch flow with two possible paths at least and deleted rules on src switch"
         def switchPair = topologyHelper.getAllNotNeighboringSwitchPairs().find { it.paths.size() > 1 } ?:
@@ -130,7 +133,7 @@ class FlowSyncV2Spec extends HealthCheckSpecification {
         and: "Flow is valid"
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
-        and: "Delete the flow and link props, reset link costs"
+        cleanup: "Delete the flow and link props, reset link costs"
         flowHelperV2.deleteFlow(flow.flowId)
         northbound.deleteLinkProps(northbound.getAllLinkProps())
         database.resetCosts()

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowValidationNegativeV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowValidationNegativeV2Spec.groovy
@@ -4,6 +4,7 @@ import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.testing.Constants.NON_EXISTENT_FLOW_ID
 
 import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.functionaltests.extension.tags.IterationTag
 import org.openkilda.messaging.command.switches.DeleteRulesAction
 import org.openkilda.messaging.error.MessageError
@@ -26,6 +27,7 @@ import spock.lang.Unroll
             """)
 class FlowValidationNegativeV2Spec extends HealthCheckSpecification {
 
+    @Tidy
     @Unroll
     @IterationTag(tags = [SMOKE], iterationNameRegex = /reverse/)
     def "Flow and switch validation should fail in case of missing rules with #flowConfig configuration"() {
@@ -80,7 +82,7 @@ class FlowValidationNegativeV2Spec extends HealthCheckSpecification {
             assert nonAffectedSwitches.every { sw -> northbound.validateSwitchRules(sw).excessRules.size() == 0 }
         }
 
-        and: "Delete the flows"
+        cleanup: "Delete the flows"
         [flowToBreak.flowId, intactFlow.flowId].each { flowHelperV2.deleteFlow(it) }
 
         where:
@@ -99,6 +101,7 @@ class FlowValidationNegativeV2Spec extends HealthCheckSpecification {
         "transit"       | getTopologyHelper().getNotNeighboringSwitchPair() | -1   | "last"   | "reverse"
     }
 
+    @Tidy
     @Unroll
     def "Unable to #action a non-existent flow"() {
         when: "Trying to #action a non-existent flow"
@@ -117,6 +120,7 @@ class FlowValidationNegativeV2Spec extends HealthCheckSpecification {
         "synchronize" | "Could not reroute flow: Flow $NON_EXISTENT_FLOW_ID not found"
     }
 
+    @Tidy
     def "Able to detect discrepancies for a flow with protected path"() {
         when: "Create a flow with protected path"
         def switchPair = topologyHelper.getNotNeighboringSwitchPair()
@@ -163,7 +167,7 @@ class FlowValidationNegativeV2Spec extends HealthCheckSpecification {
         def responseValidateFlow2 = northbound.validateFlow(flow.flowId).findAll { !it.discrepancies.empty }*.discrepancies
         assert responseValidateFlow2.size() == 4
 
-        and: "Cleanup: delete the flow"
+        cleanup: "Delete the flow"
         flowHelperV2.deleteFlow(flow.flowId)
     }
 

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/IntentionalRerouteSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/IntentionalRerouteSpec.groovy
@@ -18,7 +18,6 @@ import org.openkilda.testing.service.traffexam.TraffExamService
 import org.openkilda.testing.tools.FlowTrafficExamBuilder
 
 import org.springframework.beans.factory.annotation.Autowired
-import spock.lang.Ignore
 import spock.lang.Narrative
 
 import javax.inject.Provider
@@ -129,7 +128,6 @@ class IntentionalRerouteSpec extends HealthCheckSpecification {
      * Select a longest available path between 2 switches, then reroute to another long path. Run traffexam during the
      * reroute and expect no packet loss.
      */
-    @Tags(HARDWARE)
     def "Intentional flow reroute is not causing any packet loss"() {
         given: "An unmetered flow going through a long not preferable path(reroute potential)"
         //will be available on virtual as soon as we get the latest iperf installed in lab-service images
@@ -142,7 +140,7 @@ class IntentionalRerouteSpec extends HealthCheckSpecification {
         List<List<PathNode>> allPaths = database.getPaths(src.dpId, dst.dpId)*.path
         def longestPath = allPaths.max { it.size() }
         def changedIsls = allPaths.findAll { it != longestPath }
-                                  .collect { pathHelper.makePathMorePreferable(longestPath, it) }
+                                  .collect { pathHelper.makePathMorePreferable(longestPath, it) }.findAll()
         //and create the flow that uses the long path
         def flow = flowHelper.randomFlow(src, dst)
         flow.maximumBandwidth = 0

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/IntentionalRerouteV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/IntentionalRerouteV2Spec.groovy
@@ -142,7 +142,6 @@ class IntentionalRerouteV2Spec extends HealthCheckSpecification {
      * reroute and expect no packet loss.
      */
     @Tidy
-    @Tags(HARDWARE)
     def "Intentional flow reroute is not causing any packet loss"() {
         given: "An unmetered flow going through a long not preferable path(reroute potential)"
         //will be available on virtual as soon as we get the latest iperf installed in lab-service images
@@ -155,7 +154,7 @@ class IntentionalRerouteV2Spec extends HealthCheckSpecification {
         List<List<PathNode>> allPaths = database.getPaths(src.dpId, dst.dpId)*.path
         def longestPath = allPaths.max { it.size() }
         def changedIsls = allPaths.findAll { it != longestPath }
-                .collect { pathHelper.makePathMorePreferable(longestPath, it) }
+                .collect { pathHelper.makePathMorePreferable(longestPath, it) }.findAll()
         //and create the flow that uses the long path
         def flow = flowHelperV2.randomFlow(src, dst)
         flow.maximumBandwidth = 0

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MultiRerouteSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MultiRerouteSpec.groovy
@@ -25,7 +25,7 @@ class MultiRerouteSpec extends HealthCheckSpecification {
                 assumeTrue("No suiting switches found", false)
         List<FlowRequestV2> flows = []
         30.times {
-            def flow = flowHelperV2.randomFlow(switchPair)
+            def flow = flowHelperV2.randomFlow(switchPair, false, flows)
             flow.maximumBandwidth = 10000
             flowHelperV2.addFlow(flow)
             flows << flow

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MultiRerouteSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MultiRerouteSpec.groovy
@@ -5,6 +5,7 @@ import static org.openkilda.testing.Constants.PATH_INSTALLATION_TIME
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.info.event.IslChangeType
 import org.openkilda.messaging.payload.flow.FlowState
@@ -16,6 +17,7 @@ import java.util.concurrent.TimeUnit
 
 class MultiRerouteSpec extends HealthCheckSpecification {
 
+    @Tidy
     @Ignore("https://github.com/telstra/open-kilda/issues/3047")
     def "Simultaneous reroute of multiple flows should not oversubscribe any ISLs"() {
         given: "Two flows on the same path, with alt paths available"
@@ -78,7 +80,7 @@ class MultiRerouteSpec extends HealthCheckSpecification {
             assert it.availableBandwidth >= 0
         }
 
-        and: "Cleanup: revert system to original state"
+        cleanup: "revert system to original state"
         antiflap.portUp(islToBreak.srcSwitch.dpId, islToBreak.srcPort)
         flows.each { flowHelperV2.deleteFlow(it.flowId) }
         northbound.deleteLinkProps(northbound.getAllLinkProps())

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PartialUpdateSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PartialUpdateSpec.groovy
@@ -1,0 +1,106 @@
+package org.openkilda.functionaltests.spec.flows
+
+import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs
+import static spock.util.matcher.HamcrestSupport.expect
+
+import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.failfast.Tidy
+import org.openkilda.model.Cookie
+import org.openkilda.northbound.dto.v1.flows.FlowPatchDto
+
+import spock.lang.Unroll
+
+class PartialUpdateSpec extends HealthCheckSpecification {
+
+    @Tidy
+    @Unroll
+    def "Able to partially update flow #data.field without reinstalling its rules"() {
+        given: "A flow"
+        def swPair = topologyHelper.switchPairs.first()
+        def flow = flowHelperV2.randomFlow(swPair)
+        flowHelperV2.addFlow(flow)
+        def originalCookies = northbound.getSwitchRules(swPair.src.dpId).flowEntries.findAll {
+            Cookie.isIngressRulePassThrough(it.cookie) || !Cookie.isDefaultRule(it.cookie)
+        }*.cookie
+
+        when: "Request a flow partial update for a #field field"
+        def updateRequest = new FlowPatchDto().tap { it."$data.field" = data.newValue }
+        def response = northbound.partialUpdate(flow.flowId, updateRequest)
+
+        then: "Update response reflects the changes"
+        response."$data.field" == data.newValue
+
+        and: "Changes actually took place"
+        northbound.getFlow(flow.flowId)."$data.field" == data.newValue
+
+        and: "Flow rules have not been reinstalled"
+        northbound.getSwitchRules(swPair.src.dpId).flowEntries*.cookie.containsAll(originalCookies)
+
+        cleanup: "Remove the flow"
+        flowHelperV2.deleteFlow(flow.flowId)
+
+        where:
+        data << [
+                [
+                        field   : "maxLatency",
+                        newValue: 12345
+                ],
+                [
+                        field   : "priority",
+                        newValue: 654
+                ]
+        ]
+    }
+
+    @Tidy
+    def "Able to do partial update on a single-switch flow"() {
+        given: "A single-switch flow"
+        def swPair = topologyHelper.singleSwitchPair
+        def flow = flowHelperV2.randomFlow(swPair)
+        flowHelperV2.addFlow(flow)
+        def originalCookies = northbound.getSwitchRules(swPair.src.dpId).flowEntries.findAll {
+            Cookie.isIngressRulePassThrough(it.cookie) || !Cookie.isDefaultRule(it.cookie)
+        }*.cookie
+
+        when: "Request a flow partial update for a 'priority' field"
+        def newPriority = 777
+        def updateRequest = new FlowPatchDto().tap { it.priority = newPriority }
+        def response = northbound.partialUpdate(flow.flowId, updateRequest)
+
+        then: "Update response reflects the changes"
+        response.priority == newPriority
+
+        and: "Changes actually took place"
+        northbound.getFlow(flow.flowId).priority == newPriority
+
+        and: "Flow rules have not been reinstalled"
+        northbound.getSwitchRules(swPair.src.dpId).flowEntries*.cookie.containsAll(originalCookies)
+
+        cleanup: "Remove the flow"
+        flowHelperV2.deleteFlow(flow.flowId)
+    }
+
+    def "Partial update with empty body does not actually update flow in any way"() {
+        given: "A flow"
+        def swPair = topologyHelper.switchPairs.first()
+        def flow = flowHelperV2.randomFlow(swPair)
+        flowHelperV2.addFlow(flow)
+        def originalCookies = northbound.getSwitchRules(swPair.src.dpId).flowEntries.findAll {
+            Cookie.isIngressRulePassThrough(it.cookie) || !Cookie.isDefaultRule(it.cookie)
+        }*.cookie
+
+        when: "Request a flow partial update without specifying any fields"
+        def flowBeforeUpdate = northbound.getFlow(flow.flowId)
+        northbound.partialUpdate(flow.flowId, new FlowPatchDto())
+
+        then: "Flow is left intact"
+        expect northbound.getFlow(flow.flowId), sameBeanAs(flowBeforeUpdate)
+                .ignoring("lastUpdated")
+
+        and: "Flow rules have not been reinstalled"
+        northbound.getSwitchRules(swPair.src.dpId).flowEntries*.cookie.containsAll(originalCookies)
+
+        cleanup: "Remove the flow"
+        flowHelperV2.deleteFlow(flow.flowId)
+    }
+}

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PinnedFlowSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PinnedFlowSpec.groovy
@@ -2,6 +2,7 @@ package org.openkilda.functionaltests.spec.flows
 
 import static org.junit.Assume.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
+import static org.openkilda.functionaltests.helpers.thread.FlowHistoryConstants.REROUTE_FAIL
 import static org.openkilda.model.MeterId.MAX_SYSTEM_RULE_METER_ID
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PinnedFlowV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PinnedFlowV2Spec.groovy
@@ -13,10 +13,12 @@ import org.openkilda.messaging.info.event.IslChangeType
 import org.openkilda.messaging.info.event.PathNode
 import org.openkilda.messaging.payload.flow.FlowState
 import org.openkilda.model.Cookie
+import org.openkilda.testing.model.topology.TopologyDefinition.Switch
 
 import org.springframework.web.client.HttpClientErrorException
 import spock.lang.Narrative
 
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 @Narrative("""A new flag of flow that indicates that flow shouldn't be rerouted in case of auto-reroute.
@@ -24,6 +26,56 @@ import java.util.concurrent.TimeUnit
 - On Isl up event such flow shouldn't be re-routed as well.
   Instead kilda should verify that it's path is online and mark flow as UP.""")
 class PinnedFlowV2Spec extends HealthCheckSpecification {
+
+    @Tidy
+    def "Able to CRUD pinned flow"() {
+        when: "Create a flow"
+        def (Switch srcSwitch, Switch dstSwitch) = topology.activeSwitches
+        def flow = flowHelperV2.randomFlow(srcSwitch, dstSwitch)
+        flow.pinned = true
+        flowHelperV2.addFlow(flow)
+
+        then: "Pinned flow is created"
+        def flowInfo = northbound.getFlow(flow.flowId)
+        flowInfo.pinned
+
+        when: "Update the flow (pinned=false)"
+        northboundV2.updateFlow(flowInfo.id, flowHelperV2.toV2(flowInfo.tap { it.pinned = false }))
+
+        then: "The pinned option is disabled"
+        def newFlowInfo = northbound.getFlow(flow.flowId)
+        !newFlowInfo.pinned
+        Instant.parse(flowInfo.lastUpdated) < Instant.parse(newFlowInfo.lastUpdated)
+
+        cleanup: "Delete the flow"
+        flowHelperV2.deleteFlow(flow.flowId)
+    }
+
+    @Tidy
+    def "Able to CRUD unmetered one-switch pinned flow"() {
+        when: "Create a flow"
+        def sw = topology.getActiveSwitches().first()
+        def flow = flowHelperV2.singleSwitchFlow(sw)
+        flow.maximumBandwidth = 0
+        flow.ignoreBandwidth = true
+        flow.pinned = true
+        flowHelperV2.addFlow(flow)
+
+        then: "Pinned flow is created"
+        def flowInfo = northbound.getFlow(flow.flowId)
+        flowInfo.pinned
+
+        when: "Update the flow (pinned=false)"
+        northboundV2.updateFlow(flowInfo.id, flowHelperV2.toV2(flowInfo.tap { it.pinned = false }))
+
+        then: "The pinned option is disabled"
+        def newFlowInfo = northbound.getFlow(flow.flowId)
+        !newFlowInfo.pinned
+        Instant.parse(flowInfo.lastUpdated) < Instant.parse(newFlowInfo.lastUpdated)
+
+        cleanup: "Delete the flow"
+        flowHelperV2.deleteFlow(flow.flowId)
+    }
 
     def "System doesn't reroute(automatically) pinned flow when flow path is partially broken"() {
         given: "A pinned flow going through a long not preferable path"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PinnedFlowV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PinnedFlowV2Spec.groovy
@@ -1,6 +1,7 @@
 package org.openkilda.functionaltests.spec.flows
 
 import static org.junit.Assume.assumeTrue
+import static org.openkilda.functionaltests.helpers.thread.FlowHistoryConstants.REROUTE_FAIL
 import static org.openkilda.model.MeterId.MAX_SYSTEM_RULE_METER_ID
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
@@ -62,8 +63,10 @@ class PinnedFlowV2Spec extends HealthCheckSpecification {
 
         then: "Flow is not rerouted and marked as DOWN when the first ISL is broken"
         Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getFlowStatus(flow.flowId).status == FlowState.DOWN
-            assert pathHelper.convert(northbound.getFlowPath(flow.flowId)) == currentPath
+            Wrappers.timedLoop(2) {
+                assert northbound.getFlowStatus(flow.flowId).status == FlowState.DOWN
+                assert pathHelper.convert(northbound.getFlowPath(flow.flowId)) == currentPath
+            }
         }
         islsToBreak[1..-1].each { islToBreak ->
             antiflap.portDown(islToBreak.srcSwitch.dpId, islToBreak.srcPort)

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
@@ -4,6 +4,7 @@ import static groovyx.gpars.GParsPool.withPool
 import static org.junit.Assume.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
+import static org.openkilda.functionaltests.helpers.thread.FlowHistoryConstants.REROUTE_FAIL
 import static org.openkilda.model.MeterId.MAX_SYSTEM_RULE_METER_ID
 import static org.openkilda.testing.Constants.NON_EXISTENT_FLOW_ID
 import static org.openkilda.testing.Constants.PROTECTED_PATH_INSTALLATION_TIME
@@ -911,7 +912,10 @@ class ProtectedPathSpec extends HealthCheckSpecification {
         antiflap.portDown(currentIsls[0].dstSwitch.dpId, currentIsls[0].dstPort)
 
         then: "Flow state is changed to DOWN"
-        Wrappers.wait(WAIT_OFFSET) { assert northbound.getFlowStatus(flow.id).status == FlowState.DOWN }
+        Wrappers.wait(WAIT_OFFSET) {
+            assert northbound.getFlowStatus(flow.id).status == FlowState.DOWN
+            assert northbound.getFlowHistory(flow.id).last().histories.find { it.action == REROUTE_FAIL }
+        }
         verifyAll(northbound.getFlow(flow.id).flowStatusDetails) {
             mainFlowPathStatus == "Down"
             protectedFlowPathStatus == "Down"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathV2Spec.groovy
@@ -54,6 +54,7 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
 
     @Tidy
     @Unroll
+    @Tags(LOW_PRIORITY)
     def "Able to create a flow with protected path when maximumBandwidth=#bandwidth, vlan=#vlanId"() {
         given: "Two active not neighboring switches with two diverse paths at least"
         def switchPair = topologyHelper.getAllNotNeighboringSwitchPairs().find {
@@ -150,6 +151,7 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
     }
 
     @Tidy
+    @Tags(LOW_PRIORITY)
     def "Unable to create a single switch flow with protected path"() {
         given: "A switch"
         def sw = topology.activeSwitches.first()
@@ -171,6 +173,7 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
     }
 
     @Tidy
+    @Tags(LOW_PRIORITY)
     def "Unable to update a single switch flow to enable protected path"() {
         given: "A switch"
         def sw = topology.activeSwitches.first()
@@ -467,6 +470,7 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
     }
 
     @Tidy
+    @Tags(LOW_PRIORITY)
     def "Unable to update a flow to enable protected path when there is not enough bandwidth"() {
         given: "Two active neighboring switches"
         def isls = topology.getIslsForActiveSwitches()
@@ -883,6 +887,7 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
     }
 
     @Tidy
+    @Tags(LOW_PRIORITY)
     def "Unable to perform the 'swap' request for a flow without protected path"() {
         given: "Two active neighboring switches"
         def isls = topology.getIslsForActiveSwitches()
@@ -908,6 +913,7 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
     }
 
     @Tidy
+    @Tags(LOW_PRIORITY)
     def "Unable to swap paths for a non-existent flow"() {
         when: "Try to swap path on a non-existent flow"
         northbound.swapFlowPath(NON_EXISTENT_FLOW_ID)
@@ -919,6 +925,7 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
                 "Could not swap paths: Flow $NON_EXISTENT_FLOW_ID not found"
     }
 
+    @Tags(LOW_PRIORITY)
     def "Unable to swap paths for an inactive flow"() {
         given: "Two active neighboring switches with two not overlapping paths at least"
         def switchPair = topologyHelper.getAllNeighboringSwitchPairs().find {
@@ -1132,7 +1139,11 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
         }
 
         then: "Flow status is DEGRADED"
-        Wrappers.wait(WAIT_OFFSET) { assert northbound.getFlowStatus(flow.flowId).status == FlowState.DEGRADED }
+        Wrappers.wait(WAIT_OFFSET) {
+            assert northbound.getFlowStatus(flow.flowId).status == FlowState.DEGRADED
+            assert northbound.getFlowHistory(flow.flowId).last().histories.find { it.action == REROUTE_FAIL }
+        }
+
 
         when: "Update flow: disable protected path(allocateProtectedPath=false)"
         northboundV2.updateFlow(flow.flowId, flow.tap { it.allocateProtectedPath = false })
@@ -1155,6 +1166,7 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
     }
 
     @Tidy
+    @Tags(LOW_PRIORITY)
     def "System doesn't allow to enable the pinned flag on a protected flow"() {
         given: "A protected flow"
         def switchPair = topologyHelper.getAllNeighboringSwitchPairs().find { it.paths.size() > 1 } ?:

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathV2Spec.groovy
@@ -4,6 +4,7 @@ import static groovyx.gpars.GParsPool.withPool
 import static org.junit.Assume.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
+import static org.openkilda.functionaltests.helpers.thread.FlowHistoryConstants.REROUTE_FAIL
 import static org.openkilda.model.MeterId.MAX_SYSTEM_RULE_METER_ID
 import static org.openkilda.testing.Constants.NON_EXISTENT_FLOW_ID
 import static org.openkilda.testing.Constants.PROTECTED_PATH_INSTALLATION_TIME
@@ -966,7 +967,10 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
         antiflap.portDown(currentIsls[0].dstSwitch.dpId, currentIsls[0].dstPort)
 
         then: "Flow state is changed to DOWN"
-        Wrappers.wait(WAIT_OFFSET) { assert northbound.getFlowStatus(flow.flowId).status == FlowState.DOWN }
+        Wrappers.wait(WAIT_OFFSET) {
+            assert northbound.getFlowStatus(flow.flowId).status == FlowState.DOWN
+            assert northbound.getFlowHistory(flow.flowId).last().histories.find { it.action == REROUTE_FAIL }
+        }
         verifyAll(northbound.getFlow(flow.flowId).flowStatusDetails) {
             mainFlowPathStatus == "Down"
             protectedFlowPathStatus == "Down"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
@@ -9,6 +9,7 @@ import static org.openkilda.testing.Constants.RULES_INSTALLATION_TIME
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.PathHelper
 import org.openkilda.functionaltests.helpers.Wrappers
@@ -39,6 +40,7 @@ class SwapEndpointSpec extends HealthCheckSpecification {
     @Autowired
     Provider<TraffExamService> traffExamProvider
 
+    @Tidy
     @Unroll
     def "Able to swap endpoints(#data.description)"() {
         given: "Some flows in the system according to preconditions"
@@ -64,7 +66,7 @@ class SwapEndpointSpec extends HealthCheckSpecification {
             [it.source.datapath, it.destination.datapath].collect { findSw(it) }
         }.unique())
 
-        and: "Delete flows"
+        cleanup: "Delete flows"
         flows.each { flowHelper.deleteFlow(it.id) }
 
         where:
@@ -207,6 +209,7 @@ class SwapEndpointSpec extends HealthCheckSpecification {
         secondSwap = data.secondSwap as SwapFlowPayload
     }
 
+    @Tidy
     @Unroll
     def "Able to swap #endpointsPart (#description) for two flows with the same source and different destination \
 switches"() {
@@ -232,7 +235,7 @@ switches"() {
         validateSwitches(flow1SwitchPair)
         validateSwitches(flow2SwitchPair)
 
-        and: "Delete flows"
+        cleanup: "Delete flows"
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
 
         where:
@@ -260,6 +263,7 @@ switches"() {
         ]
     }
 
+    @Tidy
     @Unroll
     def "Able to swap endpoints (#description) for two flows with the same source and different destination \
 switches"() {
@@ -285,7 +289,7 @@ switches"() {
         validateSwitches(flow1SwitchPair)
         validateSwitches(flow2SwitchPair)
 
-        and: "Delete flows"
+        cleanup: "Delete flows"
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
 
         where:
@@ -302,6 +306,7 @@ switches"() {
         ]
     }
 
+    @Tidy
     @Unroll
     @Tags(LOW_PRIORITY)
     def "Able to swap #endpointsPart (#description) for two flows with different source and the same destination \
@@ -328,7 +333,7 @@ switches"() {
         validateSwitches(switchPairs[0])
         validateSwitches(switchPairs[1])
 
-        and: "Delete flows"
+        cleanup: "Delete flows"
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
 
         where:
@@ -360,6 +365,7 @@ switches"() {
         ]
     }
 
+    @Tidy
     @Unroll
     def "Able to swap #endpointsPart (#description) for two flows with different source and destination switches"() {
         given: "Two flows with different source and destination switches"
@@ -384,7 +390,7 @@ switches"() {
         validateSwitches(flow1SwitchPair)
         validateSwitches(flow2SwitchPair)
 
-        and: "Delete flows"
+        cleanup: "Delete flows"
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
 
         where:
@@ -412,6 +418,7 @@ switches"() {
         ]
     }
 
+    @Tidy
     @Unroll
     @Tags(LOW_PRIORITY)
     def "Able to swap endpoints (#description) for two flows with different source and destination switches"() {
@@ -437,7 +444,7 @@ switches"() {
         validateSwitches(flow1SwitchPair)
         validateSwitches(flow2SwitchPair)
 
-        and: "Delete flows"
+        cleanup: "Delete flows"
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
 
         where:
@@ -467,6 +474,7 @@ switches"() {
         ]
     }
 
+    @Tidy
     def "Unable to swap endpoints for existing flow and non-existing flow"() {
         given: "An active flow"
         def switchPair = topologyHelper.getNeighboringSwitchPair()
@@ -488,10 +496,11 @@ switches"() {
         exc.responseBodyAsString.to(MessageError).errorMessage == "Can not swap endpoints for flows: " +
                 "Flow ${flow2.id} not found"
 
-        and: "Delete the flow"
+        cleanup: "Delete the flow"
         flowHelper.deleteFlow(flow1.id)
     }
 
+    @Tidy
     @Unroll
     def "Unable to swap #endpointsPart for two flows (#description)"() {
         given: "Three active flows"
@@ -512,7 +521,7 @@ switches"() {
         exc.responseBodyAsString.to(MessageError).errorMessage.contains("Can not swap endpoints for flows: " +
                 "Requested flow '$flow1.id' conflicts with existing flow '$flow3.id'.")
 
-        and: "Delete flows"
+        cleanup: "Delete flows"
         [flow1, flow2, flow3].each { flowHelper.deleteFlow(it.id) }
 
         where:
@@ -570,6 +579,7 @@ switches"() {
         conflictingEndpoint << ["source", "destination"] * 3
     }
 
+    @Tidy
     @Unroll
     def "Unable to swap endpoints for two flows (#description)"() {
         given: "Two active flows"
@@ -589,7 +599,7 @@ switches"() {
         exc.responseBodyAsString.to(MessageError).errorMessage == "Can not swap endpoints for flows: " +
                 "New requested endpoint for '$flow2.id' conflicts with existing endpoint for '$flow1.id'"
 
-        and: "Delete flows"
+        cleanup: "Delete flows"
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
 
         where:
@@ -606,6 +616,7 @@ switches"() {
         ]
     }
 
+    @Tidy
     @Unroll
     def "Unable to swap ports for two flows (port is occupied by ISL on #switchType switch)"() {
         given: "Two active flows"
@@ -625,7 +636,7 @@ switches"() {
         exc.responseBodyAsString.to(MessageError).errorMessage == "Can not swap endpoints for flows: " +
                 "The port $islPort on the switch '${switchPair."$switchType".dpId}' is occupied by an ISL."
 
-        and: "Delete flows"
+        cleanup: "Delete flows"
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
 
         where:
@@ -648,6 +659,7 @@ switches"() {
         ]
     }
 
+    @Tidy
     def "Able to swap endpoints for two flows when all bandwidth on ISL is consumed"() {
         setup: "Create two flows with different source and the same destination switches"
         List<SwitchPair> switchPairs = topologyHelper.allNeighboringSwitchPairs.inject(null) { result, switchPair ->
@@ -725,7 +737,7 @@ switches"() {
         validateSwitches(flow1SwitchPair)
         validateSwitches(flow2SwitchPair)
 
-        and: "Restore topology and delete flows"
+        cleanup: "Restore topology and delete flows"
         broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
         northbound.deleteLinkProps(northbound.getAllLinkProps())
@@ -735,6 +747,7 @@ switches"() {
         database.resetCosts()
     }
 
+    @Tidy
     def "Unable to swap endpoints for two flows when not enough bandwidth on ISL"() {
         setup: "Create two flows with different source and the same destination switches"
         List<SwitchPair> switchPairs = topologyHelper.allNeighboringSwitchPairs.inject(null) { result, switchPair ->
@@ -808,7 +821,7 @@ switches"() {
                 "Failed to find path with requested bandwidth=${flow1.maximumBandwidth}: " +
                 "Switch ${flow2SwitchPair.src.dpId} doesn't have links with enough bandwidth"
 
-        and: "Restore topology and delete flows"
+        cleanup: "Restore topology and delete flows"
         broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
         northbound.deleteLinkProps(northbound.getAllLinkProps())
@@ -818,6 +831,7 @@ switches"() {
         database.resetCosts()
     }
 
+    @Tidy
     @Tags(LOW_PRIORITY)
     def "Able to swap endpoints for two flows when not enough bandwidth on ISL and ignore_bandwidth=true"() {
         setup: "Create two flows with different source and the same destination switches"
@@ -896,7 +910,7 @@ switches"() {
         validateSwitches(flow1SwitchPair)
         validateSwitches(flow2SwitchPair)
 
-        and: "Restore topology and delete flows"
+        cleanup: "Restore topology and delete flows"
         broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
         northbound.deleteLinkProps(northbound.getAllLinkProps())
@@ -906,6 +920,7 @@ switches"() {
         database.resetCosts()
     }
 
+    @Tidy
     def "Unable to swap endpoints for two flows when one of them is inactive"() {
         setup: "Create two flows with different source and the same destination switches"
         List<SwitchPair> switchPairs = topologyHelper.allNeighboringSwitchPairs.inject(null) { result, switchPair ->
@@ -950,7 +965,7 @@ switches"() {
                 "Failed to find path with requested bandwidth=${flow2.maximumBandwidth}: " +
                 "Switch ${flow1SwitchPair.src.dpId} doesn't have links with enough bandwidth"
 
-        and: "Restore topology and delete flows"
+        cleanup: "Restore topology and delete flows"
         broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
@@ -959,6 +974,7 @@ switches"() {
         database.resetCosts()
     }
 
+    @Tidy
     @Unroll
     @Tags(LOW_PRIORITY)
     def "Able to swap endpoints (#description) for two protected flows"() {
@@ -984,7 +1000,7 @@ switches"() {
         validateSwitches(flow1SwitchPair)
         validateSwitches(flow2SwitchPair)
 
-        and: "Delete flows"
+        cleanup: "Delete flows"
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
 
         where:
@@ -1001,6 +1017,7 @@ switches"() {
         ]
     }
 
+    @Tidy
     @Unroll
     def "A protected flow with swapped endpoint allows traffic on main and protected paths"() {
         given: "Two protected flows with different source and destination switches"
@@ -1066,10 +1083,11 @@ switches"() {
             assert traffExam.waitExam(direction).hasTraffic()
         }
 
-        and: "Delete flows"
+        cleanup: "Delete flows"
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
     }
 
+    @Tidy
     @Unroll
     @Tags(HARDWARE)
     def "Able to swap endpoints (#description) for two vxlan flows with the same source and destination switches"() {
@@ -1096,7 +1114,7 @@ switches"() {
         and: "Switch validation doesn't show any missing/excess rules and meters"
         validateSwitches(switchPair)
 
-        and: "Delete flows"
+        cleanup: "Delete flows"
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
 
         where:

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
@@ -11,6 +11,7 @@ import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
 import org.openkilda.functionaltests.extension.failfast.Tidy
+import org.openkilda.functionaltests.extension.tags.IterationTag
 import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.PathHelper
 import org.openkilda.functionaltests.helpers.Wrappers
@@ -212,6 +213,7 @@ class SwapEndpointSpec extends HealthCheckSpecification {
 
     @Tidy
     @Unroll
+    @IterationTag(tags = [LOW_PRIORITY], iterationNameRegex = /src1/)
     def "Able to swap #endpointsPart (#description) for two flows with the same source and different destination \
 switches"() {
         given: "Two flows with the same source and different destination switches"
@@ -270,6 +272,7 @@ switches"() {
 
     @Tidy
     @Unroll
+    @IterationTag(tags = [LOW_PRIORITY], iterationNameRegex = /src1/)
     def "Able to swap endpoints (#description) for two flows with the same source and different destination \
 switches"() {
         given: "Two flows with the same source and different destination switches"
@@ -376,6 +379,7 @@ switches"() {
 
     @Tidy
     @Unroll
+    @IterationTag(tags = [LOW_PRIORITY], iterationNameRegex = /dst1/)
     def "Able to swap #endpointsPart (#description) for two flows with different source and destination switches"() {
         given: "Two flows with different source and destination switches"
         flowHelper.addFlow(flow1)
@@ -511,6 +515,7 @@ switches"() {
 
     @Tidy
     @Unroll
+    @Tags(LOW_PRIORITY)
     def "Unable to swap #endpointsPart for two flows (#description)"() {
         given: "Three active flows"
         flowHelper.addFlow(flow1)
@@ -590,6 +595,7 @@ switches"() {
 
     @Tidy
     @Unroll
+    @IterationTag(tags = [LOW_PRIORITY], iterationNameRegex = /the same src endpoint for flows/)
     def "Unable to swap endpoints for two flows (#description)"() {
         given: "Two active flows"
         flowHelper.addFlow(flow1)
@@ -627,6 +633,7 @@ switches"() {
 
     @Tidy
     @Unroll
+    @IterationTag(tags = [LOW_PRIORITY], iterationNameRegex = /dst/)
     def "Unable to swap ports for two flows (port is occupied by ISL on #switchType switch)"() {
         given: "Two active flows"
         flowHelper.addFlow(flow1)

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
@@ -3,6 +3,7 @@ package org.openkilda.functionaltests.spec.flows
 import static org.junit.Assume.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
+import static org.openkilda.functionaltests.helpers.thread.FlowHistoryConstants.REROUTE_FAIL
 import static org.openkilda.testing.Constants.NON_EXISTENT_FLOW_ID
 import static org.openkilda.testing.Constants.RULES_DELETION_TIME
 import static org.openkilda.testing.Constants.RULES_INSTALLATION_TIME
@@ -232,8 +233,8 @@ switches"() {
         validateFlows(flow1, flow2)
 
         and: "Switch validation doesn't show any missing/excess rules and meters"
-        validateSwitches(flow1SwitchPair)
-        validateSwitches(flow2SwitchPair)
+        validateSwitches(switchPairs[0])
+        validateSwitches(switchPairs[1])
 
         cleanup: "Delete flows"
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
@@ -241,10 +242,14 @@ switches"() {
         where:
         endpointsPart << ["vlans", "ports", "switches"]
         description << ["src1 <-> dst2, dst1 <-> src2"] * 3
-        flow1SwitchPair << [getTopologyHelper().getNotNeighboringSwitchPair()] * 3
-        flow2SwitchPair << [getHalfDifferentNotNeighboringSwitchPair(flow1SwitchPair, "src")] * 3
-        flow1 << [getFirstFlow(flow1SwitchPair, flow2SwitchPair)] * 3
-        flow2 << [getSecondFlow(flow1SwitchPair, flow2SwitchPair, flow1)] * 3
+        switchPairs << [getTopologyHelper().getAllNotNeighboringSwitchPairs().inject(null) { result, switchPair ->
+            if (result) return result
+            def halfDifferent = getHalfDifferentNotNeighboringSwitchPair(switchPair, "src")
+            if (halfDifferent) result = [switchPair, halfDifferent]
+            return result
+        }] * 3
+        flow1 << [getFirstFlow(switchPairs[0], switchPairs[1])] * 3
+        flow2 << [getSecondFlow(switchPairs[0], switchPairs[1], flow1)] * 3
         [flow1Src, flow1Dst, flow2Src, flow2Dst] << [
                 [changePropertyValue(flow1.source, "vlanId", flow2.destination.vlanId),
                  changePropertyValue(flow1.destination, "vlanId", flow2.source.vlanId),
@@ -286,18 +291,22 @@ switches"() {
         validateFlows(flow1, flow2)
 
         and: "Switch validation doesn't show any missing/excess rules and meters"
-        validateSwitches(flow1SwitchPair)
-        validateSwitches(flow2SwitchPair)
+        validateSwitches(switchPairs[0])
+        validateSwitches(switchPairs[1])
 
         cleanup: "Delete flows"
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
 
         where:
         description << ["src1 <-> src2", "dst1 <-> dst2", "src1 <-> dst2", "dst1 <-> src2"]
-        flow1SwitchPair << [getTopologyHelper().getNotNeighboringSwitchPair()] * 4
-        flow2SwitchPair << [getHalfDifferentNotNeighboringSwitchPair(flow1SwitchPair, "src")] * 4
-        flow1 << [getFirstFlow(flow1SwitchPair, flow2SwitchPair)] * 4
-        flow2 << [getSecondFlow(flow1SwitchPair, flow2SwitchPair, flow1)] * 4
+        switchPairs << [getTopologyHelper().getAllNotNeighboringSwitchPairs().inject(null) { result, switchPair ->
+            if (result) return result
+            def halfDifferent = getHalfDifferentNotNeighboringSwitchPair(switchPair, "src")
+            if (halfDifferent) result = [switchPair, halfDifferent]
+            return result
+        }] * 4
+        flow1 << [getFirstFlow(switchPairs[0], switchPairs[1])] * 4
+        flow2 << [getSecondFlow(switchPairs[0], switchPairs[1], flow1)] * 4
         [flow1Src, flow1Dst, flow2Src, flow2Dst] << [
                 [flow2.source, flow1.destination, flow1.source, flow2.destination],
                 [flow1.source, flow2.destination, flow2.source, flow1.destination],
@@ -949,6 +958,7 @@ switches"() {
                 it.state == IslChangeType.FAILED
             }.size() == broughtDownPorts.size() * 2
             assert northbound.getFlowStatus(flow1.id).status == FlowState.DOWN
+            assert northbound.getFlowHistory(flow1.id).last().histories.find { it.action == REROUTE_FAIL }
         }
 
         when: "Try to swap endpoints for two flows"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ThrottlingRerouteSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ThrottlingRerouteSpec.groovy
@@ -3,6 +3,7 @@ package org.openkilda.functionaltests.spec.flows
 import static org.junit.Assume.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.VIRTUAL
+import static org.openkilda.functionaltests.helpers.thread.FlowHistoryConstants.REROUTE_FAIL
 import static org.openkilda.testing.Constants.PATH_INSTALLATION_TIME
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
@@ -71,15 +72,18 @@ class ThrottlingRerouteSpec extends HealthCheckSpecification {
         def waitTime = untilReroutesBegin() / 1000.0 + PATH_INSTALLATION_TIME
         Wrappers.wait(waitTime) {
             //Flow should go DOWN or change path on reroute. In our case it doesn't matter which of these happen.
-            assert northbound.getFlowStatus(flows.first().flowId).status == FlowState.DOWN ||
+            assert (northbound.getFlowStatus(flows.first().flowId).status == FlowState.DOWN &&
+                    northbound.getFlowHistory(flows.first().flowId).last().histories.find { it.action == REROUTE_FAIL }) ||
                     northbound.getFlowPath(flows.first().flowId) != flowPaths.first()
         }
 
         and: "The rest of the flows are rerouted too"
         Wrappers.wait(WAIT_OFFSET) {
             flowPaths[1..-1].each { flowPath ->
-                assert northbound.getFlowStatus(flowPath.id).status == FlowState.DOWN ||
-                        northbound.getFlowPath(flowPath.id) != flowPath
+                assert (northbound.getFlowStatus(flowPath.id).status == FlowState.DOWN && northbound
+                        .getFlowHistory(flowPath.id).last().histories.find { it.action == REROUTE_FAIL })  ||
+                        (northbound.getFlowPath(flowPath.id) != flowPath &&
+                                northbound.getFlowStatus(flowPath.id).status == FlowState.UP)
             }
         }
 
@@ -152,7 +156,8 @@ class ThrottlingRerouteSpec extends HealthCheckSpecification {
         def flowPathsClone = flowPaths.collect()
         Wrappers.wait(untilHardTimeoutEnds() + WAIT_OFFSET) {
             flowPathsClone.removeAll { flowPath ->
-                northbound.getFlowStatus(flowPath.id).status == FlowState.DOWN ||
+                (northbound.getFlowStatus(flowPath.id).status == FlowState.DOWN && northbound
+                        .getFlowHistory(flowPath.id).last().histories.find { it.action == REROUTE_FAIL }) ||
                         northbound.getFlowPath(flowPath.id) != flowPath
             }
             assert flowPathsClone.empty

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/VxlanFlowV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/VxlanFlowV2Spec.groovy
@@ -50,6 +50,7 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
     @Autowired
     Provider<TraffExamService> traffExamProvider
 
+    @Tidy
     @Ignore("https://github.com/telstra/open-kilda/issues/2995")
     @Unroll
     @Tags(HARDWARE)
@@ -175,7 +176,7 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
             }
         }
 
-        and: "Cleanup: Delete the flow"
+        cleanup: "Delete the flow"
         flowHelperV2.deleteFlow(flow.flowId)
 
         where:
@@ -184,6 +185,7 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
         FlowEncapsulationType.VXLAN        | FlowEncapsulationType.TRANSIT_VLAN
     }
 
+    @Tidy
     @Tags(HARDWARE)
     def "Able to CRUD a pinned flow with 'VXLAN' encapsulation"() {
         when: "Create a flow"
@@ -212,10 +214,11 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
             assert northbound.getFlowStatus(flow.flowId).status == FlowState.UP
         }
 
-        and: "Cleanup: Delete the flow"
+        cleanup: "Delete the flow"
         flowHelperV2.deleteFlow(flow.flowId)
     }
 
+    @Tidy
     @Tags(HARDWARE)
     def "Able to CRUD a vxlan flow with protected path"() {
         given: "Two active Noviflow switches with two available path at least"
@@ -329,10 +332,11 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
             assert direction.discrepancies.empty
         }
 
-        and: "Cleanup: Delete the flow and reset costs"
+        cleanup: "Delete the flow and reset costs"
         flowHelperV2.deleteFlow(flow.flowId)
     }
 
+    @Tidy
     @Tags(HARDWARE)
     def "System allows tagged traffic via default flow(0<->0) with 'VXLAN' encapsulation"() {
         // we can't test (0<->20, 20<->0) because iperf is not able to establish a connection
@@ -367,7 +371,7 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
             }
         }
 
-        and: "Cleanup: Delete the flow"
+        cleanup: "Delete the flow"
         flowHelperV2.deleteFlow(defaultFlow.flowId)
     }
 
@@ -486,6 +490,7 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
         initNoVxlanSwProps && SwitchHelper.updateSwitchProperties(noVxlanSw, initNoVxlanSwProps)
     }
 
+    @Tidy
     @Tags([LOW_PRIORITY, TOPOLOGY_DEPENDENT])
     def "Unable to create a vxlan flow when dst switch does not support it"() {
         given: "Noviflow and non-Noviflow switches"
@@ -508,8 +513,12 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
         errorDetails.errorDescription == "Not enough bandwidth or no path found. Failed to find path with " +
                 "requested bandwidth=$flow.maximumBandwidth: " +
                 "Switch $switchPair.dst.dpId doesn't have links with enough bandwidth"
+
+        cleanup:
+        !exc && flowHelperV2.deleteFlow(flow.flowId)
     }
 
+    @Tidy
     @Unroll
     @Tags(HARDWARE)
     def "System allows to create/update encapsulation type for a one-switch flow\
@@ -585,7 +594,7 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
             }
         }
 
-        and: "Cleanup: Delete the flow"
+        cleanup: "Delete the flow"
         flowHelperV2.deleteFlow(flow.flowId)
 
         where:

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/VxlanFlowV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/VxlanFlowV2Spec.groovy
@@ -4,6 +4,7 @@ import static groovyx.gpars.GParsPool.withPool
 import static org.junit.Assume.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
+import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE_SWITCHES
 import static org.openkilda.functionaltests.extension.tags.Tag.TOPOLOGY_DEPENDENT
 import static org.openkilda.testing.Constants.PATH_INSTALLATION_TIME
 import static org.openkilda.testing.Constants.RULES_DELETION_TIME
@@ -12,9 +13,12 @@ import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
 import org.openkilda.functionaltests.extension.failfast.Tidy
+import org.openkilda.functionaltests.extension.tags.IterationTag
+import org.openkilda.functionaltests.extension.tags.IterationTags
 import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.SwitchHelper
 import org.openkilda.functionaltests.helpers.Wrappers
+import org.openkilda.functionaltests.helpers.model.SwitchPair
 import org.openkilda.messaging.error.MessageError
 import org.openkilda.messaging.info.event.PathNode
 import org.openkilda.messaging.payload.flow.DetectConnectedDevicesPayload
@@ -29,9 +33,12 @@ import org.openkilda.northbound.dto.v1.switches.SwitchPropertiesDto
 import org.openkilda.northbound.dto.v2.flows.FlowEndpointV2
 import org.openkilda.northbound.dto.v2.flows.FlowRequestV2
 import org.openkilda.testing.model.topology.TopologyDefinition.Switch
+import org.openkilda.testing.service.traffexam.FlowNotApplicableException
 import org.openkilda.testing.service.traffexam.TraffExamService
 import org.openkilda.testing.tools.FlowTrafficExamBuilder
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.client.HttpClientErrorException
 import spock.lang.Ignore
@@ -47,6 +54,8 @@ flow with protected path, default flow) for a flow with VXLAN encapsulation.
 NOTE: A flow with the 'VXLAN' encapsulation is supported on a Noviflow switches.
 So, flow can be created on a Noviflow(src/dst/transit) switches only.""")
 class VxlanFlowV2Spec extends HealthCheckSpecification {
+    static Logger logger = LoggerFactory.getLogger(VxlanFlowV2Spec.class)
+
     @Autowired
     Provider<TraffExamService> traffExamProvider
 
@@ -54,26 +63,19 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
     @Ignore("https://github.com/telstra/open-kilda/issues/2995")
     @Unroll
     @Tags(HARDWARE)
+    @IterationTags([
+            @IterationTag(tags = [SMOKE_SWITCHES], iterationNameRegex = /TRANSIT_VLAN -> VXLAN/)
+    ])
     def "System allows to create/update encapsulation type for a flow\
-(#encapsulationCreate.toString() -> #encapsulationUpdate.toString())"() {
-        given: "Two active neighboring Noviflow switches with traffgens"
-        def allTraffgenSwitchIds = topology.activeTraffGens*.switchConnected.findAll {
-            it.noviflow && !it.wb5164
-        }*.dpId ?: assumeTrue("Should be at least two active traffgens connected to NoviFlow switches",
-                false)
-
-        def switchPair = topologyHelper.getAllNeighboringSwitchPairs().find {
-            allTraffgenSwitchIds.contains(it.src.dpId) && allTraffgenSwitchIds.contains(it.dst.dpId)
-        } ?: assumeTrue("Unable to find required switches in topology", false)
-
+(#data.encapsulationCreate.toString() -> #data.encapsulationUpdate.toString(), #swPair)"(Map data, SwitchPair swPair) {
         when: "Create a flow with #encapsulationCreate.toString() encapsulation type"
-        def flow = flowHelperV2.randomFlow(switchPair)
-        flow.encapsulationType = encapsulationCreate
+        def flow = flowHelperV2.randomFlow(swPair)
+        flow.encapsulationType = data.encapsulationCreate
         flowHelperV2.addFlow(flow)
 
         then: "Flow is created with the #encapsulationCreate.toString() encapsulation type"
         def flowInfo = northbound.getFlow(flow.flowId)
-        flowInfo.encapsulationType == encapsulationCreate.toString().toLowerCase()
+        flowInfo.encapsulationType == data.encapsulationCreate.toString().toLowerCase()
 
         and: "Correct rules are installed"
         def vxlanRule = (flowInfo.encapsulationType == FlowEncapsulationType.VXLAN.toString().toLowerCase())
@@ -81,7 +83,7 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
         // ingressRule should contain "pushVxlan"
         // egressRule should contain "tunnel-id"
         Wrappers.wait(RULES_INSTALLATION_TIME) {
-            verifyAll(northbound.getSwitchRules(switchPair.src.dpId).flowEntries) { rules ->
+            verifyAll(northbound.getSwitchRules(swPair.src.dpId).flowEntries) { rules ->
                 rules.find {
                     it.cookie == flowInfoFromDb.forwardPath.cookie.value
                 }.instructions.applyActions.pushVxlan as boolean == vxlanRule
@@ -90,7 +92,7 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
                 }.match.tunnelId as boolean == vxlanRule
             }
 
-            verifyAll(northbound.getSwitchRules(switchPair.dst.dpId).flowEntries) { rules ->
+            verifyAll(northbound.getSwitchRules(swPair.dst.dpId).flowEntries) { rules ->
                 rules.find {
                     it.cookie == flowInfoFromDb.forwardPath.cookie.value
                 }.match.tunnelId as boolean == vxlanRule
@@ -107,13 +109,20 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
 
         and: "The flow allows traffic"
         def traffExam = traffExamProvider.get()
-        def exam = new FlowTrafficExamBuilder(topology, traffExam).buildBidirectionalExam(toFlowPayload(flow), 1000, 5)
-        withPool {
-            [exam.forward, exam.reverse].eachParallel { direction ->
-                def resources = traffExam.startExam(direction)
-                direction.setResources(resources)
-                assert traffExam.waitExam(direction).hasTraffic()
+        def exam
+        try {
+            exam = new FlowTrafficExamBuilder(topology, traffExam).buildBidirectionalExam(toFlowPayload(flow), 1000, 5)
+            withPool {
+                [exam.forward, exam.reverse].eachParallel { direction ->
+                    def resources = traffExam.startExam(direction)
+                    direction.setResources(resources)
+                    assert traffExam.waitExam(direction).hasTraffic()
+                }
             }
+        } catch (FlowNotApplicableException e) {
+            //flow is not applicable for traff exam. That's fine, just inform
+            logger.warn(e.message)
+            exam = null
         }
 
         and: "Flow is pingable"
@@ -124,11 +133,11 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
 
         when: "Try to update the encapsulation type to #encapsulationUpdate.toString()"
         northboundV2.updateFlow(flowInfo.id,
-                flowHelperV2.toV2(flowInfo.tap { it.encapsulationType = encapsulationUpdate }))
+                flowHelperV2.toV2(flowInfo.tap { it.encapsulationType = data.encapsulationUpdate }))
 
         then: "The encapsulation type is changed to #encapsulationUpdate.toString()"
         def flowInfo2 = northbound.getFlow(flow.flowId)
-        flowInfo2.encapsulationType == encapsulationUpdate.toString().toLowerCase()
+        flowInfo2.encapsulationType == data.encapsulationUpdate.toString().toLowerCase()
 
         and: "Flow is valid"
         Wrappers.wait(PATH_INSTALLATION_TIME) {
@@ -136,11 +145,13 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
         }
 
         and: "The flow allows traffic"
-        withPool {
-            [exam.forward, exam.reverse].eachParallel { direction ->
-                def resources = traffExam.startExam(direction)
-                direction.setResources(resources)
-                assert traffExam.waitExam(direction).hasTraffic()
+        if(exam) {
+            withPool {
+                [exam.forward, exam.reverse].eachParallel { direction ->
+                    def resources = traffExam.startExam(direction)
+                    direction.setResources(resources)
+                    assert traffExam.waitExam(direction).hasTraffic()
+                }
             }
         }
 
@@ -157,7 +168,7 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
 
         and: "New rules are installed correctly"
         Wrappers.wait(RULES_INSTALLATION_TIME) {
-            verifyAll(northbound.getSwitchRules(switchPair.src.dpId).flowEntries) { rules ->
+            verifyAll(northbound.getSwitchRules(swPair.src.dpId).flowEntries) { rules ->
                 rules.find {
                     it.cookie == flowInfoFromDb2.forwardPath.cookie.value
                 }.instructions.applyActions.pushVxlan as boolean == !vxlanRule
@@ -166,7 +177,7 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
                 }.match.tunnelId as boolean == !vxlanRule
             }
 
-            verifyAll(northbound.getSwitchRules(switchPair.dst.dpId).flowEntries) { rules ->
+            verifyAll(northbound.getSwitchRules(swPair.dst.dpId).flowEntries) { rules ->
                 rules.find {
                     it.cookie == flowInfoFromDb2.forwardPath.cookie.value
                 }.match.tunnelId as boolean == !vxlanRule
@@ -180,9 +191,18 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
         flowHelperV2.deleteFlow(flow.flowId)
 
         where:
-        encapsulationCreate                | encapsulationUpdate
-        FlowEncapsulationType.TRANSIT_VLAN | FlowEncapsulationType.VXLAN
-        FlowEncapsulationType.VXLAN        | FlowEncapsulationType.TRANSIT_VLAN
+        [data, swPair] << ([
+                [
+                        [
+                                encapsulationCreate: FlowEncapsulationType.TRANSIT_VLAN,
+                                encapsulationUpdate: FlowEncapsulationType.VXLAN
+                        ],
+                        [
+                                encapsulationCreate: FlowEncapsulationType.VXLAN,
+                                encapsulationUpdate: FlowEncapsulationType.TRANSIT_VLAN
+                        ]
+                ], getUniqueVxlanSwitchPairs()
+        ].combinations() ?: assumeTrue("Not enough VXLAN-enabled switches in topology", false))
     }
 
     @Tidy
@@ -617,5 +637,28 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
                    .maximumBandwidth(flow.maximumBandwidth)
                    .ignoreBandwidth(flow.ignoreBandwidth)
                    .build()
+    }
+
+    /**
+     * Get minimum amount of switchPairs that will use every unique legal switch as src or dst at least once
+     */
+    List<SwitchPair> getUniqueVxlanSwitchPairs() {
+        def vxlanEnabledSwitches = topology.activeSwitches.findAll {
+            northbound.getSwitchProperties(it.dpId).supportedTransitEncapsulation
+                      .contains(FlowEncapsulationType.VXLAN.toString().toLowerCase())
+        }
+        def vxlanSwitchPairs = topologyHelper.getSwitchPairs().findAll { swPair ->
+            swPair.paths.find { pathHelper.getInvolvedSwitches(it).every { it in vxlanEnabledSwitches } }
+        }
+        def switchesToPick = vxlanSwitchPairs.collectMany { [it.src, it.dst] }
+                                             .unique { it.details.hardware + it.details.software }
+        return vxlanSwitchPairs.inject([]) { r, switchPair ->
+            if (switchPair.src in switchesToPick || switchPair.dst in switchesToPick ) {
+                r << switchPair
+                switchesToPick.remove(switchPair.src)
+                switchesToPick.remove(switchPair.dst)
+            }
+            r
+        } as List<SwitchPair>
     }
 }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/grpc/GrpcCommonSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/grpc/GrpcCommonSpec.groovy
@@ -1,8 +1,12 @@
 package org.openkilda.functionaltests.spec.grpc
 
+import org.openkilda.functionaltests.extension.failfast.Tidy
+
 import spock.lang.Unroll
 
 class GrpcCommonSpec extends GrpcBaseSpecification {
+
+    @Tidy
     @Unroll
     def "Able to get switch status on the #switches.switchId switch"() {
         when: "Get switch status"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/grpc/LogSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/grpc/LogSpec.groovy
@@ -5,6 +5,7 @@ import static org.openkilda.testing.ConstantsGrpc.DEFAULT_LOG_OF_MESSAGES_STATE
 import static org.openkilda.testing.ConstantsGrpc.REMOTE_LOG_IP
 import static org.openkilda.testing.ConstantsGrpc.REMOTE_LOG_PORT
 
+import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.grpc.speaker.model.LogMessagesDto
 import org.openkilda.grpc.speaker.model.LogOferrorsDto
 import org.openkilda.grpc.speaker.model.RemoteLogServerDto
@@ -27,6 +28,7 @@ class LogSpec extends GrpcBaseSpecification {
     @Value('${grpc.remote.log.server.port}')
     Integer defaultRemoteLogServerPort
 
+    @Tidy
     @Unroll
     def "Able to enable 'log messages' on the #switches.switchId switch"() {
         when: "Try to turn on 'log messages'"
@@ -49,6 +51,7 @@ class LogSpec extends GrpcBaseSpecification {
         switches << getNoviflowSwitches()
     }
 
+    @Tidy
     @Unroll
     def "Able to enable 'OF log messages'  on the #switches.switchId switch"() {
         when: "Try to turn on 'OF log messages'"
@@ -72,6 +75,7 @@ class LogSpec extends GrpcBaseSpecification {
         switches << getNoviflowSwitches()
     }
 
+    @Tidy
     @Unroll
     def "Able to manipulate(CRUD) with a remote log server on the #switches.switchId switch"() {
         when: "Remove current remote log server configuration"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/grpc/LogicalPortSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/grpc/LogicalPortSpec.groovy
@@ -1,5 +1,6 @@
 package org.openkilda.functionaltests.spec.grpc
 
+import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.grpc.speaker.model.LogicalPortDto
 import org.openkilda.messaging.error.MessageError
 
@@ -17,6 +18,7 @@ a list of BFD ports to them to create a LAG for fast-failover for BFD sessions.
 NOTE: The GRPC implementation supports the LAG type only and it is set by default.""")
 class LogicalPortSpec extends GrpcBaseSpecification {
 
+    @Tidy
     @Unroll
     def "Able to create/read/delete logicalport on the #switches.switchId switch"() {
         /**the update action is not working(issue on a Noviflow switch side)*/
@@ -92,6 +94,7 @@ class LogicalPortSpec extends GrpcBaseSpecification {
                 ], noviflowSwitches].combinations()
     }
 
+    @Tidy
     @Unroll
     def "Not able to delete non-existent logical port number on the #switches.switchId switch"() {
         when: "Try to delete incorrect logicalPortNumber"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/BfdSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/BfdSpec.groovy
@@ -155,7 +155,10 @@ class BfdSpec extends HealthCheckSpecification {
         assumeTrue("Require at least one a-switch BFD ISL between Noviflow switches", isl as boolean)
         antiflap.portDown(isl.srcSwitch.dpId, isl.srcPort)
         northbound.setLinkBfd(islUtils.toLinkEnableBfd(isl, true))
-        Wrappers.wait(WAIT_OFFSET) { assert islUtils.getIslInfo(isl).get().state == IslChangeType.FAILED }
+        Wrappers.wait(WAIT_OFFSET) {
+            assert northbound.getLink(isl).actualState == IslChangeType.FAILED
+            assert northbound.getLink(isl.reversed).actualState == IslChangeType.FAILED
+        }
 
         when: "Delete the link"
         northbound.deleteLink(islUtils.toLinkParameters(isl))

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/BfdSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/BfdSpec.groovy
@@ -157,11 +157,14 @@ class BfdSpec extends HealthCheckSpecification {
         northbound.setLinkBfd(islUtils.toLinkEnableBfd(isl, true))
         Wrappers.wait(WAIT_OFFSET) {
             assert northbound.getLink(isl).actualState == IslChangeType.FAILED
-            assert northbound.getLink(isl.reversed).actualState == IslChangeType.FAILED
         }
 
         when: "Delete the link"
         northbound.deleteLink(islUtils.toLinkParameters(isl))
+        Wrappers.wait(2) {
+            assert !islUtils.getIslInfo(isl)
+            assert !islUtils.getIslInfo(isl.reversed)
+        }
 
         and: "Discover the removed link again"
         antiflap.portUp(isl.srcSwitch.dpId, isl.srcPort)

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/BfdSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/BfdSpec.groovy
@@ -6,6 +6,7 @@ import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE_SWITCHES
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.info.event.IslChangeType
@@ -22,6 +23,7 @@ controller-involved discovery mechanism""")
 @Tags([HARDWARE])
 @Ignore("Temporary disabled because of problems with bfd")
 class BfdSpec extends HealthCheckSpecification {
+    @Tidy
     @Tags([SMOKE_SWITCHES])
     def "Able to create a valid BFD session between two Noviflow switches"() {
         given: "An a-switch ISL between two Noviflow switches"
@@ -84,7 +86,8 @@ class BfdSpec extends HealthCheckSpecification {
             assert northbound.getLink(isl.reversed).state == IslChangeType.FAILED
         }
 
-        and: "Cleanup: restore broken ISL"
+        cleanup: "Restore broken ISL"
+        createBfdResponse && !removeBfdResponse && northbound.setLinkBfd(islUtils.toLinkEnableBfd(isl, false))
         lockKeeper.addFlows([isl.aswitch])
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             assert northbound.getLink(isl).state == IslChangeType.DISCOVERED
@@ -92,6 +95,7 @@ class BfdSpec extends HealthCheckSpecification {
         }
     }
 
+    @Tidy
     def "Reacting on BFD events can be turned on/off by a feature toggle"() {
         given: "An a-switch ISL between two Noviflow switches with BFD enabled"
         def isl = topology.islsForActiveSwitches.find { it.srcSwitch.noviflow && it.dstSwitch.noviflow &&
@@ -100,7 +104,7 @@ class BfdSpec extends HealthCheckSpecification {
         northbound.setLinkBfd(islUtils.toLinkEnableBfd(isl, true))
 
         when: "Set BFD toggle to 'off' state"
-        northbound.toggleFeature(FeatureTogglesDto.builder().useBfdForIslIntegrityCheck(false).build())
+        def toggleOff = northbound.toggleFeature(FeatureTogglesDto.builder().useBfdForIslIntegrityCheck(false).build())
 
         and: "Interrupt ISL connection by breaking rule on a-switch"
         lockKeeper.removeFlows([isl.aswitch])
@@ -119,7 +123,7 @@ class BfdSpec extends HealthCheckSpecification {
 
         when: "Set BFD toggle back to 'on' state and restore the ISL"
         lockKeeper.addFlows([isl.aswitch])
-        northbound.toggleFeature(FeatureTogglesDto.builder().useBfdForIslIntegrityCheck(true).build())
+        def toggleOn = northbound.toggleFeature(FeatureTogglesDto.builder().useBfdForIslIntegrityCheck(true).build())
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             assert northbound.getLink(isl).state == IslChangeType.DISCOVERED
             assert northbound.getLink(isl.reversed).state == IslChangeType.DISCOVERED
@@ -134,7 +138,8 @@ class BfdSpec extends HealthCheckSpecification {
             assert northbound.getLink(isl.reversed).state == IslChangeType.FAILED
         }
 
-        and: "Cleanup: restore ISL and remove BFD session"
+        cleanup: "Restore ISL and remove BFD session"
+        toggleOff && !toggleOn && northbound.toggleFeature(FeatureTogglesDto.builder().useBfdForIslIntegrityCheck(true).build())
         lockKeeper.addFlows([isl.aswitch])
         northbound.setLinkBfd(islUtils.toLinkEnableBfd(isl, false))
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkPropertiesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkPropertiesSpec.groovy
@@ -4,6 +4,7 @@ import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.functionaltests.extension.fixture.TestFixture
 import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
@@ -34,6 +35,7 @@ class LinkPropertiesSpec extends HealthCheckSpecification {
         database.resetCosts()
     }
 
+    @Tidy
     def "Empty list is returned if there are no properties"() {
         expect: "Get link properties is empty for no properties"
         northbound.getAllLinkProps().empty
@@ -42,7 +44,8 @@ class LinkPropertiesSpec extends HealthCheckSpecification {
     //TODO(ylobankov): Actually this is abnormal behavior and we should have an error. But this test is aligned
     // with the current system behavior to verify that system is not hanging. Need to rework the test when system
     // behavior is fixed.
-    def "Link props are created with empty values when sending not a valid link props key"() {
+    @Tidy
+    def "Link props are created with empty values when sending an invalid link props key"() {
         when: "Send link property request with invalid character"
         def response = northbound.updateLinkProps([new LinkPropsDto("00:00:00:00:00:00:00:01", 1,
                 "00:00:00:00:00:00:00:02", 1, ["`cost": "700"])])
@@ -55,7 +58,7 @@ class LinkPropertiesSpec extends HealthCheckSpecification {
         linkProps.size() == 2
         linkProps.each { assert it.props.isEmpty() }
 
-        and: "Delete created link props"
+        cleanup: "Delete created link props"
         northbound.deleteLinkProps(linkProps)
     }
 
@@ -83,6 +86,7 @@ class LinkPropertiesSpec extends HealthCheckSpecification {
         key << ["cost", "max_bandwidth"]
     }
 
+    @Tidy
     @Unroll
     @TestFixture(setup = "prepareLinkPropsForSearch", cleanup = "cleanLinkPropsAfterSearch")
     def "Searching for link props with #data.descr"() {

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkPropertiesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkPropertiesSpec.groovy
@@ -206,13 +206,15 @@ class LinkPropertiesSpec extends HealthCheckSpecification {
         antiflap.portDown(isl.srcSwitch.dpId, isl.srcPort)
         Wrappers.wait(WAIT_OFFSET) {
             assert northbound.getLink(isl).actualState == IslChangeType.FAILED
-            assert northbound.getLink(isl.reversed).actualState == IslChangeType.FAILED
         }
 
         and: "Delete the link"
         northbound.deleteLink(islUtils.toLinkParameters(isl))
-        assert !islUtils.getIslInfo(isl)
-        assert !islUtils.getIslInfo(isl.reversed)
+        Wrappers.wait(2) {
+            assert !islUtils.getIslInfo(isl)
+            assert !islUtils.getIslInfo(isl.reversed)
+        }
+
 
         and: "Set cost and max bandwidth on the deleted link via link props"
         def costValue = "12345"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkPropertiesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkPropertiesSpec.groovy
@@ -204,7 +204,10 @@ class LinkPropertiesSpec extends HealthCheckSpecification {
 
         and: "Bring port down on the source switch"
         antiflap.portDown(isl.srcSwitch.dpId, isl.srcPort)
-        Wrappers.wait(WAIT_OFFSET) { assert islUtils.getIslInfo(isl).get().state == IslChangeType.FAILED }
+        Wrappers.wait(WAIT_OFFSET) {
+            assert northbound.getLink(isl).actualState == IslChangeType.FAILED
+            assert northbound.getLink(isl.reversed).actualState == IslChangeType.FAILED
+        }
 
         and: "Delete the link"
         northbound.deleteLink(islUtils.toLinkParameters(isl))

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
@@ -15,7 +15,6 @@ import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.error.MessageError
 import org.openkilda.messaging.info.event.IslChangeType
 import org.openkilda.messaging.info.event.IslInfoData
-import org.openkilda.messaging.info.event.PathNode
 import org.openkilda.messaging.info.event.SwitchChangeType
 import org.openkilda.messaging.payload.flow.FlowState
 import org.openkilda.model.SwitchId
@@ -316,15 +315,20 @@ class LinkSpec extends HealthCheckSpecification {
         given: "An inactive link"
         assumeTrue("Unable to locate $islDescription ISL for this test", isl as boolean)
         antiflap.portDown(isl.srcSwitch.dpId, isl.srcPort)
-        Wrappers.wait(WAIT_OFFSET) { assert islUtils.getIslInfo(isl).get().state == IslChangeType.FAILED }
+        Wrappers.wait(WAIT_OFFSET) {
+            assert northbound.getLink(isl).actualState == IslChangeType.FAILED
+            assert northbound.getLink(isl.reversed).actualState == IslChangeType.FAILED
+        }
 
         when: "Try to delete the link"
         def response = northbound.deleteLink(islUtils.toLinkParameters(isl))
 
         then: "The link is actually deleted"
         response.size() == 2
-        !islUtils.getIslInfo(isl)
-        !islUtils.getIslInfo(isl.reversed)
+        Wrappers.wait(2) {
+            assert !islUtils.getIslInfo(isl)
+            assert !islUtils.getIslInfo(isl.reversed)
+        }
 
         when: "Removed link becomes active again (port brought UP)"
         antiflap.portUp(isl.srcSwitch.dpId, isl.srcPort)

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
@@ -229,6 +229,7 @@ class LinkSpec extends HealthCheckSpecification {
         }
     }
 
+    @Tidy
     @Unroll
     def "Unable to get flows for NOT existing link (#item doesn't exist)"() {
         when: "Get flows for NOT existing link"
@@ -248,6 +249,7 @@ class LinkSpec extends HealthCheckSpecification {
         getIsl().srcSwitch.dpId | getIsl().srcPort | getIsl().dstSwitch.dpId | 4096             | "dst_port"
     }
 
+    @Tidy
     @Unroll
     def "Unable to get flows with specifying invalid query parameters (#item is invalid)"() {
         when: "Get flows with specifying invalid #item"
@@ -284,6 +286,7 @@ class LinkSpec extends HealthCheckSpecification {
         getIsl().srcSwitch.dpId | getIsl().srcPort | getIsl().dstSwitch.dpId | null      | "dst_port"
     }
 
+    @Tidy
     def "Unable to delete a nonexistent link"() {
         given: "Parameters of nonexistent link"
         def parameters = new LinkParametersDto(new SwitchId(1).toString(), 100, new SwitchId(2).toString(), 100)
@@ -317,7 +320,6 @@ class LinkSpec extends HealthCheckSpecification {
         antiflap.portDown(isl.srcSwitch.dpId, isl.srcPort)
         Wrappers.wait(WAIT_OFFSET) {
             assert northbound.getLink(isl).actualState == IslChangeType.FAILED
-            assert northbound.getLink(isl.reversed).actualState == IslChangeType.FAILED
         }
 
         when: "Try to delete the link"
@@ -393,6 +395,7 @@ class LinkSpec extends HealthCheckSpecification {
         northbound.deleteLinkProps(northbound.getAllLinkProps())
     }
 
+    @Tidy
     @Unroll
     def "Unable to reroute flows with specifying NOT existing link (#item doesn't exist)"() {
         when: "Reroute flows with specifying NOT existing link"
@@ -412,6 +415,7 @@ class LinkSpec extends HealthCheckSpecification {
         getIsl().srcSwitch.dpId | getIsl().srcPort | getIsl().dstSwitch.dpId | 4096             | "dst_port"
     }
 
+    @Tidy
     @Unroll
     def "Unable to reroute flows with specifying invalid query parameters (#item is invalid)"() {
         when: "Reroute flows with specifying invalid #item"
@@ -429,6 +433,7 @@ class LinkSpec extends HealthCheckSpecification {
         getIsl().srcSwitch.dpId | -3               | getIsl().dstSwitch.dpId | -4               | "src_port & dst_port"
     }
 
+    @Tidy
     @Unroll
     def "Unable to reroute flows without full specifying a particular link (#item is missing)"() {
         when: "Reroute flows without specifying #item"
@@ -447,6 +452,7 @@ class LinkSpec extends HealthCheckSpecification {
         getIsl().srcSwitch.dpId | getIsl().srcPort | getIsl().dstSwitch.dpId | null      | "dst_port"
     }
 
+    @Tidy
     @Unroll
     def "Get links with specifying query parameters"() {
         when: "Get links with specifying query parameters"
@@ -464,6 +470,7 @@ class LinkSpec extends HealthCheckSpecification {
         getIsl().srcSwitch.dpId | getIsl().srcPort | getIsl().dstSwitch.dpId | getIsl().dstPort
     }
 
+    @Tidy
     @Unroll
     def "Get links with specifying NOT existing query parameters (#item doesn't exist)"() {
         when: "Get links with specifying NOT existing query parameters"
@@ -480,6 +487,7 @@ class LinkSpec extends HealthCheckSpecification {
         getIsl().srcSwitch.dpId | getIsl().srcPort | getIsl().dstSwitch.dpId | 4096             | "dst_port"
     }
 
+    @Tidy
     @Unroll
     def "Unable to get links with specifying invalid query parameters (#item is invalid)"() {
         when: "Get links with specifying invalid #item"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/multitable/MultitableFlowsSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/multitable/MultitableFlowsSpec.groovy
@@ -5,6 +5,7 @@ import static org.junit.Assume.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE_SWITCHES
 import static org.openkilda.functionaltests.extension.tags.Tag.TOPOLOGY_DEPENDENT
+import static org.openkilda.functionaltests.helpers.thread.FlowHistoryConstants.REROUTE_FAIL
 import static org.openkilda.testing.Constants.EGRESS_RULE_MULTI_TABLE_ID
 import static org.openkilda.testing.Constants.INGRESS_RULE_MULTI_TABLE_ID
 import static org.openkilda.testing.Constants.PATH_INSTALLATION_TIME
@@ -841,6 +842,7 @@ mode with existing flows and hold flows of different table-mode types"() {
         //flow is pinned, so that's why the flow is not rerouted
         Wrappers.wait(WAIT_OFFSET) {
             assert northbound.getFlowStatus(flow.flowId).status == FlowState.DOWN
+            assert northbound.getFlowHistory(flow.flowId).last().histories.find { it.action == REROUTE_FAIL }
             assert pathHelper.convert(northbound.getFlowPath(flow.flowId)) == desiredPath
         }
 

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/FloodlightKafkaConnectionSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/FloodlightKafkaConnectionSpec.groovy
@@ -24,6 +24,7 @@ class FloodlightKafkaConnectionSpec extends HealthCheckSpecification {
 
     def "System survives temporary connection outage between Floodlight and Kafka"() {
         when: "Controller loses connection to Kafka"
+        sleep(3000) //Not respecting this 'sleep' may lead to subsequent tests instability
         def flOut = false
         lockKeeper.knockoutFloodlight()
         flOut = true
@@ -98,5 +99,6 @@ class FloodlightKafkaConnectionSpec extends HealthCheckSpecification {
             assert islUtils.getIslInfo(isls, isl).get().state == IslChangeType.DISCOVERED
             assert islUtils.getIslInfo(isls, isl.reversed).get().state == IslChangeType.DISCOVERED
         }
+        database.resetCosts()
     }
 }

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/RollbacksSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/RollbacksSpec.groovy
@@ -112,9 +112,9 @@ and at least 1 path must remain safe"
         }
         if(portDown) {
             antiflap.portUp(islToBreak.srcSwitch.dpId, islToBreak.srcPort)
-            Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-                assert northbound.getLink(islToBreak).state == IslChangeType.DISCOVERED
-            }
+        }
+        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
+            assert northbound.getActiveLinks().size() == topology.islsForActiveSwitches.size() * 2
         }
         northbound.deleteLinkProps(northbound.getAllLinkProps())
         database.resetCosts()

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/MflStatSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/MflStatSpec.groovy
@@ -198,9 +198,9 @@ class MflStatSpec extends HealthCheckSpecification {
         then: "Stat on the src switch should not be collected because it is disconnected from controllers"
         def statAfterDeletingControllers
         Wrappers.timedLoop(statsRouterInterval) {
+            sleep((waitInterval * 1000).toLong())
             statAfterDeletingControllers = otsdb.query(startTime, metric, tags).dps
             assert statAfterDeletingControllers.size() == statFromStatsController.size()
-            sleep((waitInterval * 1000).toLong())
         }
 
         when: "Restore default controllers on the src switches"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesSpec.groovy
@@ -12,6 +12,7 @@ import static org.openkilda.testing.Constants.WAIT_OFFSET
 import static spock.util.matcher.HamcrestSupport.expect
 
 import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.Message
@@ -25,6 +26,7 @@ import org.openkilda.testing.model.topology.TopologyDefinition.Switch
 import spock.lang.Unroll
 
 class DefaultRulesSpec extends HealthCheckSpecification {
+    @Tidy
     @Unroll("Default rules are installed on an #sw.ofVersion switch(#sw.dpId)")
     @Tags([TOPOLOGY_DEPENDENT, SMOKE, SMOKE_SWITCHES])
     def "Default rules are installed on switches"() {
@@ -57,6 +59,7 @@ class DefaultRulesSpec extends HealthCheckSpecification {
         }
     }
 
+    @Tidy
     @Unroll
     @Tags([TOPOLOGY_DEPENDENT, SMOKE_SWITCHES])
     def "Able to install default rule on an #sw.ofVersion switch(#sw.dpId, install-action=#data.installRulesAction)"(
@@ -79,7 +82,7 @@ class DefaultRulesSpec extends HealthCheckSpecification {
             compareRules(northbound.getSwitchRules(sw.dpId).flowEntries, expectedRules)
         }
 
-        and: "Install missing default rules"
+        cleanup: "Install missing default rules"
         northbound.installSwitchRules(sw.dpId, InstallRulesAction.INSTALL_DEFAULTS)
         Wrappers.wait(RULES_INSTALLATION_TIME) {
             assert northbound.getSwitchRules(sw.dpId).flowEntries.size() == defaultRules.size()
@@ -127,6 +130,7 @@ class DefaultRulesSpec extends HealthCheckSpecification {
         }
     }
 
+    @Tidy
     @Unroll
     @Tags([TOPOLOGY_DEPENDENT, SMOKE_SWITCHES])
     def "Able to install default multitable rule on an #sw.ofVersion \
@@ -151,7 +155,7 @@ switch(#sw.dpId, install-action=#data.installRulesAction)"(Map data, Switch sw) 
             compareRules(northbound.getSwitchRules(sw.dpId).flowEntries, expectedRules)
         }
 
-        and: "Cleanup: Install missing default rules and restore switch properties"
+        cleanup: "Install missing default rules and restore switch properties"
         northbound.installSwitchRules(sw.dpId, InstallRulesAction.INSTALL_DEFAULTS)
         Wrappers.wait(RULES_INSTALLATION_TIME) {
             assert northbound.getSwitchRules(sw.dpId).flowEntries.size() == defaultRules.size()
@@ -212,6 +216,7 @@ switch(#sw.dpId, install-action=#data.installRulesAction)"(Map data, Switch sw) 
         sw << getTopology().getActiveSwitches().unique { sw -> sw.description }
     }
 
+    @Tidy
     @Unroll
     @Tags([TOPOLOGY_DEPENDENT, SMOKE, SMOKE_SWITCHES])
     def "Able to delete default rule from an #sw.ofVersion switch (#sw.dpId, delete-action=#data.deleteRulesAction)"(
@@ -242,7 +247,7 @@ switch(#sw.dpId, install-action=#data.installRulesAction)"(Map data, Switch sw) 
             rules.proper.sort() == sw.defaultCookies.findAll { it != data.cookie }.sort()
         }
 
-        and: "Install default rules back"
+        cleanup: "Install default rules back"
         northbound.installSwitchRules(sw.dpId, InstallRulesAction.INSTALL_DEFAULTS)
         Wrappers.wait(RULES_INSTALLATION_TIME) {
             assert northbound.getSwitchRules(sw.dpId).flowEntries.size() == defaultRules.size()
@@ -277,6 +282,7 @@ switch(#sw.dpId, install-action=#data.installRulesAction)"(Map data, Switch sw) 
         }
     }
 
+    @Tidy
     @Unroll
     @Tags([TOPOLOGY_DEPENDENT, SMOKE_SWITCHES])
     def "Able to delete default multitable rule from an #sw.ofVersion \
@@ -312,7 +318,7 @@ switch (#sw.dpId, delete-action=#data.deleteRulesAction)"(Map data, Switch sw) {
             rules.proper.sort() == sw.defaultCookies.findAll { it != data.cookie }.sort()
         }
 
-        and: "Cleanup: Install default rules back"
+        cleanup: "Install default rules back"
         northbound.installSwitchRules(sw.dpId, InstallRulesAction.INSTALL_DEFAULTS)
         Wrappers.wait(RULES_INSTALLATION_TIME) {
             assert northbound.getSwitchRules(sw.dpId).flowEntries.size() == defaultRules.size()

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesValidationSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesValidationSpec.groovy
@@ -3,6 +3,7 @@ package org.openkilda.functionaltests.spec.switches
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 
 import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.functionaltests.extension.tags.Tags
 
 import spock.lang.Narrative
@@ -20,6 +21,7 @@ class DefaultRulesValidationSpec extends HealthCheckSpecification {
     test coverage is only provided on unit-test level (ValidationServiceImplTest)
      */
 
+    @Tidy
     @Unroll
     @Tags(SMOKE)
     def "Switch and rule validation can properly detect default rules to 'proper' section (#sw.name)"() {

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortAntiflapSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortAntiflapSpec.groovy
@@ -5,6 +5,7 @@ import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.functionaltests.helpers.thread.PortBlinker
@@ -98,6 +99,7 @@ timeout"() {
         blinker?.isRunning() && blinker.stop(true)
     }
 
+    @Tidy
     def "Port goes down in 'antiflap.min' seconds if no flapping occurs"() {
         given: "Switch, port and ISL related to that port"
         def sw = topology.activeSwitches.first()
@@ -113,7 +115,7 @@ timeout"() {
             islUtils.getIslInfo(isl).get().state == IslChangeType.FAILED
         }
 
-        and: "Cleanup: bring port up"
+        cleanup: "Bring port up"
         antiflap.portUp(sw.dpId, islPort)
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             islUtils.getIslInfo(isl).get().state == IslChangeType.DISCOVERED

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortPropertiesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortPropertiesSpec.groovy
@@ -131,8 +131,9 @@ class PortPropertiesSpec extends HealthCheckSpecification {
 
         // Bring port down on the src switch
         antiflap.portDown(islToManipulate.srcSwitch.dpId, islToManipulate.srcPort)
-        Wrappers.wait(discoveryTimeout + WAIT_OFFSET) {
-            islUtils.getIslInfo(islToManipulate).get().state == IslChangeType.FAILED
+        Wrappers.wait(WAIT_OFFSET) {
+            assert northbound.getLink(islToManipulate).actualState == IslChangeType.FAILED
+            assert northbound.getLink(islToManipulate.reversed).actualState == IslChangeType.FAILED
         }
 
         // delete link

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortPropertiesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortPropertiesSpec.groovy
@@ -133,11 +133,14 @@ class PortPropertiesSpec extends HealthCheckSpecification {
         antiflap.portDown(islToManipulate.srcSwitch.dpId, islToManipulate.srcPort)
         Wrappers.wait(WAIT_OFFSET) {
             assert northbound.getLink(islToManipulate).actualState == IslChangeType.FAILED
-            assert northbound.getLink(islToManipulate.reversed).actualState == IslChangeType.FAILED
         }
 
         // delete link
         northbound.deleteLink(islUtils.toLinkParameters(islToManipulate))
+        Wrappers.wait(2) {
+            assert !islUtils.getIslInfo(islToManipulate)
+            assert !islUtils.getIslInfo(islToManipulate.reversed)
+        }
 
         when: "Disable port discovery property on the src and dst switches"
         northboundV2.updatePortProperties(islToManipulate.srcSwitch.dpId, islToManipulate.srcPort,

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortPropertiesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortPropertiesSpec.groovy
@@ -6,6 +6,7 @@ import static org.openkilda.testing.Constants.NON_EXISTENT_SWITCH_ID
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.error.MessageError
@@ -31,6 +32,7 @@ class PortPropertiesSpec extends HealthCheckSpecification {
     @Autowired
     NorthboundServiceV2 northboundV2
 
+    @Tidy
     def "Able to manipulate port properties"() {
         given: "A port with port properties"
         // can't use `getAllowedPortsForSwitch` for virtual env in this test,
@@ -70,6 +72,7 @@ class PortPropertiesSpec extends HealthCheckSpecification {
                 new PortPropertiesDto(discoveryEnabled: DISCOVERY_ENABLED_DEFAULT))
     }
 
+    @Tidy
     def "Informative error is returned when trying to get/update port properties with non-existing switch"() {
         when: "Try to get port properties info for non-existing switch"
         //assume port 10 is always exist on a switch
@@ -94,6 +97,7 @@ class PortPropertiesSpec extends HealthCheckSpecification {
  Switch ${NON_EXISTENT_SWITCH_ID} not found."
     }
 
+    @Tidy
     def "Informative error is returned when trying to update port properties with non-existing port number"() {
         when: "Try to get port properties info for non-existing port"
         // Actually we have strange behaviour here, we can get port property for a non-existent port, but can't update
@@ -197,6 +201,7 @@ class PortPropertiesSpec extends HealthCheckSpecification {
         }
     }
 
+    @Tidy
     def "Link is stopped from being discovered after disabling port discovery property"() {
         given: "An active link"
         def islToManipulate = topology.islsForActiveSwitches.first()

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchDeleteSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchDeleteSpec.groovy
@@ -6,6 +6,7 @@ import static org.openkilda.testing.Constants.NON_EXISTENT_SWITCH_ID
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.info.event.IslChangeType
@@ -16,6 +17,7 @@ import spock.lang.Unroll
 import java.util.concurrent.TimeUnit
 
 class SwitchDeleteSpec extends HealthCheckSpecification {
+    @Tidy
     def "Unable to delete a nonexistent switch"() {
         when: "Try to delete a nonexistent switch"
         northbound.deleteSwitch(NON_EXISTENT_SWITCH_ID, false)
@@ -25,6 +27,7 @@ class SwitchDeleteSpec extends HealthCheckSpecification {
         exc.rawStatusCode == 404
     }
 
+    @Tidy
     @Tags(SMOKE)
     def "Unable to delete an active switch"() {
         given: "An active switch"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
@@ -3,6 +3,7 @@ package org.openkilda.functionaltests.spec.switches
 import static org.junit.Assume.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.VIRTUAL
+import static org.openkilda.functionaltests.helpers.thread.FlowHistoryConstants.REROUTE_FAIL
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
@@ -59,7 +60,8 @@ class SwitchFailuresSpec extends HealthCheckSpecification {
         Wrappers.wait(rerouteDelay + WAIT_OFFSET) {
             def currentIsls = pathHelper.getInvolvedIsls(PathHelper.convert(northbound.getFlowPath(flow.flowId)))
             def pathChanged = !currentIsls.contains(isl) && !currentIsls.contains(isl.reversed)
-            assert pathChanged || northbound.getFlowStatus(flow.flowId).status == FlowState.DOWN
+            assert pathChanged || (northbound.getFlowStatus(flow.flowId).status == FlowState.DOWN &&
+                    northbound.getFlowHistory(flow.flowId).last().histories.find { it.action == REROUTE_FAIL })
         }
 
         and: "Cleanup: restore connection, remove the flow"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchPropertiesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchPropertiesSpec.groovy
@@ -24,6 +24,7 @@ Properties can be read/updated via API '/api/v1/switches/:switch-id/properties'.
 Main purpose of that is to understand which feature is supported by a switch(encapsulation type, multi table)""")
 class SwitchPropertiesSpec extends HealthCheckSpecification {
 
+    @Tidy
     @Ignore("https://github.com/telstra/open-kilda/issues/3059")
     @Tags([TOPOLOGY_DEPENDENT])
     def "Able to manipulate with switch properties"() {
@@ -59,6 +60,7 @@ class SwitchPropertiesSpec extends HealthCheckSpecification {
         SwitchHelper.updateSwitchProperties(sw, initSwitchProperties)
     }
 
+    @Tidy
     def "Informative error is returned when trying to get/update switch properties with non-existing id"() {
         when: "Try to get switch properties info for non-existing switch"
         northbound.getSwitchProperties(NON_EXISTENT_SWITCH_ID)
@@ -82,6 +84,7 @@ class SwitchPropertiesSpec extends HealthCheckSpecification {
                 "Switch properties for switch id '$NON_EXISTENT_SWITCH_ID' not found."
     }
 
+    @Tidy
     def "Informative error is returned when trying to update switch properties with incorrect information"() {
         given: "A switch"
         def sw = topology.activeSwitches.first()
@@ -103,6 +106,7 @@ class SwitchPropertiesSpec extends HealthCheckSpecification {
         null                          | "Supported transit encapsulations should not be null or empty"
     }
 
+    @Tidy
     def "Unable to turn on switchLldp property without turning on multiTable property"() {
         given: "A switch"
         def sw = topology.activeSwitches.first()

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchSyncSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchSyncSpec.groovy
@@ -8,6 +8,7 @@ import static org.openkilda.testing.Constants.RULES_DELETION_TIME
 import static org.openkilda.testing.Constants.RULES_INSTALLATION_TIME
 
 import org.openkilda.functionaltests.BaseSpecification
+import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.Message
@@ -41,6 +42,7 @@ class SwitchSyncSpec extends BaseSpecification {
     @Qualifier("kafkaProducerProperties")
     Properties producerProps
 
+    @Tidy
     @Unroll
     def "Able to synchronize switch without any rule and meter discrepancies (removeExcess=#removeExcess)"() {
         given: "An active switch"
@@ -66,6 +68,7 @@ class SwitchSyncSpec extends BaseSpecification {
         removeExcess << [false, true]
     }
 
+    @Tidy
     def "Able to synchronize switch (install missing rules and meters)"() {
         given: "Two active not neighboring switches"
         def switchPair = topologyHelper.allNotNeighboringSwitchPairs.find { it.src.ofVersion != "OF_12" &&
@@ -138,7 +141,7 @@ class SwitchSyncSpec extends BaseSpecification {
         and: "Flow continues to write stats"
         statsHelper.verifyFlowWritesStats(flow.flowId)
 
-        and: "Delete the flow"
+        cleanup: "Delete the flow"
         flowHelperV2.deleteFlow(flow.flowId)
     }
 
@@ -230,6 +233,7 @@ class SwitchSyncSpec extends BaseSpecification {
         flowHelperV2.deleteFlow(flow.flowId)
     }
 
+    @Tidy
     @Tags(HARDWARE)
     @Ignore("https://github.com/telstra/open-kilda/issues/3021")
     def "Able to synchronize switch with 'vxlan' rule(install missing rules and meters)"() {
@@ -328,7 +332,7 @@ class SwitchSyncSpec extends BaseSpecification {
             }
         }
 
-        and: "Delete the flow"
+        cleanup: "Delete the flow"
         flowHelperV2.deleteFlow(flow.flowId)
     }
 

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
@@ -4,6 +4,7 @@ import static org.junit.Assume.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.VIRTUAL
+import static org.openkilda.functionaltests.helpers.thread.FlowHistoryConstants.REROUTE_FAIL
 import static org.openkilda.testing.Constants.NON_EXISTENT_SWITCH_ID
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
@@ -157,7 +158,10 @@ class SwitchesSpec extends HealthCheckSpecification {
         }
 
         and: "Get all flows going through the src switch"
-        Wrappers.wait(WAIT_OFFSET) { assert northbound.getFlowStatus(protectedFlow.flowId).status == FlowState.DOWN }
+        Wrappers.wait(WAIT_OFFSET) {
+            assert northbound.getFlowStatus(protectedFlow.flowId).status == FlowState.DOWN
+            assert northbound.getFlowHistory(protectedFlow.flowId).last().histories.find { it.action == REROUTE_FAIL }
+        }
         def getSwitchFlowsResponse6 = northbound.getSwitchFlows(switchPair.src.dpId)
 
         then: "The created flows are in the response list"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
@@ -8,6 +8,7 @@ import static org.openkilda.testing.Constants.NON_EXISTENT_SWITCH_ID
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.command.switches.DeleteRulesAction
@@ -22,11 +23,13 @@ import org.springframework.web.client.HttpClientErrorException
 import spock.lang.Ignore
 
 class SwitchesSpec extends HealthCheckSpecification {
+    @Tidy
     def "System is able to return a list of all switches"() {
         expect: "System can return list of all switches"
         !northbound.getAllSwitches().empty
     }
 
+    @Tidy
     @Tags(SMOKE)
     def "System is able to return a certain switch info by its id"() {
         when: "Request info about certain switch from Northbound"
@@ -46,6 +49,7 @@ class SwitchesSpec extends HealthCheckSpecification {
         response.state == SwitchChangeType.ACTIVATED
     }
 
+    @Tidy
     def "Informative error is returned when requesting switch info with non-existing id"() {
         when: "Request info about non-existing switch from Northbound"
         northbound.getSwitch(NON_EXISTENT_SWITCH_ID)
@@ -56,6 +60,7 @@ class SwitchesSpec extends HealthCheckSpecification {
         e.responseBodyAsString.to(MessageError).errorMessage == "Switch $NON_EXISTENT_SWITCH_ID not found."
     }
 
+    @Tidy
     @Ignore("https://github.com/telstra/open-kilda/issues/2885")
     def "Systems allows to get a flow that goes through a switch"() {
         given: "Two active not neighboring switches with two diverse paths at least"
@@ -141,6 +146,7 @@ class SwitchesSpec extends HealthCheckSpecification {
         getSwitchFlowsResponse5*.id.sort() == [protectedFlow.flowId, singleFlow.flowId, defaultFlow.flowId].sort()
 
         when: "Bring down all ports on src switch to make flow DOWN"
+        def doPortDowns = true //helper var for cleanup
         topology.getBusyPortsForSwitch(switchPair.src).each {
             antiflap.portDown(switchPair.src.dpId, it)
         }
@@ -157,8 +163,8 @@ class SwitchesSpec extends HealthCheckSpecification {
         then: "The created flows are in the response list"
         getSwitchFlowsResponse6*.id.sort() == [protectedFlow.flowId, singleFlow.flowId, defaultFlow.flowId].sort()
 
-        and: "Cleanup: Delete the flows"
-        topology.getBusyPortsForSwitch(switchPair.src).each { antiflap.portUp(switchPair.src.dpId, it) }
+        cleanup: "Delete the flows"
+        doPortDowns && topology.getBusyPortsForSwitch(switchPair.src).each { antiflap.portUp(switchPair.src.dpId, it) }
         [protectedFlow, singleFlow, defaultFlow].each { flowHelperV2.deleteFlow(it.flowId) }
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
@@ -166,6 +172,7 @@ class SwitchesSpec extends HealthCheckSpecification {
         database.resetCosts()
     }
 
+    @Tidy
     def "Informative error is returned when requesting all flows going through non-existing switch"() {
         when: "Get all flows going through non-existing switch"
         northbound.getSwitchFlows(NON_EXISTENT_SWITCH_ID)
@@ -176,6 +183,7 @@ class SwitchesSpec extends HealthCheckSpecification {
         exc.responseBodyAsString.to(MessageError).errorMessage == "Switch $NON_EXISTENT_SWITCH_ID not found."
     }
 
+    @Tidy
     @Tags(VIRTUAL)
     def "Systems allows to get all flows that goes through a DEACTIVATED switch"() {
         given: "Two active not neighboring switches"
@@ -203,7 +211,7 @@ class SwitchesSpec extends HealthCheckSpecification {
         then: "The created flows are in the response list from the deactivated src switch"
         switchFlowsResponseSrcSwitch*.id.sort() == [simpleFlow.flowId, singleFlow.flowId].sort()
 
-        and: "Cleanup: Revive the src switch and delete the flows"
+        cleanup: "Revive the src switch and delete the flows"
         lockKeeper.reviveSwitch(switchToDisconnect)
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             assert northbound.getSwitch(switchToDisconnect.dpId).state == SwitchChangeType.ACTIVATED
@@ -211,6 +219,7 @@ class SwitchesSpec extends HealthCheckSpecification {
         [simpleFlow, singleFlow].each { flowHelperV2.deleteFlow(it.flowId) }
     }
 
+    @Tidy
     @Tags(LOW_PRIORITY)
     def "System returns human readable error when requesting switch ports from non-existing switch"() {
         when: "Request all ports info from non-existing switch"
@@ -222,6 +231,7 @@ class SwitchesSpec extends HealthCheckSpecification {
         e.responseBodyAsString.to(MessageError).errorMessage == "Switch $NON_EXISTENT_SWITCH_ID not found"
     }
 
+    @Tidy
     @Tags(LOW_PRIORITY)
     def "System returns human readable error when requesting switch rules from non-existing switch"() {
         when: "Request all rules from non-existing switch"
@@ -233,6 +243,7 @@ class SwitchesSpec extends HealthCheckSpecification {
         e.responseBodyAsString.to(MessageError).errorMessage == "Switch $NON_EXISTENT_SWITCH_ID not found"
     }
 
+    @Tidy
     @Tags(LOW_PRIORITY)
     def "System returns human readable error when installing switch rules on non-existing switch"() {
         when: "Install switch rules on non-existing switch"
@@ -244,6 +255,7 @@ class SwitchesSpec extends HealthCheckSpecification {
         e.responseBodyAsString.to(MessageError).errorMessage == "Switch $NON_EXISTENT_SWITCH_ID not found"
     }
 
+    @Tidy
     @Tags(LOW_PRIORITY)
     def "System returns human readable error when deleting switch rules on non-existing switch"() {
         when: "Delete switch rules on non-existing switch"
@@ -255,6 +267,7 @@ class SwitchesSpec extends HealthCheckSpecification {
         e.responseBodyAsString.to(MessageError).errorMessage == "Switch $NON_EXISTENT_SWITCH_ID not found"
     }
 
+    @Tidy
     @Tags(LOW_PRIORITY)
     def "System returns human readable error when setting under maintenance non-existing switch"() {
         when: "set under maintenance non-existing switch"
@@ -266,6 +279,7 @@ class SwitchesSpec extends HealthCheckSpecification {
         e.responseBodyAsString.to(MessageError).errorMessage == "Switch $NON_EXISTENT_SWITCH_ID not found."
     }
 
+    @Tidy
     @Tags(LOW_PRIORITY)
     def "System returns human readable error when requesting all meters from non-existing switch"() {
         when: "Request all meters from non-existing switch"
@@ -277,6 +291,7 @@ class SwitchesSpec extends HealthCheckSpecification {
         e.responseBodyAsString.to(MessageError).errorMessage == "Switch $NON_EXISTENT_SWITCH_ID not found"
     }
 
+    @Tidy
     @Tags(LOW_PRIORITY)
     def "System returns human readable error when deleting meter on non-existing switch"() {
         when: "Delete meter on non-existing switch"
@@ -288,6 +303,7 @@ class SwitchesSpec extends HealthCheckSpecification {
         e.responseBodyAsString.to(MessageError).errorMessage == "Switch $NON_EXISTENT_SWITCH_ID not found"
     }
 
+    @Tidy
     @Tags(LOW_PRIORITY)
     def "System returns human readable error when configuring port on non-existing switch"() {
         when: "Configure port on non-existing switch"

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/toggles/FeatureTogglesSpec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/toggles/FeatureTogglesSpec.groovy
@@ -20,11 +20,9 @@ creation of new flows via Northbound API. This spec verifies that Feature Toggle
 /*Note that the 'flowReroute' toggle is tested under AutoRerouteSpec#"Flow goes to 'Down' status when an intermediate
 switch is disconnected and there is no ability to reroute".
 BFD toggle is tested in BfdSpec*/
-@Tags([SMOKE, LOW_PRIORITY])
+//TODO (andriidovhan) remove VIRTUAL tag when mapping is disabled
+@Tags([SMOKE, LOW_PRIORITY, VIRTUAL])
 class FeatureTogglesSpec extends HealthCheckSpecification {
-    @Tags(VIRTUAL)
-    //TODO (andriidovhan) remove VIRTUAL tag and add new message when Issue 2797 is fixed
-    // new error message in APIv2 "Could not create flow: Flow create feature is disabled"
     def "System forbids creating new flows when 'create_flow' toggle is set to false"() {
         given: "Existing flow"
         def flow = flowHelper.randomFlow(topology.activeSwitches[0], topology.activeSwitches[1])

--- a/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/toggles/FeatureTogglesV2Spec.groovy
+++ b/services/src/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/toggles/FeatureTogglesV2Spec.groovy
@@ -4,7 +4,6 @@ import static groovyx.gpars.GParsPool.withPool
 import static org.junit.Assume.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
-import static org.openkilda.functionaltests.extension.tags.Tag.VIRTUAL
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
@@ -28,14 +27,11 @@ import spock.lang.Narrative
 Feature Toggles is a special lever that allows to turn on/off certain Kilda features. For example, we can disable
 creation of new flows via Northbound API. This spec verifies that Feature Toggle restrictions are applied correctly.
 """)
-/*Note that the 'flowReroute' toggle is tested under AutoRerouteSpec#"Flow goes to 'Down' status when an intermediate
+/*Note that the 'flowReroute' toggle is tested under AutoRerouteV2Spec#"Flow goes to 'Down' status when an intermediate
 switch is disconnected and there is no ability to reroute".
 BFD toggle is tested in BfdSpec*/
 @Tags(SMOKE)
 class FeatureTogglesV2Spec extends HealthCheckSpecification {
-    @Tags(VIRTUAL)
-    //TODO (andriidovhan) remove VIRTUAL tag and add new message when Issue 2797 is fixed
-    // new error message in APIv2 "Could not create flow: Flow create feature is disabled"
     def "System forbids creating new flows when 'create_flow' toggle is set to false"() {
         given: "Existing flow"
         def flow = flowHelperV2.randomFlow(topology.activeSwitches[0], topology.activeSwitches[1])

--- a/services/src/kilda-core/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/TransitVlanRepository.java
+++ b/services/src/kilda-core/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/TransitVlanRepository.java
@@ -24,6 +24,8 @@ import java.util.Optional;
 public interface TransitVlanRepository extends Repository<TransitVlan> {
     Collection<TransitVlan> findByPathId(PathId pathId, PathId oppositePathId);
 
+    Optional<TransitVlan> findByPathId(PathId pathId);
+
     Optional<TransitVlan> findByVlan(int vlan);
 
     /**

--- a/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jTransitVlanRepository.java
+++ b/services/src/kilda-core/kilda-persistence-neo4j/src/main/java/org/openkilda/persistence/repositories/impl/Neo4jTransitVlanRepository.java
@@ -62,12 +62,26 @@ public class Neo4jTransitVlanRepository extends Neo4jGenericRepository<TransitVl
     }
 
     @Override
+    public Optional<TransitVlan> findByPathId(PathId pathId) {
+        Filter pathIdFilter = new Filter(PATH_ID_PROPERTY_NAME, ComparisonOperator.EQUALS, pathId);
+        Collection<TransitVlan> transitVlans = loadAll(pathIdFilter);
+        if (transitVlans.size() > 1) {
+            throw new PersistenceException(format("Found more than 1 Transit VLAN entity for path ID '%s'", pathId));
+        }
+        if (transitVlans.size() == 1) {
+            return Optional.of(transitVlans.iterator().next());
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
     public Optional<TransitVlan> findByVlan(int vlan) {
         Filter vlanFilter = new Filter(VLAN_PROPERTY_NAME, ComparisonOperator.EQUALS, vlan);
         Collection<TransitVlan> transitVlans = loadAll(vlanFilter);
 
         if (transitVlans.size() > 1) {
-            throw new PersistenceException(format("Found more that 1 Transit VLAN entity by vlan ID '%s'", vlan));
+            throw new PersistenceException(format("Found more than 1 Transit VLAN entity for vlan ID '%s'", vlan));
         }
         if (transitVlans.size() == 1) {
             return Optional.of(transitVlans.iterator().next());

--- a/services/src/northbound-service/nb-api/src/main/java/org/openkilda/northbound/dto/v1/flows/FlowPatchDto.java
+++ b/services/src/northbound-service/nb-api/src/main/java/org/openkilda/northbound/dto/v1/flows/FlowPatchDto.java
@@ -18,8 +18,10 @@ package org.openkilda.northbound.dto.v1.flows;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 public class FlowPatchDto {
 
     @JsonProperty("max-latency")

--- a/services/src/performance-tests/src/main/groovy/org/openkilda/performancetests/helpers/TopologyHelper.groovy
+++ b/services/src/performance-tests/src/main/groovy/org/openkilda/performancetests/helpers/TopologyHelper.groovy
@@ -43,6 +43,10 @@ class TopologyHelper extends org.openkilda.functionaltests.helpers.TopologyHelpe
     @Value("#{'\${floodlight.controllers.stat}'.split(',')}")
     List<String> statControllers
 
+    /**
+     * First connect all switches in a 'line'. Then start randomly adding hordes.
+     * Requested amount of isls must be >= (switchesAmount - 1) in order to guarantee the initial 'line'
+     */
     CustomTopology createRandomTopology(int switchesAmount, int islsAmount) {
         if (islsAmount < (switchesAmount - 1)) {
             throw new RuntimeException("Not enough ISLs were requested. islsAmount should be >= (switchesAmount - 1)")
@@ -52,7 +56,7 @@ class TopologyHelper extends org.openkilda.functionaltests.helpers.TopologyHelpe
             def region = i % regions.take(2).size() //TODO(rtretiak): to remove 'take' when stage env deals with '3' region
             topo.addCasualSwitch("${managementControllers[region]} ${statControllers[region]}")
         }
-        //create links between neighbor switches
+        //form a line of switches
         def allSwitches = topo.getSwitches()
         for (def i = 0; i < allSwitches.size() - 1; i++) {
             topo.addIsl(allSwitches[i], allSwitches[i + 1])

--- a/services/src/test-library/src/main/java/org/openkilda/testing/service/database/Database.java
+++ b/services/src/test-library/src/main/java/org/openkilda/testing/service/database/Database.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public interface Database {
 
@@ -71,6 +72,8 @@ public interface Database {
     Flow getFlow(String flowId);
 
     Collection<TransitVlan> getTransitVlans(PathId forwardPathId, PathId reversePathId);
+
+    Optional<TransitVlan> getTransitVlan(PathId pathId);
 
     void updateFlowBandwidth(String flowId, long newBw);
 

--- a/services/src/test-library/src/main/java/org/openkilda/testing/service/database/DatabaseSupportImpl.java
+++ b/services/src/test-library/src/main/java/org/openkilda/testing/service/database/DatabaseSupportImpl.java
@@ -341,6 +341,11 @@ public class DatabaseSupportImpl implements Database {
         return transitVlanRepository.findByPathId(forwardPathId, reversePathId);
     }
 
+    @Override
+    public Optional<TransitVlan> getTransitVlan(PathId pathId) {
+        return transitVlanRepository.findByPathId(pathId);
+    }
+
     /**
      * Update flow bandwidth.
      *

--- a/services/src/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundService.java
+++ b/services/src/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundService.java
@@ -37,6 +37,7 @@ import org.openkilda.messaging.payload.network.PathsDto;
 import org.openkilda.model.SwitchId;
 import org.openkilda.northbound.dto.BatchResults;
 import org.openkilda.northbound.dto.v1.flows.FlowConnectedDevicesResponse;
+import org.openkilda.northbound.dto.v1.flows.FlowPatchDto;
 import org.openkilda.northbound.dto.v1.flows.FlowValidationDto;
 import org.openkilda.northbound.dto.v1.flows.PingInput;
 import org.openkilda.northbound.dto.v1.flows.PingOutput;
@@ -101,6 +102,8 @@ public interface NorthboundService {
     FlowPayload swapFlowPath(String flowId);
 
     SwapFlowEndpointPayload swapFlowEndpoint(SwapFlowPayload firstFlow, SwapFlowPayload secondFlow);
+
+    FlowResponsePayload partialUpdate(String flowId, FlowPatchDto payload);
 
     //switches
 

--- a/services/src/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundServiceImpl.java
+++ b/services/src/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundServiceImpl.java
@@ -44,6 +44,7 @@ import org.openkilda.model.PortStatus;
 import org.openkilda.model.SwitchId;
 import org.openkilda.northbound.dto.BatchResults;
 import org.openkilda.northbound.dto.v1.flows.FlowConnectedDevicesResponse;
+import org.openkilda.northbound.dto.v1.flows.FlowPatchDto;
 import org.openkilda.northbound.dto.v1.flows.FlowValidationDto;
 import org.openkilda.northbound.dto.v1.flows.PingInput;
 import org.openkilda.northbound.dto.v1.flows.PingOutput;
@@ -326,6 +327,13 @@ public class NorthboundServiceImpl implements NorthboundService {
                 new SwapFlowEndpointPayload(firstFlow, secondFlow), buildHeadersWithCorrelationId());
         return restTemplate.exchange("/api/v2/flows/swap-endpoint", HttpMethod.POST, httpEntity,
                 SwapFlowEndpointPayload.class).getBody();
+    }
+
+    @Override
+    public FlowResponsePayload partialUpdate(String flowId, FlowPatchDto payload) {
+        return restTemplate.exchange("/api/v1/flows/{flow_id}", HttpMethod.PATCH,
+                new HttpEntity<>(payload, buildHeadersWithCorrelationId()), FlowResponsePayload.class, flowId)
+                .getBody();
     }
 
     @Override


### PR DESCRIPTION
test fixes and improvements:

- minor improvements in flowHistoryV2 (#3111) 
- remove ignore annotation according to 2904 (#3114) 
- add test for #1150 (#3115) 
- minor improvements in featureToogle spec (#3116) 
- add test: "System reroutes flow to more preferable path while updatinig" (#3126)
- Add test for partial update API (#3040) 
- Add test for flow with endpoint vlan matching transit vlan (#3079) 
- Supply most tests with comprehensive cleanup and mark them as @tidy (#3096)
- Fix flow creation in MultiRerouteSpec (#3101) 
- Minor fixes to make stats verifications work properly on stage env (#3102)
- Add test for #3087 (#3113) 
- Tests stability improved (#3120) 
- Update EnduranceSpec with more assertions (#3122) 
- Extend smoke_switches test suite (#3127) 