### PR TITLE
Fix cleanups to always delete flows before bringing ports up

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
@@ -50,8 +50,8 @@ class AutoRerouteSpec extends HealthCheckSpecification {
         }
 
         cleanup: "Revive the ISL back (bring switch port up) and delete the flow"
-        antiflap.portUp(islToFail.srcSwitch.dpId, islToFail.srcPort)
         flowHelper.deleteFlow(flow.id)
+        antiflap.portUp(islToFail.srcSwitch.dpId, islToFail.srcPort)
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }
@@ -93,9 +93,9 @@ class AutoRerouteSpec extends HealthCheckSpecification {
         }
 
         cleanup: "Restore topology to the original state, remove the flow"
+        flowHelper.deleteFlow(flow.id)
         portDown && !portUp && antiflap.portUp(isl.dstSwitch.dpId, isl.dstPort)
         broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
-        flowHelper.deleteFlow(flow.id)
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }
@@ -130,10 +130,10 @@ class AutoRerouteSpec extends HealthCheckSpecification {
         }
 
         and: "Connect the intermediate switch back and delete the flow"
+        flowHelper.deleteFlow(flow.id)
         lockKeeper.reviveSwitch(sw, blockData)
         Wrappers.wait(WAIT_OFFSET) { assert flowPath[1].switchId in northbound.getActiveSwitches()*.switchId }
         northbound.deleteSwitchRules(flowPath[1].switchId, DeleteRulesAction.IGNORE_DEFAULTS) || true
-        flowHelper.deleteFlow(flow.id)
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }
@@ -174,8 +174,8 @@ class AutoRerouteSpec extends HealthCheckSpecification {
         Wrappers.wait(WAIT_OFFSET) { assert northbound.getFlowStatus(flow.id).status == FlowState.UP }
 
         and: "Bring port involved in the original path up and delete the flow"
-        antiflap.portUp(flowPath.first().switchId, flowPath.first().portNo)
         flowHelper.deleteFlow(flow.id)
+        antiflap.portUp(flowPath.first().switchId, flowPath.first().portNo)
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }
@@ -278,8 +278,8 @@ class AutoRerouteSpec extends HealthCheckSpecification {
         PathHelper.convert(northbound.getFlowPath(flow.id)) == flowPath
 
         and: "Bring flow ports up and delete the flow"
-        ["source", "destination"].each { antiflap.portUp(flow."$it".datapath, flow."$it".portNumber) }
         flowHelper.deleteFlow(flow.id)
+        ["source", "destination"].each { antiflap.portUp(flow."$it".datapath, flow."$it".portNumber) }
         database.resetCosts()
     }
 
@@ -333,9 +333,9 @@ class AutoRerouteSpec extends HealthCheckSpecification {
         }
 
         and: "Cleanup: Restore topology, delete flow and reset costs/bandwidth"
+        flowHelper.deleteFlow(flow.id)
         broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         antiflap.portUp(islToBreak.srcSwitch.dpId, islToBreak.srcPort)
-        flowHelper.deleteFlow(flow.id)
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteV2Spec.groovy
@@ -109,9 +109,9 @@ class AutoRerouteV2Spec extends HealthCheckSpecification {
         }
 
         cleanup: "Restore topology to the original state, remove the flow"
+        flowHelperV2.deleteFlow(flow.flowId)
         portDown && !portUp && antiflap.portUp(isl.dstSwitch.dpId, isl.dstPort)
         broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
-        flowHelperV2.deleteFlow(flow.flowId)
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             assert northbound.getActiveLinks().size() == topology.islsForActiveSwitches.size() * 2
         }
@@ -192,8 +192,8 @@ class AutoRerouteV2Spec extends HealthCheckSpecification {
         Wrappers.wait(WAIT_OFFSET) { assert northbound.getFlowStatus(flow.flowId).status == FlowState.UP }
 
         and: "Bring port involved in the original path up and delete the flow"
-        antiflap.portUp(flowPath.first().switchId, flowPath.first().portNo)
         flowHelperV2.deleteFlow(flow.flowId)
+        antiflap.portUp(flowPath.first().switchId, flowPath.first().portNo)
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             assert northbound.getActiveLinks().size() == topology.islsForActiveSwitches.size() * 2
         }
