### PR TITLE
extract knockout/reviveSwitch into switchHelper

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
@@ -129,8 +129,7 @@ class AutoRerouteSpec extends HealthCheckSpecification {
         }
 
         and: "Connect the intermediate switch back and delete the flow"
-        lockKeeper.reviveSwitch(findSw(flowPath[1].switchId))
-        Wrappers.wait(WAIT_OFFSET) { assert flowPath[1].switchId in northbound.getActiveSwitches()*.switchId }
+        switchHelper.reviveSwitch(findSw(flowPath[1].switchId))
         northbound.deleteSwitchRules(flowPath[1].switchId, DeleteRulesAction.IGNORE_DEFAULTS) || true
         flowHelper.deleteFlow(flow.id)
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteV2Spec.groovy
@@ -530,9 +530,7 @@ class AutoRerouteV2Spec extends HealthCheckSpecification {
 
         then: "Flow is not triggered for reroute due to switchUp event because switch is not related to the flow"
         TimeUnit.SECONDS.sleep(rerouteDelay * 2) // it helps to be sure that the auto-reroute operation is completed
-        Wrappers.timedLoop(rerouteDelay) { // just in case
-            assert northbound.getFlowHistory(flow.flowId).findAll { it.action == "Flow rerouting" }.size() == 1
-        }
+        northbound.getFlowHistory(flow.flowId).findAll { it.action == "Flow rerouting" }.size() == 1
 
         cleanup: "Restore topology, delete the flow and reset costs"
         flow && flowHelperV2.deleteFlow(flow.flowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
@@ -760,10 +760,7 @@ class FlowCrudSpec extends HealthCheckSpecification {
         given: "A deactivated switch"
         def sw = topology.getActiveSwitches().first()
         def swIsls = topology.getRelatedIsls(sw)
-        lockKeeper.knockoutSwitch(sw)
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getSwitch(sw.dpId).state == SwitchChangeType.DEACTIVATED
-        }
+        switchHelper.knockoutSwitch(sw)
 
         when: "Create a flow"
         def flow = flowHelper.singleSwitchFlow(sw)
@@ -775,12 +772,7 @@ class FlowCrudSpec extends HealthCheckSpecification {
         exc.responseBodyAsString.to(MessageError).errorMessage == "Switch $sw.dpId not found"
 
         and: "Cleanup: Activate the switch and reset costs"
-        lockKeeper.reviveSwitch(sw)
-        Wrappers.wait(discoveryTimeout + WAIT_OFFSET) {
-            assert northbound.getSwitch(sw.dpId).state == SwitchChangeType.ACTIVATED
-            def links = northbound.getAllLinks()
-            swIsls.each { assert islUtils.getIslInfo(links, it).get().state == DISCOVERED }
-        }
+        switchHelper.reviveSwitch(sw, true)
     }
 
     @Ignore("https://github.com/telstra/open-kilda/issues/2625")

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV2Spec.groovy
@@ -753,10 +753,7 @@ class FlowCrudV2Spec extends HealthCheckSpecification {
         given: "Disconnected switch"
         def sw = topology.getActiveSwitches()[0]
         def swIsls = topology.getRelatedIsls(sw)
-        lockKeeper.knockoutSwitch(sw)
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getSwitch(sw.dpId).state == SwitchChangeType.DEACTIVATED
-        }
+        switchHelper.knockoutSwitch(sw)
 
         when: "Try to create a one-switch flow on a deactivated switch"
         def flow = flowHelperV2.singleSwitchFlow(sw)
@@ -771,12 +768,7 @@ class FlowCrudV2Spec extends HealthCheckSpecification {
                 "Destination switch $sw.dpId are not connected to the controller"
 
         and: "Cleanup: Connect switch back to the controller"
-        lockKeeper.reviveSwitch(sw)
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            assert northbound.getSwitch(sw.dpId).state == SwitchChangeType.ACTIVATED
-            def links = northbound.getAllLinks()
-            swIsls.each { assert islUtils.getIslInfo(links, it).get().state == IslChangeType.DISCOVERED }
-        }
+        switchHelper.reviveSwitch(sw)
     }
 
     @Tidy

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowPingSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowPingSpec.groovy
@@ -291,6 +291,7 @@ class FlowPingSpec extends HealthCheckSpecification {
         flow && flowHelperV2.deleteFlow(flow.flowId)
     }
 
+    @Tidy
     def "Able to turn on periodic pings on a flow"() {
         when: "Create a flow with periodic pings turned on"
         def flow = flowHelperV2.randomFlow(topologyHelper.notNeighboringSwitchPair).tap {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
@@ -194,16 +194,14 @@ class LinkSpec extends HealthCheckSpecification {
     def "ISL should immediately fail if the port went down while switch was disconnected"() {
         when: "A switch disconnects"
         def isl = topology.islsForActiveSwitches.find { it.aswitch?.inPort && it.aswitch?.outPort }
-        lockKeeper.knockoutSwitch(isl.srcSwitch)
-        Wrappers.wait(WAIT_OFFSET) { northbound.getSwitch(isl.srcSwitch.dpId).state == SwitchChangeType.DEACTIVATED }
+        switchHelper.knockoutSwitch(isl.srcSwitch)
 
         and: "One of its ports goes down"
         //Bring down port on a-switch, which will lead to a port down on the Kilda switch
         lockKeeper.portsDown([isl.aswitch.inPort])
 
         and: "The switch reconnects back with a port being down"
-        lockKeeper.reviveSwitch(isl.srcSwitch)
-        Wrappers.wait(WAIT_OFFSET) { northbound.getSwitch(isl.srcSwitch.dpId).state == SwitchChangeType.ACTIVATED }
+        switchHelper.reviveSwitch(isl.srcSwitch)
 
         then: "The related ISL immediately goes down"
         Wrappers.wait(WAIT_OFFSET) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/UnstableIslSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/UnstableIslSpec.groovy
@@ -71,23 +71,13 @@ class UnstableIslSpec extends HealthCheckSpecification {
         def swIsls = topology.getRelatedIsls(sw)
 
         when: "Deactivate the switch"
-        lockKeeper.knockoutSwitch(sw)
-        Wrappers.wait(discoveryTimeout + WAIT_OFFSET) {
-            assert northbound.getSwitch(sw.dpId).state == SwitchChangeType.DEACTIVATED
-            def links = northbound.getAllLinks()
-            swIsls.each { assert islUtils.getIslInfo(links, it).get().state == FAILED }
-        }
+        switchHelper.knockoutSwitch(sw, true)
 
         then: "Switch ISL is not 'unstable'"
         [swIsls[0], swIsls[0].reversed].each { assert database.getIslTimeUnstable(it) == null }
 
         when: "Activate the switch"
-        lockKeeper.reviveSwitch(sw)
-        Wrappers.wait(discoveryTimeout + WAIT_OFFSET) {
-            assert northbound.getSwitch(sw.dpId).state == SwitchChangeType.ACTIVATED
-            def links = northbound.getAllLinks()
-            swIsls.each { assert islUtils.getIslInfo(links, it).get().state == DISCOVERED }
-        }
+        switchHelper.reviveSwitch(sw, true)
 
         then: "Switch ISL is not 'unstable'"
         [swIsls[0], swIsls[0].reversed].each { assert database.getIslTimeUnstable(it) == null }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/MflStatSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/MflStatSpec.groovy
@@ -98,8 +98,7 @@ class MflStatSpec extends HealthCheckSpecification {
         }
 
         when: "Disconnect the src switch from the management and statistic controllers"
-        lockKeeper.knockoutSwitch(srcSwitch)
-        Wrappers.wait(WAIT_OFFSET) { assert !(srcSwitch.dpId in northbound.getActiveSwitches()*.switchId) }
+        switchHelper.knockoutSwitch(srcSwitch)
 
         and: "Generate traffic on the given flow"
         exam.setResources(traffExam.startExam(exam, true))
@@ -114,11 +113,7 @@ class MflStatSpec extends HealthCheckSpecification {
         }
 
         when: "Restore default controllers on the src switches"
-        lockKeeper.reviveSwitch(srcSwitch)
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            assert srcSwitch.dpId in northbound.getActiveSwitches()*.switchId
-            assert northbound.getAllLinks().findAll { it.state == IslChangeType.FAILED }.empty
-        }
+        switchHelper.reviveSwitch(srcSwitch, true)
 
         then: "Old statistic should be collected"
         Wrappers.wait(statsRouterInterval + WAIT_OFFSET, waitInterval) {
@@ -192,8 +187,7 @@ class MflStatSpec extends HealthCheckSpecification {
         }
 
         when: "Disconnect the src switch from the management and statistic controllers"
-        lockKeeper.knockoutSwitch(srcSwitch)
-        Wrappers.wait(WAIT_OFFSET) { assert !(srcSwitch.dpId in northbound.getActiveSwitches()*.switchId) }
+        switchHelper.knockoutSwitch(srcSwitch)
 
         and: "Generate traffic on the given flow"
         exam.setResources(traffExam.startExam(exam, true))
@@ -208,11 +202,7 @@ class MflStatSpec extends HealthCheckSpecification {
         }
 
         when: "Restore default controllers on the src switches"
-        lockKeeper.reviveSwitch(srcSwitch)
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            assert srcSwitch.dpId in northbound.getActiveSwitches()*.switchId
-            assert northbound.getAllLinks().findAll { it.state == IslChangeType.FAILED }.empty
-        }
+        switchHelper.reviveSwitch(srcSwitch, true)
 
         then: "Old statistic should be collected"
         Wrappers.wait(statsRouterInterval + WAIT_OFFSET, waitInterval) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesSpec.groovy
@@ -45,12 +45,10 @@ class DefaultRulesSpec extends HealthCheckSpecification {
         northbound.deleteSwitchRules(sw.dpId, DeleteRulesAction.DROP_ALL)
         Wrappers.wait(RULES_DELETION_TIME) { assert northbound.getSwitchRules(sw.dpId).flowEntries.isEmpty() }
 
-        lockKeeper.knockoutSwitch(sw)
-        Wrappers.wait(WAIT_OFFSET) { assert !(sw.dpId in northbound.getActiveSwitches()*.switchId) }
+        switchHelper.knockoutSwitch(sw)
 
         when: "Connect the switch to the controller"
-        lockKeeper.reviveSwitch(sw)
-        Wrappers.wait(WAIT_OFFSET) { assert sw.dpId in northbound.getActiveSwitches()*.switchId }
+        switchHelper.reviveSwitch(sw)
 
         then: "Default rules are installed on the switch"
         Wrappers.wait(RULES_INSTALLATION_TIME) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/FlowRulesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/FlowRulesSpec.groovy
@@ -83,12 +83,10 @@ class FlowRulesSpec extends HealthCheckSpecification {
             assert defaultPlusFlowRules.size() == srcSwDefaultRules.size() + flowRulesCount + multiTableFlowRules
         }
 
-        lockKeeper.knockoutSwitch(srcSwitch)
-        Wrappers.wait(WAIT_OFFSET) { assert !(srcSwitch.dpId in northbound.getActiveSwitches()*.switchId) }
+        switchHelper.knockoutSwitch(srcSwitch)
 
         when: "Connect the switch to the controller"
-        lockKeeper.reviveSwitch(srcSwitch)
-        Wrappers.wait(WAIT_OFFSET) { assert srcSwitch.dpId in northbound.getActiveSwitches()*.switchId }
+        switchHelper.reviveSwitch(srcSwitch)
 
         then: "Previously installed rules are not deleted from the switch"
         compareRules(northbound.getSwitchRules(srcSwitch.dpId).flowEntries, defaultPlusFlowRules)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortHistorySpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortHistorySpec.groovy
@@ -187,10 +187,7 @@ class PortHistorySpec extends HealthCheckSpecification {
 
         and: "Deactivate the src switch"
         def switchToDisconnect = isl.srcSwitch
-        lockKeeper.knockoutSwitch(switchToDisconnect)
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getSwitch(switchToDisconnect.dpId).state == SwitchChangeType.DEACTIVATED
-        }
+        switchHelper.knockoutSwitch(switchToDisconnect)
 
         then: "Port history on the src switch is still available"
         northboundV2.getPortHistory(isl.srcSwitch.dpId, isl.srcPort, timestampBefore, timestampAfter).size() == 4
@@ -202,10 +199,7 @@ class PortHistorySpec extends HealthCheckSpecification {
                 assert islUtils.getIslInfo(isl).get().state == IslChangeType.DISCOVERED
             }
         }
-        switchToDisconnect && lockKeeper.reviveSwitch(switchToDisconnect)
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getSwitch(switchToDisconnect.dpId).state == SwitchChangeType.ACTIVATED
-        }
+        switchToDisconnect && switchHelper.reviveSwitch(switchToDisconnect)
     }
 
     def "Port history is able to show ANTI_FLAP statistic"() {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
@@ -204,10 +204,7 @@ class SwitchesSpec extends HealthCheckSpecification {
 
         when: "Deactivate the src switch"
         def switchToDisconnect = topology.switches.find { it.dpId == switchPair.src.dpId }
-        lockKeeper.knockoutSwitch(switchToDisconnect)
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getSwitch(switchToDisconnect.dpId).state == SwitchChangeType.DEACTIVATED
-        }
+        switchHelper.knockoutSwitch(switchToDisconnect)
 
         and: "Get all flows going through the deactivated src switch"
         def switchFlowsResponseSrcSwitch = northbound.getSwitchFlows(switchPair.src.dpId)
@@ -217,10 +214,7 @@ class SwitchesSpec extends HealthCheckSpecification {
 
         cleanup: "Revive the src switch and delete the flows"
         [simpleFlow, singleFlow].each { flowHelperV2.deleteFlow(it.flowId) }
-        lockKeeper.reviveSwitch(switchToDisconnect)
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            assert northbound.getSwitch(switchToDisconnect.dpId).state == SwitchChangeType.ACTIVATED
-        }
+        switchToDisconnect && switchHelper.reviveSwitch(switchToDisconnect)
     }
 
     @Tidy


### PR DESCRIPTION
The main idea of this pr is add knockout/reviveSwitch methods into `switchHelper`

Also two specs are improved:
- remove needless timeLoop in `AutoRerouteV2Spec`
- add missing annotation in `FlowPingSpec`

