### PR TITLE
Fixed PCE for diverse flow with not enough bandwidth ISL

### DIFF
--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/impl/AvailableNetwork.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/impl/AvailableNetwork.java
@@ -93,6 +93,13 @@ public class AvailableNetwork {
             Node srcNode = getSwitch(segment.getSrcSwitch().getSwitchId());
             Node dstNode = getSwitch(segment.getDestSwitch().getSwitchId());
 
+            if (dstNode != null) {
+                dstNode.increaseDiversityGroupUseCounter();
+            }
+            if (srcNode != null && segment.getSeqId() == 0) {
+                srcNode.increaseDiversityGroupUseCounter();
+            }
+
             if (srcNode == null || dstNode == null) {
                 log.debug("Diversity segment {} don't present in AvailableNetwork", segment);
                 continue;
@@ -110,10 +117,6 @@ public class AvailableNetwork {
                 Edge edge = edgeOptional.get();
 
                 edge.increaseDiversityGroupUseCounter();
-                edge.getDestSwitch().increaseDiversityGroupUseCounter();
-                if (segment.getSeqId() == 0) {
-                    edge.getSrcSwitch().increaseDiversityGroupUseCounter();
-                }
             }
         }
     }

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/AvailableNetworkTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/AvailableNetworkTest.java
@@ -392,7 +392,9 @@ public class AvailableNetworkTest {
 
         Edge edge = srcSwitch.getOutgoingLinks().iterator().next();
         assertEquals(0, edge.getDiversityGroupUseCounter());
-        assertEquals(0, edge.getDestSwitch().getDiversityGroupUseCounter());
+        // as switches are in AvailableNetwork
+        assertEquals(1, edge.getDestSwitch().getDiversityGroupUseCounter());
+        assertEquals(1, edge.getSrcSwitch().getDiversityGroupUseCounter());
     }
 
     private void addLink(AvailableNetwork network, SwitchId srcDpid, SwitchId dstDpid, int srcPort, int dstPort,


### PR DESCRIPTION
When we are getting available network for flow we collect only ISLs
with enough bandwidth. If diverse flow has segments with not enough
bandwidth - we do not increase devirse counter on Nodes in AvailableNetwork.