### PR TITLE
Allow flowhs speaker request retry for all error codes

### DIFF
--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/create/action/EmitVerifyRulesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/create/action/EmitVerifyRulesAction.java
@@ -17,6 +17,7 @@ package org.openkilda.wfm.topology.flowhs.fsm.create.action;
 
 import org.openkilda.floodlight.api.request.FlowSegmentRequest;
 import org.openkilda.floodlight.api.request.factory.FlowSegmentRequestFactory;
+import org.openkilda.floodlight.flow.response.FlowErrorResponse.ErrorCode;
 import org.openkilda.wfm.topology.flowhs.fsm.common.SpeakerCommandFsm;
 import org.openkilda.wfm.topology.flowhs.fsm.common.actions.HistoryRecordingAction;
 import org.openkilda.wfm.topology.flowhs.fsm.create.FlowCreateContext;
@@ -27,6 +28,7 @@ import com.fasterxml.uuid.Generators;
 import com.fasterxml.uuid.NoArgGenerator;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
@@ -46,9 +48,9 @@ abstract class EmitVerifyRulesAction
         for (FlowSegmentRequestFactory factory : requestFactories) {
             FlowSegmentRequest request = factory.makeVerifyRequest(commandIdGenerator.generate());
 
-            SpeakerCommandObserver commandObserver = new SpeakerCommandObserver(speakerCommandFsmBuilder, request);
+            SpeakerCommandObserver commandObserver = new SpeakerCommandObserver(speakerCommandFsmBuilder,
+                    Collections.singleton(ErrorCode.MISSING_OF_FLOWS), request);
             commandObserver.start();
-            // TODO ensure no conflicts
             pendingCommands.put(request.getCommandId(), commandObserver);
         }
     }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/SpeakerCommandObserver.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/SpeakerCommandObserver.java
@@ -17,10 +17,14 @@ package org.openkilda.wfm.topology.flowhs.service;
 
 import org.openkilda.floodlight.api.request.FlowSegmentRequest;
 import org.openkilda.floodlight.api.response.SpeakerFlowSegmentResponse;
