### PR TITLE
Put test reports to 'build' instead of 'target'

### DIFF
--- a/src-java/testing/atdd-staging/src/main/resources/log4j2.xml
+++ b/src-java/testing/atdd-staging/src/main/resources/log4j2.xml
@@ -4,10 +4,10 @@
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{ISO8601} %-5p %c{1}:%L - %m%n"/>
         </Console>
-        <File name="RequestLogsFile" fileName="target/logs/request_logs.log">
+        <File name="RequestLogsFile" fileName="build/logs/request_logs.log">
             <PatternLayout pattern="%d{ISO8601} %-5p %c{1}:%L - %m%n"/>
         </File>
-        <File name="KildaLogFile" fileName="target/logs/logs.log">
+        <File name="KildaLogFile" fileName="build/logs/logs.log">
             <PatternLayout pattern="%d{ISO8601} %-5p %c{1}:%L - %m%n"/>
         </File>
     </Appenders>

--- a/src-java/testing/functional-tests/README.md
+++ b/src-java/testing/functional-tests/README.md
@@ -54,7 +54,7 @@ Note that other properties should
 correspond to actual Kilda properties that were used for deployment of the target env.
 - Check your `topology.yaml`. It should represent your actual expected hardware topology. You can automatically generate 
 `topology.yaml` based on currently discovered topology, but be aware that this will prevent you from catching
-some switch/isl discovery-related issues: `make test-topology PARAMS="--tests GenerateTopologyConfig"` && `cp functional-tests/target/topology.yaml functional-tests/`
+some switch/isl discovery-related issues: `make test-topology PARAMS="--tests GenerateTopologyConfig"` && `cp functional-tests/build/topology.yaml functional-tests/`
 - Now you can run tests by executing the following command in the terminal:  
 `make func-tests`.
 
@@ -80,10 +80,10 @@ Common usages:
 func tests for each PR on github 
 
 ## Artifacts
-* Logs - ```target/logs```
+* Logs - ```build/logs```
   * `request_logs` - stores all HTTP transactions being made during test run
   * `logs` - casual test log including DEBUG+ messages
-* Reports - ```target/spock-reports```
+* Reports - ```build/reports```
 
 # How to create a test
 - Get understanding of what [SpockFramework](http://spockframework.org/) and [Groovy](http://groovy-lang.org/) is.

--- a/src-java/testing/functional-tests/build.gradle
+++ b/src-java/testing/functional-tests/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
     implementation 'org.spockframework:spock-spring:1.3-groovy-2.5'
     implementation 'org.spockframework:spock-core:1.3-groovy-2.5'
-    implementation 'com.athaydes:spock-reports:1.6.0'
+    implementation 'com.athaydes:spock-reports:1.7.1'
     implementation 'net.jodah:failsafe'
     implementation 'org.hamcrest:hamcrest-all:1.3'
 }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/special/GenerateTopologyConfig.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/special/GenerateTopologyConfig.groovy
@@ -26,6 +26,6 @@ class GenerateTopologyConfig extends BaseSpecification {
         then: "Able to serialize and save it to 'target'"
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory().configure(Feature.USE_NATIVE_OBJECT_ID, false))
         mapper.setSerializationInclusion(Include.NON_NULL)
-        new File("target/topology.yaml").write(mapper.writeValueAsString(topo))
+        new File("build/topology.yaml").write(mapper.writeValueAsString(topo))
     }
 }

--- a/src-java/testing/functional-tests/src/test/resources/META-INF/services/com.athaydes.spockframework.report.IReportCreator.properties
+++ b/src-java/testing/functional-tests/src/test/resources/META-INF/services/com.athaydes.spockframework.report.IReportCreator.properties
@@ -1,4 +1,4 @@
 # Show the source code for each block
-com.athaydes.spockframework.report.showCodeBlocks=false
+com.athaydes.spockframework.report.showCodeBlocks=true
 # Output directory (where the spock reports will be created) - relative to working directory
-com.athaydes.spockframework.report.outputDir=target/spock-reports
+com.athaydes.spockframework.report.outputDir=build/reports/spock-reports

--- a/src-java/testing/functional-tests/src/test/resources/log4j2.xml
+++ b/src-java/testing/functional-tests/src/test/resources/log4j2.xml
@@ -4,13 +4,13 @@
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{ISO8601} %-5p %c{1}:%L - %m%n"/>
         </Console>
-        <File name="RequestLogsFile" fileName="target/logs/request_logs.log">
+        <File name="RequestLogsFile" fileName="build/logs/request_logs.log">
             <PatternLayout pattern="%d{ISO8601} %-5p %c{1}:%L - %m%n"/>
         </File>
-        <File name="KildaLogFile" fileName="target/logs/logs.log">
+        <File name="KildaLogFile" fileName="build/logs/logs.log">
             <PatternLayout pattern="%d{ISO8601} %-5p %c{1}:%L - %m%n"/>
         </File>
-        <File name="SkippedTestsFile" fileName="target/logs/skipped_tests.log" append="false">
+        <File name="SkippedTestsFile" fileName="build/logs/skipped_tests.log" append="false">
             <PatternLayout pattern="%m%n%n"/>
         </File>
     </Appenders>

--- a/src-java/testing/performance-tests/src/test/resources/META-INF/services/com.athaydes.spockframework.report.IReportCreator.properties
+++ b/src-java/testing/performance-tests/src/test/resources/META-INF/services/com.athaydes.spockframework.report.IReportCreator.properties
@@ -1,4 +1,4 @@
 # Show the source code for each block
 com.athaydes.spockframework.report.showCodeBlocks=false
 # Output directory (where the spock reports will be created) - relative to working directory
-com.athaydes.spockframework.report.outputDir=target/spock-reports
+com.athaydes.spockframework.report.outputDir=build/reports/spock-reports

--- a/src-java/testing/performance-tests/src/test/resources/log4j2.xml
+++ b/src-java/testing/performance-tests/src/test/resources/log4j2.xml
@@ -4,13 +4,13 @@
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{ISO8601} %-5p %c{1}:%L - %m%n"/>
         </Console>
-        <File name="RequestLogsFile" fileName="target/logs/request_logs.log">
+        <File name="RequestLogsFile" fileName="build/logs/request_logs.log">
             <PatternLayout pattern="%d{ISO8601} %-5p %c{1}:%L - %m%n"/>
         </File>
-        <File name="KildaLogFile" fileName="target/logs/logs.log">
+        <File name="KildaLogFile" fileName="build/logs/logs.log">
             <PatternLayout pattern="%d{ISO8601} %-5p %c{1}:%L - %m%n"/>
         </File>
-        <File name="SkippedTestsFile" fileName="target/logs/skipped_tests.log" append="false">
+        <File name="SkippedTestsFile" fileName="build/logs/skipped_tests.log" append="false">
             <PatternLayout pattern="%m%n%n"/>
         </File>
     </Appenders>


### PR DESCRIPTION
- Upgrade spock-reports version and allow code blocks in spock reports