### PR TITLE
Added a filter in SwitchManagerTopology to check only the paths contained in flow.

### DIFF
--- a/src-java/kilda-model/src/main/java/org/openkilda/model/Flow.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/Flow.java
@@ -551,4 +551,12 @@ public class Flow implements Serializable {
             }
         }
     }
+
+    /**
+     * Checks if pathId belongs to the current flow.
+     */
+    public boolean isActualPathId(PathId pathId) {
+        return pathId != null && (pathId.equals(this.getForwardPathId()) || pathId.equals(this.getReversePathId())
+                || pathId.equals(this.getProtectedForwardPathId()) || pathId.equals(this.getProtectedReversePathId()));
+    }
 }

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/main/java/org/openkilda/wfm/topology/switchmanager/service/impl/ValidationServiceImpl.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/main/java/org/openkilda/wfm/topology/switchmanager/service/impl/ValidationServiceImpl.java
@@ -78,6 +78,7 @@ public class ValidationServiceImpl implements ValidationService {
         log.debug("Validating rules on switch {}", switchId);
 
         Set<Long> expectedCookies = flowPathRepository.findBySegmentDestSwitch(switchId).stream()
+                .filter(flowPath -> flowPath.getFlow().isActualPathId(flowPath.getPathId()))
                 .map(FlowPath::getCookie)
                 .map(Cookie::getValue)
                 .collect(Collectors.toSet());
@@ -85,6 +86,7 @@ public class ValidationServiceImpl implements ValidationService {
         Collection<FlowPath> paths = flowPathRepository.findByEndpointSwitch(switchId);
 
         paths.stream()
+                .filter(flowPath -> flowPath.getFlow().isActualPathId(flowPath.getPathId()))
                 .map(FlowPath::getCookie)
                 .map(Cookie::getValue)
                 .forEach(expectedCookies::add);
@@ -203,7 +205,10 @@ public class ValidationServiceImpl implements ValidationService {
                 .map(MeterEntryMapper.INSTANCE::map)
                 .collect(toList());
 
-        Collection<FlowPath> paths = flowPathRepository.findBySrcSwitch(switchId);
+        Collection<FlowPath> paths = flowPathRepository.findBySrcSwitch(switchId).stream()
+                .filter(flowPath -> flowPath.getFlow().isActualPathId(flowPath.getPathId()))
+                .collect(Collectors.toList());
+
         if (!paths.isEmpty()) {
             expectedMeters.addAll(getExpectedFlowMeters(paths));
         }


### PR DESCRIPTION
Related with: #3090. We should be able to synchronize switches with such flow.