+import org.openkilda.floodlight.flow.response.FlowErrorResponse.ErrorCode;
 import org.openkilda.wfm.topology.flowhs.fsm.common.SpeakerCommandFsm;
 import org.openkilda.wfm.topology.flowhs.fsm.common.SpeakerCommandFsm.Event;
 
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collections;
+import java.util.Set;
 
 @Slf4j
 public class SpeakerCommandObserver {
@@ -28,7 +32,12 @@ public class SpeakerCommandObserver {
     private final SpeakerCommandFsm commandExecutor;
 
     public SpeakerCommandObserver(SpeakerCommandFsm.Builder builder, FlowSegmentRequest request) {
-        commandExecutor = builder.newInstance(request);
+        this(builder, Collections.emptySet(), request);
+    }
+
+    public SpeakerCommandObserver(
+            SpeakerCommandFsm.Builder builder, Set<ErrorCode> giveUpErrors, FlowSegmentRequest request) {
+        commandExecutor = builder.newInstance(giveUpErrors, request);
     }
 
     /**

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowCreateServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowCreateServiceTest.java
@@ -21,7 +21,10 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 import org.openkilda.floodlight.api.request.EgressFlowSegmentInstallRequest;
+import org.openkilda.floodlight.api.request.EgressFlowSegmentVerifyRequest;
 import org.openkilda.floodlight.api.request.FlowSegmentRequest;
+import org.openkilda.floodlight.api.request.IngressFlowSegmentInstallRequest;
+import org.openkilda.floodlight.api.request.IngressFlowSegmentVerifyRequest;
 import org.openkilda.floodlight.api.response.SpeakerFlowSegmentResponse;
 import org.openkilda.floodlight.flow.response.FlowErrorResponse;
 import org.openkilda.floodlight.flow.response.FlowErrorResponse.ErrorCode;
@@ -40,6 +43,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FlowCreateServiceTest extends AbstractFlowTest {
@@ -215,59 +224,50 @@ public class FlowCreateServiceTest extends AbstractFlowTest {
     }
 
     @Test
-    public void shouldCreateFlowWithRetryNonIngressRuleIfSwitchIsUnavailable() throws Exception {
-        when(pathComputer.getPath(any(Flow.class))).thenReturn(make3SwitchesPathPair());
-
-
-        String key = "retries_non_ingress_installation";
-        FlowRequest flowRequest = makeRequest()
-                .flowId("failed_flow_id")
-                .build();
-
-        int retriesLimit = 10;
-        FlowCreateService service = makeService(retriesLimit);
-
-        service.handleRequest(key, new CommandContext(), flowRequest);
-
-        Flow inProgress = verifyFlowStatus(flowRequest.getFlowId(), FlowStatus.IN_PROGRESS);
-        verifyFlowPathStatus(inProgress.getForwardPath(), FlowPathStatus.IN_PROGRESS, "forward");
-        verifyFlowPathStatus(inProgress.getReversePath(), FlowPathStatus.IN_PROGRESS, "reverse");
-
-        verifyNorthboundSuccessResponse(carrier);
-
-        int remainingRetries = retriesLimit;
-        FlowSegmentRequest request;
-        while ((request = requests.poll()) != null) {
-            if (request.isVerifyRequest()) {
-                service.handleAsyncResponse(key, buildResponseOnVerifyRequest(request));
-            } else {
-                if (request instanceof EgressFlowSegmentInstallRequest && remainingRetries > 0) {
-                    handleErrorResponse(service, key, request, ErrorCode.SWITCH_UNAVAILABLE);
-                    remainingRetries--;
-                } else {
-                    handleResponse(service, key, request);
-                }
-            }
-        }
-
-        assertEquals(0, remainingRetries);
-        Flow result = verifyFlowStatus(flowRequest.getFlowId(), FlowStatus.UP);
-        verifyFlowPathStatus(result.getForwardPath(), FlowPathStatus.ACTIVE, "forward");
-        verifyFlowPathStatus(result.getReversePath(), FlowPathStatus.ACTIVE, "reverse");
+    public void shouldRetryNotIngressRequestOnSwitchUnavailable() throws Exception {
+        testSpeakerCommandRetry(EgressFlowSegmentInstallRequest.class, ErrorCode.SWITCH_UNAVAILABLE, true);
     }
 
     @Test
-    public void shouldCreateFlowWithRetryIngressRuleIfSwitchIsUnavailable() throws Exception {
-        when(pathComputer.getPath(any(Flow.class))).thenReturn(make3SwitchesPathPair());
+    public void shouldRetryNotIngressRequestOnTimeout() throws Exception {
+        testSpeakerCommandRetry(EgressFlowSegmentInstallRequest.class, ErrorCode.OPERATION_TIMED_OUT, true);
+    }
 
+    @Test
+    public void shouldRetryIngressRequestOnSwitchUnavailable() throws Exception {
+        testSpeakerCommandRetry(IngressFlowSegmentInstallRequest.class, ErrorCode.SWITCH_UNAVAILABLE, true);
+    }
+
+    @Test
+    public void shouldRetryIngressRequestOnTimeout() throws Exception {
+        testSpeakerCommandRetry(EgressFlowSegmentInstallRequest.class, ErrorCode.OPERATION_TIMED_OUT, true);
+    }
+
+    @Test
+    public void shouldRetryNotIngressValidationRequestOnSwitchUnavailable() throws Exception {
+        testSpeakerCommandRetry(EgressFlowSegmentVerifyRequest.class, ErrorCode.SWITCH_UNAVAILABLE, true);
+    }
+
+    @Test
+    public void shouldRetryIngressValidationRequestOnSwitchUnavailable() throws Exception {
+        testSpeakerCommandRetry(IngressFlowSegmentVerifyRequest.class, ErrorCode.SWITCH_UNAVAILABLE, true);
+    }
+
+    @Test
+    public void shouldNotRetryValidationOnPermanentError() throws Exception {
+        testSpeakerCommandRetry(EgressFlowSegmentVerifyRequest.class, ErrorCode.MISSING_OF_FLOWS, false);
+    }
+
+    private void testSpeakerCommandRetry(Class<?> failRequest, ErrorCode error, boolean mustRetry) throws Exception {
         String key = "retries_non_ingress_installation";
         FlowRequest flowRequest = makeRequest()
-                .flowId("failed_flow_id")
+                .flowId("dummy_flow_id")
                 .build();
 
         int retriesLimit = 10;
         FlowCreateService service = makeService(retriesLimit);
 
+        preparePathComputation(flowRequest.getFlowId(), make2SwitchesPathPair());
         service.handleRequest(key, new CommandContext(), flowRequest);
 
         Flow inProgress = verifyFlowStatus(flowRequest.getFlowId(), FlowStatus.IN_PROGRESS);
@@ -276,25 +276,88 @@ public class FlowCreateServiceTest extends AbstractFlowTest {
 
         verifyNorthboundSuccessResponse(carrier);
 
-        int remainingRetries = retriesLimit;
+        Set<UUID> producedErrors = new HashSet<>();
+        Map<UUID, Integer> remainingRetries = new HashMap<>();
+        Map<UUID, Integer> seenCounter = new HashMap<>();
+
         FlowSegmentRequest request;
         while ((request = requests.poll()) != null) {
-            if (request.isVerifyRequest()) {
+            UUID commandId = request.getCommandId();
+            seenCounter.put(commandId, seenCounter.getOrDefault(commandId, 0) + 1);
+            Integer remaining = remainingRetries.getOrDefault(commandId, retriesLimit);
+            if (failRequest.isInstance(request) && remaining > 0) {
+                producedErrors.add(commandId);
+                remainingRetries.put(commandId, remaining - 1);
+
+                handleErrorResponse(service, key, request, error);
+            } else if (request.isVerifyRequest()) {
                 service.handleAsyncResponse(key, buildResponseOnVerifyRequest(request));
             } else {
-                if (remainingRetries > 0) {
-                    handleErrorResponse(service, key, request, ErrorCode.SWITCH_UNAVAILABLE);
-                    remainingRetries--;
-                } else {
-                    handleResponse(service, key, request);
-                }
+                handleResponse(service, key, request);
             }
         }
 
-        assertEquals(0, remainingRetries);
-        Flow result = verifyFlowStatus(flowRequest.getFlowId(), FlowStatus.UP);
-        verifyFlowPathStatus(result.getForwardPath(), FlowPathStatus.ACTIVE, "forward");
-        verifyFlowPathStatus(result.getReversePath(), FlowPathStatus.ACTIVE, "reverse");
+        Assert.assertFalse(producedErrors.isEmpty());
+        for (Map.Entry<UUID, Integer> entry : seenCounter.entrySet()) {
+            if (! producedErrors.contains(entry.getKey())) {
+                continue;
+            }
+
+            Integer counter = entry.getValue();
+            if (mustRetry) {
+                Assert.assertEquals(retriesLimit + 1, (int) counter);
+            } else {
+                Assert.assertEquals(1, (int) counter);
+            }
+        }
+
+        if (mustRetry) {
+            Flow result = verifyFlowStatus(flowRequest.getFlowId(), FlowStatus.UP);
+            verifyFlowPathStatus(result.getForwardPath(), FlowPathStatus.ACTIVE, "forward");
+            verifyFlowPathStatus(result.getReversePath(), FlowPathStatus.ACTIVE, "reverse");
+        } else {
+            verifyFlowStatus(flowRequest.getFlowId(), FlowStatus.DOWN);
+        }
+    }
+
+    @Test
+    public void shouldNotRetryForever() throws Exception {
+        String key = "retries_non_ingress_installation";
+        FlowRequest flowRequest = makeRequest()
+                .flowId("dummy_flow_id")
+                .build();
+
+        int retriesLimit = 10;
+        FlowCreateService service = makeService(retriesLimit);
+
+        preparePathComputation(flowRequest.getFlowId(), make2SwitchesPathPair());
+        service.handleRequest(key, new CommandContext(), flowRequest);
+
+        Flow inProgress = verifyFlowStatus(flowRequest.getFlowId(), FlowStatus.IN_PROGRESS);
+        verifyFlowPathStatus(inProgress.getForwardPath(), FlowPathStatus.IN_PROGRESS, "forward");
+        verifyFlowPathStatus(inProgress.getReversePath(), FlowPathStatus.IN_PROGRESS, "reverse");
+
+        verifyNorthboundSuccessResponse(carrier);
+
+        FlowSegmentRequest request;
+
+        Map<UUID, Integer> remainingRetries = new HashMap<>();
+        while ((request = requests.poll()) != null) {
+            UUID commandId = request.getCommandId();
+            Integer remaining = remainingRetries.getOrDefault(commandId, retriesLimit + 1);
+            Assert.assertTrue(0 < remaining);
+            if (request instanceof EgressFlowSegmentInstallRequest) {
+                remainingRetries.put(commandId, remaining - 1);
+
+                handleErrorResponse(service, key, request, ErrorCode.SWITCH_UNAVAILABLE);
+            } else if (request.isVerifyRequest()) {
+                service.handleAsyncResponse(key, buildResponseOnVerifyRequest(request));
+            } else {
+                handleResponse(service, key, request);
+            }
+        }
+
+        verifyFlowStatus(flowRequest.getFlowId(), FlowStatus.DOWN);
     }
 
     private void handleResponse(FlowCreateService service, String key, FlowSegmentRequest request) {


### PR DESCRIPTION
Flow H&S create operation use separate set of tools to perform speaker
request retries. It allow to retry only for SWITCH_UNAVAILABE error.
Other CRUD operation do retry on any error code. Rework create operation
to mimic speaker retry logic of all other CRUD operations.