@@ -299,8 +299,8 @@ class AutoRerouteV2Spec extends HealthCheckSpecification {
         PathHelper.convert(northbound.getFlowPath(flow.flowId)) == flowPath
 
         and: "Bring flow ports up and delete the flow"
-        ["source", "destination"].each { antiflap.portUp(flow."$it".switchId, flow."$it".portNumber) }
         flowHelperV2.deleteFlow(flow.flowId)
+        ["source", "destination"].each { antiflap.portUp(flow."$it".switchId, flow."$it".portNumber) }
         database.resetCosts()
     }
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV2Spec.groovy
@@ -712,10 +712,10 @@ class FlowCrudV2Spec extends HealthCheckSpecification {
         errorDetails.errorDescription == getPortViolationError("create", isl.srcPort, isl.srcSwitch.dpId)
 
         cleanup: "Restore state of the ISL"
+        !exc && flow && flowHelperV2.deleteFlow(flow.flowId)
         antiflap.portUp(isl.srcSwitch.dpId, isl.srcPort)
         islUtils.waitForIslStatus([isl, isl.reversed], DISCOVERED)
         database.resetCosts()
-        !exc && flow && flowHelperV2.deleteFlow(flow.flowId)
     }
 
     def "Unable to create a flow on an isl port when ISL status is MOVED"() {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowDiversitySpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowDiversitySpec.groovy
@@ -188,8 +188,8 @@ class FlowDiversitySpec extends HealthCheckSpecification {
         flow2Path == flow1Path
 
         and: "Restore topology, delete flows and reset costs"
-        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
+        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowPingSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowPingSpec.groovy
@@ -154,8 +154,8 @@ class FlowPingSpec extends HealthCheckSpecification {
                 .ignoring("forward.latency").ignoring("reverse.latency")
 
         cleanup: "Restore rules, costs and remove the flow"
-        rulesToRemove && lockKeeper.addFlows(rulesToRemove)
         flow && flowHelperV2.deleteFlow(flow.flowId)
+        rulesToRemove && lockKeeper.addFlows(rulesToRemove)
         northbound.deleteLinkProps(northbound.getAllLinkProps())
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             assert islUtils.getIslInfo(islToBreak).get().state == IslChangeType.DISCOVERED

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
@@ -668,8 +668,8 @@ class ProtectedPathSpec extends HealthCheckSpecification {
                 " Couldn't find non overlapping protected path"
 
         and: "Restore topology, delete flows and reset costs"
-        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         flowHelper.deleteFlow(flow.id)
+        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }
@@ -964,8 +964,8 @@ class ProtectedPathSpec extends HealthCheckSpecification {
         }
 
         and: "Cleanup: Restore topology, delete flows and reset costs"
-        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         flowHelper.deleteFlow(flow.id)
+        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }
@@ -1033,9 +1033,9 @@ class ProtectedPathSpec extends HealthCheckSpecification {
         pathHelper.convert(newFlowPathInfo.protectedPath) == alternativePath
 
         and: "Cleanup: Restore topology, delete flow and reset costs"
+        flowHelper.deleteFlow(flow.id)
         antiflap.portUp(protectedIslToBreak.dstSwitch.dpId, protectedIslToBreak.dstPort)
         broughtDownPorts.each { antiflap.portUp(it.switchId, it.portNo) }
-        flowHelper.deleteFlow(flow.id)
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             assert northbound.getActiveLinks().size() == topology.islsForActiveSwitches.size() * 2
         }
@@ -1084,8 +1084,8 @@ class ProtectedPathSpec extends HealthCheckSpecification {
         Wrappers.wait(WAIT_OFFSET) { assert northbound.getFlowStatus(flow.id).status == FlowState.UP }
 
         and: "Cleanup: Restore topology, delete flow and reset costs"
-        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         flowHelper.deleteFlow(flow.id)
+        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathV2Spec.groovy
@@ -672,12 +672,12 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
                 " Couldn't find non overlapping protected path"
 
         cleanup: "Restore topology, delete flows and reset costs"
+        !exc && flowHelperV2.deleteFlow(flow.flowId)
         broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }
         database.resetCosts()
-        !exc && flowHelperV2.deleteFlow(flow.flowId)
 
         where:
         flowDescription | bandwidth
@@ -727,8 +727,8 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
                 " Couldn't find non overlapping protected path"
 
         cleanup: "Restore topology, delete flows and reset costs"
-        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         flowHelperV2.deleteFlow(flow.flowId)
+        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }
@@ -1029,8 +1029,8 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
         }
 
         and: "Cleanup: Restore topology, delete flows and reset costs"
