### PR TITLE
extract knockout/reviveSwitch into switchHelper

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
@@ -131,8 +131,7 @@ class AutoRerouteSpec extends HealthCheckSpecification {
 
         and: "Connect the intermediate switch back and delete the flow"
         flowHelper.deleteFlow(flow.id)
-        lockKeeper.reviveSwitch(sw, blockData)
-        Wrappers.wait(WAIT_OFFSET) { assert flowPath[1].switchId in northbound.getActiveSwitches()*.switchId }
+        switchHelper.reviveSwitch(sw, blockData)
         northbound.deleteSwitchRules(flowPath[1].switchId, DeleteRulesAction.IGNORE_DEFAULTS) || true
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteV2Spec.groovy
@@ -130,7 +130,8 @@ class AutoRerouteV2Spec extends HealthCheckSpecification {
         def flowPath = PathHelper.convert(northbound.getFlowPath(flow.flowId))
 
         when: "An intermediate switch is disconnected"
-        def blockData = lockKeeper.knockoutSwitch(findSw(flowPath[1].switchId), mgmtFlManager)
+        def sw = findSw(flowPath[1].switchId)
+        def blockData = lockKeeper.knockoutSwitch(sw, mgmtFlManager)
 
         then: "All ISLs going through the intermediate switch are 'FAILED'"
         Wrappers.wait(discoveryTimeout * 1.5 + WAIT_OFFSET) {
@@ -149,8 +150,7 @@ class AutoRerouteV2Spec extends HealthCheckSpecification {
 
         and: "Connect the intermediate switch back and delete the flow"
         flowHelperV2.deleteFlow(flow.flowId)
-        lockKeeper.reviveSwitch(findSw(flowPath[1].switchId), blockData)
-        Wrappers.wait(WAIT_OFFSET) { assert flowPath[1].switchId in northbound.getActiveSwitches()*.switchId }
+        switchHelper.reviveSwitch(sw, blockData)
         northbound.deleteSwitchRules(flowPath[1].switchId, DeleteRulesAction.IGNORE_DEFAULTS) || true
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             assert northbound.getActiveLinks().size() == topology.islsForActiveSwitches.size() * 2
@@ -433,10 +433,7 @@ class AutoRerouteV2Spec extends HealthCheckSpecification {
         when: "Disconnect the src switch of the first flow from the controller"
         def islToBreak = pathHelper.getInvolvedIsls(firstFlowMainPath).first()
         def islToReroute = pathHelper.getInvolvedIsls(firstFlowBackupPath).first()
-        def blockData = lockKeeper.knockoutSwitch(switchPair1.src, mgmtFlManager)
-        Wrappers.wait(discoveryTimeout + WAIT_OFFSET) {
-            assert northbound.getSwitch(switchPair1.src.dpId).state == SwitchChangeType.DEACTIVATED
-        }
+        def blockData = switchHelper.knockoutSwitch(switchPair1.src, mgmtFlManager)
         def isSwitchActivated = false
 
         and: "Mark the switch as ACTIVE in db" // just to reproduce #3131
@@ -462,10 +459,7 @@ class AutoRerouteV2Spec extends HealthCheckSpecification {
 
         when: "Connect the switch back to the controller"
         database.setSwitchStatus(switchPair1.src.dpId, SwitchStatus.INACTIVE) // set real status
-        lockKeeper.reviveSwitch(switchPair1.src, blockData)
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getSwitch(switchPair1.src.dpId).state == SwitchChangeType.ACTIVATED
-        }
+        switchHelper.reviveSwitch(switchPair1.src, blockData)
         isSwitchActivated = true
 
         then: "Both flows are rerouted"
@@ -492,10 +486,7 @@ class AutoRerouteV2Spec extends HealthCheckSpecification {
         cleanup: "Restore topology, delete the flow and reset costs"
         firstFlow && flowHelperV2.deleteFlow(firstFlow.flowId)
         secondFlow && flowHelperV2.deleteFlow(secondFlow.flowId)
-        !isSwitchActivated && blockData && lockKeeper.reviveSwitch(switchPair1.src, blockData)
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getSwitch(switchPair1.src.dpId).state == SwitchChangeType.ACTIVATED
-        }
+        !isSwitchActivated && blockData && switchHelper.reviveSwitch(switchPair1.src, blockData)
         islToBreak && antiflap.portUp(islToBreak.dstSwitch.dpId, islToBreak.dstPort)
         islsToBreak && withPool { islsToBreak.eachParallel { antiflap.portUp(it.srcSwitch.dpId, it.srcPort) } }
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
@@ -537,30 +528,19 @@ class AutoRerouteV2Spec extends HealthCheckSpecification {
         when: "Generate switchUp event on switch which is not related to the flow"
         def involvedSwitches = pathHelper.getInvolvedSwitches(flowPath)*.dpId
         def switchToManipulate = topology.activeSwitches.find { !(it.dpId in involvedSwitches) }
-        def blockData = lockKeeper.knockoutSwitch(switchToManipulate, mgmtFlManager)
-        Wrappers.wait(discoveryTimeout + WAIT_OFFSET) {
-            assert northbound.getSwitch(switchToManipulate.dpId).state == SwitchChangeType.DEACTIVATED
-        }
+        def blockData = switchHelper.knockoutSwitch(switchToManipulate, mgmtFlManager)
         def isSwitchActivated = false
-        lockKeeper.reviveSwitch(switchToManipulate, blockData)
-        Wrappers.wait(discoveryTimeout + WAIT_OFFSET) {
-            assert northbound.getSwitch(switchToManipulate.dpId).state == SwitchChangeType.ACTIVATED
-        }
+        switchHelper.reviveSwitch(switchToManipulate, blockData)
         isSwitchActivated = true
 
         then: "Flow is not triggered for reroute due to switchUp event because switch is not related to the flow"
         TimeUnit.SECONDS.sleep(rerouteDelay * 2) // it helps to be sure that the auto-reroute operation is completed
-        Wrappers.timedLoop(rerouteDelay) { // just in case
-            assert northbound.getFlowHistory(flow.flowId).findAll { it.action == REROUTE_ACTION }.size() == 1
-        }
+        northbound.getFlowHistory(flow.flowId).findAll { it.action == REROUTE_ACTION }.size() == 1
 
         cleanup: "Restore topology, delete the flow and reset costs"
         flow && flowHelperV2.deleteFlow(flow.flowId)
         islToBreak && antiflap.portUp(islToBreak.srcSwitch.dpId, islToBreak.srcPort)
-        !isSwitchActivated && blockData && lockKeeper.reviveSwitch(switchToManipulate, blockData)
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getSwitch(switchToManipulate.dpId).state == SwitchChangeType.ACTIVATED
-        }
+        !isSwitchActivated && blockData && switchHelper.reviveSwitch(switchToManipulate, blockData)
         broughtDownPorts && broughtDownPorts.each { antiflap.portUp(it.switchId, it.portNo) }
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             assert northbound.getActiveLinks().size() == topology.islsForActiveSwitches.size() * 2

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV2Spec.groovy
@@ -25,7 +25,6 @@ import org.openkilda.functionaltests.helpers.model.SwitchPair
 import org.openkilda.messaging.error.MessageError
 import org.openkilda.messaging.info.event.IslChangeType
 import org.openkilda.messaging.info.event.PathNode
-import org.openkilda.messaging.info.event.SwitchChangeType
 import org.openkilda.messaging.payload.flow.DetectConnectedDevicesPayload
 import org.openkilda.messaging.payload.flow.FlowEndpointPayload
 import org.openkilda.messaging.payload.flow.FlowPayload
@@ -752,11 +751,7 @@ class FlowCrudV2Spec extends HealthCheckSpecification {
     def "System doesn't allow to create a one-switch flow on a DEACTIVATED switch"() {
         given: "Disconnected switch"
         def sw = topology.getActiveSwitches()[0]
-        def swIsls = topology.getRelatedIsls(sw)
-        def blockData = lockKeeper.knockoutSwitch(sw, mgmtFlManager)
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getSwitch(sw.dpId).state == SwitchChangeType.DEACTIVATED
-        }
+        def blockData = switchHelper.knockoutSwitch(sw, mgmtFlManager)
 
         when: "Try to create a one-switch flow on a deactivated switch"
         def flow = flowHelperV2.singleSwitchFlow(sw)
@@ -771,12 +766,7 @@ class FlowCrudV2Spec extends HealthCheckSpecification {
                 "Destination switch $sw.dpId are not connected to the controller"
 
         and: "Cleanup: Connect switch back to the controller"
-        lockKeeper.reviveSwitch(sw, blockData)
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            assert northbound.getSwitch(sw.dpId).state == SwitchChangeType.ACTIVATED
-            def links = northbound.getAllLinks()
-            swIsls.each { assert islUtils.getIslInfo(links, it).get().state == IslChangeType.DISCOVERED }
-        }
+        switchHelper.reviveSwitch(sw, blockData, true)
     }
 
     @Tidy

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowPingSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowPingSpec.groovy
@@ -295,6 +295,7 @@ class FlowPingSpec extends HealthCheckSpecification {
         flow && flowHelperV2.deleteFlow(flow.flowId)
     }
 
+    @Tidy
     def "Able to turn on periodic pings on a flow"() {
         when: "Create a flow with periodic pings turned on"
         def flow = flowHelperV2.randomFlow(topologyHelper.notNeighboringSwitchPair).tap {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
@@ -194,16 +194,14 @@ class LinkSpec extends HealthCheckSpecification {
     def "ISL should immediately fail if the port went down while switch was disconnected"() {
         when: "A switch disconnects"
         def isl = topology.islsForActiveSwitches.find { it.aswitch?.inPort && it.aswitch?.outPort }
-        def blockData = lockKeeper.knockoutSwitch(isl.srcSwitch, mgmtFlManager)
-        Wrappers.wait(WAIT_OFFSET) { northbound.getSwitch(isl.srcSwitch.dpId).state == SwitchChangeType.DEACTIVATED }
+        def blockData = switchHelper.knockoutSwitch(isl.srcSwitch, mgmtFlManager)
 
         and: "One of its ports goes down"
         //Bring down port on a-switch, which will lead to a port down on the Kilda switch
         lockKeeper.portsDown([isl.aswitch.inPort])
 
         and: "The switch reconnects back with a port being down"
-        lockKeeper.reviveSwitch(isl.srcSwitch, blockData)
-        Wrappers.wait(WAIT_OFFSET) { northbound.getSwitch(isl.srcSwitch.dpId).state == SwitchChangeType.ACTIVATED }
+        switchHelper.reviveSwitch(isl.srcSwitch, blockData)
 
         then: "The related ISL immediately goes down"
         Wrappers.wait(WAIT_OFFSET) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/multitable/MultitableFlowsSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/multitable/MultitableFlowsSpec.groovy
@@ -1274,24 +1274,12 @@ mode with existing flows and hold flows of different table-mode types"() {
         assert !northbound.getSwitchProperties(sw.dpId).multiTable
 
         when: "Disconnect the switch and remove it from DB. Pretend this switch never existed"
-        def blockData = lockKeeper.knockoutSwitch(sw, mgmtFlManager)
-        Wrappers.wait(discoveryTimeout + WAIT_OFFSET) {
-            assert northbound.getSwitch(sw.dpId).state == SwitchChangeType.DEACTIVATED
-            assert northbound.getAllLinks().findAll { it.state == IslChangeType.FAILED }.size() == isls.size() * 2
-        }
+        def blockData = switchHelper.knockoutSwitch(sw, mgmtFlManager, true)
         isls.each { northbound.deleteLink(islUtils.toLinkParameters(it)) }
         northbound.deleteSwitch(sw.dpId, false)
 
         and: "New switch connects"
-        lockKeeper.reviveSwitch(sw, blockData)
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            assert northbound.getSwitch(sw.dpId).state == SwitchChangeType.ACTIVATED
-            def allIsls = northbound.getAllLinks()
-            isls.each {
-                assert islUtils.getIslInfo(allIsls, it).get().state == IslChangeType.DISCOVERED
-                assert islUtils.getIslInfo(allIsls, it.reversed).get().state == IslChangeType.DISCOVERED
-            }
-        }
+        switchHelper.reviveSwitch(sw, blockData, true)
 
         then: "Switch is added with disabled multiTable mode"
         !northbound.getSwitchProperties(sw.dpId).multiTable

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/RollbacksSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/RollbacksSpec.groovy
@@ -61,10 +61,7 @@ and at least 1 path must remain safe"
         northbound.deleteLinkProps(northbound.getAllLinkProps())
         switchPair.paths.findAll { it != failoverPath }.each { pathHelper.makePathMorePreferable(failoverPath, it) }
         //disconnect the switch, but make it look like 'active'
-        def blockData = lockKeeper.knockoutSwitch(switchToBreak, mgmtFlManager)
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getSwitch(switchToBreak.dpId).state == SwitchChangeType.DEACTIVATED
-        }
+        def blockData = switchHelper.knockoutSwitch(switchToBreak, mgmtFlManager)
         database.setSwitchStatus(switchToBreak.dpId, SwitchStatus.ACTIVE)
 
         when: "Main path of the flow breaks initiating a reroute"
@@ -104,10 +101,7 @@ and at least 1 path must remain safe"
         flow && flowHelperV2.deleteFlow(flow.flowId)
         if(blockData) {
             database.setSwitchStatus(switchToBreak.dpId, SwitchStatus.INACTIVE)
-            lockKeeper.reviveSwitch(switchToBreak, blockData)
-            Wrappers.wait(WAIT_OFFSET) {
-                assert northbound.getSwitch(switchToBreak.dpId).state == SwitchChangeType.ACTIVATED
-            }
+            switchHelper.reviveSwitch(switchToBreak, blockData)
         }
         if(portDown) {
             antiflap.portUp(islToBreak.srcSwitch.dpId, islToBreak.srcPort)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesSpec.groovy
@@ -45,12 +45,10 @@ class DefaultRulesSpec extends HealthCheckSpecification {
         northbound.deleteSwitchRules(sw.dpId, DeleteRulesAction.DROP_ALL)
         Wrappers.wait(RULES_DELETION_TIME) { assert northbound.getSwitchRules(sw.dpId).flowEntries.isEmpty() }
 
-        def blockData = lockKeeper.knockoutSwitch(sw, mgmtFlManager)
-        Wrappers.wait(WAIT_OFFSET) { assert !(sw.dpId in northbound.getActiveSwitches()*.switchId) }
+        def blockData = switchHelper.knockoutSwitch(sw, mgmtFlManager)
 
         when: "Connect the switch to the controller"
-        lockKeeper.reviveSwitch(sw, blockData)
-        Wrappers.wait(WAIT_OFFSET) { assert sw.dpId in northbound.getActiveSwitches()*.switchId }
+        switchHelper.reviveSwitch(sw, blockData)
 
         then: "Default rules are installed on the switch"
         Wrappers.wait(RULES_INSTALLATION_TIME) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/FlowRulesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/FlowRulesSpec.groovy
@@ -83,12 +83,10 @@ class FlowRulesSpec extends HealthCheckSpecification {
             assert defaultPlusFlowRules.size() == srcSwDefaultRules.size() + flowRulesCount + multiTableFlowRules
         }
 
-        def blockData = lockKeeper.knockoutSwitch(srcSwitch, mgmtFlManager)
-        Wrappers.wait(WAIT_OFFSET) { assert !(srcSwitch.dpId in northbound.getActiveSwitches()*.switchId) }
+        def blockData = switchHelper.knockoutSwitch(srcSwitch, mgmtFlManager)
 
         when: "Connect the switch to the controller"
-        lockKeeper.reviveSwitch(srcSwitch, blockData)
-        Wrappers.wait(WAIT_OFFSET) { assert srcSwitch.dpId in northbound.getActiveSwitches()*.switchId }
+        switchHelper.reviveSwitch(srcSwitch, blockData)
 
         then: "Previously installed rules are not deleted from the switch"
         compareRules(northbound.getSwitchRules(srcSwitch.dpId).flowEntries, defaultPlusFlowRules)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortHistorySpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortHistorySpec.groovy
@@ -187,10 +187,7 @@ class PortHistorySpec extends HealthCheckSpecification {
 
         and: "Deactivate the src switch"
         def switchToDisconnect = isl.srcSwitch
-        def blockData = lockKeeper.knockoutSwitch(switchToDisconnect, mgmtFlManager)
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getSwitch(switchToDisconnect.dpId).state == SwitchChangeType.DEACTIVATED
-        }
+        def blockData = switchHelper.knockoutSwitch(switchToDisconnect, mgmtFlManager)
 
         then: "Port history on the src switch is still available"
         northboundV2.getPortHistory(isl.srcSwitch.dpId, isl.srcPort, timestampBefore, timestampAfter).size() == 4
@@ -202,10 +199,7 @@ class PortHistorySpec extends HealthCheckSpecification {
                 assert islUtils.getIslInfo(isl).get().state == IslChangeType.DISCOVERED
             }
         }
-        switchToDisconnect && lockKeeper.reviveSwitch(switchToDisconnect, blockData)
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getSwitch(switchToDisconnect.dpId).state == SwitchChangeType.ACTIVATED
-        }
+        switchToDisconnect && switchHelper.reviveSwitch(switchToDisconnect, blockData)
     }
 
     def "Port history is able to show ANTI_FLAP statistic"() {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchActivationSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchActivationSpec.groovy
@@ -64,12 +64,10 @@ class SwitchActivationSpec extends HealthCheckSpecification {
             }
         }
 
-        def blockData = lockKeeper.knockoutSwitch(switchPair.src, mgmtFlManager)
-        Wrappers.wait(WAIT_OFFSET) { assert !(switchPair.src.dpId in northbound.getActiveSwitches()*.switchId) }
+        def blockData = switchHelper.knockoutSwitch(switchPair.src, mgmtFlManager)
 
         when: "Connect the switch to the controller"
-        lockKeeper.reviveSwitch(switchPair.src, blockData)
-        Wrappers.wait(WAIT_OFFSET) { assert switchPair.src.dpId in northbound.getActiveSwitches()*.switchId }
+        switchHelper.reviveSwitch(switchPair.src, blockData)
 
         then: "Missing flow rules/meters were synced during switch activation"
         verifyAll(northbound.validateSwitch(switchPair.src.dpId)) {
@@ -117,12 +115,10 @@ class SwitchActivationSpec extends HealthCheckSpecification {
             }
         }
 
-        def blockData = lockKeeper.knockoutSwitch(sw, mgmtFlManager)
-        Wrappers.wait(WAIT_OFFSET) { assert !(sw.dpId in northbound.getActiveSwitches()*.switchId) }
+        def blockData = switchHelper.knockoutSwitch(sw, mgmtFlManager)
 
         when: "Connect the switch to the controller"
-        lockKeeper.reviveSwitch(sw, blockData)
-        Wrappers.wait(WAIT_OFFSET) { assert sw.dpId in northbound.getActiveSwitches()*.switchId }
+        switchHelper.reviveSwitch(sw, blockData)
 
         then: "Excess meters/rules were synced during switch activation"
         verifyAll(northbound.validateSwitch(sw.dpId)) {
@@ -135,11 +131,7 @@ class SwitchActivationSpec extends HealthCheckSpecification {
         setup: "Disconnect one of the switches and remove it from DB. Pretend this switch never existed"
         def sw = topology.activeSwitches.first()
         def isls = topology.getRelatedIsls(sw)
-        def blockData = lockKeeper.knockoutSwitch(sw, mgmtFlManager)
-        Wrappers.wait(discoveryTimeout + WAIT_OFFSET) {
-            assert northbound.getSwitch(sw.dpId).state == SwitchChangeType.DEACTIVATED
-            assert northbound.getAllLinks().findAll { it.state == IslChangeType.FAILED }.size() == isls.size() * 2
-        }
+        def blockData = switchHelper.knockoutSwitch(sw, mgmtFlManager, true)
         isls.each { northbound.deleteLink(islUtils.toLinkParameters(it)) }
         northbound.deleteSwitch(sw.dpId, false)
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchDeleteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchDeleteSpec.groovy
@@ -49,8 +49,7 @@ class SwitchDeleteSpec extends HealthCheckSpecification {
         def swIsls = topology.getRelatedIsls(sw)
 
         // deactivate switch
-        def blockData = lockKeeper.knockoutSwitch(sw, mgmtFlManager)
-        Wrappers.wait(WAIT_OFFSET) { assert !northbound.activeSwitches.any { it.switchId == sw.dpId } }
+        def blockData = switchHelper.knockoutSwitch(sw, mgmtFlManager)
 
         when: "Try to delete the switch"
         northbound.deleteSwitch(sw.dpId, false)
@@ -62,13 +61,7 @@ class SwitchDeleteSpec extends HealthCheckSpecification {
                 "Unplug and remove them first.*")
 
         and: "Cleanup: activate the switch back"
-        lockKeeper.reviveSwitch(sw, blockData)
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            assert northbound.activeSwitches.any { it.switchId == sw.dpId }
-
-            def links = northbound.getAllLinks()
-            swIsls.each { assert islUtils.getIslInfo(links, it).get().state == IslChangeType.DISCOVERED }
-        }
+        switchHelper.reviveSwitch(sw, blockData, true)
     }
 
     @Tags(VIRTUAL)
@@ -84,8 +77,7 @@ class SwitchDeleteSpec extends HealthCheckSpecification {
         }
 
         // deactivate switch
-        def blockData = lockKeeper.knockoutSwitch(sw, mgmtFlManager)
-        Wrappers.wait(WAIT_OFFSET) { assert !northbound.activeSwitches.any { it.switchId == sw.dpId } }
+        def blockData = switchHelper.knockoutSwitch(sw, mgmtFlManager)
 
         when: "Try to delete the switch"
         northbound.deleteSwitch(sw.dpId, false)
@@ -97,8 +89,7 @@ class SwitchDeleteSpec extends HealthCheckSpecification {
                 "Remove them first.*")
 
         and: "Cleanup: activate the switch back and reset costs"
-        lockKeeper.reviveSwitch(sw, blockData)
-        Wrappers.wait(WAIT_OFFSET) { assert northbound.activeSwitches.any { it.switchId == sw.dpId } }
+        switchHelper.reviveSwitch(sw, blockData)
 
         swIsls.each { antiflap.portUp(sw.dpId, it.srcPort) }
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
@@ -116,8 +107,7 @@ class SwitchDeleteSpec extends HealthCheckSpecification {
 
         when: "Deactivate the switch"
         def swToDeactivate = topology.switches.find { it.dpId == flow.source.switchId }
-        def blockData = lockKeeper.knockoutSwitch(swToDeactivate, mgmtFlManager)
-        Wrappers.wait(WAIT_OFFSET) { assert !northbound.activeSwitches.any { it.switchId == flow.source.switchId } }
+        def blockData = switchHelper.knockoutSwitch(swToDeactivate, mgmtFlManager)
 
         and: "Try to delete the switch"
         northbound.deleteSwitch(flow.source.switchId, false)
@@ -129,8 +119,7 @@ class SwitchDeleteSpec extends HealthCheckSpecification {
 
         and: "Cleanup: activate the switch back and remove the flow"
         flowHelperV2.deleteFlow(flow.flowId)
-        lockKeeper.reviveSwitch(swToDeactivate, blockData)
-        Wrappers.wait(WAIT_OFFSET) { assert northbound.activeSwitches.any { it.switchId == flow.source.switchId } }
+        switchHelper.reviveSwitch(swToDeactivate, blockData)
 
         where:
         flowType        | flow
@@ -156,8 +145,7 @@ class SwitchDeleteSpec extends HealthCheckSpecification {
         }
 
         // deactivate switch
-        def blockData = lockKeeper.knockoutSwitch(sw, mgmtFlManager)
-        Wrappers.wait(WAIT_OFFSET) { assert !northbound.activeSwitches.any { it.switchId == sw.dpId } }
+        def blockData = switchHelper.knockoutSwitch(sw, mgmtFlManager)
 
         when: "Try to delete the switch"
         def response = northbound.deleteSwitch(sw.dpId, false)
@@ -168,8 +156,7 @@ class SwitchDeleteSpec extends HealthCheckSpecification {
 
         and: "Cleanup: activate the switch back, restore ISLs and reset costs"
         // restore switch
-        lockKeeper.reviveSwitch(sw, blockData)
-        Wrappers.wait(WAIT_OFFSET) { assert northbound.activeSwitches.any { it.switchId == sw.dpId } }
+        switchHelper.reviveSwitch(sw, blockData)
 
         // restore ISLs
         swIsls.each { antiflap.portUp(sw.dpId, it.srcPort) }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
@@ -203,10 +203,7 @@ class SwitchesSpec extends HealthCheckSpecification {
 
         when: "Deactivate the src switch"
         def switchToDisconnect = topology.switches.find { it.dpId == switchPair.src.dpId }
-        def blockData = lockKeeper.knockoutSwitch(switchToDisconnect, mgmtFlManager)
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getSwitch(switchToDisconnect.dpId).state == SwitchChangeType.DEACTIVATED
-        }
+        def blockData = switchHelper.knockoutSwitch(switchToDisconnect, mgmtFlManager)
 
         and: "Get all flows going through the deactivated src switch"
         def switchFlowsResponseSrcSwitch = northbound.getSwitchFlows(switchPair.src.dpId)
@@ -216,10 +213,7 @@ class SwitchesSpec extends HealthCheckSpecification {
 
         cleanup: "Revive the src switch and delete the flows"
         [simpleFlow, singleFlow].each { flowHelperV2.deleteFlow(it.flowId) }
-        lockKeeper.reviveSwitch(switchToDisconnect, blockData)
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            assert northbound.getSwitch(switchToDisconnect.dpId).state == SwitchChangeType.ACTIVATED
-        }
+        switchHelper.reviveSwitch(switchToDisconnect, blockData)
     }
 
     @Tidy


### PR DESCRIPTION
This PR the same as  #3244 
I found to hard rebase mentioned PR on the develop branch, so I've just created the new PR.


The main idea of this pr is add knockout/reviveSwitch methods into switchHelper
Also two specs are improved:
- remove needless `timeLoop` in `AutoRerouteV2Spec`
-  add missing annotation in `FlowPingSpec`
