### PR TITLE
Push all path related data into FlowCommandBuilder

### DIFF
--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/model/FlowPathSpeakerView.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/model/FlowPathSpeakerView.java
@@ -15,20 +15,25 @@
 
 package org.openkilda.wfm.share.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import org.openkilda.model.FlowPath;
+import org.openkilda.wfm.share.flow.resources.FlowResources;
 
-@Data
-@Builder
-@AllArgsConstructor
-@EqualsAndHashCode
-public class SpeakerRequestBuildContext {
-    private boolean removeCustomerPortRule;
-    private boolean removeOppositeCustomerPortRule;
-    private boolean removeCustomerPortLldpRule;
-    private boolean removeOppositeCustomerPortLldpRule;
-    private boolean removeCustomerPortArpRule;
-    private boolean removeOppositeCustomerPortArpRule;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder(toBuilder = true)
+public class FlowPathSpeakerView {
+    private final FlowPath path;
+
+    private final FlowResources.PathResources resources;
+
+    private final boolean removeCustomerPortRule;
+    private final boolean removeCustomerPortLldpRule;
+    private final boolean removeCustomerPortArpRule;
+
+    public static FlowPathSpeakerViewBuilder builder(FlowPath path) {
+        return new FlowPathSpeakerViewBuilder()
+                .path(path);
+    }
 }

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowCommandBuilder.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowCommandBuilder.java
@@ -17,39 +17,27 @@ package org.openkilda.wfm.topology.flowhs.service;
 
 import org.openkilda.floodlight.api.request.factory.FlowSegmentRequestFactory;
 import org.openkilda.model.Flow;
-import org.openkilda.model.FlowPath;
 import org.openkilda.wfm.CommandContext;
-import org.openkilda.wfm.share.model.SpeakerRequestBuildContext;
+import org.openkilda.wfm.share.model.FlowPathSpeakerView;
 
 import java.util.List;
 
 public interface FlowCommandBuilder {
-    List<FlowSegmentRequestFactory> buildAll(
-            CommandContext context, Flow flow, FlowPath forwardPath, FlowPath reversePath);
-
-    List<FlowSegmentRequestFactory> buildAll(CommandContext context, Flow flow,
-                                             FlowPath forwardPath, FlowPath reversePath,
-                                             SpeakerRequestBuildContext speakerRequestBuildContext);
-
     /**
-     * Build install commands for transit(if needed) and egress rules for active forward and reverse paths.
+     * Build flow segment request factories for all segments for provided paths.
      */
-    List<FlowSegmentRequestFactory> buildAllExceptIngress(CommandContext context, Flow flow);
+    List<FlowSegmentRequestFactory> buildAll(
+            CommandContext context, Flow flow, FlowPathSpeakerView path, FlowPathSpeakerView oppositePath);
 
     /**
-     * Build install commands for transit(if needed) and egress rules for provided paths.
+     * Build flow segment request factories for transit(if needed) and egress segments for provided paths.
      */
     List<FlowSegmentRequestFactory> buildAllExceptIngress(
-            CommandContext context, Flow flow, FlowPath path, FlowPath oppositePath);
+            CommandContext context, Flow flow, FlowPathSpeakerView path, FlowPathSpeakerView oppositePath);
 
     /**
-     * Build install commands for ingress rules for active forward and reverse paths.
-     */
-    List<FlowSegmentRequestFactory> buildIngressOnly(CommandContext context, Flow flow);
-
-    /**
-     * Build install commands for ingress rules for provided paths.
+     * Build flow segment request factories for ingress segments for provided paths.
      */
     List<FlowSegmentRequestFactory> buildIngressOnly(
-            CommandContext context, Flow flow, FlowPath path, FlowPath oppositePath);
+            CommandContext context, Flow flow, FlowPathSpeakerView path, FlowPathSpeakerView oppositePath);
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowPathSwappingFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowPathSwappingFsm.java
@@ -19,9 +19,9 @@ import org.openkilda.floodlight.api.request.factory.FlowSegmentRequestFactory;
 import org.openkilda.floodlight.api.response.SpeakerFlowSegmentResponse;
 import org.openkilda.floodlight.flow.response.FlowErrorResponse;
 import org.openkilda.model.FlowPathStatus;
-import org.openkilda.model.PathId;
 import org.openkilda.wfm.CommandContext;
 import org.openkilda.wfm.share.flow.resources.FlowResources;
+import org.openkilda.wfm.share.model.FlowPathSpeakerView;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -43,21 +43,23 @@ public abstract class FlowPathSwappingFsm<T extends NbTrackableFsm<T, S, E, C>, 
 
     protected final String flowId;
 
+    // TODO - ensure usage
     protected FlowResources newPrimaryResources;
     protected FlowResources newProtectedResources;
-    protected PathId newPrimaryForwardPath;
-    protected PathId newPrimaryReversePath;
-    protected PathId newProtectedForwardPath;
-    protected PathId newProtectedReversePath;
+
+    protected FlowPathSpeakerView newPrimaryForwardPath;
+    protected FlowPathSpeakerView newPrimaryReversePath;
+    protected FlowPathSpeakerView newProtectedForwardPath;
+    protected FlowPathSpeakerView newProtectedReversePath;
 
     protected final Collection<FlowResources> oldResources = new ArrayList<>();
-    protected PathId oldPrimaryForwardPath;
+    protected FlowPathSpeakerView oldPrimaryForwardPath;
     protected FlowPathStatus oldPrimaryForwardPathStatus;
-    protected PathId oldPrimaryReversePath;
+    protected FlowPathSpeakerView oldPrimaryReversePath;
     protected FlowPathStatus oldPrimaryReversePathStatus;
-    protected PathId oldProtectedForwardPath;
+    protected FlowPathSpeakerView oldProtectedForwardPath;
     protected FlowPathStatus oldProtectedForwardPathStatus;
-    protected PathId oldProtectedReversePath;
+    protected FlowPathSpeakerView oldProtectedReversePath;
     protected FlowPathStatus oldProtectedReversePathStatus;
 
     protected final Set<UUID> pendingCommands = new HashSet<>();

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseFlowRuleRemovalAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseFlowRuleRemovalAction.java
@@ -46,7 +46,7 @@ public abstract class BaseFlowRuleRemovalAction<T extends FlowProcessingFsm<T, S
 
     public BaseFlowRuleRemovalAction(PersistenceManager persistenceManager, FlowResourcesManager resourcesManager) {
         super(persistenceManager);
-        this.commandBuilderFactory = new FlowCommandBuilderFactory(resourcesManager);
+        this.commandBuilderFactory = new FlowCommandBuilderFactory();
         switchPropertiesRepository = persistenceManager.getRepositoryFactory().createSwitchPropertiesRepository();
     }
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseResourceAllocationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseResourceAllocationAction.java
@@ -42,6 +42,7 @@ import org.openkilda.wfm.share.history.model.FlowDumpData;
 import org.openkilda.wfm.share.history.model.FlowDumpData.DumpType;
 import org.openkilda.wfm.share.logger.FlowOperationsDashboardLogger;
 import org.openkilda.wfm.share.mappers.HistoryMapper;
+import org.openkilda.wfm.share.model.FlowPathSpeakerView;
 import org.openkilda.wfm.topology.flow.model.FlowPathPair;
 import org.openkilda.wfm.topology.flowhs.fsm.common.FlowPathSwappingFsm;
 import org.openkilda.wfm.topology.flowhs.service.FlowPathBuilder;
@@ -101,7 +102,7 @@ public abstract class BaseResourceAllocationAction<T extends FlowPathSwappingFsm
             allocateInTransaction(stateMachine);
 
             return Optional.empty();
-        } catch (UnroutableFlowException  ex) {
+        } catch (UnroutableFlowException ex) {
             String errorMessage = format("Not enough bandwidth or no path found. %s", ex.getMessage());
             stateMachine.saveActionToHistory(errorMessage);
             stateMachine.fireNoPathFound(errorMessage);
@@ -259,5 +260,38 @@ public abstract class BaseResourceAllocationAction<T extends FlowPathSwappingFsm
                 format("The flow paths %s / %s were created (with allocated resources)",
                         newFlowPaths.getForward().getPathId(), newFlowPaths.getReverse().getPathId()),
                 dumpData);
