### PR TITLE
Remove potential reordering of OF events

### DIFF
--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/ChunkedInfoMessage.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/ChunkedInfoMessage.java
@@ -51,11 +51,4 @@ public class ChunkedInfoMessage extends InfoMessage {
         this.messageId = String.join(" : ", String.valueOf(messageIndex), correlationId);
         this.totalMessages = totalMessages;
     }
-
-    public ChunkedInfoMessage(InfoData data, long timestamp, String correlationId,
-                              int messageIndex, int totalMessages, String region) {
-        super(data, timestamp, correlationId, region);
-        this.messageId = String.join(" : ", String.valueOf(messageIndex), correlationId);
-        this.totalMessages = totalMessages;
-    }
 }

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
@@ -191,8 +191,6 @@ class RecordHandler implements Runnable {
 
         try {
             handleCommand(message, replyToTopic, replyDestination);
-        } catch (SwitchOperationException e) {
-            logger.error("Unable to handle request {}: {}", message.getData().getClass().getName(), e.getMessage());
         } catch (FlowCommandException e) {
             String errorMessage = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
             logger.error("Failed to handle message {}: {}", message, errorMessage);
@@ -205,7 +203,7 @@ class RecordHandler implements Runnable {
     }
 
     private void handleCommand(CommandMessage message, String replyToTopic, Destination replyDestination)
-            throws FlowCommandException, SwitchOperationException {
+            throws FlowCommandException {
         logger.debug("Handling message: '{}'. Reply topic: '{}'. Reply destination: '{}'.",
                 message, replyToTopic, replyDestination);
         CommandData data = message.getData();
@@ -775,11 +773,11 @@ class RecordHandler implements Runnable {
      *
      * @param message NetworkCommandData
      */
-    private void doNetworkDump(final CommandMessage message) throws SwitchOperationException {
+    private void doNetworkDump(final CommandMessage message) {
         logger.info("Processing request from WFM to dump switches. {}", message.getCorrelationId());
 
         SwitchTrackingService switchTracking = context.getModuleContext().getServiceImpl(SwitchTrackingService.class);
-        switchTracking.dumpAllSwitches(message.getCorrelationId());
+        switchTracking.dumpAllSwitches();
     }
 
     private void doInstallSwitchRules(final CommandMessage message) {


### PR DESCRIPTION
Use "correct" kafka-key for each switch-dump event produced by
OF-speaker on network-dump request. It guarantees correct selection of
kafka-partition for such messages and as a result, it guarantees correct
ordering of produced events.

Close #3369 