### PR TITLE
Improve get Flow DB requests for Connected Devices Service

### DIFF
--- a/src-java/connecteddevices-topology/connecteddevices-storm-topology/src/main/java/org/openkilda/wfm/topology/connecteddevices/service/PacketService.java
+++ b/src-java/connecteddevices-topology/connecteddevices-storm-topology/src/main/java/org/openkilda/wfm/topology/connecteddevices/service/PacketService.java
@@ -29,7 +29,6 @@ import static org.openkilda.model.Cookie.LLDP_POST_INGRESS_COOKIE;
 import static org.openkilda.model.Cookie.LLDP_POST_INGRESS_ONE_SWITCH_COOKIE;
 import static org.openkilda.model.Cookie.LLDP_POST_INGRESS_VXLAN_COOKIE;
 import static org.openkilda.model.Cookie.LLDP_TRANSIT_COOKIE;
-import static org.openkilda.persistence.FetchStrategy.DIRECT_RELATIONS;
 
 import org.openkilda.messaging.info.event.ArpInfoData;
 import org.openkilda.messaging.info.event.ConnectedDevicePacketBase;
@@ -306,7 +305,7 @@ public class PacketService {
             log.info("Couldn't find flow encapsulation resources by Transit vlan '{}", vlan);
             return null;
         }
-        Optional<Flow> flow = flowRepository.findById(transitVlan.get().getFlowId(), DIRECT_RELATIONS);
+        Optional<Flow> flow = flowRepository.findByIdWithEndpoints(transitVlan.get().getFlowId());
         if (!flow.isPresent()) {
             log.warn("Couldn't find flow by flow ID '{}", transitVlan.get().getFlowId());
             return null;
@@ -333,13 +332,13 @@ public class PacketService {
     }
 
     private Flow getFlowBySwitchIdInPortAndOutVlan(SwitchId switchId, int inPort, int outVlan, String packetName) {
-        Optional<Flow> flow = flowRepository.findBySwitchIdInPortAndOutVlan(switchId, inPort, outVlan);
+        Optional<Flow> flow = flowRepository.findOneSwitchFlowBySwitchIdInPortAndOutVlan(switchId, inPort, outVlan);
 
         if (flow.isPresent()) {
             return flow.get();
         } else {
             // may be it's a full port flow
-            Optional<Flow> fullPortFlow = flowRepository.findBySwitchIdInPortAndOutVlan(
+            Optional<Flow> fullPortFlow = flowRepository.findOneSwitchFlowBySwitchIdInPortAndOutVlan(
                     switchId, inPort, FULL_PORT_VLAN);
             if (fullPortFlow.isPresent()) {
                 return fullPortFlow.get();

--- a/src-java/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/FlowRepository.java
+++ b/src-java/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/FlowRepository.java
@@ -39,6 +39,13 @@ public interface FlowRepository extends Repository<Flow> {
 
     Optional<Flow> findById(String flowId, FetchStrategy fetchStrategy);
 
+    /**
+     * Find flow by flow ID.
+     * <p/>
+     * IMPORTANT: the method completes the flow entity only with Switch objects (Flow paths will be null)
+     */
+    Optional<Flow> findByIdWithEndpoints(String flowId);
+
     Collection<Flow> findByGroupId(String flowGroupId);
 
     Collection<String> findFlowsIdByGroupId(String flowGroupId);
@@ -50,16 +57,16 @@ public interface FlowRepository extends Repository<Flow> {
     /**
      * Find flow by endpoint (SwitchId, port and vlan).
      * <p/>
-     * IMPORTANT: the method doesn't complete the flow and flow path entities with related path segments!
+     * IMPORTANT: the method completes the flow entity only with Switch objects (Flow paths will be null)
      */
     Optional<Flow> findByEndpointAndVlan(SwitchId switchId, int port, int vlan);
 
     /**
-     * Find flow by SwitchId, input port and output vlan.
+     * Find one switch flow by SwitchId, input port and output vlan.
      * <p/>
-     * IMPORTANT: the method doesn't complete the flow and flow path entities with related path segments!
+     * IMPORTANT: the method completes the flow entity only with Switch objects (Flow paths will be null)
      */
-    Optional<Flow> findBySwitchIdInPortAndOutVlan(SwitchId switchId, int inPort, int outVlan);
+    Optional<Flow> findOneSwitchFlowBySwitchIdInPortAndOutVlan(SwitchId switchId, int inPort, int outVlan);
 
     Collection<Flow> findByEndpointWithMultiTableSupport(SwitchId switchId, int port);
 


### PR DESCRIPTION
Do not load any Objects (except Switches) into Flow entity while
getting flow in Connected Devices Topology