+    }
+
+    protected void flushPathChanges(FlowPathPair pathPair) {
+        flowPathRepository.createOrUpdate(pathPair.getForward());
+        flowPathRepository.createOrUpdate(pathPair.getReverse());
+    }
+
+    protected void savePrimaryPaths(
+            FlowPathSwappingFsm<?, ?, ?, ?> stateMachine, Flow flow, FlowPathPair newPaths, FlowResources flowResources)
+            throws ResourceAllocationException {
+        stateMachine.setNewPrimaryForwardPath(makeFlowPathNewView(
+                flow, newPaths.getForward(), flowResources.getForward()));
+        stateMachine.setNewPrimaryReversePath(makeFlowPathNewView(
+                flow, newPaths.getReverse(), flowResources.getReverse()));
+    }
+
+    protected void saveProtectedPaths(
+            FlowPathSwappingFsm<?, ?, ?, ?> stateMachine, Flow flow, FlowPathPair newPaths, FlowResources flowResources)
+            throws ResourceAllocationException {
+        // Process shared resources for protected paths in same way as it done for primary paths. So they will be
+        // available if we will swap paths.
+        stateMachine.setNewProtectedForwardPath(makeFlowPathNewView(
+                flow, newPaths.getForward(), flowResources.getForward()));
+        stateMachine.setNewProtectedReversePath(makeFlowPathNewView(
+                flow, newPaths.getReverse(), flowResources.getReverse()));
+    }
+
+    protected FlowPath extractPath(Flow flow, FlowPathSpeakerView pathSnapshot, FlowPath fallback) {
+        Optional<FlowPath> path = Optional.empty();
+        if (pathSnapshot != null) {
+            path = flow.getPath(pathSnapshot.getPath().getPathId());
+        }
+        return path.orElse(fallback);
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/FlowProcessingAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/FlowProcessingAction.java
@@ -17,16 +17,23 @@ package org.openkilda.wfm.topology.flowhs.fsm.common.actions;
 
 import static java.lang.String.format;
 
+import org.openkilda.adapter.FlowSideAdapter;
 import org.openkilda.messaging.error.ErrorType;
 import org.openkilda.model.Flow;
+import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowPath;
 import org.openkilda.model.PathId;
 import org.openkilda.model.SwitchId;
+import org.openkilda.model.SwitchProperties;
 import org.openkilda.persistence.FetchStrategy;
 import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.persistence.repositories.FlowPathRepository;
 import org.openkilda.persistence.repositories.FlowRepository;
 import org.openkilda.persistence.repositories.RepositoryFactory;
+import org.openkilda.persistence.repositories.SwitchPropertiesRepository;
+import org.openkilda.wfm.share.flow.resources.FlowResources.PathResources;
+import org.openkilda.wfm.share.flow.resources.ResourceAllocationException;
+import org.openkilda.wfm.share.model.FlowPathSpeakerView;
 import org.openkilda.wfm.topology.flowhs.exception.FlowProcessingException;
 import org.openkilda.wfm.topology.flowhs.fsm.common.FlowProcessingFsm;
 
@@ -35,10 +42,12 @@ import com.fasterxml.uuid.NoArgGenerator;
 import lombok.extern.slf4j.Slf4j;
 import org.squirrelframework.foundation.fsm.AnonymousAction;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 public abstract class FlowProcessingAction<T extends FlowProcessingFsm<T, S, E, C>, S, E, C>
@@ -49,12 +58,14 @@ public abstract class FlowProcessingAction<T extends FlowProcessingFsm<T, S, E, 
     protected final PersistenceManager persistenceManager;
     protected final FlowRepository flowRepository;
     protected final FlowPathRepository flowPathRepository;
+    protected final SwitchPropertiesRepository switchPropertiesRepository;
 
     public FlowProcessingAction(PersistenceManager persistenceManager) {
         this.persistenceManager = persistenceManager;
         RepositoryFactory repositoryFactory = persistenceManager.getRepositoryFactory();
         this.flowRepository = repositoryFactory.createFlowRepository();
         this.flowPathRepository = repositoryFactory.createFlowPathRepository();
+        this.switchPropertiesRepository = repositoryFactory.createSwitchPropertiesRepository();
     }
 
     @Override
@@ -82,6 +93,18 @@ public abstract class FlowProcessingAction<T extends FlowProcessingFsm<T, S, E, 
                         format("Flow %s not found", flowId)));
     }
 
