### PR TITLE
Fix the appearance of excess rules when flow update V2.

### DIFF
--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/FlowProcessingAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/FlowProcessingAction.java
@@ -36,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.squirrelframework.foundation.fsm.AnonymousAction;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -93,14 +94,8 @@ public abstract class FlowProcessingAction<T extends FlowProcessingFsm<T, S, E, 
                         format("Flow path %s not found", pathId)));
     }
 
-    protected boolean isRemoveCustomerPortSharedCatchRule(String flowId,
-                                                          SwitchId ingressSwitchId, int ingressPort) {
-        Set<String> flowIds = flowRepository.findByEndpointWithMultiTableSupport(ingressSwitchId, ingressPort)
-                .stream()
-                .map(Flow::getFlowId)
-                .collect(Collectors.toSet());
-
-        return flowIds.size() == 1 && flowIds.iterator().next().equals(flowId);
+    protected Set<String> findFlowsIdsByEndpointWithMultiTable(SwitchId switchId, int port) {
+        return new HashSet<>(flowRepository.findFlowsIdsByEndpointWithMultiTableSupport(switchId, port));
     }
 
     protected Set<String> getDiverseWithFlowIds(Flow flow) {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RemoveOldRulesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RemoveOldRulesAction.java
@@ -78,6 +78,8 @@ public class RemoveOldRulesAction extends BaseFlowRuleRemovalAction<FlowUpdateFs
         RequestedFlow targetFlow = stateMachine.getTargetFlow();
 
         return SpeakerRequestBuildContext.builder()
+                .removeCustomerPortRule(removeForwardCustomerPortSharedCatchRule(originalFlow, targetFlow))
+                .removeOppositeCustomerPortRule(removeReverseCustomerPortSharedCatchRule(originalFlow, targetFlow))
                 .removeCustomerPortLldpRule(removeForwardSharedLldpRule(originalFlow, targetFlow))
                 .removeOppositeCustomerPortLldpRule(removeReverseSharedLldpRule(originalFlow, targetFlow))
                 .removeCustomerPortArpRule(removeForwardSharedArpRule(originalFlow, targetFlow))

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RevertNewRulesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RevertNewRulesAction.java
@@ -100,6 +100,8 @@ public class RevertNewRulesAction extends BaseFlowRuleRemovalAction<FlowUpdateFs
         RequestedFlow targetFlow = stateMachine.getTargetFlow();
 
         return SpeakerRequestBuildContext.builder()
+                .removeCustomerPortRule(removeForwardCustomerPortSharedCatchRule(targetFlow, originalFlow))
+                .removeOppositeCustomerPortRule(removeReverseCustomerPortSharedCatchRule(targetFlow, originalFlow))
                 .removeCustomerPortLldpRule(removeForwardSharedLldpRule(targetFlow, originalFlow))
                 .removeOppositeCustomerPortLldpRule(removeReverseSharedLldpRule(targetFlow, originalFlow))
                 .removeCustomerPortArpRule(removeForwardSharedArpRule(targetFlow, originalFlow))

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/model/RequestedFlow.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/model/RequestedFlow.java
@@ -48,4 +48,7 @@ public class RequestedFlow {
     private FlowEncapsulationType flowEncapsulationType;
     private PathComputationStrategy pathComputationStrategy;
     private DetectConnectedDevices detectConnectedDevices;
+
+    private boolean srcWithMultiTable;
+    private boolean destWithMultiTable;
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/mapper/RequestedFlowMapperTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/mapper/RequestedFlowMapperTest.java
@@ -20,7 +20,9 @@ import static org.junit.Assert.assertTrue;
 
 import org.openkilda.messaging.command.flow.FlowRequest;
 import org.openkilda.messaging.model.DetectConnectedDevicesDto;
+import org.openkilda.model.Flow;
 import org.openkilda.model.FlowEncapsulationType;
+import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.topology.flowhs.model.DetectConnectedDevices;
 import org.openkilda.wfm.topology.flowhs.model.RequestedFlow;
@@ -64,6 +66,29 @@ public class RequestedFlowMapperTest {
             .periodicPings(true)
             .build();
 
+    private Flow flow = Flow.builder()
+            .flowId(FLOW_ID)
+            .srcSwitch(Switch.builder().switchId(SRC_SWITCH_ID).build())
+            .srcPort(SRC_PORT)
+            .srcVlan(SRC_VLAN)
+            .destSwitch(Switch.builder().switchId(DST_SWITCH_ID).build())
+            .destPort(DST_PORT)
+            .destVlan(DST_VLAN)
+            .priority(PRIORITY)
+            .description(DESCRIPTION)
+            .bandwidth(BANDWIDTH)
+            .maxLatency(MAX_LATENCY)
+            .encapsulationType(FlowEncapsulationType.TRANSIT_VLAN)
+            .detectConnectedDevices(
+                    new org.openkilda.model.DetectConnectedDevices(true, true, true, true, true, true, true, true))
+            .pinned(true)
+            .allocateProtectedPath(true)
+            .ignoreBandwidth(true)
+            .periodicPings(true)
+            .srcWithMultiTable(true)
+            .destWithMultiTable(true)
+            .build();
+
     @Test
     public void mapFlowRequestToRequestedFlowTest() {
         RequestedFlow requestedFlow = RequestedFlowMapper.INSTANCE.toRequestedFlow(flowRequest);
@@ -86,5 +111,33 @@ public class RequestedFlowMapperTest {
         assertTrue(requestedFlow.isPeriodicPings());
         assertEquals(new DetectConnectedDevices(true, true, true, true, true, true, true, true),
                 requestedFlow.getDetectConnectedDevices());
+    }
+
+    @Test
+    public void mapFlowToRequestedFlowTest() {
+        RequestedFlow requestedFlow = RequestedFlowMapper.INSTANCE.toRequestedFlow(flow);
+        assertEquals(FLOW_ID, requestedFlow.getFlowId());
+        assertEquals(SRC_SWITCH_ID, requestedFlow.getSrcSwitch());
+        assertEquals(SRC_PORT, requestedFlow.getSrcPort());
+        assertEquals(SRC_VLAN, requestedFlow.getSrcVlan());
+        assertEquals(DST_SWITCH_ID, requestedFlow.getDestSwitch());
+        assertEquals(DST_PORT, requestedFlow.getDestPort());
+        assertEquals(DST_VLAN, requestedFlow.getDestVlan());
+        assertEquals(PRIORITY, requestedFlow.getPriority());
+        assertEquals(DESCRIPTION, requestedFlow.getDescription());
+        assertEquals(BANDWIDTH, requestedFlow.getBandwidth());
+        assertEquals(MAX_LATENCY, requestedFlow.getMaxLatency());
+        assertEquals(ENCAPSULATION_TYPE, requestedFlow.getFlowEncapsulationType());
+        assertTrue(requestedFlow.isPinned());
+        assertTrue(requestedFlow.isAllocateProtectedPath());
+        assertTrue(requestedFlow.isIgnoreBandwidth());
+        assertTrue(requestedFlow.isPeriodicPings());
+        assertTrue(requestedFlow.isSrcWithMultiTable());
+        assertTrue(requestedFlow.isDestWithMultiTable());
+        assertEquals(new DetectConnectedDevices(true, true, true, true, true, true, true, true),
+                requestedFlow.getDetectConnectedDevices());
+
+        Flow mappedFlow = RequestedFlowMapper.INSTANCE.toFlow(requestedFlow);
+        assertEquals(flow, mappedFlow);
     }
 }

--- a/src-java/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/FlowRepository.java
+++ b/src-java/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/FlowRepository.java
@@ -63,6 +63,8 @@ public interface FlowRepository extends Repository<Flow> {
 
     Collection<Flow> findByEndpointWithMultiTableSupport(SwitchId switchId, int port);
 
+    Collection<String> findFlowsIdsByEndpointWithMultiTableSupport(SwitchId switchId, int port);
+
     Collection<Flow> findByEndpointSwitch(SwitchId switchId);
 
     Collection<Flow> findByEndpointSwitchWithMultiTableSupport(SwitchId switchId);


### PR DESCRIPTION
When updating flow, we save the old flow in the RequestedFlow object using the mapper. And when deleting old rules, we take information from this object. We need these two flags to build commands for removing rules. Also the conditions for removing customer port shared rules have been added.

Closes: #3266.