### PR TITLE
Make parallelism level configurable

### DIFF
--- a/confd/templates/base-storm-topology/topology.properties.tmpl
+++ b/confd/templates/base-storm-topology/topology.properties.tmpl
@@ -3,9 +3,9 @@
 
 environment.naming.prefix = {{ getv "/kilda_environment_naming_prefix" }}
 
-parallelism.new = 2
-parallelism = 1
-workers = 1
+parallelism.new = {{ getv "/kilda_storm_parallelism_level_new" }}
+parallelism = {{ getv "/kilda_storm_parallelism_level" }}
+workers = {{ getv "/kilda_storm_parallelism_workers_count" }}
 
 #######
 # Storm-specific topology configuration.

--- a/confd/vars/main.yaml
+++ b/confd/vars/main.yaml
@@ -137,6 +137,10 @@ kilda_latency_update_interval: 300
 kilda_latency_update_time_range: 600
 kilda_latency_discovery_interval_multiplier: 3
 
+kilda_storm_parallelism_level_new: 2
+kilda_storm_parallelism_level: 1
+kilda_storm_parallelism_workers_count: 1
+
 kilda_storm_disruptor_wait_timeout: 1000
 kilda_storm_disruptor_batch_timeout: 10
 kilda_storm_spout_wait_sleep_timeout: 100


### PR DESCRIPTION
Fill parallelism related properties from template variables. It allows
to change parallelism setittings without rebuiulding deployed images.