-        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         flowHelperV2.deleteFlow(flow.flowId)
+        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }
@@ -1155,8 +1155,8 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
         Wrappers.wait(WAIT_OFFSET) { assert northbound.getFlowStatus(flow.flowId).status == FlowState.UP }
 
         cleanup: "Restore topology, delete flow and reset costs"
-        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         flowHelperV2.deleteFlow(flow.flowId)
+        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
@@ -744,8 +744,8 @@ switches"() {
         validateSwitches(flow2SwitchPair)
 
         cleanup: "Restore topology and delete flows"
-        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
+        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         northbound.deleteLinkProps(northbound.getAllLinkProps())
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
@@ -828,8 +828,8 @@ switches"() {
                 "Switch ${flow2SwitchPair.src.dpId} doesn't have links with enough bandwidth"
 
         cleanup: "Restore topology and delete flows"
-        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
+        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         northbound.deleteLinkProps(northbound.getAllLinkProps())
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
@@ -917,8 +917,8 @@ switches"() {
         validateSwitches(flow2SwitchPair)
 
         cleanup: "Restore topology and delete flows"
-        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
+        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         northbound.deleteLinkProps(northbound.getAllLinkProps())
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
@@ -973,8 +973,8 @@ switches"() {
                 "Switch ${flow1SwitchPair.src.dpId} doesn't have links with enough bandwidth"
 
         cleanup: "Restore topology and delete flows"
-        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         [flow1, flow2].each { flowHelper.deleteFlow(it.id) }
+        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/UnstableIslSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/UnstableIslSpec.groovy
@@ -173,8 +173,8 @@ class UnstableIslSpec extends HealthCheckSpecification {
         }
 
         and: "Restore topology, delete the flow and reset costs"
-        broughtDownPorts.each { antiflap.portUp(it.switchId, it.portNo) }
         flowHelperV2.deleteFlow(flow.flowId)
+        broughtDownPorts.each { antiflap.portUp(it.switchId, it.portNo) }
         northbound.deleteLinkProps(northbound.getAllLinkProps())
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != FAILED }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/multitable/MultitableFlowsSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/multitable/MultitableFlowsSpec.groovy
@@ -648,8 +648,8 @@ mode with existing flows and hold flows of different table-mode types"() {
         }
 
         cleanup: "Restore init switch properties and delete the flow"
-        antiflap.portUp(islToBreak.srcSwitch.dpId, islToBreak.srcPort)
         flowHelperV2.deleteFlow(flow.flowId)
+        antiflap.portUp(islToBreak.srcSwitch.dpId, islToBreak.srcPort)
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }
@@ -769,8 +769,8 @@ mode with existing flows and hold flows of different table-mode types"() {
         }
 
         cleanup: "Restore init switch properties and delete the flow"
-        antiflap.portUp(islToBreak.srcSwitch.dpId, islToBreak.srcPort)
         flowHelperV2.deleteFlow(flow.flowId)
