### PR TITLE
Changed alert level of mapstruct warning "unmappedTargetField" from WARN to ERROR

### DIFF
--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/mappers/HistoryMapper.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/mappers/HistoryMapper.java
@@ -152,6 +152,8 @@ public abstract class HistoryMapper {
     @Mapping(source = "dumpType", target = "dumpType")
     @Mapping(target = "forwardCookie", ignore = true)
     @Mapping(target = "reverseCookie", ignore = true)
+    @Mapping(target = "forwardStatus", ignore = true)
+    @Mapping(target = "reverseStatus", ignore = true)
     protected abstract FlowDumpData generatedMap(Flow flow, FlowResources resources, DumpType dumpType);
 
     /**

--- a/src-java/build.gradle
+++ b/src-java/build.gradle
@@ -139,6 +139,10 @@ subprojects {
         from("${project.file('build.gradle')}") { into "${project.name}" }
     }
 
+    compileJava {
+        options.compilerArgs << '-Amapstruct.unmappedTargetPolicy=ERROR'
+    }
+
     checkstyle {
         toolVersion '8.18'
         configDirectory = rootProject.file('checkstyle')

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/converter/FlowMapper.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/converter/FlowMapper.java
@@ -150,6 +150,8 @@ public abstract class FlowMapper {
     public abstract FlowRequest toFlowRequest(FlowRequestV2 request);
 
     @Mapping(target = "outerVlanId", source = "vlanId")
+    @Mapping(target = "trackLldpConnectedDevices", source = "detectConnectedDevices.lldp")
+    @Mapping(target = "trackArpConnectedDevices", source = "detectConnectedDevices.arp")
     public abstract FlowEndpoint mapFlowEndpoint(FlowEndpointV2 input);
 
     public FlowRequest toFlowCreateRequest(FlowRequestV2 source) {
@@ -227,6 +229,12 @@ public abstract class FlowMapper {
     protected abstract void generatedMap(@MappingTarget FlowPayload target, FlowDto f);
 
     @Mapping(target = "diverseWith", source = "diverseWith")
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "maximumBandwidth", ignore = true)
+    @Mapping(target = "source", ignore = true)
+    @Mapping(target = "destination", ignore = true)
+    @Mapping(target = "created", ignore = true)
+    @Mapping(target = "status", ignore = true)
     protected abstract void generatedFlowResponsePayloadMap(@MappingTarget FlowResponsePayload target, FlowDto f);
 
     @Mapping(target = "flowId", source = "flowId")


### PR DESCRIPTION
PR #3276 fixed all unmappedTargetField warnings, but future patches bring new warns.

This patch changes alert level for WARN to ERROR to do not pass such warns in future