### PR TITLE
SpeakerRequestBuildContext refactoring

### DIFF
--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/model/SpeakerRequestBuildContext.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/model/SpeakerRequestBuildContext.java
@@ -25,10 +25,19 @@ import lombok.EqualsAndHashCode;
 @AllArgsConstructor
 @EqualsAndHashCode
 public class SpeakerRequestBuildContext {
-    private boolean removeCustomerPortRule;
-    private boolean removeOppositeCustomerPortRule;
-    private boolean removeCustomerPortLldpRule;
-    private boolean removeOppositeCustomerPortLldpRule;
-    private boolean removeCustomerPortArpRule;
-    private boolean removeOppositeCustomerPortArpRule;
+    public static final SpeakerRequestBuildContext EMPTY = SpeakerRequestBuildContext.builder()
+            .forward(PathContext.builder().build())
+            .reverse(PathContext.builder().build())
+            .build();
+
+    private PathContext forward;
+    private PathContext reverse;
+
+    @Data
+    @Builder
+    public static class PathContext {
+        private boolean removeCustomerPortRule;
+        private boolean removeCustomerPortLldpRule;
+        private boolean removeCustomerPortArpRule;
+    }
 }

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/service/SpeakerFlowSegmentRequestBuilder.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/service/SpeakerFlowSegmentRequestBuilder.java
@@ -24,7 +24,7 @@ import org.openkilda.floodlight.api.request.factory.IngressFlowSegmentRequestFac
 import org.openkilda.floodlight.api.request.factory.OneSwitchFlowRequestFactory;
 import org.openkilda.floodlight.api.request.factory.TransitFlowSegmentRequestFactory;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowEncapsulationType;
