### PR TITLE
Expose OF transaction id into speaker logs

### DIFF
--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/ping/PingResponseCommand.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/ping/PingResponseCommand.java
@@ -49,6 +49,7 @@ public class PingResponseCommand extends PingCommand {
             return null;
         }
 
+        log.info("Receive flow ping packet from switch {} OF-xid:{}", input.getDpId(), input.getMessage().getXid());
         try {
             PingData pingData = decode(payload);
             getContext().setCorrelationId(pingData.getPingId().toString());

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/pathverification/PathVerificationService.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/pathverification/PathVerificationService.java
@@ -312,12 +312,12 @@ public class PathVerificationService implements IFloodlightModule, IPathVerifica
                 }
 
                 if (result) {
-                    logIsl.info("push discovery package via: {}-{} id:{}", srcSwitch.getId(), port.getPortNumber(),
-                            packetId);
+                    logIsl.info("push discovery package via: {}-{} id:{} OF-xid:{}", srcSwitch.getId(),
+                                port.getPortNumber(), packetId, ofPacketOut.getXid());
                 } else {
                     logger.error(
-                            "Failed to send PACKET_OUT(ISL discovery packet) via {}-{} id: {}",
-                            srcSwitch.getId(), port.getPortNumber(), packetId);
+                            "Failed to send PACKET_OUT(ISL discovery packet) via {}-{} id:{} OF-xid:{}",
+                            srcSwitch.getId(), port.getPortNumber(), packetId, ofPacketOut.getXid());
                 }
             }
         } catch (Exception exception) {
@@ -570,8 +570,9 @@ public class PathVerificationService implements IFloodlightModule, IPathVerifica
     private void handleDiscoveryPacket(OfInput input, IOFSwitch destSwitch, DiscoveryPacketData data) {
         OFPort inPort = OFMessageUtils.getInPort((OFPacketIn) input.getMessage());
         long latency = measureLatency(input, data.getTimestamp());
-        logIsl.info("link discovered: {}-{} ===( {} ns )===> {}-{} id:{}",
-                data.getRemoteSwitchId(), data.getRemotePort(), latency, input.getDpId(), inPort, data.getPacketId());
+        logIsl.info("link discovered: {}-{} ===( {} ns )===> {}-{} id:{} OF-xid:{}",
+                    data.getRemoteSwitchId(), data.getRemotePort(), latency, input.getDpId(), inPort,
+                    data.getPacketId(), input.getMessage().getXid());
 
         // this discovery packet was sent from remote switch/port to received switch/port
         // so the link direction is from remote switch/port to received switch/port

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/connected/ConnectedDevicesService.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/connected/ConnectedDevicesService.java
@@ -53,7 +53,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-
 public class ConnectedDevicesService implements IService, IInputTranslator {
     private static final Logger logger = LoggerFactory.getLogger(ConnectedDevicesService.class);
     public static final int MAC_ADDRESS_LENGTH_IN_BYTES = 6;
@@ -121,6 +120,7 @@ public class ConnectedDevicesService implements IService, IInputTranslator {
             return;
         }
 
+        logger.info("Receive connected device packet from {} OF-xid:{}", input.getDpId(), input.getMessage().getXid());
         long cookie = rawCookie.getValue();
         SwitchId switchId = new SwitchId(input.getDpId().getLong());
 

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/session/Session.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/session/Session.java
@@ -189,7 +189,7 @@ public class Session implements AutoCloseable {
 
     private void actualWrite(OFMessage message)
             throws SwitchWriteException {
-        log.debug("push OF message to {}: {}", sw.getId(), message);
+        log.info("push OF message to {}: {}", sw.getId(), message);
         if (!sw.write(message)) {
             error = true;
             throw new SwitchWriteException(sw.getId(), message);


### PR DESCRIPTION
Extend speaker log message by addind OF transaction ID (xid) into all
services that produce/parse OF messages. It should help to correlate
open-kilda logs with switch logs.