+    protected FlowPathSpeakerView getFlowPath(FlowPathSpeakerView pathSnapshot) {
+        return pathSnapshot.toBuilder()
+                .path(getFlowPath(pathSnapshot.getPath().getPathId()))
+                .build();
+    }
+
+    protected FlowPathSpeakerView getFlowPath(Flow flow, FlowPathSpeakerView pathSnapshot) {
+        return pathSnapshot.toBuilder()
+                .path(getFlowPath(flow, pathSnapshot.getPath().getPathId()))
+                .build();
+    }
+
     protected FlowPath getFlowPath(Flow flow, PathId pathId) {
         return flow.getPath(pathId)
                 .orElseThrow(() -> new FlowProcessingException(ErrorType.NOT_FOUND,
@@ -98,10 +121,83 @@ public abstract class FlowProcessingAction<T extends FlowProcessingFsm<T, S, E, 
         return new HashSet<>(flowRepository.findFlowsIdsByEndpointWithMultiTableSupport(switchId, port));
     }
 
+    protected FlowPathSpeakerView makeFlowPathNewView(Flow flow, FlowPath path, PathResources resources)
+            throws ResourceAllocationException {
+        FlowPathSpeakerView.FlowPathSpeakerViewBuilder pathSnapshot = FlowPathSpeakerView.builder(path)
+                .resources(resources);
+        return pathSnapshot.build();
+    }
+
+    protected FlowPathSpeakerView makeFlowPathOldView(
+            Flow flow, PathId pathId, PathResources resources) {
+        FlowPath path = getFlowPath(pathId);  // need to ensure that all relations are loaded
+        FlowPathSpeakerView.FlowPathSpeakerViewBuilder pathView = FlowPathSpeakerView.builder(path)
+                .resources(resources);
+
+        FlowEndpoint ingressEndpoint = FlowSideAdapter.makeIngressAdapter(flow, path).getEndpoint();
+        SwitchProperties switchProperties = getSwitchProperties(ingressEndpoint.getSwitchId());
+        pathView.removeCustomerPortRule(
+                checkIfSharedCustomerPortForwardingFlowCanBeRemoved(flow.getFlowId(), ingressEndpoint));
+        pathView.removeCustomerPortLldpRule(
+                checkIfSharedLldpPortRuleCanBeRemoved(flow.getFlowId(), ingressEndpoint, switchProperties));
+        pathView.removeCustomerPortArpRule(
+                checkIfSharedArpPortRuleCanBeRemoved(flow.getFlowId(), ingressEndpoint, switchProperties));
+        return pathView.build();
+    }
+
+    private boolean checkIfSharedCustomerPortForwardingFlowCanBeRemoved(String flowId, FlowEndpoint endpoint) {
+        Collection<Flow> occupiedByFlows = flowRepository.findByEndpointWithMultiTableSupport(
+                endpoint.getSwitchId(), endpoint.getPortNumber());
+        long refsCount = filterOutFlow(occupiedByFlows.stream(), flowId).count();
+        return refsCount == 0;
+    }
+
+    protected boolean checkIfSharedLldpPortRuleCanBeRemoved(
+            String flowId, FlowEndpoint endpoint, SwitchProperties switchProperties) {
+        int portNumber = endpoint.getPortNumber();
+        Stream<Flow> flows = filterOutFlow(
+                flowRepository.findByEndpoint(endpoint.getSwitchId(), portNumber).stream(),
+                flowId);
+
+        if (switchProperties.isSwitchLldp()) {
+            return flows.count() == 0;
+        }
+
+        return flows.noneMatch(
+                f -> f.getSrcPort() == portNumber && f.getDetectConnectedDevices().isSrcLldp()
+                        || f.getDestPort() == portNumber && f.getDetectConnectedDevices().isDstLldp());
+    }
+
+    protected boolean checkIfSharedArpPortRuleCanBeRemoved(
+            String flowId, FlowEndpoint endpoint, SwitchProperties switchProperties) {
+        int portNumber = endpoint.getPortNumber();
+        Stream<Flow> flows = filterOutFlow(
+                flowRepository.findByEndpoint(endpoint.getSwitchId(), portNumber).stream(),
+                flowId);
+
+        if (switchProperties.isSwitchArp()) {
+            return flows.count() == 0;
+        }
+
+        return flows
+                .noneMatch(f -> f.getSrcPort() == portNumber && f.getDetectConnectedDevices().isSrcArp()
+                        || f.getDestPort() == portNumber && f.getDetectConnectedDevices().isDstArp());
+    }
+
+    private SwitchProperties getSwitchProperties(SwitchId switchId) {
+        return switchPropertiesRepository.findBySwitchId(switchId)
+                .orElseThrow(() -> new FlowProcessingException(ErrorType.NOT_FOUND,
+                        format("Properties for switch %s not found", switchId)));
+    }
+
     protected Set<String> getDiverseWithFlowIds(Flow flow) {
         return flow.getGroupId() == null ? Collections.emptySet() :
                 flowRepository.findFlowsIdByGroupId(flow.getGroupId()).stream()
                         .filter(flowId -> !flowId.equals(flow.getFlowId()))
                         .collect(Collectors.toSet());
+    }
+
+    private Stream<Flow> filterOutFlow(Stream<Flow> stream, String flowId) {
+        return stream.filter(entry -> !entry.getFlowId().equals(flowId));
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/PathSwappingAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/PathSwappingAction.java
@@ -1,0 +1,145 @@
+/* Copyright 2019 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.fsm.common.actions;
+
+import org.openkilda.model.Flow;
+import org.openkilda.model.FlowEncapsulationType;
+import org.openkilda.model.FlowPath;
+import org.openkilda.model.PathId;
+import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.wfm.share.flow.resources.EncapsulationResources;
+import org.openkilda.wfm.share.flow.resources.FlowResources;
+import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
+import org.openkilda.wfm.topology.flowhs.fsm.common.FlowPathSwappingFsm;
+import org.openkilda.wfm.topology.flowhs.fsm.common.FlowProcessingFsm;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+
+@Slf4j
+public abstract class PathSwappingAction<T extends FlowProcessingFsm<T, S, E, C>, S, E, C>
+        extends FlowProcessingAction<T, S, E, C> {
+    private final FlowResourcesManager resourcesManager;
+
+    public PathSwappingAction(PersistenceManager persistenceManager, FlowResourcesManager resourcesManager) {
+        super(persistenceManager);
+        this.resourcesManager = resourcesManager;
+    }
+
+    protected void saveOldPrimaryPaths(
+            FlowPathSwappingFsm<?, ?, ?, ?> stateMachine, Flow flow, FlowPath forwardPath, FlowPath reversePath,
+            FlowEncapsulationType encapsulationType) {
+
+        FlowResources resources = fetchFlowResources(forwardPath, reversePath, encapsulationType);
+
+        log.debug("Save old primary paths resources: {}", resources);
+        if (forwardPath != null && resources.getForward() != null) {
+            stateMachine.setOldPrimaryForwardPath(makeFlowPathOldView(
+                    flow, forwardPath.getPathId(), resources.getForward()));
+            stateMachine.setOldPrimaryForwardPathStatus(forwardPath.getStatus());
+        }
+        if (reversePath != null && resources.getReverse() != null) {
+            stateMachine.setOldPrimaryReversePath(makeFlowPathOldView(
+                    flow, reversePath.getPathId(), resources.getReverse()));
+            stateMachine.setOldPrimaryReversePathStatus(reversePath.getStatus());
+        }
+
+        stateMachine.getOldResources().add(fixFlowResources(resources));
+    }
+
+    protected void saveOldProtectedPaths(
+            FlowPathSwappingFsm<?, ?, ?, ?> stateMachine, Flow flow, FlowPath forwardPath, FlowPath reversePath,
+            FlowEncapsulationType encapsulationType) {
+
+        FlowResources resources = fetchFlowResources(forwardPath, reversePath, encapsulationType);
+
+        log.debug("Save old protected paths resources: {}", resources);
+        if (forwardPath != null && resources.getForward() != null) {
+            stateMachine.setOldProtectedForwardPath(makeFlowPathOldView(
+                    flow, forwardPath.getPathId(), resources.getForward()));
+            stateMachine.setOldProtectedForwardPathStatus(forwardPath.getStatus());
+        }
+        if (reversePath != null && resources.getReverse() != null) {
+            stateMachine.setOldProtectedReversePath(makeFlowPathOldView(
+                    flow, reversePath.getPathId(), resources.getReverse()));
+            stateMachine.setOldProtectedReversePathStatus(reversePath.getStatus());
+        }
+
+        stateMachine.getOldResources().add(fixFlowResources(resources));
+    }
+
+    private FlowResources fixFlowResources(FlowResources rawResources) {
+        if (rawResources.getForward() != null && rawResources.getReverse() != null) {
+            return rawResources;
+        }
+
+        FlowResources.PathResources forward = rawResources.getForward();
+        FlowResources.PathResources reverse = rawResources.getReverse();
+        if (forward == null) {
+            forward = reverse;
+        }
+        if (reverse == null) {
+            reverse = forward;
+        }
+        return FlowResources.builder()
+                .forward(forward)
+                .reverse(reverse)
+                .build();
+    }
+
+    private FlowResources fetchFlowResources(
+            FlowPath forwardPath, FlowPath reversePath, FlowEncapsulationType encapsulationType) {
+        EncapsulationResources forwardEncapsulationResources = fetchPathResources(
+                forwardPath, reversePath, encapsulationType)
+                .orElse(null);
+        EncapsulationResources reverseEncapsulationResources = fetchPathResources(
+                reversePath, forwardPath, encapsulationType)
+                .orElse(forwardEncapsulationResources);
+
+        if (forwardEncapsulationResources == null) {
+            forwardEncapsulationResources = reverseEncapsulationResources;
+        }
+
+        return FlowResources.builder()
+                .forward(makePathResources(forwardPath, forwardEncapsulationResources).orElse(null))
+                .reverse(makePathResources(reversePath, reverseEncapsulationResources).orElse(null))
+                .build();
+    }
+
+    private Optional<EncapsulationResources> fetchPathResources(
+            FlowPath path, FlowPath oppositePath, FlowEncapsulationType encapsulationType) {
+        if (path == null) {
+            return Optional.empty();
+        }
+
+        PathId oppositePathId = oppositePath != null ? oppositePath.getPathId() : null;
+        return resourcesManager.getEncapsulationResources(path.getPathId(), oppositePathId, encapsulationType);
+    }
+
+    private Optional<FlowResources.PathResources> makePathResources(
+            FlowPath path, EncapsulationResources encapsulationResources) {
+        if (path == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(FlowResources.PathResources.builder()
+                .pathId(path.getPathId())
+                .meterId(path.getMeterId())
+                .encapsulationResources(encapsulationResources)
+                .build());
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/create/FlowCreateFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/create/FlowCreateFsm.java
@@ -20,13 +20,13 @@ import org.openkilda.messaging.Message;
 import org.openkilda.messaging.error.ErrorData;
 import org.openkilda.messaging.error.ErrorMessage;
 import org.openkilda.messaging.error.ErrorType;
-import org.openkilda.model.PathId;
 import org.openkilda.pce.PathComputer;
 import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.wfm.CommandContext;
 import org.openkilda.wfm.share.flow.resources.FlowResources;
 import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
 import org.openkilda.wfm.share.logger.FlowOperationsDashboardLogger;
+import org.openkilda.wfm.share.model.FlowPathSpeakerView;
 import org.openkilda.wfm.topology.flowhs.fsm.common.NbTrackableFsm;
 import org.openkilda.wfm.topology.flowhs.fsm.common.SpeakerCommandFsm;
 import org.openkilda.wfm.topology.flowhs.fsm.create.FlowCreateFsm.Event;
@@ -79,10 +79,10 @@ public final class FlowCreateFsm extends NbTrackableFsm<FlowCreateFsm, State, Ev
     private RequestedFlow targetFlow;
     private final String flowId;
     private List<FlowResources> flowResources = new ArrayList<>();
-    private PathId forwardPathId;
-    private PathId reversePathId;
-    private PathId protectedForwardPathId;
-    private PathId protectedReversePathId;
+    private FlowPathSpeakerView forwardPath;
+    private FlowPathSpeakerView reversePath;
+    private FlowPathSpeakerView protectedForwardPath;
+    private FlowPathSpeakerView protectedReversePath;
 
     private List<FlowSegmentRequestFactory> sentCommands = new ArrayList<>();
     private Map<UUID, SpeakerCommandObserver> pendingCommands = new HashMap<>();
@@ -185,10 +185,10 @@ public final class FlowCreateFsm extends NbTrackableFsm<FlowCreateFsm, State, Ev
         pendingCommands.clear();
         sentCommands.clear();
 
-        forwardPathId = null;
-        reversePathId = null;
-        protectedForwardPathId = null;
-        protectedReversePathId = null;
+        forwardPath = null;
+        reversePath = null;
+        protectedForwardPath = null;
+        protectedReversePath = null;
     }
 
     public static FlowCreateFsm.Factory factory(PersistenceManager persistenceManager, FlowCreateHubCarrier carrier,

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/create/action/CompleteFlowCreateAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/create/action/CompleteFlowCreateAction.java
@@ -50,11 +50,13 @@ public class CompleteFlowCreateAction extends FlowProcessingAction<FlowCreateFsm
                         "Couldn't complete flow creation. The flow was deleted");
             }
 
-            flowPathRepository.updateStatus(stateMachine.getForwardPathId(), FlowPathStatus.ACTIVE);
-            flowPathRepository.updateStatus(stateMachine.getReversePathId(), FlowPathStatus.ACTIVE);
-            if (stateMachine.getProtectedForwardPathId() != null && stateMachine.getProtectedReversePathId() != null) {
-                flowPathRepository.updateStatus(stateMachine.getProtectedForwardPathId(), FlowPathStatus.ACTIVE);
-                flowPathRepository.updateStatus(stateMachine.getProtectedReversePathId(), FlowPathStatus.ACTIVE);
+            flowPathRepository.updateStatus(stateMachine.getForwardPath().getPath().getPathId(), FlowPathStatus.ACTIVE);
+            flowPathRepository.updateStatus(stateMachine.getReversePath().getPath().getPathId(), FlowPathStatus.ACTIVE);
+            if (stateMachine.getProtectedForwardPath() != null && stateMachine.getProtectedReversePath() != null) {
+                flowPathRepository.updateStatus(
+                        stateMachine.getProtectedForwardPath().getPath().getPathId(), FlowPathStatus.ACTIVE);
+                flowPathRepository.updateStatus(
+                        stateMachine.getProtectedReversePath().getPath().getPathId(), FlowPathStatus.ACTIVE);
             }
 
             flowRepository.updateStatus(flowId, FlowStatus.UP);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/FlowRerouteFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/FlowRerouteFsm.java
@@ -195,7 +195,7 @@ public final class FlowRerouteFsm extends FlowPathSwappingFsm<FlowRerouteFsm, St
 
             builder.transition().from(State.PROTECTED_RESOURCES_ALLOCATED).to(State.RESOURCE_ALLOCATION_COMPLETED)
                     .on(Event.NEXT)
-                    .perform(new PostResourceAllocationAction(persistenceManager, dashboardLogger));
+                    .perform(new PostResourceAllocationAction(persistenceManager));
             builder.transition().from(State.PROTECTED_RESOURCES_ALLOCATED).to(State.MARKING_FLOW_DOWN)
                     .on(Event.NO_PATH_FOUND);
             builder.transitions().from(State.PROTECTED_RESOURCES_ALLOCATED)
@@ -204,7 +204,7 @@ public final class FlowRerouteFsm extends FlowPathSwappingFsm<FlowRerouteFsm, St
 
             builder.transition().from(State.RESOURCE_ALLOCATION_COMPLETED).to(State.INSTALLING_NON_INGRESS_RULES)
                     .on(Event.NEXT)
-                    .perform(new InstallNonIngressRulesAction(persistenceManager, resourcesManager));
+                    .perform(new InstallNonIngressRulesAction(persistenceManager));
             builder.transition().from(State.RESOURCE_ALLOCATION_COMPLETED).to(State.FINISHED_WITH_ERROR)
                     .on(Event.REROUTE_IS_SKIPPED)
                     .perform(new RevertFlowStatusAction(persistenceManager));
@@ -252,7 +252,7 @@ public final class FlowRerouteFsm extends FlowPathSwappingFsm<FlowRerouteFsm, St
                     .onEach(Event.TIMEOUT, Event.ERROR);
 
             builder.transition().from(State.PATHS_SWAPPED).to(State.INSTALLING_INGRESS_RULES).on(Event.NEXT)
-                    .perform(new InstallIngressRulesAction(persistenceManager, resourcesManager));
+                    .perform(new InstallIngressRulesAction(persistenceManager));
             builder.transitions().from(State.PATHS_SWAPPED)
                     .toAmong(State.REVERTING_PATHS_SWAP, State.REVERTING_PATHS_SWAP)
                     .onEach(Event.TIMEOUT, Event.ERROR);
@@ -296,7 +296,7 @@ public final class FlowRerouteFsm extends FlowPathSwappingFsm<FlowRerouteFsm, St
 
             builder.transition().from(State.NEW_PATHS_INSTALLATION_COMPLETED)
                     .to(State.REMOVING_OLD_RULES).on(Event.NEXT)
-                    .perform(new RemoveOldRulesAction(persistenceManager, resourcesManager));
+                    .perform(new RemoveOldRulesAction(persistenceManager));
             builder.transitions().from(State.NEW_PATHS_INSTALLATION_COMPLETED)
                     .toAmong(State.REVERTING_PATHS_SWAP, State.REVERTING_PATHS_SWAP)
                     .onEach(Event.TIMEOUT, Event.ERROR);
@@ -346,7 +346,7 @@ public final class FlowRerouteFsm extends FlowPathSwappingFsm<FlowRerouteFsm, St
             builder.transitions().from(State.PATHS_SWAP_REVERTED)
                     .toAmong(State.REVERTING_NEW_RULES, State.REVERTING_NEW_RULES)
                     .onEach(Event.NEXT, Event.ERROR)
-                    .perform(new RevertNewRulesAction(persistenceManager, resourcesManager));
+                    .perform(new RevertNewRulesAction(persistenceManager));
 
             builder.internalTransition().within(State.REVERTING_NEW_RULES).on(Event.RESPONSE_RECEIVED)
                     .perform(new OnReceivedRemoveOrRevertResponseAction(speakerCommandRetriesLimit));

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocatePrimaryResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocatePrimaryResourcesAction.java
@@ -81,8 +81,9 @@ public class AllocatePrimaryResourcesAction extends
 
             FlowPathPair newPaths = createFlowPathPair(flow, oldPaths, potentialPath, flowResources);
             log.debug("New primary path has been created: {}", newPaths);
-            stateMachine.setNewPrimaryForwardPath(newPaths.getForward().getPathId());
-            stateMachine.setNewPrimaryReversePath(newPaths.getReverse().getPathId());
+
+            savePrimaryPaths(stateMachine, flow, newPaths, flowResources);
+            flushPathChanges(newPaths);
 
             saveAllocationActionWithDumpsToHistory(stateMachine, flow, "primary", newPaths);
         } else {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocateProtectedResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocateProtectedResourcesAction.java
@@ -40,8 +40,8 @@ import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteFsm.State;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class AllocateProtectedResourcesAction extends
-        BaseResourceAllocationAction<FlowRerouteFsm, State, Event, FlowRerouteContext> {
+public class AllocateProtectedResourcesAction
+        extends BaseResourceAllocationAction<FlowRerouteFsm, State, Event, FlowRerouteContext> {
     public AllocateProtectedResourcesAction(PersistenceManager persistenceManager, int transactionRetriesLimit,
                                             int pathAllocationRetriesLimit, int pathAllocationRetryDelay,
                                             PathComputer pathComputer, FlowResourcesManager resourcesManager,
@@ -61,10 +61,8 @@ public class AllocateProtectedResourcesAction extends
         String flowId = stateMachine.getFlowId();
         Flow flow = getFlow(flowId);
 
-        FlowPath primaryForwardPath = flow.getPath(stateMachine.getNewPrimaryForwardPath())
-                .orElse(flow.getForwardPath());
-        FlowPath primaryReversePath = flow.getPath(stateMachine.getNewPrimaryReversePath())
-                .orElse(flow.getReversePath());
+        FlowPath primaryForwardPath = extractPath(flow, stateMachine.getNewPrimaryForwardPath(), flow.getForwardPath());
+        FlowPath primaryReversePath = extractPath(flow, stateMachine.getNewPrimaryReversePath(), flow.getReversePath());
 
         if (stateMachine.getNewEncapsulationType() != null) {
             // This is for PCE to use proper (updated) encapsulation type.
@@ -114,8 +112,9 @@ public class AllocateProtectedResourcesAction extends
 
                 FlowPathPair newPaths = createFlowPathPair(flow, oldPaths, potentialPath, flowResources);
                 log.debug("New protected path has been created: {}", newPaths);
-                stateMachine.setNewProtectedForwardPath(newPaths.getForward().getPathId());
-                stateMachine.setNewProtectedReversePath(newPaths.getReverse().getPathId());
+
+                saveProtectedPaths(stateMachine, flow, newPaths, flowResources);
+                flushPathChanges(newPaths);
 
                 saveAllocationActionWithDumpsToHistory(stateMachine, flow, "protected", newPaths);
             } else {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/CompleteFlowPathInstallationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/CompleteFlowPathInstallationAction.java
@@ -39,8 +39,8 @@ public class CompleteFlowPathInstallationAction extends
     protected void perform(State from, State to, Event event, FlowRerouteContext context, FlowRerouteFsm stateMachine) {
         persistenceManager.getTransactionManager().doInTransaction(() -> {
             if (stateMachine.getNewPrimaryForwardPath() != null && stateMachine.getNewPrimaryReversePath() != null) {
-                PathId newForward = stateMachine.getNewPrimaryForwardPath();
-                PathId newReverse = stateMachine.getNewPrimaryReversePath();
+                PathId newForward = stateMachine.getNewPrimaryForwardPath().getPath().getPathId();
+                PathId newReverse = stateMachine.getNewPrimaryReversePath().getPath().getPathId();
 
                 log.debug("Completing installation of the flow primary path {} / {}", newForward, newReverse);
                 flowPathRepository.updateStatus(newForward, FlowPathStatus.ACTIVE);
@@ -52,8 +52,8 @@ public class CompleteFlowPathInstallationAction extends
 
             if (stateMachine.getNewProtectedForwardPath() != null
                     && stateMachine.getNewProtectedReversePath() != null) {
-                PathId newForward = stateMachine.getNewProtectedForwardPath();
-                PathId newReverse = stateMachine.getNewProtectedReversePath();
+                PathId newForward = stateMachine.getNewProtectedForwardPath().getPath().getPathId();
+                PathId newReverse = stateMachine.getNewProtectedReversePath().getPath().getPathId();
 
                 log.debug("Completing installation of the flow protected path {} / {}", newForward, newReverse);
                 flowPathRepository.updateStatus(newForward, FlowPathStatus.ACTIVE);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/InstallIngressRulesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/InstallIngressRulesAction.java
@@ -15,13 +15,11 @@
 
 package org.openkilda.wfm.topology.flowhs.fsm.reroute.actions;
 
-import org.openkilda.floodlight.api.request.FlowSegmentRequest;
 import org.openkilda.floodlight.api.request.factory.FlowSegmentRequestFactory;
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowEncapsulationType;
-import org.openkilda.model.FlowPath;
 import org.openkilda.persistence.PersistenceManager;
-import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
+import org.openkilda.wfm.share.model.FlowPathSpeakerView;
 import org.openkilda.wfm.topology.flowhs.fsm.common.actions.FlowProcessingAction;
 import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteContext;
 import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteFsm;
@@ -29,28 +27,25 @@ import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteFsm.Event;
 import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteFsm.State;
 import org.openkilda.wfm.topology.flowhs.service.FlowCommandBuilder;
 import org.openkilda.wfm.topology.flowhs.service.FlowCommandBuilderFactory;
+import org.openkilda.wfm.topology.flowhs.utils.SpeakerInstallSegmentEmitter;
 
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.UUID;
 
 @Slf4j
 public class InstallIngressRulesAction extends FlowProcessingAction<FlowRerouteFsm, State, Event, FlowRerouteContext> {
     private final FlowCommandBuilderFactory commandBuilderFactory;
 
-    public InstallIngressRulesAction(PersistenceManager persistenceManager, FlowResourcesManager resourcesManager) {
+    public InstallIngressRulesAction(PersistenceManager persistenceManager) {
         super(persistenceManager);
-        commandBuilderFactory = new FlowCommandBuilderFactory(resourcesManager);
+        commandBuilderFactory = new FlowCommandBuilderFactory();
     }
 
     @Override
     protected void perform(State from, State to, Event event, FlowRerouteContext context, FlowRerouteFsm stateMachine) {
-        String flowId = stateMachine.getFlowId();
-        Flow flow = getFlow(flowId);
+        Flow flow = getFlow(stateMachine.getFlowId());
 
         FlowEncapsulationType encapsulationType = stateMachine.getNewEncapsulationType() != null
                 ? stateMachine.getNewEncapsulationType() : flow.getEncapsulationType();
@@ -58,21 +53,18 @@ public class InstallIngressRulesAction extends FlowProcessingAction<FlowRerouteF
 
         Collection<FlowSegmentRequestFactory> requestFactories = new ArrayList<>();
         if (stateMachine.getNewPrimaryForwardPath() != null && stateMachine.getNewPrimaryReversePath() != null) {
-            FlowPath newForward = getFlowPath(flow, stateMachine.getNewPrimaryForwardPath());
-            FlowPath newReverse = getFlowPath(flow, stateMachine.getNewPrimaryReversePath());
+            FlowPathSpeakerView newForward = getFlowPath(flow, stateMachine.getNewPrimaryForwardPath());
+            FlowPathSpeakerView newReverse = getFlowPath(flow, stateMachine.getNewPrimaryReversePath());
             requestFactories.addAll(commandBuilder.buildIngressOnly(
                     stateMachine.getCommandContext(), flow, newForward, newReverse));
         }
 
         // Installation of ingress rules for protected paths is skipped. These paths are activated on swap.
 
-        Map<UUID, FlowSegmentRequestFactory> requestsStorage = stateMachine.getIngressCommands();
-        for (FlowSegmentRequestFactory factory : requestFactories) {
-            FlowSegmentRequest request = factory.makeInstallRequest(commandIdGenerator.generate());
-            requestsStorage.put(request.getCommandId(), factory);
-            stateMachine.getCarrier().sendSpeakerRequest(request);
-        }
-        stateMachine.getPendingCommands().addAll(new HashSet<>(requestsStorage.keySet()));
+        stateMachine.getIngressCommands().clear();
+        SpeakerInstallSegmentEmitter.INSTANCE.emitBatch(
+                stateMachine.getCarrier(), requestFactories, stateMachine.getIngressCommands());
+        stateMachine.getPendingCommands().addAll(stateMachine.getIngressCommands().keySet());
         stateMachine.getRetriedCommands().clear();
 
         if (requestFactories.isEmpty()) {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/PostResourceAllocationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/PostResourceAllocationAction.java
@@ -22,11 +22,9 @@ import org.openkilda.messaging.info.flow.FlowRerouteResponse;
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowPath;
 import org.openkilda.model.FlowStatus;
-import org.openkilda.model.PathId;
 import org.openkilda.persistence.FetchStrategy;
 import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.wfm.CommandContext;
-import org.openkilda.wfm.share.logger.FlowOperationsDashboardLogger;
 import org.openkilda.wfm.share.mappers.FlowPathMapper;
 import org.openkilda.wfm.topology.flowhs.fsm.common.actions.NbTrackableAction;
 import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteContext;
@@ -41,32 +39,15 @@ import java.util.Optional;
 @Slf4j
 public class PostResourceAllocationAction extends
         NbTrackableAction<FlowRerouteFsm, State, Event, FlowRerouteContext> {
-    private final FlowOperationsDashboardLogger dashboardLogger;
-
-    public PostResourceAllocationAction(PersistenceManager persistenceManager,
-                                        FlowOperationsDashboardLogger dashboardLogger) {
+    public PostResourceAllocationAction(PersistenceManager persistenceManager) {
         super(persistenceManager);
-        this.dashboardLogger = dashboardLogger;
     }
 
     @Override
     protected Optional<Message> performWithResponse(State from, State to, Event event, FlowRerouteContext context,
                                                     FlowRerouteFsm stateMachine) {
-        String flowId = stateMachine.getFlowId();
-
-        FlowPath newForwardPath = null;
-        if (stateMachine.getNewPrimaryForwardPath() != null) {
-            newForwardPath = getFlowPath(stateMachine.getNewPrimaryForwardPath());
-        }
-
-        PathId currentForwardId;
-        if (newForwardPath != null) {
-            currentForwardId = newForwardPath.getFlow().getForwardPathId();
-        } else {
-            Flow flow = getFlow(flowId, FetchStrategy.NO_RELATIONS);
-            currentForwardId = flow.getForwardPathId();
-        }
-        FlowPath currentForwardPath = getFlowPath(currentForwardId);
+        Flow flow = getFlow(stateMachine.getFlowId(), FetchStrategy.NO_RELATIONS);
+        FlowPath currentForwardPath = getFlowPath(flow.getForwardPathId());
 
         if (stateMachine.getNewPrimaryForwardPath() == null && stateMachine.getNewPrimaryReversePath() == null
                 && stateMachine.getNewProtectedForwardPath() == null
@@ -74,8 +55,13 @@ public class PostResourceAllocationAction extends
             stateMachine.fireRerouteIsSkipped("Reroute is unsuccessful. Couldn't find new path(s)");
         } else if (stateMachine.isEffectivelyDown()) {
             log.warn("Flow {} is mentioned as effectively DOWN, so it will be forced to DOWN state if reroute fail",
-                     flowId);
+                     flow.getFlowId());
             stateMachine.setOriginalFlowStatus(FlowStatus.DOWN);
+        }
+
+        FlowPath newForwardPath = null;
+        if (stateMachine.getNewPrimaryForwardPath() != null) {
+            newForwardPath = getFlowPath(stateMachine.getNewPrimaryForwardPath()).getPath();
         }
 
         return Optional.of(buildRerouteResponseMessage(currentForwardPath, newForwardPath,

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/RevertNewRulesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/RevertNewRulesAction.java
@@ -18,9 +18,8 @@ package org.openkilda.wfm.topology.flowhs.fsm.reroute.actions;
 import org.openkilda.floodlight.api.request.factory.FlowSegmentRequestFactory;
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowEncapsulationType;
-import org.openkilda.model.FlowPath;
 import org.openkilda.persistence.PersistenceManager;
-import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
+import org.openkilda.wfm.share.model.FlowPathSpeakerView;
 import org.openkilda.wfm.topology.flowhs.fsm.common.actions.FlowProcessingAction;
 import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteContext;
 import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteFsm;
@@ -42,9 +41,9 @@ import java.util.UUID;
 public class RevertNewRulesAction extends FlowProcessingAction<FlowRerouteFsm, State, Event, FlowRerouteContext> {
     private final FlowCommandBuilderFactory commandBuilderFactory;
 
-    public RevertNewRulesAction(PersistenceManager persistenceManager, FlowResourcesManager resourcesManager) {
+    public RevertNewRulesAction(PersistenceManager persistenceManager) {
         super(persistenceManager);
-        commandBuilderFactory = new FlowCommandBuilderFactory(resourcesManager);
+        commandBuilderFactory = new FlowCommandBuilderFactory();
     }
 
     @Override
@@ -58,8 +57,8 @@ public class RevertNewRulesAction extends FlowProcessingAction<FlowRerouteFsm, S
         Collection<FlowSegmentRequestFactory> installCommands = new ArrayList<>();
         // Reinstall old ingress rules that may be overridden by new ingress.
         if (stateMachine.getOldPrimaryForwardPath() != null && stateMachine.getOldPrimaryReversePath() != null) {
-            FlowPath oldForward = getFlowPath(flow, stateMachine.getOldPrimaryForwardPath());
-            FlowPath oldReverse = getFlowPath(flow, stateMachine.getOldPrimaryReversePath());
+            FlowPathSpeakerView oldForward = getFlowPath(flow, stateMachine.getOldPrimaryForwardPath());
+            FlowPathSpeakerView oldReverse = getFlowPath(flow, stateMachine.getOldPrimaryReversePath());
             installCommands.addAll(commandBuilder.buildIngressOnly(
                     stateMachine.getCommandContext(), flow, oldForward, oldReverse));
         }
@@ -72,14 +71,14 @@ public class RevertNewRulesAction extends FlowProcessingAction<FlowRerouteFsm, S
         // Remove possible installed flow segments
         Collection<FlowSegmentRequestFactory> removeCommands = new ArrayList<>();
         if (stateMachine.getNewPrimaryForwardPath() != null && stateMachine.getNewPrimaryReversePath() != null) {
-            FlowPath newForward = getFlowPath(flow, stateMachine.getNewPrimaryForwardPath());
-            FlowPath newReverse = getFlowPath(flow, stateMachine.getNewPrimaryReversePath());
+            FlowPathSpeakerView newForward = getFlowPath(flow, stateMachine.getNewPrimaryForwardPath());
+            FlowPathSpeakerView newReverse = getFlowPath(flow, stateMachine.getNewPrimaryReversePath());
             removeCommands.addAll(commandBuilder.buildAll(
                     stateMachine.getCommandContext(), flow, newForward, newReverse));
         }
         if (stateMachine.getNewProtectedForwardPath() != null && stateMachine.getNewProtectedReversePath() != null) {
-            FlowPath newForward = getFlowPath(flow, stateMachine.getNewProtectedForwardPath());
-            FlowPath newReverse = getFlowPath(flow, stateMachine.getNewProtectedReversePath());
+            FlowPathSpeakerView newForward = getFlowPath(flow, stateMachine.getNewProtectedForwardPath());
+            FlowPathSpeakerView newReverse = getFlowPath(flow, stateMachine.getNewProtectedReversePath());
             removeCommands.addAll(commandBuilder.buildAllExceptIngress(
                     stateMachine.getCommandContext(), flow, newForward, newReverse));
         }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/RevertPathsSwapAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/RevertPathsSwapAction.java
@@ -47,13 +47,13 @@ public class RevertPathsSwapAction extends FlowProcessingAction<FlowRerouteFsm, 
             }
 
             if (stateMachine.getOldPrimaryForwardPath() != null && stateMachine.getOldPrimaryReversePath() != null) {
-                FlowPath oldForward = getFlowPath(stateMachine.getOldPrimaryForwardPath());
+                FlowPath oldForward = getFlowPath(stateMachine.getOldPrimaryForwardPath()).getPath();
                 if (oldForward.getStatus() != FlowPathStatus.ACTIVE) {
                     flowPathRepository.updateStatus(oldForward.getPathId(),
                             stateMachine.getOldPrimaryForwardPathStatus());
                 }
 
-                FlowPath oldReverse = getFlowPath(stateMachine.getOldPrimaryReversePath());
+                FlowPath oldReverse = getFlowPath(stateMachine.getOldPrimaryReversePath()).getPath();
                 if (oldReverse.getStatus() != FlowPathStatus.ACTIVE) {
                     flowPathRepository.updateStatus(oldReverse.getPathId(),
                             stateMachine.getOldPrimaryReversePathStatus());
@@ -71,13 +71,13 @@ public class RevertPathsSwapAction extends FlowProcessingAction<FlowRerouteFsm, 
 
             if (stateMachine.getOldProtectedForwardPath() != null
                     && stateMachine.getOldProtectedReversePath() != null) {
-                FlowPath oldForward = getFlowPath(stateMachine.getOldProtectedForwardPath());
+                FlowPath oldForward = getFlowPath(stateMachine.getOldProtectedForwardPath()).getPath();
                 if (oldForward.getStatus() != FlowPathStatus.ACTIVE) {
                     flowPathRepository.updateStatus(oldForward.getPathId(),
                             stateMachine.getOldProtectedForwardPathStatus());
                 }
 
-                FlowPath oldReverse = getFlowPath(stateMachine.getOldProtectedReversePath());
+                FlowPath oldReverse = getFlowPath(stateMachine.getOldProtectedReversePath()).getPath();
                 if (oldReverse.getStatus() != FlowPathStatus.ACTIVE) {
                     flowPathRepository.updateStatus(oldReverse.getPathId(),
                             stateMachine.getOldProtectedReversePathStatus());

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/RevertResourceAllocationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/RevertResourceAllocationAction.java
@@ -70,16 +70,16 @@ public class RevertResourceAllocationAction extends
             FlowPath newPrimaryReverse = null;
             if (stateMachine.getNewPrimaryForwardPath() != null
                     && stateMachine.getNewPrimaryReversePath() != null) {
-                newPrimaryForward = getFlowPath(stateMachine.getNewPrimaryForwardPath());
-                newPrimaryReverse = getFlowPath(stateMachine.getNewPrimaryReversePath());
+                newPrimaryForward = getFlowPath(stateMachine.getNewPrimaryForwardPath()).getPath();
+                newPrimaryReverse = getFlowPath(stateMachine.getNewPrimaryReversePath()).getPath();
             }
 
             FlowPath newProtectedForward = null;
             FlowPath newProtectedReverse = null;
             if (stateMachine.getNewProtectedForwardPath() != null
                     && stateMachine.getNewProtectedReversePath() != null) {
-                newProtectedForward = getFlowPath(stateMachine.getNewProtectedForwardPath());
-                newProtectedReverse = getFlowPath(stateMachine.getNewProtectedReversePath());
+                newProtectedForward = getFlowPath(stateMachine.getNewProtectedForwardPath()).getPath();
+                newProtectedReverse = getFlowPath(stateMachine.getNewProtectedReversePath()).getPath();
             }
 
             flowPathRepository.lockInvolvedSwitches(Stream.of(newPrimaryForward, newPrimaryReverse,

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/SwapFlowPathsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/SwapFlowPathsAction.java
@@ -18,16 +18,14 @@ package org.openkilda.wfm.topology.flowhs.fsm.reroute.actions;
 import static java.lang.String.format;
 
 import org.openkilda.model.Flow;
+import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.FlowPath;
 import org.openkilda.model.FlowPathStatus;
 import org.openkilda.model.PathId;
 import org.openkilda.persistence.FetchStrategy;
 import org.openkilda.persistence.PersistenceManager;
-import org.openkilda.wfm.share.flow.resources.EncapsulationResources;
-import org.openkilda.wfm.share.flow.resources.FlowResources;
-import org.openkilda.wfm.share.flow.resources.FlowResources.PathResources;
 import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
-import org.openkilda.wfm.topology.flowhs.fsm.common.actions.FlowProcessingAction;
+import org.openkilda.wfm.topology.flowhs.fsm.common.actions.PathSwappingAction;
 import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteContext;
 import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteFsm;
 import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteFsm.Event;
@@ -36,12 +34,9 @@ import org.openkilda.wfm.topology.flowhs.fsm.reroute.FlowRerouteFsm.State;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class SwapFlowPathsAction extends FlowProcessingAction<FlowRerouteFsm, State, Event, FlowRerouteContext> {
-    private final FlowResourcesManager resourcesManager;
-
+public class SwapFlowPathsAction extends PathSwappingAction<FlowRerouteFsm, State, Event, FlowRerouteContext> {
     public SwapFlowPathsAction(PersistenceManager persistenceManager, FlowResourcesManager resourcesManager) {
-        super(persistenceManager);
-        this.resourcesManager = resourcesManager;
+        super(persistenceManager, resourcesManager);
     }
 
     @Override
@@ -49,57 +44,48 @@ public class SwapFlowPathsAction extends FlowProcessingAction<FlowRerouteFsm, St
         persistenceManager.getTransactionManager().doInTransaction(() -> {
             Flow flow = getFlow(stateMachine.getFlowId(), FetchStrategy.DIRECT_RELATIONS);
 
+            final FlowEncapsulationType flowEncapsulationType = flow.getEncapsulationType();
+
             if (stateMachine.getNewPrimaryForwardPath() != null && stateMachine.getNewPrimaryReversePath() != null) {
-                FlowPath oldForward = getFlowPath(flow, flow.getForwardPathId());
-                stateMachine.setOldPrimaryForwardPath(oldForward.getPathId());
-                stateMachine.setOldPrimaryForwardPathStatus(oldForward.getStatus());
-                flowPathRepository.updateStatus(oldForward.getPathId(), FlowPathStatus.IN_PROGRESS);
+                flowPathRepository.updateStatus(flow.getForwardPathId(), FlowPathStatus.IN_PROGRESS);
+                flowPathRepository.updateStatus(flow.getReversePathId(), FlowPathStatus.IN_PROGRESS);
 
-                FlowPath oldReverse = getFlowPath(flow, flow.getReversePathId());
-                stateMachine.setOldPrimaryReversePath(oldReverse.getPathId());
-                stateMachine.setOldPrimaryReversePathStatus(oldReverse.getStatus());
-                flowPathRepository.updateStatus(oldReverse.getPathId(), FlowPathStatus.IN_PROGRESS);
-
-                FlowResources oldResources = getResources(flow, oldForward, oldReverse);
-                stateMachine.getOldResources().add(oldResources);
-
-                PathId newForward = stateMachine.getNewPrimaryForwardPath();
-                flow.setForwardPath(newForward);
-                PathId newReverse = stateMachine.getNewPrimaryReversePath();
-                flow.setReversePath(newReverse);
+                FlowPath newForward = stateMachine.getNewPrimaryForwardPath().getPath();
+                FlowPath newReverse = stateMachine.getNewPrimaryReversePath().getPath();
 
                 log.debug("Swapping the primary paths {}/{} with {}/{}",
-                        oldForward.getPathId(), oldReverse.getPathId(),
-                        newForward, newReverse);
+                          flow.getForwardPathId(), flow.getReversePathId(),
+                          newForward.getPathId(), newReverse.getPathId());
 
-                saveHistory(stateMachine, flow.getFlowId(), newForward, newReverse);
+                saveOldPrimaryPaths(
+                        stateMachine, flow, flow.getForwardPath(), flow.getReversePath(), flowEncapsulationType);
+
+                flow.setForwardPath(newForward.getPathId());
+                flow.setReversePath(newReverse.getPathId());
+
+                saveHistory(stateMachine, flow.getFlowId(), newForward.getPathId(), newReverse.getPathId());
             }
 
             if (stateMachine.getNewProtectedForwardPath() != null
                     && stateMachine.getNewProtectedReversePath() != null) {
-                FlowPath oldForward = getFlowPath(flow, flow.getProtectedForwardPathId());
-                stateMachine.setOldProtectedForwardPath(oldForward.getPathId());
-                stateMachine.setOldProtectedForwardPathStatus(oldForward.getStatus());
-                flowPathRepository.updateStatus(oldForward.getPathId(), FlowPathStatus.IN_PROGRESS);
+                flowPathRepository.updateStatus(flow.getProtectedForwardPathId(), FlowPathStatus.IN_PROGRESS);
+                flowPathRepository.updateStatus(flow.getProtectedReversePathId(), FlowPathStatus.IN_PROGRESS);
 
-                FlowPath oldReverse = getFlowPath(flow, flow.getProtectedReversePathId());
-                stateMachine.setOldProtectedReversePath(oldReverse.getPathId());
-                stateMachine.setOldProtectedReversePathStatus(oldReverse.getStatus());
-                flowPathRepository.updateStatus(oldReverse.getPathId(), FlowPathStatus.IN_PROGRESS);
-
-                FlowResources oldResources = getResources(flow, oldForward, oldReverse);
-                stateMachine.getOldResources().add(oldResources);
-
-                PathId newForward = stateMachine.getNewProtectedForwardPath();
-                flow.setProtectedForwardPath(newForward);
-                PathId newReverse = stateMachine.getNewProtectedReversePath();
-                flow.setProtectedReversePath(newReverse);
+                FlowPath newForward = stateMachine.getNewProtectedForwardPath().getPath();
+                FlowPath newReverse = stateMachine.getNewProtectedReversePath().getPath();
 
                 log.debug("Swapping the protected paths {}/{} with {}/{}",
-                        oldForward.getPathId(), oldReverse.getPathId(),
-                        newForward, newReverse);
+                          flow.getProtectedForwardPathId(), flow.getProtectedReversePathId(),
+                          newForward, newReverse);
 
-                saveHistory(stateMachine, flow.getFlowId(), newForward, newReverse);
+                saveOldProtectedPaths(
+                        stateMachine, flow, flow.getProtectedForwardPath(), flow.getProtectedReversePath(),
+                        flowEncapsulationType);
+
+                flow.setProtectedForwardPath(newForward);
+                flow.setProtectedReversePath(newReverse);
+
+                saveHistory(stateMachine, flow.getFlowId(), newForward.getPathId(), newReverse.getPathId());
             }
 
             if (stateMachine.getNewEncapsulationType() != null) {
@@ -108,24 +94,6 @@ public class SwapFlowPathsAction extends FlowProcessingAction<FlowRerouteFsm, St
 
             flowRepository.createOrUpdate(flow);
         });
-    }
-
-    private FlowResources getResources(Flow flow, FlowPath forwardPath, FlowPath reversePath) {
-        EncapsulationResources encapsulationResources = resourcesManager.getEncapsulationResources(
-                forwardPath.getPathId(), reversePath.getPathId(), flow.getEncapsulationType()).orElse(null);
-        return FlowResources.builder()
-                .unmaskedCookie(forwardPath.getCookie().getUnmaskedValue())
-                .forward(PathResources.builder()
-                        .pathId(forwardPath.getPathId())
-                        .meterId(forwardPath.getMeterId())
-                        .encapsulationResources(encapsulationResources)
-                        .build())
-                .reverse(PathResources.builder()
-                        .pathId(reversePath.getPathId())
-                        .meterId(reversePath.getMeterId())
-                        .encapsulationResources(encapsulationResources)
-                        .build())
-                .build();
     }
 
     private void saveHistory(FlowRerouteFsm stateMachine, String flowId, PathId forwardPath, PathId reversePath) {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/FlowUpdateFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/FlowUpdateFsm.java
@@ -169,7 +169,7 @@ public final class FlowUpdateFsm extends FlowPathSwappingFsm<FlowUpdateFsm, Stat
 
             builder.transition().from(State.RESOURCE_ALLOCATION_COMPLETED).to(State.INSTALLING_NON_INGRESS_RULES)
                     .on(Event.NEXT)
-                    .perform(new InstallNonIngressRulesAction(persistenceManager, resourcesManager));
+                    .perform(new InstallNonIngressRulesAction(persistenceManager));
             builder.transitions().from(State.RESOURCE_ALLOCATION_COMPLETED)
                     .toAmong(State.REVERTING_ALLOCATED_RESOURCES, State.REVERTING_ALLOCATED_RESOURCES)
                     .onEach(Event.TIMEOUT, Event.ERROR);
@@ -210,7 +210,7 @@ public final class FlowUpdateFsm extends FlowPathSwappingFsm<FlowUpdateFsm, Stat
                     .onEach(Event.TIMEOUT, Event.ERROR);
 
             builder.transition().from(State.PATHS_SWAPPED).to(State.INSTALLING_INGRESS_RULES).on(Event.NEXT)
-                    .perform(new InstallIngressRulesAction(persistenceManager, resourcesManager));
+                    .perform(new InstallIngressRulesAction(persistenceManager));
             builder.transitions().from(State.PATHS_SWAPPED)
                     .toAmong(State.REVERTING_PATHS_SWAP, State.REVERTING_PATHS_SWAP)
                     .onEach(Event.TIMEOUT, Event.ERROR);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocatePrimaryResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocatePrimaryResourcesAction.java
@@ -71,8 +71,9 @@ public class AllocatePrimaryResourcesAction extends
                 .build();
         FlowPathPair newPaths = createFlowPathPair(flow, oldPaths, potentialPath, flowResources);
         log.debug("New primary path has been created: {}", newPaths);
-        stateMachine.setNewPrimaryForwardPath(newPaths.getForward().getPathId());
-        stateMachine.setNewPrimaryReversePath(newPaths.getReverse().getPathId());
+
+        savePrimaryPaths(stateMachine, flow, newPaths, flowResources);
+        flushPathChanges(newPaths);
 
         saveAllocationActionWithDumpsToHistory(stateMachine, flow, "primary", newPaths);
     }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/CompleteFlowPathInstallationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/CompleteFlowPathInstallationAction.java
@@ -38,8 +38,8 @@ public class CompleteFlowPathInstallationAction extends
     @Override
     protected void perform(State from, State to, Event event, FlowUpdateContext context, FlowUpdateFsm stateMachine) {
         persistenceManager.getTransactionManager().doInTransaction(() -> {
-            PathId newPrimaryForward = stateMachine.getNewPrimaryForwardPath();
-            PathId newPrimaryReverse = stateMachine.getNewPrimaryReversePath();
+            PathId newPrimaryForward = stateMachine.getNewPrimaryForwardPath().getPath().getPathId();
+            PathId newPrimaryReverse = stateMachine.getNewPrimaryReversePath().getPath().getPathId();
 
             log.debug("Completing installation of the flow primary path {} / {}", newPrimaryForward, newPrimaryReverse);
             flowPathRepository.updateStatus(newPrimaryForward, FlowPathStatus.ACTIVE);
@@ -50,8 +50,8 @@ public class CompleteFlowPathInstallationAction extends
 
             if (stateMachine.getNewProtectedForwardPath() != null
                     && stateMachine.getNewProtectedReversePath() != null) {
-                PathId newForward = stateMachine.getNewProtectedForwardPath();
-                PathId newReverse = stateMachine.getNewProtectedReversePath();
+                PathId newForward = stateMachine.getNewProtectedForwardPath().getPath().getPathId();
+                PathId newReverse = stateMachine.getNewProtectedReversePath().getPath().getPathId();
 
                 log.debug("Completing installation of the flow protected path {} / {}", newForward, newReverse);
                 flowPathRepository.updateStatus(newForward, FlowPathStatus.ACTIVE);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/CompleteFlowPathRemovalAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/CompleteFlowPathRemovalAction.java
@@ -59,15 +59,15 @@ public class CompleteFlowPathRemovalAction extends
         FlowPath oldPrimaryForward = null;
         FlowPath oldPrimaryReverse = null;
         if (stateMachine.getOldPrimaryForwardPath() != null && stateMachine.getOldPrimaryReversePath() != null) {
-            oldPrimaryForward = getFlowPath(flow, stateMachine.getOldPrimaryForwardPath());
-            oldPrimaryReverse = getFlowPath(flow, stateMachine.getOldPrimaryReversePath());
+            oldPrimaryForward = getFlowPath(flow, stateMachine.getOldPrimaryForwardPath()).getPath();
+            oldPrimaryReverse = getFlowPath(flow, stateMachine.getOldPrimaryReversePath()).getPath();
         }
         FlowPath oldProtectedForward = null;
         FlowPath oldProtectedReverse = null;
         if (stateMachine.getOldProtectedForwardPath() != null
                 && stateMachine.getOldProtectedReversePath() != null) {
-            oldProtectedForward = getFlowPath(flow, stateMachine.getOldProtectedForwardPath());
-            oldProtectedReverse = getFlowPath(flow, stateMachine.getOldProtectedReversePath());
+            oldProtectedForward = getFlowPath(flow, stateMachine.getOldProtectedForwardPath()).getPath();
+            oldProtectedReverse = getFlowPath(flow, stateMachine.getOldProtectedReversePath()).getPath();
         }
 
         flowPathRepository.lockInvolvedSwitches(Stream.of(oldPrimaryForward, oldPrimaryReverse,

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RevertPathsSwapAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RevertPathsSwapAction.java
@@ -23,7 +23,6 @@ import org.openkilda.model.FlowPathStatus;
 import org.openkilda.model.PathId;
 import org.openkilda.persistence.FetchStrategy;
 import org.openkilda.persistence.PersistenceManager;
-import org.openkilda.persistence.repositories.SwitchRepository;
 import org.openkilda.wfm.topology.flowhs.fsm.common.actions.FlowProcessingAction;
 import org.openkilda.wfm.topology.flowhs.fsm.update.FlowUpdateContext;
 import org.openkilda.wfm.topology.flowhs.fsm.update.FlowUpdateFsm;
@@ -34,11 +33,8 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class RevertPathsSwapAction extends FlowProcessingAction<FlowUpdateFsm, State, Event, FlowUpdateContext> {
-    private final SwitchRepository switchRepository;
-
     public RevertPathsSwapAction(PersistenceManager persistenceManager) {
         super(persistenceManager);
-        switchRepository = persistenceManager.getRepositoryFactory().createSwitchRepository();
     }
 
     @Override
@@ -47,13 +43,13 @@ public class RevertPathsSwapAction extends FlowProcessingAction<FlowUpdateFsm, S
             Flow flow = getFlow(stateMachine.getFlowId(), FetchStrategy.DIRECT_RELATIONS);
 
             if (stateMachine.getOldPrimaryForwardPath() != null && stateMachine.getOldPrimaryReversePath() != null) {
-                FlowPath oldForward = getFlowPath(stateMachine.getOldPrimaryForwardPath());
+                FlowPath oldForward = getFlowPath(stateMachine.getOldPrimaryForwardPath()).getPath();
                 if (oldForward.getStatus() != FlowPathStatus.ACTIVE) {
                     flowPathRepository.updateStatus(oldForward.getPathId(),
                             stateMachine.getOldPrimaryForwardPathStatus());
                 }
 
-                FlowPath oldReverse = getFlowPath(stateMachine.getOldPrimaryReversePath());
+                FlowPath oldReverse = getFlowPath(stateMachine.getOldPrimaryReversePath()).getPath();
                 if (oldReverse.getStatus() != FlowPathStatus.ACTIVE) {
                     flowPathRepository.updateStatus(oldReverse.getPathId(),
                             stateMachine.getOldPrimaryReversePathStatus());
@@ -71,13 +67,13 @@ public class RevertPathsSwapAction extends FlowProcessingAction<FlowUpdateFsm, S
 
             if (stateMachine.getOldProtectedForwardPath() != null
                     && stateMachine.getOldProtectedReversePath() != null) {
-                FlowPath oldForward = getFlowPath(stateMachine.getOldProtectedForwardPath());
+                FlowPath oldForward = getFlowPath(stateMachine.getOldProtectedForwardPath()).getPath();
                 if (oldForward.getStatus() != FlowPathStatus.ACTIVE) {
                     flowPathRepository.updateStatus(oldForward.getPathId(),
                             stateMachine.getOldProtectedForwardPathStatus());
                 }
 
-                FlowPath oldReverse = getFlowPath(stateMachine.getOldProtectedReversePath());
+                FlowPath oldReverse = getFlowPath(stateMachine.getOldProtectedReversePath()).getPath();
                 if (oldReverse.getStatus() != FlowPathStatus.ACTIVE) {
                     flowPathRepository.updateStatus(oldReverse.getPathId(),
                             stateMachine.getOldProtectedReversePathStatus());

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RevertResourceAllocationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RevertResourceAllocationAction.java
@@ -70,16 +70,16 @@ public class RevertResourceAllocationAction extends
             FlowPath newPrimaryReverse = null;
             if (stateMachine.getNewPrimaryForwardPath() != null
                     && stateMachine.getNewPrimaryReversePath() != null) {
-                newPrimaryForward = getFlowPath(stateMachine.getNewPrimaryForwardPath());
-                newPrimaryReverse = getFlowPath(stateMachine.getNewPrimaryReversePath());
+                newPrimaryForward = getFlowPath(stateMachine.getNewPrimaryForwardPath()).getPath();
+                newPrimaryReverse = getFlowPath(stateMachine.getNewPrimaryReversePath()).getPath();
             }
 
             FlowPath newProtectedForward = null;
             FlowPath newProtectedReverse = null;
             if (stateMachine.getNewProtectedForwardPath() != null
                     && stateMachine.getNewProtectedReversePath() != null) {
-                newProtectedForward = getFlowPath(stateMachine.getNewProtectedForwardPath());
-                newProtectedReverse = getFlowPath(stateMachine.getNewProtectedReversePath());
+                newProtectedForward = getFlowPath(stateMachine.getNewProtectedForwardPath()).getPath();
+                newProtectedReverse = getFlowPath(stateMachine.getNewProtectedReversePath()).getPath();
             }
 
             flowPathRepository.lockInvolvedSwitches(Stream.of(newPrimaryForward, newPrimaryReverse,

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowCommandBuilderFactory.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowCommandBuilderFactory.java
@@ -16,16 +16,9 @@
 package org.openkilda.wfm.topology.flowhs.service;
 
 import org.openkilda.model.FlowEncapsulationType;
-import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
 import org.openkilda.wfm.share.service.SpeakerFlowSegmentRequestBuilder;
 
 public class FlowCommandBuilderFactory {
-    private final FlowResourcesManager resourcesManager;
-
-    public FlowCommandBuilderFactory(FlowResourcesManager resourcesManager) {
-        this.resourcesManager = resourcesManager;
-    }
-
     /**
      * Provides a flow command factory depending on the encapsulation type.
      *
@@ -36,7 +29,7 @@ public class FlowCommandBuilderFactory {
         switch (encapsulationType) {
             case TRANSIT_VLAN:
             case VXLAN:
-                return new SpeakerFlowSegmentRequestBuilder(resourcesManager);
+                return new SpeakerFlowSegmentRequestBuilder();
             default:
                 throw new UnsupportedOperationException(
                         String.format("Encapsulation type %s is not supported", encapsulationType));


### PR DESCRIPTION
To ensure data consistency remove any data collection into
FlowCommandBuilder and provide all required data in advance.

Some input data types have been reworked to simplify FlowCommandBuilder
it's API.