### PR TITLE
fix cleanup in "Unable to create flow with conflicting vlans" test

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
@@ -410,7 +410,7 @@ class FlowCrudSpec extends HealthCheckSpecification {
         error.statusCode == HttpStatus.CONFLICT
         error.responseBodyAsString.to(MessageError).errorMessage == data.getError(flow, conflictingFlow)
 
-        and: "Cleanup: delete the dominant flow"
+        cleanup:
         flowHelper.deleteFlow(flow.id)
         !error && flowHelper.deleteFlow(conflictingFlow.id)
 


### PR DESCRIPTION
fix cleanup in "Unable to create flow with conflicting vlans or flow IDs" test