### PR TITLE
Docker base image for Lab-Api bumped to Ubuntu Eoan

### DIFF
--- a/docker/base/kilda-base-lab-service/Dockerfile
+++ b/docker/base/kilda-base-lab-service/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-ARG base_image=ubuntu:cosmic
+ARG base_image=ubuntu:eoan
 FROM ${base_image}
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Docker base image for Lab-Api bumped to Ubuntu Eoan due Ubuntu Cosmic deletion.