### PR TITLE
adjust grpc tests to work with grpc-stub

### DIFF
--- a/confd/templates/atdd-staging/kilda.properties.tmpl
+++ b/confd/templates/atdd-staging/kilda.properties.tmpl
@@ -77,3 +77,4 @@ latency.update.time.range = {{ getv "/kilda_latency_update_time_range" }}
 latency.discovery.interval.multiplier = {{ getv "/kilda_latency_discovery_interval_multiplier" }}
 
 flow.ping.interval=5
+docker.host=localhost

--- a/src-java/testing/functional-tests/kilda.properties.example
+++ b/src-java/testing/functional-tests/kilda.properties.example
@@ -71,3 +71,5 @@ use.multitable=true
 cleanup.verifier=true
 
 flow.ping.interval=5
+# remote docker host http://<ip>:2376
+docker.host=localhost

--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/DockerHelper.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/DockerHelper.groovy
@@ -1,0 +1,36 @@
+package org.openkilda.functionaltests.helpers
+
+import com.spotify.docker.client.DefaultDockerClient
+import com.spotify.docker.client.DockerClient
+import com.spotify.docker.client.DockerClient.ListContainersParam
+import groovy.util.logging.Slf4j
+
+@Slf4j
+class DockerHelper {
+
+    DockerClient dockerClient
+    String networkName
+
+    DockerHelper(String host) {
+        log.debug("Configuring docker client");
+        if (host == 'localhost') {
+            dockerClient = DefaultDockerClient.fromEnv().build()
+        } else {
+            dockerClient = DefaultDockerClient.fromEnv().uri(host).build()
+        }
+        log.debug("Connected to Docker Host: $host")
+
+        networkName = getNetworkName()
+        log.debug("Network name: $networkName")
+    }
+
+    String getContainerIp(String containerName) {
+        dockerClient.listContainers(ListContainersParam.allContainers()).find {
+            it.names().contains("/" + containerName)
+        }.networkSettings().networks()[networkName].ipAddress()
+    }
+
+    private String getNetworkName() {
+        dockerClient.listNetworks()*.name().find { it.contains('_default')}
+    }
+}

--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/DockerHelper.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/DockerHelper.groovy
@@ -30,6 +30,14 @@ class DockerHelper {
         }.networkSettings().networks()[networkName].ipAddress()
     }
 
+    void restartContainer(String containerId) {
+        dockerClient.restartContainer(containerId)
+    }
+
+    void waitContainer(String containerId) {
+        dockerClient.waitContainer(containerId)
+    }
+
     private String getNetworkName() {
         dockerClient.listNetworks()*.name().find { it.contains('_default')}
     }

--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/WfmManipulator.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/WfmManipulator.groovy
@@ -1,6 +1,5 @@
 package org.openkilda.functionaltests.helpers
 
-import com.spotify.docker.client.DefaultDockerClient
 import com.spotify.docker.client.DockerClient
 import com.spotify.docker.client.DockerClient.ListContainersParam
 import com.spotify.docker.client.messages.Container