+        antiflap.portUp(islToBreak.srcSwitch.dpId, islToBreak.srcPort)
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/FlowStatSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/FlowStatSpec.groovy
@@ -288,11 +288,11 @@ class FlowStatSpec extends HealthCheckSpecification {
         newMainReverseCookieStat.size() == mainReverseCookieStat.size()
 
         and: "Cleanup: revert system to original state"
+        flowHelper.deleteFlow(flow.id)
         antiflap.portUp(islToBreak.srcSwitch.dpId, islToBreak.srcPort)
         Wrappers.wait(WAIT_OFFSET + discoveryInterval) {
             assert islUtils.getIslInfo(islToBreak).get().state == IslChangeType.DISCOVERED
         }
-        flowHelper.deleteFlow(flow.id)
         database.resetCosts()
     }
 
@@ -366,10 +366,10 @@ class FlowStatSpec extends HealthCheckSpecification {
         }
 
         and: "Cleanup: Restore topology, delete flows and reset costs"
+        flowHelperV2.deleteFlow(flow.flowId)
         antiflap.portUp(protectedIsls[0].srcSwitch.dpId, protectedIsls[0].srcPort)
         antiflap.portUp(protectedIsls[0].dstSwitch.dpId, protectedIsls[0].dstPort)
         broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
-        flowHelperV2.deleteFlow(flow.flowId)
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/FlowRulesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/FlowRulesSpec.groovy
@@ -669,8 +669,8 @@ class FlowRulesSpec extends HealthCheckSpecification {
         checkTrafficCountersInRules(flow.destination, false)
 
         cleanup: "Revive the ISL back (bring switch port up), delete the flow and reset costs"
-        portDown && antiflap.portUp(islToFail.srcSwitch.dpId, islToFail.srcPort)
         flowHelperV2.deleteFlow(flow.flowId)
+        portDown && antiflap.portUp(islToFail.srcSwitch.dpId, islToFail.srcPort)
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
@@ -70,8 +70,8 @@ class SwitchFailuresSpec extends HealthCheckSpecification {
         }
 
         and: "Cleanup: restore connection, remove the flow"
-        lockKeeper.addFlows([isl.aswitch])
         flowHelperV2.deleteFlow(flow.flowId)
+        lockKeeper.addFlows([isl.aswitch])
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }
@@ -186,9 +186,9 @@ class SwitchFailuresSpec extends HealthCheckSpecification {
         PathHelper.convert(northbound.getFlowPath(flow.flowId)) == originalPath
 
         and: "Revive switch, remove the flow"
+        flowHelper.deleteFlow(flow.flowId)
         lockKeeper.reviveSwitch(uniqueSwitch, blockData)
         Wrappers.wait(WAIT_OFFSET) { northbound.getSwitch(uniqueSwitch.dpId).state == SwitchChangeType.ACTIVATED }
-        flowHelper.deleteFlow(flow.flowId)
         northbound.deleteLinkProps(northbound.getAllLinkProps())
         Wrappers.wait(discoveryInterval) { northbound.getAllLinks().each { it.state == IslChangeType.DISCOVERED } }
     }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/toggles/FeatureTogglesV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/toggles/FeatureTogglesV2Spec.groovy
@@ -273,6 +273,7 @@ feature toogle"() {
         northbound.getFlowStatus(flow.flowId).status == FlowState.UP
 
         and: "Cleanup: Revert system to origin state"
+        flowHelperV2.deleteFlow(flow.flowId)
         antiflap.portUp(islToBreak.srcSwitch.dpId, islToBreak.srcPort)
         northbound.toggleFeature(FeatureTogglesDto.builder()
                 .flowsRerouteUsingDefaultEncapType(initFeatureToggle.flowsRerouteUsingDefaultEncapType).build())
@@ -281,7 +282,6 @@ feature toogle"() {
         Wrappers.wait(antiflapMin + 2) {
             assert islUtils.getIslInfo(islToBreak).get().state == IslChangeType.DISCOVERED
         }
-        flowHelperV2.deleteFlow(flow.flowId)
     }
 
     @Tidy


### PR DESCRIPTION
This is aimed to prevent flow from changing status to 'In Progress' thus making it impossible to delete until reroute is finished