### PR TITLE
Increase accuracy extra OF commands produces for ingress flow segment

### DIFF
--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentInstallCommand.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentInstallCommand.java
@@ -64,6 +64,10 @@ public class IngressFlowSegmentInstallCommand extends IngressFlowSegmentCommand 
         if (encapsulation.getType() == FlowEncapsulationType.VXLAN) {
             required.add(SwitchFeature.NOVIFLOW_COPY_FIELD);
         }
+        if (metadata.isMultiTable()) {
+            required.add(SwitchFeature.MULTI_TABLE);
+        }
+
         return required;
     }
 

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentRemoveCommand.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/IngressFlowSegmentRemoveCommand.java
@@ -26,6 +26,7 @@ import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowTransitEncapsulation;
 import org.openkilda.model.MeterConfig;
 import org.openkilda.model.MeterId;
+import org.openkilda.model.SwitchFeature;
 import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -70,7 +71,7 @@ public class IngressFlowSegmentRemoveCommand extends IngressFlowSegmentCommand {
     @Override
     protected List<OFFlowMod> makeIngressModMessages(MeterId effectiveMeterId) {
         List<OFFlowMod> ofMessages = super.makeIngressModMessages(effectiveMeterId);
-        if (rulesContext != null) {
+        if (getSwitchFeatures().contains(SwitchFeature.MULTI_TABLE) && rulesContext != null) {
             if (rulesContext.isRemoveCustomerCatchRule()) {
                 ofMessages.add(getFlowModFactory().makeCustomerPortSharedCatchMessage());
             }

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/OneSwitchFlowInstallCommand.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/OneSwitchFlowInstallCommand.java
@@ -25,12 +25,14 @@ import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.MeterConfig;
 import org.openkilda.model.MeterId;
+import org.openkilda.model.SwitchFeature;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.projectfloodlight.openflow.protocol.OFFlowMod;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -77,6 +79,16 @@ public class OneSwitchFlowInstallCommand extends OneSwitchFlowCommand {
             }
         }
         return ofMessages;
+    }
+
+    @Override
+    protected Set<SwitchFeature> getRequiredFeatures() {
+        Set<SwitchFeature> required = super.getRequiredFeatures();
+        if (metadata.isMultiTable()) {
+            required.add(SwitchFeature.MULTI_TABLE);
+        }
+
+        return required;
     }
 
     @Override

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/OneSwitchFlowRemoveCommand.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/OneSwitchFlowRemoveCommand.java
@@ -25,6 +25,7 @@ import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.MeterConfig;
 import org.openkilda.model.MeterId;
+import org.openkilda.model.SwitchFeature;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -65,7 +66,7 @@ public class OneSwitchFlowRemoveCommand extends OneSwitchFlowCommand {
     @Override
     protected List<OFFlowMod> makeIngressModMessages(MeterId effectiveMeterId) {
         List<OFFlowMod> ofMessages = super.makeIngressModMessages(effectiveMeterId);
-        if (rulesContext != null) {
+        if (getSwitchFeatures().contains(SwitchFeature.MULTI_TABLE) && rulesContext != null) {
             if (rulesContext.isRemoveCustomerCatchRule()) {
                 ofMessages.add(getFlowModFactory().makeCustomerPortSharedCatchMessage());
             }

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/of/IngressFlowModFactory.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/of/IngressFlowModFactory.java
@@ -26,7 +26,6 @@ import org.openkilda.model.SwitchFeature;
 import org.openkilda.model.cookie.Cookie;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -35,7 +34,6 @@ import org.projectfloodlight.openflow.protocol.OFFactory;
 import org.projectfloodlight.openflow.protocol.OFFlowMod;
 import org.projectfloodlight.openflow.protocol.OFFlowModFlags;
 import org.projectfloodlight.openflow.protocol.instruction.OFInstruction;
-import org.projectfloodlight.openflow.protocol.instruction.OFInstructionWriteMetadata;
 import org.projectfloodlight.openflow.protocol.match.MatchField;
 import org.projectfloodlight.openflow.types.EthType;
 import org.projectfloodlight.openflow.types.OFPort;
@@ -109,8 +107,7 @@ public abstract class IngressFlowModFactory {
                 .setMatch(of.buildMatch()
                                   .setExact(MatchField.IN_PORT, OFPort.of(endpoint.getPortNumber()))
                                   .build())
-                .setInstructions(ImmutableList.of(
-                        of.instructions().gotoTable(TableId.of(SwitchManager.PRE_INGRESS_TABLE_ID))))
+                .setInstructions(makeCustomerPortSharedCatchInstructions())
                 .build();
     }
 
@@ -121,12 +118,6 @@ public abstract class IngressFlowModFactory {
      */
     public OFFlowMod makeLldpInputCustomerFlowMessage() {
         FlowEndpoint endpoint = command.getEndpoint();
-        RoutingMetadata metadata = RoutingMetadata.builder().lldpFlag(true).build(switchFeatures);
-        OFInstructionWriteMetadata writeMetadata = of.instructions().buildWriteMetadata()
-                .setMetadata(metadata.getValue())
-                .setMetadataMask(metadata.getMask())
-                .build();
-
         return flowModBuilderFactory.makeBuilder(of, SwitchManager.INPUT_TABLE_ID)
                 .setPriority(SwitchManager.LLDP_INPUT_CUSTOMER_PRIORITY)
                 .setCookie(U64.of(Cookie.encodeLldpInputCustomer(endpoint.getPortNumber())))
@@ -135,9 +126,8 @@ public abstract class IngressFlowModFactory {
                         .setExact(MatchField.IN_PORT, OFPort.of(endpoint.getPortNumber()))
                         .setExact(MatchField.ETH_TYPE, EthType.LLDP)
                         .build())
-                .setInstructions(ImmutableList.of(
-                        of.instructions().gotoTable(TableId.of(SwitchManager.PRE_INGRESS_TABLE_ID)),
-                        writeMetadata))
+                .setInstructions(makeConnectedDevicesMatchInstructions(
+                        RoutingMetadata.builder().lldpFlag(true).build(switchFeatures)))
                 .build();
     }
 
@@ -148,12 +138,6 @@ public abstract class IngressFlowModFactory {
      */
     public OFFlowMod makeArpInputCustomerFlowMessage() {
         FlowEndpoint endpoint = command.getEndpoint();
-        RoutingMetadata metadata = RoutingMetadata.builder().arpFlag(true).build(switchFeatures);
-        OFInstructionWriteMetadata writeMetadata = of.instructions().buildWriteMetadata()
-                .setMetadata(metadata.getValue())
-                .setMetadataMask(metadata.getMask())
-                .build();
-
         return flowModBuilderFactory.makeBuilder(of, SwitchManager.INPUT_TABLE_ID)
                 .setPriority(SwitchManager.ARP_INPUT_CUSTOMER_PRIORITY)
                 .setCookie(U64.of(Cookie.encodeArpInputCustomer(endpoint.getPortNumber())))
@@ -162,9 +146,8 @@ public abstract class IngressFlowModFactory {
                         .setExact(MatchField.IN_PORT, OFPort.of(endpoint.getPortNumber()))
                         .setExact(MatchField.ETH_TYPE, EthType.ARP)
                         .build())
-                .setInstructions(ImmutableList.of(
-                        of.instructions().gotoTable(TableId.of(SwitchManager.PRE_INGRESS_TABLE_ID)),
-                        writeMetadata))
+                .setInstructions(makeConnectedDevicesMatchInstructions(
+                        RoutingMetadata.builder().arpFlag(true).build(switchFeatures)))
                 .build();
     }
 
@@ -177,4 +160,8 @@ public abstract class IngressFlowModFactory {
     }
 
     protected abstract List<OFInstruction> makeForwardMessageInstructions(OFFactory of, MeterId effectiveMeterId);
+
+    protected abstract List<OFInstruction> makeCustomerPortSharedCatchInstructions();
+
+    protected abstract List<OFInstruction> makeConnectedDevicesMatchInstructions(RoutingMetadata metadata);
 }

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/of/IngressInstallFlowModFactory.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/of/IngressInstallFlowModFactory.java
@@ -19,9 +19,11 @@ import org.openkilda.floodlight.command.flow.ingress.IngressFlowSegmentBase;
 import org.openkilda.floodlight.switchmanager.SwitchManager;
 import org.openkilda.floodlight.utils.OfAdapter;
 import org.openkilda.floodlight.utils.OfFlowModBuilderFactory;
+import org.openkilda.floodlight.utils.metadata.RoutingMetadata;
 import org.openkilda.model.MeterId;
 import org.openkilda.model.SwitchFeature;
 
+import com.google.common.collect.ImmutableList;
 import net.floodlightcontroller.core.IOFSwitch;
 import org.projectfloodlight.openflow.protocol.OFFactory;
 import org.projectfloodlight.openflow.protocol.action.OFAction;
@@ -58,6 +60,22 @@ public abstract class IngressInstallFlowModFactory extends IngressFlowModFactory
         }
 
         return instructions;
+    }
+
+    @Override
+    protected List<OFInstruction> makeCustomerPortSharedCatchInstructions() {
+        return ImmutableList.of(
+                of.instructions().gotoTable(TableId.of(SwitchManager.PRE_INGRESS_TABLE_ID)));
+    }
+
+    @Override
+    protected List<OFInstruction> makeConnectedDevicesMatchInstructions(RoutingMetadata metadata) {
+        return ImmutableList.of(
+                of.instructions().gotoTable(TableId.of(SwitchManager.PRE_INGRESS_TABLE_ID)),
+                of.instructions().buildWriteMetadata()
+                        .setMetadata(metadata.getValue())
+                        .setMetadataMask(metadata.getMask())
+                        .build());
     }
 
     protected abstract List<OFAction> makeTransformActions();

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/of/IngressRemoveFlowModFactory.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/ingress/of/IngressRemoveFlowModFactory.java
@@ -17,6 +17,7 @@ package org.openkilda.floodlight.command.flow.ingress.of;
 
 import org.openkilda.floodlight.command.flow.ingress.IngressFlowSegmentBase;
 import org.openkilda.floodlight.utils.OfFlowModBuilderFactory;
+import org.openkilda.floodlight.utils.metadata.RoutingMetadata;
 import org.openkilda.model.MeterId;
 import org.openkilda.model.SwitchFeature;
 
@@ -37,6 +38,16 @@ public abstract class IngressRemoveFlowModFactory extends IngressFlowModFactory 
 
     @Override
     protected List<OFInstruction> makeForwardMessageInstructions(OFFactory of, MeterId effectiveMeterId) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    protected List<OFInstruction> makeCustomerPortSharedCatchInstructions() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    protected List<OFInstruction> makeConnectedDevicesMatchInstructions(RoutingMetadata metadata) {
         return Collections.emptyList();
     }
 }

--- a/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/ingress/IngressCommandInstallTest.java
+++ b/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/ingress/IngressCommandInstallTest.java
@@ -21,7 +21,9 @@ import org.openkilda.floodlight.command.flow.FlowSegmentReport;
 import org.openkilda.floodlight.error.SwitchErrorResponseException;
 import org.openkilda.floodlight.error.SwitchOperationException;
 import org.openkilda.floodlight.error.UnsupportedSwitchOperationException;
+import org.openkilda.model.SwitchFeature;
 
+import net.floodlightcontroller.core.IOFSwitch;
 import org.junit.Assert;
 import org.junit.Test;
 import org.projectfloodlight.openflow.protocol.OFBadRequestCode;
@@ -34,9 +36,16 @@ import org.projectfloodlight.openflow.protocol.instruction.OFInstructionMeter;
 import org.projectfloodlight.openflow.protocol.instruction.OFInstructionWriteActions;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 abstract class IngressCommandInstallTest extends IngressCommandTest {
+    @Override
+    protected void switchFeaturesSetup(IOFSwitch target, Set<SwitchFeature> features) {
+        features.add(SwitchFeature.MULTI_TABLE);
+        super.switchFeaturesSetup(target, features);
+    }
+
     @Test
     public void noMeterRequested() throws Exception {
         IngressFlowSegmentBase command = makeCommand(endpointIngressOneVlan, null, makeMetadata());


### PR DESCRIPTION
Keep empty instructions set for remove flow mod requests.

Ensure the switch is multi-table capable before injecting requests
operates on multiple tables.

Close #3446