@@ -22,8 +21,8 @@ class WfmManipulator {
     DockerClient dockerClient
     Container wfmContainer
 
-    WfmManipulator() {
-        dockerClient = DefaultDockerClient.fromEnv().build()
+    WfmManipulator(String dockerHost) {
+        dockerClient = new DockerHelper(dockerHost).dockerClient
         wfmContainer = dockerClient.listContainers(ListContainersParam.allContainers()).find {
             it.names().contains(WFM_CONTAINER_NAME)
         }

--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/WfmManipulator.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/WfmManipulator.groovy
@@ -11,7 +11,6 @@ import java.util.concurrent.TimeUnit
 @Slf4j
 class WfmManipulator {
     private static final String WFM_CONTAINER_NAME = "/wfm"
-    private static final String KILDA_NETWORK_NAME = "open-kilda_default"
     /* Storm topologies require some time to fully roll after booting.
      * TODO(rtretiak): find a more reliable way to wait for the H-hour
      * Not respecting this wait may lead to subsequent tests instability
@@ -19,10 +18,12 @@ class WfmManipulator {
     private static final int WFM_WARMUP_SECONDS = 180
 
     DockerClient dockerClient
+    DockerHelper dockerHelper
     Container wfmContainer
 
     WfmManipulator(String dockerHost) {
-        dockerClient = new DockerHelper(dockerHost).dockerClient
+        dockerHelper = new DockerHelper(dockerHost)
+        dockerClient = dockerHelper.dockerClient
         wfmContainer = dockerClient.listContainers(ListContainersParam.allContainers()).find {
             it.names().contains(WFM_CONTAINER_NAME)
         }
@@ -34,9 +35,9 @@ class WfmManipulator {
      */
     def restartWfm(boolean wait = true) {
         log.warn "Restarting wfm"
-        dockerClient.restartContainer(wfmContainer.id())
+        dockerHelper.restartContainer(wfmContainer.id())
         if (wait) {
-            dockerClient.waitContainer(wfmContainer.id())
+            dockerHelper.waitContainer(wfmContainer.id())
             TimeUnit.SECONDS.sleep(WFM_WARMUP_SECONDS)
         }
     }
@@ -62,7 +63,7 @@ class WfmManipulator {
                                          "PATH=\${PATH}:/opt/storm/bin;make -C /app $action-$topologyName".toString()])
                                    .build(), null, null)
             container = dockerClient.createContainer(ContainerConfig.builder().image(image.id()).build())
-            def network = dockerClient.listNetworks().find { it.name() == KILDA_NETWORK_NAME }
+            def network = dockerClient.listNetworks().find { it.name() == dockerHelper.networkName }
             dockerClient.connectToNetwork(container.id(), network.id())
             dockerClient.startContainer(container.id())
         } finally {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MultiRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MultiRerouteSpec.groovy
@@ -80,8 +80,8 @@ class MultiRerouteSpec extends HealthCheckSpecification {
         }
 
         cleanup: "revert system to original state"
-        antiflap.portUp(islToBreak.srcSwitch.dpId, islToBreak.srcPort)
         flows.each { flowHelperV2.deleteFlow(it.flowId) }
+        antiflap.portUp(islToBreak.srcSwitch.dpId, islToBreak.srcPort)
         northbound.deleteLinkProps(northbound.getAllLinkProps())
         [thinIsl, thinIsl.reversed].each { database.resetIslBandwidth(it) }
         database.resetCosts()

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/grpc/GrpcBaseSpecification.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/grpc/GrpcBaseSpecification.groovy
@@ -1,28 +1,44 @@
 package org.openkilda.functionaltests.spec.grpc
 
-import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE_SWITCHES
+import static org.openkilda.testing.ConstantsGrpc.GRPC_STUB_CONTAINER_NAME
+import static org.openkilda.testing.Constants.NON_EXISTENT_SWITCH_ID
 
 import org.openkilda.functionaltests.HealthCheckSpecification
 import org.openkilda.functionaltests.extension.tags.Tags
+import org.openkilda.functionaltests.helpers.DockerHelper
+import org.openkilda.messaging.info.event.SwitchChangeType
 import org.openkilda.northbound.dto.v1.switches.SwitchDto
 import org.openkilda.testing.service.grpc.GrpcService
 
 import groovy.transform.Memoized
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import spock.lang.See
 
 @See("https://github.com/telstra/open-kilda/tree/develop/docs/design/grpc-client")
-@Tags([HARDWARE, SMOKE_SWITCHES])
+@Tags(SMOKE_SWITCHES)
 class GrpcBaseSpecification extends HealthCheckSpecification {
+    @Value('${spring.profiles.active}')
+    String profile
     @Autowired
     GrpcService grpc
+    @Value('${docker.host}')
+    String dockerHost
 
     @Memoized
     List<SwitchDto> getNoviflowSwitches() {
-        northbound.activeSwitches.findAll {
-            def matcher = it.description =~ /NW[0-9]+.([0-9].[0-9])/
-            return matcher && matcher[0][1] >= "2.7"
-        }.unique { [it.hardware, it.software] }
+        if (profile == "virtual") {
+            /* Create fake switch for running test using grpc-stub
+            NOTE: The grpc-stub service covers positive test cases only */
+            def grpcStubIp = new DockerHelper(dockerHost).getContainerIp(GRPC_STUB_CONTAINER_NAME)
+            new SwitchDto(NON_EXISTENT_SWITCH_ID, grpcStubIp,37040, "host", "desc",  SwitchChangeType.ACTIVATED,
+                    false, "of_version", "manufacturer", "hardware", "software", "serial_number") as List
+        } else {
+            northbound.activeSwitches.findAll {
+                def matcher = it.description =~ /NW[0-9]+.([0-9].[0-9])/
+                return matcher && matcher[0][1] >= "2.7"
+            }.unique { [it.hardware, it.software] }
+        }
     }
 }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/grpc/LicenseSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/grpc/LicenseSpec.groovy
@@ -1,5 +1,8 @@
 package org.openkilda.functionaltests.spec.grpc
 
+import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
+
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.extension.failfast.Tidy
 import org.openkilda.grpc.speaker.model.LicenseDto
 import org.openkilda.messaging.error.MessageError
@@ -16,6 +19,7 @@ If you want to test full functionality then you have to perform the following ma
 class LicenseSpec extends GrpcBaseSpecification {
     @Tidy
     @Unroll
+    @Tags(HARDWARE)
     def "Not able to set incorrect license on the #switches.switchId switch"() {
         when: "Try to set incorrect license key"
         String licenseFileName = "incorrectLicenseFileName.key"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/grpc/LogSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/grpc/LogSpec.groovy
@@ -1,11 +1,13 @@
 package org.openkilda.functionaltests.spec.grpc
 
+import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
 import static org.openkilda.testing.ConstantsGrpc.DEFAULT_LOG_MESSAGES_STATE
 import static org.openkilda.testing.ConstantsGrpc.DEFAULT_LOG_OF_MESSAGES_STATE
 import static org.openkilda.testing.ConstantsGrpc.REMOTE_LOG_IP
 import static org.openkilda.testing.ConstantsGrpc.REMOTE_LOG_PORT
 
 import org.openkilda.functionaltests.extension.failfast.Tidy
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.grpc.speaker.model.LogMessagesDto
 import org.openkilda.grpc.speaker.model.LogOferrorsDto
 import org.openkilda.grpc.speaker.model.RemoteLogServerDto
@@ -108,6 +110,7 @@ class LogSpec extends GrpcBaseSpecification {
     }
 
     @Unroll
+    @Tags(HARDWARE)
     def "Not able to set incorrect remote log server configuration(ip/port): #data.remoteIp/#data.remotePort \
 on the #sw.switchId switch"() {
         when: "Try to set incorrect configuration"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/grpc/LogicalPortSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/grpc/LogicalPortSpec.groovy
@@ -1,6 +1,9 @@
 package org.openkilda.functionaltests.spec.grpc
 
+import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
+
 import org.openkilda.functionaltests.extension.failfast.Tidy
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.grpc.speaker.model.LogicalPortDto
 import org.openkilda.messaging.error.MessageError
 
@@ -66,6 +69,7 @@ class LogicalPortSpec extends GrpcBaseSpecification {
     }
 
     @Unroll
+    @Tags(HARDWARE)
     def "Not able to create logical port with incorrect port number(lPort/sPort): \
 #data.logicalPortNumber/#data.portNumber on the #sw.switchId switch"() {
         when:
@@ -98,6 +102,7 @@ class LogicalPortSpec extends GrpcBaseSpecification {
 
     @Tidy
     @Unroll
+    @Tags(HARDWARE)
     def "Not able to delete non-existent logical port number on the #switches.switchId switch"() {
         when: "Try to delete incorrect logicalPortNumber"
         //        TODO(andriidovhan) add check that fakeNumber is not exist on a switch

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/StormLcmSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/StormLcmSpec.groovy
@@ -13,6 +13,7 @@ import org.openkilda.messaging.info.event.IslChangeType
 import org.openkilda.messaging.info.event.SwitchChangeType
 import org.openkilda.messaging.payload.flow.FlowPayload
 
+import org.springframework.beans.factory.annotation.Value
 import spock.lang.Ignore
 import spock.lang.Narrative
 import spock.lang.Shared
@@ -33,12 +34,14 @@ verify their consistency after restart.
 class StormLcmSpec extends HealthCheckSpecification {
     @Shared
     WfmManipulator wfmManipulator
+    @Value('${docker.host}')
+    String dockerHost
 
     def setupOnce() {
         //since we simulate storm restart by restarting the docker container, for now this is only possible on virtual
         //TODO(rtretiak): this can possibly be achieved for 'hardware' via lock-keeper instance
         requireProfiles("virtual")
-        wfmManipulator = new WfmManipulator()
+        wfmManipulator = new WfmManipulator(dockerHost)
     }
 
     def "System survives Storm topologies restart"() {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/StormLcmSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/StormLcmSpec.groovy
@@ -1,6 +1,7 @@
 package org.openkilda.functionaltests.spec.resilience
 
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs
+import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 import static org.openkilda.functionaltests.extension.tags.Tag.VIRTUAL
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 import static spock.util.matcher.HamcrestSupport.expect
@@ -30,7 +31,6 @@ verify their consistency after restart.
  * Aborting it in the middle of execution may lead to Kilda malfunction.
  */
 @Tags(VIRTUAL)
-@Ignore
 class StormLcmSpec extends HealthCheckSpecification {
     @Shared
     WfmManipulator wfmManipulator
@@ -44,6 +44,7 @@ class StormLcmSpec extends HealthCheckSpecification {
         wfmManipulator = new WfmManipulator(dockerHost)
     }
 
+    @Tags(LOW_PRIORITY) // note: it takes ~15 minutes to run this test
     def "System survives Storm topologies restart"() {
         given: "Non-empty system with some flows created"
         List<FlowPayload> flows = []

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/ConstantsGrpc.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/ConstantsGrpc.java
@@ -22,6 +22,7 @@ public final class ConstantsGrpc {
     public static final Integer REMOTE_LOG_PORT = 10514;
     public static final OnOffState DEFAULT_LOG_MESSAGES_STATE = OnOffState.OFF;
     public static final OnOffState DEFAULT_LOG_OF_MESSAGES_STATE = OnOffState.OFF;
+    public static final String GRPC_STUB_CONTAINER_NAME = "grpc-stub";
 
     private ConstantsGrpc() {
         throw new UnsupportedOperationException();

--- a/src-python/lab-service/lab/service/lockkeeper.py
+++ b/src-python/lab-service/lab/service/lockkeeper.py
@@ -210,6 +210,12 @@ def remove_floodlight_access_restrictions():
     return jsonify({'status': 'All iptables rules in INPUT/OUTPUT chains were removed'})
 
 
+@app.route('/get-container-ip/<string:name>')
+def get_container_ip(name):
+    response = docker.from_env().containers.get(name).exec_run("hostname -i").output
+    return Response(response)
+
+
 def get_iptables_commands(address, operation):
     commands = []
     if 'ip' in address and 'port' in address:


### PR DESCRIPTION
- adjust grpc tests to work with grpc-stub;
- add DockerHelper;
- fix wfmManipulator;
- unignore StormLcmSpec;
- add new endpoint to lockkeeper(`get-container-ip/<string:name>`)
- fix MultiRerouteSpec(sequence of cleanup)