### PR TITLE
Fixed flow corruption by reroute after this flow has been updated.

### DIFF
--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/SwapFlowPathsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/SwapFlowPathsAction.java
@@ -109,6 +109,9 @@ public class SwapFlowPathsAction extends FlowProcessingAction<FlowUpdateFsm, Sta
                         newProtectedForward, newProtectedReverse);
 
                 saveHistory(stateMachine, flow.getFlowId(), newProtectedForward, newProtectedReverse);
+            } else {
+                flow.setProtectedForwardPath((FlowPath) null);
+                flow.setProtectedReversePath((FlowPath) null);
             }
 
             flowRepository.createOrUpdate(flow);


### PR DESCRIPTION
When updating a flow with removing `allocate_protected_path` flag, we don't update protected path ids. This makes it impossible to reroute the flow, because we are trying to take the path from the database using an outdated identifier.

Closes: #3338.