@@ -122,7 +122,7 @@ public class SpeakerFlowSegmentRequestBuilder implements FlowCommandBuilder {
         }
 
         List<FlowSegmentRequestFactory> requests = new ArrayList<>(makePathRequests(flow, path, context, encapsulation,
-                doIngress, doTransit, doEgress, new RemoveSharedRulesContext(
+                doIngress, doTransit, doEgress, new RulesContext(
                         speakerRequestBuildContext.isRemoveCustomerPortRule(),
                         speakerRequestBuildContext.isRemoveCustomerPortLldpRule(),
                         speakerRequestBuildContext.isRemoveCustomerPortArpRule())));
@@ -132,7 +132,7 @@ public class SpeakerFlowSegmentRequestBuilder implements FlowCommandBuilder {
                         flow.getEncapsulationType(), oppositePath.getPathId(), path.getPathId());
             }
             requests.addAll(makePathRequests(flow, oppositePath, context, encapsulation, doIngress, doTransit, doEgress,
-                    new RemoveSharedRulesContext(
+                    new RulesContext(
                             speakerRequestBuildContext.isRemoveOppositeCustomerPortRule(),
                             speakerRequestBuildContext.isRemoveOppositeCustomerPortLldpRule(),
                             speakerRequestBuildContext.isRemoveOppositeCustomerPortArpRule())));
@@ -143,7 +143,7 @@ public class SpeakerFlowSegmentRequestBuilder implements FlowCommandBuilder {
     @SuppressWarnings("squid:S00107")
     private List<FlowSegmentRequestFactory> makePathRequests(
             @NonNull Flow flow, @NonNull FlowPath path, CommandContext context, FlowTransitEncapsulation encapsulation,
-            boolean doIngress, boolean doTransit, boolean doEgress, RemoveSharedRulesContext removeSharedRulesContext) {
+            boolean doIngress, boolean doTransit, boolean doEgress, RulesContext rulesContext) {
         final FlowSideAdapter ingressSide = FlowSideAdapter.makeIngressAdapter(flow, path);
         final FlowSideAdapter egressSide = FlowSideAdapter.makeEgressAdapter(flow, path);
 
@@ -154,7 +154,7 @@ public class SpeakerFlowSegmentRequestBuilder implements FlowCommandBuilder {
             if (lastSegment == null) {
                 if (doIngress) {
                     requests.add(makeIngressRequest(context, path, encapsulation, ingressSide, segment, egressSide,
-                            removeSharedRulesContext));
+                            rulesContext));
                 }
             } else {
                 if (doTransit) {
@@ -170,7 +170,7 @@ public class SpeakerFlowSegmentRequestBuilder implements FlowCommandBuilder {
             }
         } else if (doIngress) {
             // one switch flow (path without path segments)
-            requests.add(makeOneSwitchRequest(context, path, ingressSide, egressSide, removeSharedRulesContext));
+            requests.add(makeOneSwitchRequest(context, path, ingressSide, egressSide, rulesContext));
         }
 
         return requests;
@@ -179,7 +179,7 @@ public class SpeakerFlowSegmentRequestBuilder implements FlowCommandBuilder {
     private FlowSegmentRequestFactory makeIngressRequest(
             CommandContext context, FlowPath path, FlowTransitEncapsulation encapsulation,
             FlowSideAdapter flowSide, PathSegment segment, FlowSideAdapter egressFlowSide,
-            RemoveSharedRulesContext removeSharedRulesContext) {
+            RulesContext rulesContext) {
         PathSegmentSide segmentSide = makePathSegmentSourceSide(segment);
 
         UUID commandId = commandIdGenerator.generate();
@@ -197,7 +197,7 @@ public class SpeakerFlowSegmentRequestBuilder implements FlowCommandBuilder {
                 .egressSwitchId(egressFlowSide.getEndpoint().getSwitchId())
                 .islPort(segmentSide.getEndpoint().getPortNumber())
                 .encapsulation(encapsulation)
-                .removeSharedRulesContext(removeSharedRulesContext)
+                .rulesContext(rulesContext)
                 .build();
     }
 
@@ -256,7 +256,7 @@ public class SpeakerFlowSegmentRequestBuilder implements FlowCommandBuilder {
 
     private FlowSegmentRequestFactory makeOneSwitchRequest(
             CommandContext context, FlowPath path, FlowSideAdapter ingressSide, FlowSideAdapter egressSide,
-            RemoveSharedRulesContext removeSharedRulesContext) {
+            RulesContext rulesContext) {
         Flow flow = ingressSide.getFlow();
 
         UUID commandId = commandIdGenerator.generate();
@@ -271,7 +271,7 @@ public class SpeakerFlowSegmentRequestBuilder implements FlowCommandBuilder {
                 .endpoint(ingressSide.getEndpoint())
                 .meterConfig(getMeterConfig(path))
                 .egressEndpoint(egressSide.getEndpoint())
-                .removeSharedRulesContext(removeSharedRulesContext)
+                .rulesContext(rulesContext)
                 .build();
     }
 

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/IngressFlowSegmentBase.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/IngressFlowSegmentBase.java
@@ -16,7 +16,7 @@
 package org.openkilda.floodlight.api.request;
 
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.MeterConfig;
@@ -43,18 +43,18 @@ abstract class IngressFlowSegmentBase extends FlowSegmentRequest {
     @JsonProperty("egress_switch")
     protected final SwitchId egressSwitchId;
 
-    @JsonProperty("remove_shared_rules_context")
-    protected final RemoveSharedRulesContext removeSharedRulesContext;
+    @JsonProperty("rules_context")
+    protected final RulesContext rulesContext;
 
     IngressFlowSegmentBase(
             MessageContext context, UUID commandId, FlowSegmentMetadata metadata, @NonNull FlowEndpoint endpoint,
             MeterConfig meterConfig, @NonNull SwitchId egressSwitchId,
-            RemoveSharedRulesContext removeSharedRulesContext) {
+            RulesContext rulesContext) {
         super(context, endpoint.getSwitchId(), commandId, metadata);
 
         this.endpoint = endpoint;
         this.meterConfig = meterConfig;
         this.egressSwitchId = egressSwitchId;
-        this.removeSharedRulesContext = removeSharedRulesContext;
+        this.rulesContext = rulesContext;
     }
 }

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/IngressFlowSegmentInstallRequest.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/IngressFlowSegmentInstallRequest.java
@@ -16,7 +16,7 @@
 package org.openkilda.floodlight.api.request;
 
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowTransitEncapsulation;
@@ -49,9 +49,9 @@ public class IngressFlowSegmentInstallRequest extends IngressFlowSegmentRequest 
             @JsonProperty("egress_switch") SwitchId egressSwitchId,
             @JsonProperty("isl_port") int islPort,
             @JsonProperty("encapsulation") FlowTransitEncapsulation encapsulation,
-            @JsonProperty("remove_shared_rules_context") RemoveSharedRulesContext removeSharedRulesContext) {
+            @JsonProperty("rules_context") RulesContext rulesContext) {
         super(messageContext, commandId, metadata, endpoint, meterConfig, egressSwitchId, islPort, encapsulation,
-                removeSharedRulesContext);
+                rulesContext);
     }
 
     public IngressFlowSegmentInstallRequest(IngressFlowSegmentRequest other, UUID commandId) {

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/IngressFlowSegmentRemoveRequest.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/IngressFlowSegmentRemoveRequest.java
@@ -16,7 +16,7 @@
 package org.openkilda.floodlight.api.request;
 
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowTransitEncapsulation;
@@ -49,9 +49,9 @@ public class IngressFlowSegmentRemoveRequest extends IngressFlowSegmentRequest {
             @JsonProperty("egress_switch") SwitchId egressSwitchId,
             @JsonProperty("isl_port") int islPort,
             @JsonProperty("encapsulation") FlowTransitEncapsulation encapsulation,
-            @JsonProperty("remove_shared_rules_context") RemoveSharedRulesContext removeSharedRulesContext) {
+            @JsonProperty("rules_context") RulesContext rulesContext) {
         super(messageContext, commandId, metadata, endpoint, meterConfig, egressSwitchId, islPort, encapsulation,
-                removeSharedRulesContext);
+                rulesContext);
     }
 
     public IngressFlowSegmentRemoveRequest(IngressFlowSegmentRequest other, UUID commandId) {

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/IngressFlowSegmentRequest.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/IngressFlowSegmentRequest.java
@@ -16,7 +16,7 @@
 package org.openkilda.floodlight.api.request;
 
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowTransitEncapsulation;
@@ -47,8 +47,8 @@ public abstract class IngressFlowSegmentRequest extends IngressFlowSegmentBase {
     protected IngressFlowSegmentRequest(
             MessageContext context, UUID commandId, FlowSegmentMetadata metadata,
             FlowEndpoint endpoint, MeterConfig meterConfig, SwitchId egressSwitchId, int islPort,
-            @NonNull FlowTransitEncapsulation encapsulation, RemoveSharedRulesContext removeSharedRulesContext) {
-        super(context, commandId, metadata, endpoint, meterConfig, egressSwitchId, removeSharedRulesContext);
+            @NonNull FlowTransitEncapsulation encapsulation, RulesContext rulesContext) {
+        super(context, commandId, metadata, endpoint, meterConfig, egressSwitchId, rulesContext);
 
         this.islPort = islPort;
         this.encapsulation = encapsulation;
@@ -57,6 +57,6 @@ public abstract class IngressFlowSegmentRequest extends IngressFlowSegmentBase {
     protected IngressFlowSegmentRequest(@NonNull IngressFlowSegmentRequest other, @NonNull UUID commandId) {
         this(
                 other.messageContext, commandId, other.metadata, other.endpoint, other.meterConfig,
-                other.egressSwitchId, other.islPort, other.encapsulation, other.removeSharedRulesContext);
+                other.egressSwitchId, other.islPort, other.encapsulation, other.rulesContext);
     }
 }

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/IngressFlowSegmentVerifyRequest.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/IngressFlowSegmentVerifyRequest.java
@@ -16,7 +16,7 @@
 package org.openkilda.floodlight.api.request;
 
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowTransitEncapsulation;
@@ -49,9 +49,9 @@ public class IngressFlowSegmentVerifyRequest extends IngressFlowSegmentRequest {
             @JsonProperty("egress_switch") SwitchId egressSwitchId,
             @JsonProperty("isl_port") int islPort,
             @JsonProperty("encapsulation") FlowTransitEncapsulation encapsulation,
-            @JsonProperty("remove_shared_rules_context") RemoveSharedRulesContext removeSharedRulesContext) {
+            @JsonProperty("rules_context") RulesContext rulesContext) {
         super(messageContext, commandId, metadata, endpoint, meterConfig, egressSwitchId, islPort, encapsulation,
-                removeSharedRulesContext);
+                rulesContext);
     }
 
     public IngressFlowSegmentVerifyRequest(IngressFlowSegmentRequest other, UUID commandId) {

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/OneSwitchFlowInstallRequest.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/OneSwitchFlowInstallRequest.java
@@ -16,7 +16,7 @@
 package org.openkilda.floodlight.api.request;
 
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.MeterConfig;
@@ -45,8 +45,8 @@ public class OneSwitchFlowInstallRequest extends OneSwitchFlowRequest {
             @JsonProperty("endpoint") FlowEndpoint endpoint,
             @JsonProperty("meter_config") MeterConfig meterConfig,
             @JsonProperty("egress_endpoint") FlowEndpoint egressEndpoint,
-            @JsonProperty("remove_shared_rules_context") RemoveSharedRulesContext removeSharedRulesContext) {
-        super(messageContext, commandId, metadata, endpoint, meterConfig, egressEndpoint, removeSharedRulesContext);
+            @JsonProperty("rules_context") RulesContext rulesContext) {
+        super(messageContext, commandId, metadata, endpoint, meterConfig, egressEndpoint, rulesContext);
     }
 
     public OneSwitchFlowInstallRequest(OneSwitchFlowRequest other, UUID commandId) {

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/OneSwitchFlowRemoveRequest.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/OneSwitchFlowRemoveRequest.java
@@ -16,7 +16,7 @@
 package org.openkilda.floodlight.api.request;
 
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.MeterConfig;
@@ -45,8 +45,8 @@ public class OneSwitchFlowRemoveRequest extends OneSwitchFlowRequest {
             @JsonProperty("endpoint") FlowEndpoint endpoint,
             @JsonProperty("meter_config") MeterConfig meterConfig,
             @JsonProperty("egress_endpoint") FlowEndpoint egressEndpoint,
-            @JsonProperty("remove_shared_rules_context") RemoveSharedRulesContext removeSharedRulesContext) {
-        super(messageContext, commandId, metadata, endpoint, meterConfig, egressEndpoint, removeSharedRulesContext);
+            @JsonProperty("rules_context") RulesContext rulesContext) {
+        super(messageContext, commandId, metadata, endpoint, meterConfig, egressEndpoint, rulesContext);
     }
 
     public OneSwitchFlowRemoveRequest(OneSwitchFlowRequest other, UUID commandId) {

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/OneSwitchFlowRequest.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/OneSwitchFlowRequest.java
@@ -16,7 +16,7 @@
 package org.openkilda.floodlight.api.request;
 
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.MeterConfig;
@@ -41,9 +41,9 @@ public class OneSwitchFlowRequest extends IngressFlowSegmentBase {
     protected OneSwitchFlowRequest(
             MessageContext context, UUID commandId, FlowSegmentMetadata metadata, FlowEndpoint endpoint,
             MeterConfig meterConfig, @NonNull FlowEndpoint egressEndpoint,
-            RemoveSharedRulesContext removeSharedRulesContext) {
+            RulesContext rulesContext) {
         super(context, commandId, metadata, endpoint, meterConfig, egressEndpoint.getSwitchId(),
-                removeSharedRulesContext);
+                rulesContext);
 
         if (! getSwitchId().equals(egressEndpoint.getSwitchId())) {
             throw new IllegalArgumentException(String.format(
@@ -57,6 +57,6 @@ public class OneSwitchFlowRequest extends IngressFlowSegmentBase {
     protected OneSwitchFlowRequest(@NonNull OneSwitchFlowRequest other, @NonNull UUID commandId) {
         this(
                 other.messageContext, commandId, other.metadata, other.endpoint, other.meterConfig,
-                other.egressEndpoint, other.removeSharedRulesContext);
+                other.egressEndpoint, other.rulesContext);
     }
 }

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/OneSwitchFlowVerifyRequest.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/OneSwitchFlowVerifyRequest.java
@@ -16,7 +16,7 @@
 package org.openkilda.floodlight.api.request;
 
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.MeterConfig;
@@ -45,9 +45,9 @@ public class OneSwitchFlowVerifyRequest extends OneSwitchFlowRequest {
             @JsonProperty("endpoint") FlowEndpoint endpoint,
             @JsonProperty("meter_config") MeterConfig meterConfig,
             @JsonProperty("egress_endpoint") FlowEndpoint egressEndpoint,
-            @JsonProperty("remove_shared_rules_context") RemoveSharedRulesContext removeSharedRulesContext) {
+            @JsonProperty("rules_context") RulesContext rulesContext) {
         super(messageContext, commandId, metadata, endpoint, meterConfig, egressEndpoint,
-                removeSharedRulesContext);
+                rulesContext);
     }
 
     public OneSwitchFlowVerifyRequest(OneSwitchFlowRequest other, UUID commandId) {

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/factory/IngressFlowSegmentRequestFactory.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/factory/IngressFlowSegmentRequestFactory.java
@@ -20,7 +20,7 @@ import org.openkilda.floodlight.api.request.IngressFlowSegmentRemoveRequest;
 import org.openkilda.floodlight.api.request.IngressFlowSegmentRequest;
 import org.openkilda.floodlight.api.request.IngressFlowSegmentVerifyRequest;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowTransitEncapsulation;
@@ -39,9 +39,9 @@ public class IngressFlowSegmentRequestFactory extends FlowSegmentRequestFactory 
     public IngressFlowSegmentRequestFactory(
             MessageContext messageContext, FlowSegmentMetadata metadata,
             FlowEndpoint endpoint, MeterConfig meterConfig, SwitchId egressSwitchId, int islPort,
-            FlowTransitEncapsulation encapsulation, RemoveSharedRulesContext removeSharedRulesContext) {
+            FlowTransitEncapsulation encapsulation, RulesContext rulesContext) {
         this(new RequestBlank(messageContext, metadata, endpoint, meterConfig, egressSwitchId, islPort, encapsulation,
-                removeSharedRulesContext));
+                rulesContext));
     }
 
     private IngressFlowSegmentRequestFactory(IngressFlowSegmentRequest requestBlank) {
@@ -68,9 +68,9 @@ public class IngressFlowSegmentRequestFactory extends FlowSegmentRequestFactory 
         RequestBlank(
                 MessageContext context, FlowSegmentMetadata metadata,
                 FlowEndpoint endpoint, MeterConfig meterConfig, SwitchId egressSwitchId, int islPort,
-                FlowTransitEncapsulation encapsulation, RemoveSharedRulesContext removeSharedRulesContext) {
+                FlowTransitEncapsulation encapsulation, RulesContext rulesContext) {
             super(context, dummyCommandId, metadata, endpoint, meterConfig, egressSwitchId, islPort, encapsulation,
-                    removeSharedRulesContext);
+                    rulesContext);
         }
     }
 }

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/factory/OneSwitchFlowRequestFactory.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/factory/OneSwitchFlowRequestFactory.java
@@ -20,7 +20,7 @@ import org.openkilda.floodlight.api.request.OneSwitchFlowRemoveRequest;
 import org.openkilda.floodlight.api.request.OneSwitchFlowRequest;
 import org.openkilda.floodlight.api.request.OneSwitchFlowVerifyRequest;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.MeterConfig;
@@ -35,9 +35,9 @@ public class OneSwitchFlowRequestFactory extends FlowSegmentRequestFactory {
     @Builder
     public OneSwitchFlowRequestFactory(
             MessageContext messageContext, FlowSegmentMetadata metadata, FlowEndpoint endpoint, MeterConfig meterConfig,
-            FlowEndpoint egressEndpoint, RemoveSharedRulesContext removeSharedRulesContext) {
+            FlowEndpoint egressEndpoint, RulesContext rulesContext) {
         this(new RequestBlank(messageContext, metadata, endpoint, meterConfig, egressEndpoint,
-                removeSharedRulesContext));
+                rulesContext));
     }
 
     private OneSwitchFlowRequestFactory(OneSwitchFlowRequest requestBlank) {
@@ -63,8 +63,8 @@ public class OneSwitchFlowRequestFactory extends FlowSegmentRequestFactory {
     private static class RequestBlank extends OneSwitchFlowRequest {
         RequestBlank(
                 MessageContext context, FlowSegmentMetadata metadata, FlowEndpoint endpoint, MeterConfig meterConfig,
-                FlowEndpoint egressEndpoint, RemoveSharedRulesContext removeSharedRulesContext) {
-            super(context, dummyCommandId, metadata, endpoint, meterConfig, egressEndpoint, removeSharedRulesContext);
+                FlowEndpoint egressEndpoint, RulesContext rulesContext) {
+            super(context, dummyCommandId, metadata, endpoint, meterConfig, egressEndpoint, rulesContext);
         }
     }
 }

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/model/RulesContext.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/model/RulesContext.java
@@ -29,7 +29,7 @@ import java.io.Serializable;
 @AllArgsConstructor
 @JsonNaming(value = SnakeCaseStrategy.class)
 @Builder
-public class RemoveSharedRulesContext implements Serializable {
+public class RulesContext implements Serializable {
     private boolean removeCustomerCatchRule;
     private boolean removeCustomerLldpRule;
     private boolean removeCustomerArpRule;

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentBase.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentBase.java
@@ -29,7 +29,7 @@ import org.openkilda.floodlight.command.meter.MeterVerifyCommand;
 import org.openkilda.floodlight.command.meter.MeterVerifyReport;
 import org.openkilda.floodlight.error.UnsupportedSwitchOperationException;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.floodlight.service.session.Session;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
@@ -62,7 +62,7 @@ public abstract class IngressFlowSegmentBase extends FlowSegmentCommand {
     protected final FlowEndpoint endpoint;
     protected final MeterConfig meterConfig;
     protected final SwitchId egressSwitchId;
-    protected final RemoveSharedRulesContext removeSharedRulesContext;
+    protected final RulesContext rulesContext;
 
     // operation data
     @Getter(AccessLevel.PROTECTED)
@@ -72,12 +72,12 @@ public abstract class IngressFlowSegmentBase extends FlowSegmentCommand {
     IngressFlowSegmentBase(
             MessageContext messageContext, SwitchId switchId, UUID commandId, FlowSegmentMetadata metadata,
             @NonNull FlowEndpoint endpoint, MeterConfig meterConfig, @NonNull SwitchId egressSwitchId,
-            RemoveSharedRulesContext removeSharedRulesContext) {
+            RulesContext rulesContext) {
         super(messageContext, switchId, commandId, metadata);
         this.endpoint = endpoint;
         this.meterConfig = meterConfig;
         this.egressSwitchId = egressSwitchId;
-        this.removeSharedRulesContext = removeSharedRulesContext;
+        this.rulesContext = rulesContext;
     }
 
     @Override

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentCommand.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentCommand.java
@@ -16,7 +16,7 @@
 package org.openkilda.floodlight.command.flow.ingress;
 
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowTransitEncapsulation;
@@ -38,10 +38,10 @@ public abstract class IngressFlowSegmentCommand extends IngressFlowSegmentBase {
     IngressFlowSegmentCommand(
             MessageContext messageContext, UUID commandId, FlowSegmentMetadata metadata,
             FlowEndpoint endpoint, MeterConfig meterConfig, SwitchId egressSwitchId, int islPort,
-            @NonNull FlowTransitEncapsulation encapsulation, RemoveSharedRulesContext removeSharedRulesContext) {
+            @NonNull FlowTransitEncapsulation encapsulation, RulesContext rulesContext) {
         super(
                 messageContext, endpoint.getSwitchId(), commandId, metadata, endpoint, meterConfig,
-                egressSwitchId, removeSharedRulesContext);
+                egressSwitchId, rulesContext);
         this.islPort = islPort;
         this.encapsulation = encapsulation;
     }

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentInstallCommand.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentInstallCommand.java
@@ -20,7 +20,7 @@ import org.openkilda.floodlight.command.flow.FlowSegmentReport;
 import org.openkilda.floodlight.command.flow.ingress.of.IngressFlowSegmentInstallMultiTableFlowModFactory;
 import org.openkilda.floodlight.command.flow.ingress.of.IngressFlowSegmentInstallSingleTableFlowModFactory;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.FlowEndpoint;
@@ -53,9 +53,9 @@ public class IngressFlowSegmentInstallCommand extends IngressFlowSegmentCommand 
             @JsonProperty("egress_switch") SwitchId egressSwitchId,
             @JsonProperty("isl_port") int islPort,
             @JsonProperty("encapsulation") FlowTransitEncapsulation encapsulation,
-            @JsonProperty("remove_shared_rules_context") RemoveSharedRulesContext removeSharedRulesContext) {
+            @JsonProperty("rules_context") RulesContext rulesContext) {
         super(context, commandId, metadata, endpoint, meterConfig, egressSwitchId, islPort, encapsulation,
-                removeSharedRulesContext);
+                rulesContext);
     }
 
     @Override

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentRemoveCommand.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentRemoveCommand.java
@@ -20,7 +20,7 @@ import org.openkilda.floodlight.command.flow.FlowSegmentReport;
 import org.openkilda.floodlight.command.flow.ingress.of.IngressFlowSegmentRemoveMultiTableFlowModFactory;
 import org.openkilda.floodlight.command.flow.ingress.of.IngressFlowSegmentRemoveSingleTableFlowModFactory;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowTransitEncapsulation;
@@ -46,9 +46,9 @@ public class IngressFlowSegmentRemoveCommand extends IngressFlowSegmentCommand {
             @JsonProperty("egress_switch") SwitchId egressSwitchId,
             @JsonProperty("isl_port") int islPort,
             @JsonProperty("encapsulation") FlowTransitEncapsulation encapsulation,
-            @JsonProperty("remove_shared_rules_context") RemoveSharedRulesContext removeSharedRulesContext) {
+            @JsonProperty("rules_context") RulesContext rulesContext) {
         super(context, commandId, metadata, endpoint, meterConfig, egressSwitchId, islPort, encapsulation,
-                removeSharedRulesContext);
+                rulesContext);
     }
 
     @Override
@@ -70,14 +70,14 @@ public class IngressFlowSegmentRemoveCommand extends IngressFlowSegmentCommand {
     @Override
     protected List<OFFlowMod> makeIngressModMessages(MeterId effectiveMeterId) {
         List<OFFlowMod> ofMessages = super.makeIngressModMessages(effectiveMeterId);
-        if (removeSharedRulesContext != null) {
-            if (removeSharedRulesContext.isRemoveCustomerCatchRule()) {
+        if (rulesContext != null) {
+            if (rulesContext.isRemoveCustomerCatchRule()) {
                 ofMessages.add(getFlowModFactory().makeCustomerPortSharedCatchMessage());
             }
-            if (removeSharedRulesContext.isRemoveCustomerLldpRule()) {
+            if (rulesContext.isRemoveCustomerLldpRule()) {
                 ofMessages.add(getFlowModFactory().makeLldpInputCustomerFlowMessage());
             }
-            if (removeSharedRulesContext.isRemoveCustomerArpRule()) {
+            if (rulesContext.isRemoveCustomerArpRule()) {
                 ofMessages.add(getFlowModFactory().makeArpInputCustomerFlowMessage());
             }
         }

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentVerifyCommand.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentVerifyCommand.java
@@ -18,7 +18,7 @@ package org.openkilda.floodlight.command.flow.ingress;
 import org.openkilda.floodlight.command.SpeakerCommandProcessor;
 import org.openkilda.floodlight.command.flow.FlowSegmentReport;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowTransitEncapsulation;
@@ -43,9 +43,9 @@ public class IngressFlowSegmentVerifyCommand extends IngressFlowSegmentInstallCo
             @JsonProperty("egress_switch") SwitchId egressSwitchId,
             @JsonProperty("isl_port") int islPort,
             @JsonProperty("encapsulation") FlowTransitEncapsulation encapsulation,
-            @JsonProperty("remove_shared_rules_context") RemoveSharedRulesContext removeSharedRulesContext) {
+            @JsonProperty("rules_context") RulesContext rulesContext) {
         super(context, commandId, metadata, endpoint, meterConfig, egressSwitchId, islPort, encapsulation,
-                removeSharedRulesContext);
+                rulesContext);
     }
 
     @Override

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/OneSwitchFlowCommand.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/OneSwitchFlowCommand.java
@@ -16,7 +16,7 @@
 package org.openkilda.floodlight.command.flow.ingress;
 
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.MeterConfig;
@@ -33,10 +33,10 @@ public abstract class OneSwitchFlowCommand extends IngressFlowSegmentBase {
     OneSwitchFlowCommand(
             MessageContext messageContext, UUID commandId, FlowSegmentMetadata metadata,
             FlowEndpoint endpoint, MeterConfig meterConfig, @NonNull FlowEndpoint egressEndpoint,
-            RemoveSharedRulesContext removeSharedRulesContext) {
+            RulesContext rulesContext) {
         super(
                 messageContext, endpoint.getSwitchId(), commandId, metadata, endpoint, meterConfig,
-                egressEndpoint.getSwitchId(), removeSharedRulesContext);
+                egressEndpoint.getSwitchId(), rulesContext);
         this.egressEndpoint = egressEndpoint;
     }
 

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/OneSwitchFlowInstallCommand.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/OneSwitchFlowInstallCommand.java
@@ -20,7 +20,7 @@ import org.openkilda.floodlight.command.flow.FlowSegmentReport;
 import org.openkilda.floodlight.command.flow.ingress.of.OneSwitchFlowInstallMultiTableFlowModFactory;
 import org.openkilda.floodlight.command.flow.ingress.of.OneSwitchFlowInstallSingleTableFlowModFactory;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.MeterConfig;
@@ -44,8 +44,8 @@ public class OneSwitchFlowInstallCommand extends OneSwitchFlowCommand {
             @JsonProperty("endpoint") FlowEndpoint endpoint,
             @JsonProperty("meter_config") MeterConfig meterConfig,
             @JsonProperty("egress_endpoint") FlowEndpoint egressEndpoint,
-            @JsonProperty("remove_shared_rules_context") RemoveSharedRulesContext removeSharedRulesContext) {
-        super(context, commandId, metadata, endpoint, meterConfig, egressEndpoint, removeSharedRulesContext);
+            @JsonProperty("rules_context") RulesContext rulesContext) {
+        super(context, commandId, metadata, endpoint, meterConfig, egressEndpoint, rulesContext);
     }
 
     @Override

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/OneSwitchFlowRemoveCommand.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/OneSwitchFlowRemoveCommand.java
@@ -20,7 +20,7 @@ import org.openkilda.floodlight.command.flow.FlowSegmentReport;
 import org.openkilda.floodlight.command.flow.ingress.of.OneSwitchFlowRemoveMultiTableFlowModFactory;
 import org.openkilda.floodlight.command.flow.ingress.of.OneSwitchFlowRemoveSingleTableFlowModFactory;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.MeterConfig;
@@ -44,8 +44,8 @@ public class OneSwitchFlowRemoveCommand extends OneSwitchFlowCommand {
             @JsonProperty("endpoint") FlowEndpoint endpoint,
             @JsonProperty("meter_config") MeterConfig meterConfig,
             @JsonProperty("egress_endpoint") FlowEndpoint egressEndpoint,
-            @JsonProperty("remove_shared_rules_context") RemoveSharedRulesContext removeSharedRulesContext) {
-        super(context, commandId, metadata, endpoint, meterConfig, egressEndpoint, removeSharedRulesContext);
+            @JsonProperty("rules_context") RulesContext rulesContext) {
+        super(context, commandId, metadata, endpoint, meterConfig, egressEndpoint, rulesContext);
     }
 
     @Override
@@ -65,14 +65,14 @@ public class OneSwitchFlowRemoveCommand extends OneSwitchFlowCommand {
     @Override
     protected List<OFFlowMod> makeIngressModMessages(MeterId effectiveMeterId) {
         List<OFFlowMod> ofMessages = super.makeIngressModMessages(effectiveMeterId);
-        if (removeSharedRulesContext != null) {
-            if (removeSharedRulesContext.isRemoveCustomerCatchRule()) {
+        if (rulesContext != null) {
+            if (rulesContext.isRemoveCustomerCatchRule()) {
                 ofMessages.add(getFlowModFactory().makeCustomerPortSharedCatchMessage());
             }
-            if (removeSharedRulesContext.isRemoveCustomerLldpRule()) {
+            if (rulesContext.isRemoveCustomerLldpRule()) {
                 ofMessages.add(getFlowModFactory().makeLldpInputCustomerFlowMessage());
             }
-            if (removeSharedRulesContext.isRemoveCustomerArpRule()) {
+            if (rulesContext.isRemoveCustomerArpRule()) {
                 ofMessages.add(getFlowModFactory().makeArpInputCustomerFlowMessage());
             }
         }

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/OneSwitchFlowVerifyCommand.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/OneSwitchFlowVerifyCommand.java
@@ -18,7 +18,7 @@ package org.openkilda.floodlight.command.flow.ingress;
 import org.openkilda.floodlight.command.SpeakerCommandProcessor;
 import org.openkilda.floodlight.command.flow.FlowSegmentReport;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.MeterConfig;
@@ -39,8 +39,8 @@ public class OneSwitchFlowVerifyCommand extends OneSwitchFlowInstallCommand {
             @JsonProperty("endpoint") FlowEndpoint endpoint,
             @JsonProperty("meter_config") MeterConfig meterConfig,
             @JsonProperty("egress_endpoint") FlowEndpoint egressEndpoint,
-            @JsonProperty("remove_shared_rules_context") RemoveSharedRulesContext removeSharedRulesContext) {
-        super(context, commandId, metadata, endpoint, meterConfig, egressEndpoint, removeSharedRulesContext);
+            @JsonProperty("rules_context") RulesContext rulesContext) {
+        super(context, commandId, metadata, endpoint, meterConfig, egressEndpoint, rulesContext);
     }
 
     @Override

--- a/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentCommandJsonTest.java
+++ b/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentCommandJsonTest.java
@@ -19,7 +19,7 @@ import org.openkilda.floodlight.api.request.IngressFlowSegmentRequest;
 import org.openkilda.floodlight.api.request.factory.IngressFlowSegmentRequestFactory;
 import org.openkilda.floodlight.command.AbstractSpeakerCommandJsonTest;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.Cookie;
 import org.openkilda.model.FlowEncapsulationType;
@@ -42,7 +42,7 @@ abstract class IngressFlowSegmentCommandJsonTest
         Assert.assertEquals(request.getMeterConfig(), command.getMeterConfig());
         Assert.assertEquals(request.getIslPort(), command.getIslPort());
         Assert.assertEquals(request.getEncapsulation(), command.getEncapsulation());
-        Assert.assertEquals(request.getRemoveSharedRulesContext(), command.getRemoveSharedRulesContext());
+        Assert.assertEquals(request.getRulesContext(), command.getRulesContext());
     }
 
     @Override
@@ -56,7 +56,7 @@ abstract class IngressFlowSegmentCommandJsonTest
                 new SwitchId(20),
                 8,
                 new FlowTransitEncapsulation(9, FlowEncapsulationType.TRANSIT_VLAN),
-                RemoveSharedRulesContext.builder().build());
+                RulesContext.builder().build());
         return makeRequest(factory);
     }
 

--- a/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentInstallCommandTest.java
+++ b/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentInstallCommandTest.java
@@ -19,7 +19,7 @@ import org.openkilda.floodlight.command.flow.ingress.of.IngressFlowModFactory;
 import org.openkilda.floodlight.command.flow.ingress.of.IngressFlowSegmentInstallMultiTableFlowModFactory;
 import org.openkilda.floodlight.command.flow.ingress.of.IngressFlowSegmentInstallSingleTableFlowModFactory;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowTransitEncapsulation;
@@ -82,7 +82,7 @@ public class IngressFlowSegmentInstallCommandTest extends IngressCommandInstallT
         UUID commandId = UUID.randomUUID();
         return new CommandStub(
                 new MessageContext(commandId.toString()), commandId, metadata, endpoint, meterConfig,
-                egressEndpoint.getSwitchId(), 6, encapsulationVlan, RemoveSharedRulesContext.builder().build());
+                egressEndpoint.getSwitchId(), 6, encapsulationVlan, RulesContext.builder().build());
     }
 
     static class CommandStub extends IngressFlowSegmentInstallCommand implements IFlowModFactoryOverride {
@@ -92,9 +92,9 @@ public class IngressFlowSegmentInstallCommandTest extends IngressCommandInstallT
         public CommandStub(
                 MessageContext context, UUID commandId, FlowSegmentMetadata metadata, FlowEndpoint endpoint,
                 MeterConfig meterConfig, SwitchId egressSwitchId, Integer islPort,
-                FlowTransitEncapsulation encapsulation, RemoveSharedRulesContext removeSharedRulesContext) {
+                FlowTransitEncapsulation encapsulation, RulesContext rulesContext) {
             super(context, commandId, metadata, endpoint, meterConfig, egressSwitchId, islPort, encapsulation,
-                    removeSharedRulesContext);
+                    rulesContext);
         }
 
         @Override

--- a/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentRemoveCommandTest.java
+++ b/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentRemoveCommandTest.java
@@ -19,7 +19,7 @@ import org.openkilda.floodlight.command.flow.ingress.of.IngressFlowModFactory;
 import org.openkilda.floodlight.command.flow.ingress.of.IngressFlowSegmentRemoveMultiTableFlowModFactory;
 import org.openkilda.floodlight.command.flow.ingress.of.IngressFlowSegmentRemoveSingleTableFlowModFactory;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowTransitEncapsulation;
@@ -68,7 +68,7 @@ public class IngressFlowSegmentRemoveCommandTest extends IngressCommandRemoveTes
         UUID commandId = UUID.randomUUID();
         return new CommandStub(
                 new MessageContext(commandId.toString()), commandId, metadata, endpoint, meterConfig,
-                egressEndpoint.getSwitchId(), 6, encapsulationVlan, RemoveSharedRulesContext.builder().build());
+                egressEndpoint.getSwitchId(), 6, encapsulationVlan, RulesContext.builder().build());
     }
 
     static class CommandStub extends IngressFlowSegmentRemoveCommand implements IFlowModFactoryOverride {
@@ -78,9 +78,9 @@ public class IngressFlowSegmentRemoveCommandTest extends IngressCommandRemoveTes
         public CommandStub(
                 MessageContext context, UUID commandId, FlowSegmentMetadata metadata, FlowEndpoint endpoint,
                 MeterConfig meterConfig, SwitchId egressSwitchId, Integer islPort,
-                FlowTransitEncapsulation encapsulation, RemoveSharedRulesContext removeSharedRulesContext) {
+                FlowTransitEncapsulation encapsulation, RulesContext rulesContext) {
             super(context, commandId, metadata, endpoint, meterConfig, egressSwitchId, islPort, encapsulation,
-                    removeSharedRulesContext);
+                    rulesContext);
         }
 
         @Override

--- a/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/ingress/OneSwitchFlowCommandJsonTest.java
+++ b/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/ingress/OneSwitchFlowCommandJsonTest.java
@@ -19,7 +19,7 @@ import org.openkilda.floodlight.api.request.OneSwitchFlowRequest;
 import org.openkilda.floodlight.api.request.factory.OneSwitchFlowRequestFactory;
 import org.openkilda.floodlight.command.AbstractSpeakerCommandJsonTest;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.Cookie;
 import org.openkilda.model.FlowEndpoint;
@@ -39,7 +39,7 @@ abstract class OneSwitchFlowCommandJsonTest
         Assert.assertEquals(request.getEndpoint(), command.getEndpoint());
         Assert.assertEquals(request.getMeterConfig(), command.getMeterConfig());
         Assert.assertEquals(request.getEgressEndpoint(), command.getEgressEndpoint());
-        Assert.assertEquals(request.getRemoveSharedRulesContext(), command.getRemoveSharedRulesContext());
+        Assert.assertEquals(request.getRulesContext(), command.getRulesContext());
     }
 
     @Override
@@ -51,7 +51,7 @@ abstract class OneSwitchFlowCommandJsonTest
                 new FlowEndpoint(swId, 3, 4),
                 new MeterConfig(new MeterId(6), 7000),
                 new FlowEndpoint(swId, 8, 9),
-                RemoveSharedRulesContext.builder().build());
+                RulesContext.builder().build());
         return makeRequest(factory);
     }
 

--- a/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/ingress/OneSwitchFlowInstallCommandTest.java
+++ b/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/ingress/OneSwitchFlowInstallCommandTest.java
@@ -19,7 +19,7 @@ import org.openkilda.floodlight.command.flow.ingress.of.IngressFlowModFactory;
 import org.openkilda.floodlight.command.flow.ingress.of.OneSwitchFlowInstallMultiTableFlowModFactory;
 import org.openkilda.floodlight.command.flow.ingress.of.OneSwitchFlowInstallSingleTableFlowModFactory;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.MeterConfig;
@@ -79,7 +79,7 @@ public class OneSwitchFlowInstallCommandTest extends IngressCommandInstallTest {
             FlowEndpoint endpoint, FlowEndpoint egressEndpoint, MeterConfig meterConfig, FlowSegmentMetadata metadata) {
         UUID commandId = UUID.randomUUID();
         return new CommandStub(new MessageContext(commandId.toString()), commandId, metadata, endpoint, meterConfig,
-                egressEndpoint, RemoveSharedRulesContext.builder().build());
+                egressEndpoint, RulesContext.builder().build());
     }
 
     static class CommandStub extends OneSwitchFlowInstallCommand implements IFlowModFactoryOverride {
@@ -89,8 +89,8 @@ public class OneSwitchFlowInstallCommandTest extends IngressCommandInstallTest {
         public CommandStub(
                 MessageContext context, UUID commandId, FlowSegmentMetadata metadata, FlowEndpoint endpoint,
                 MeterConfig meterConfig, FlowEndpoint egressEndpoint,
-                RemoveSharedRulesContext removeSharedRulesContext) {
-            super(context, commandId, metadata, endpoint, meterConfig, egressEndpoint, removeSharedRulesContext);
+                RulesContext rulesContext) {
+            super(context, commandId, metadata, endpoint, meterConfig, egressEndpoint, rulesContext);
         }
 
         @Override

--- a/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/ingress/OneSwitchFlowRemoveCommandTest.java
+++ b/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/ingress/OneSwitchFlowRemoveCommandTest.java
@@ -19,7 +19,7 @@ import org.openkilda.floodlight.command.flow.ingress.of.IngressFlowModFactory;
 import org.openkilda.floodlight.command.flow.ingress.of.OneSwitchFlowRemoveMultiTableFlowModFactory;
 import org.openkilda.floodlight.command.flow.ingress.of.OneSwitchFlowRemoveSingleTableFlowModFactory;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.MeterConfig;
@@ -49,7 +49,7 @@ public class OneSwitchFlowRemoveCommandTest extends IngressCommandRemoveTest {
             FlowEndpoint endpoint, FlowEndpoint egressEndpoint, MeterConfig meterConfig, FlowSegmentMetadata metadata) {
         UUID commandId = UUID.randomUUID();
         return new CommandStub(new MessageContext(commandId.toString()), commandId, metadata, endpoint, meterConfig,
-                egressEndpoint, RemoveSharedRulesContext.builder().build());
+                egressEndpoint, RulesContext.builder().build());
     }
 
     static class CommandStub extends OneSwitchFlowRemoveCommand implements IFlowModFactoryOverride {
@@ -59,8 +59,8 @@ public class OneSwitchFlowRemoveCommandTest extends IngressCommandRemoveTest {
         public CommandStub(
                 MessageContext context, UUID commandId, FlowSegmentMetadata metadata, FlowEndpoint endpoint,
                 MeterConfig meterConfig, FlowEndpoint egressEndpoint,
-                RemoveSharedRulesContext removeSharedRulesContext) {
-            super(context, commandId, metadata, endpoint, meterConfig, egressEndpoint, removeSharedRulesContext);
+                RulesContext rulesContext) {
+            super(context, commandId, metadata, endpoint, meterConfig, egressEndpoint, rulesContext);
         }
 
         @Override

--- a/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/ingress/of/IngressFlowSegmentInstallFlowModFactoryTest.java
+++ b/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/ingress/of/IngressFlowSegmentInstallFlowModFactoryTest.java
@@ -17,7 +17,7 @@ package org.openkilda.floodlight.command.flow.ingress.of;
 
 import org.openkilda.floodlight.command.flow.ingress.IngressFlowSegmentInstallCommand;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.floodlight.utils.OfAdapter;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
@@ -239,7 +239,7 @@ abstract class IngressFlowSegmentInstallFlowModFactoryTest extends IngressFlowMo
         return new IngressFlowSegmentInstallCommand(
                 new MessageContext(commandId.toString()), commandId, makeMetadata(), endpoint, meterConfig,
                 new SwitchId(datapathIdBeta.getLong()), 1, encapsulation,
-                RemoveSharedRulesContext.builder().build());
+                RulesContext.builder().build());
     }
 
     abstract FlowSegmentMetadata makeMetadata();

--- a/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/ingress/of/OneSwitchFlowInstallFlowModFactoryTest.java
+++ b/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/ingress/of/OneSwitchFlowInstallFlowModFactoryTest.java
@@ -17,7 +17,7 @@ package org.openkilda.floodlight.command.flow.ingress.of;
 
 import org.openkilda.floodlight.command.flow.ingress.OneSwitchFlowInstallCommand;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.model.RemoveSharedRulesContext;
+import org.openkilda.floodlight.model.RulesContext;
 import org.openkilda.floodlight.utils.OfAdapter;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
@@ -214,7 +214,7 @@ abstract class OneSwitchFlowInstallFlowModFactoryTest extends IngressFlowModFact
         UUID commandId = UUID.randomUUID();
         return new OneSwitchFlowInstallCommand(
                 new MessageContext(commandId.toString()), commandId, makeMetadata(), endpoint, meterConfig,
-                egressEndpoint, RemoveSharedRulesContext.builder().build());
+                egressEndpoint, RulesContext.builder().build());
     }
 
     abstract FlowSegmentMetadata makeMetadata();

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RemoveOldRulesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RemoveOldRulesAction.java
@@ -78,13 +78,6 @@ public class RemoveOldRulesAction extends BaseFlowRuleRemovalAction<FlowUpdateFs
         RequestedFlow originalFlow = stateMachine.getOriginalFlow();
         RequestedFlow targetFlow = stateMachine.getTargetFlow();
 
-        return SpeakerRequestBuildContext.builder()
-                .removeCustomerPortRule(removeForwardCustomerPortSharedCatchRule(originalFlow, targetFlow))
-                .removeOppositeCustomerPortRule(removeReverseCustomerPortSharedCatchRule(originalFlow, targetFlow))
-                .removeCustomerPortLldpRule(removeForwardSharedLldpRule(originalFlow, targetFlow))
-                .removeOppositeCustomerPortLldpRule(removeReverseSharedLldpRule(originalFlow, targetFlow))
-                .removeCustomerPortArpRule(removeForwardSharedArpRule(originalFlow, targetFlow))
-                .removeOppositeCustomerPortArpRule(removeReverseSharedArpRule(originalFlow, targetFlow))
-                .build();
+        return buildSpeakerContextForRemoval(originalFlow, targetFlow);
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RevertNewRulesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RevertNewRulesAction.java
@@ -74,7 +74,7 @@ public class RevertNewRulesAction extends BaseFlowRuleRemovalAction<FlowUpdateFs
             FlowPath newReverse = getFlowPath(flow, stateMachine.getNewPrimaryReversePath());
             removeCommands.addAll(commandBuilder.buildAll(
                     stateMachine.getCommandContext(), flow, newForward, newReverse,
-                    getSpeakerRequestBuildContext(stateMachine)));
+                    getSpeakerRequestBuildContextForRemoval(stateMachine)));
         }
         if (stateMachine.getNewProtectedForwardPath() != null && stateMachine.getNewProtectedReversePath() != null) {
             FlowPath newForward = getFlowPath(flow, stateMachine.getNewProtectedForwardPath());
@@ -95,17 +95,10 @@ public class RevertNewRulesAction extends BaseFlowRuleRemovalAction<FlowUpdateFs
                 "Commands for removing new rules and re-installing original ingress rule have been sent");
     }
 
-    private SpeakerRequestBuildContext getSpeakerRequestBuildContext(FlowUpdateFsm stateMachine) {
+    private SpeakerRequestBuildContext getSpeakerRequestBuildContextForRemoval(FlowUpdateFsm stateMachine) {
         RequestedFlow originalFlow = stateMachine.getOriginalFlow();
         RequestedFlow targetFlow = stateMachine.getTargetFlow();
 
-        return SpeakerRequestBuildContext.builder()
-                .removeCustomerPortRule(removeForwardCustomerPortSharedCatchRule(targetFlow, originalFlow))
-                .removeOppositeCustomerPortRule(removeReverseCustomerPortSharedCatchRule(targetFlow, originalFlow))
-                .removeCustomerPortLldpRule(removeForwardSharedLldpRule(targetFlow, originalFlow))
-                .removeOppositeCustomerPortLldpRule(removeReverseSharedLldpRule(targetFlow, originalFlow))
-                .removeCustomerPortArpRule(removeForwardSharedArpRule(targetFlow, originalFlow))
-                .removeOppositeCustomerPortArpRule(removeReverseSharedArpRule(targetFlow, originalFlow))
-                .build();
+        return buildSpeakerContextForRemoval(targetFlow, originalFlow);
     }
 }


### PR DESCRIPTION
* all variables were placed into `forward` and `reverse` fiends
* `RemoveSharedRulesContext` was renamed to `RulesContext` because it will contain other options for server 42.