### PR TITLE
Fix NPE in H&S reroute and update thrown for a flow with no paths

### DIFF
--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/mappers/FlowPathMapper.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/mappers/FlowPathMapper.java
@@ -41,19 +41,20 @@ public abstract class FlowPathMapper {
      */
     public PathInfoData map(FlowPath path) {
         PathInfoData result = new PathInfoData();
-        result.setLatency(path.getLatency());
+        if (path != null) {
+            result.setLatency(path.getLatency());
 
-        int seqId = 0;
-        List<PathNode> nodes = new ArrayList<>();
-        for (PathSegment pathSegment : path.getSegments()) {
-            nodes.add(new PathNode(pathSegment.getSrcSwitch().getSwitchId(), pathSegment.getSrcPort(),
-                    seqId++, pathSegment.getLatency()));
-            nodes.add(new PathNode(pathSegment.getDestSwitch().getSwitchId(), pathSegment.getDestPort(),
-                    seqId++));
+            int seqId = 0;
+            List<PathNode> nodes = new ArrayList<>();
+            for (PathSegment pathSegment : path.getSegments()) {
+                nodes.add(new PathNode(pathSegment.getSrcSwitch().getSwitchId(), pathSegment.getSrcPort(),
+                        seqId++, pathSegment.getLatency()));
+                nodes.add(new PathNode(pathSegment.getDestSwitch().getSwitchId(), pathSegment.getDestPort(),
+                        seqId++));
+            }
+
+            result.setPath(nodes);
         }
-
-        result.setPath(nodes);
-
         return result;
     }
 

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/service/SpeakerFlowSegmentRequestBuilder.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/service/SpeakerFlowSegmentRequestBuilder.java
@@ -59,6 +59,17 @@ public class SpeakerFlowSegmentRequestBuilder implements FlowCommandBuilder {
     }
 
     @Override
+    public List<FlowSegmentRequestFactory> buildAll(CommandContext context, Flow flow, FlowPath path) {
+        return buildAll(context, flow, path, (FlowPath) null);
+    }
+
+    @Override
+    public List<FlowSegmentRequestFactory> buildAll(CommandContext context, Flow flow, FlowPath path,
+                                                    SpeakerRequestBuildContext speakerRequestBuildContext) {
+        return makeRequests(context, flow, path, null, true, true, true, speakerRequestBuildContext);
+    }
+
+    @Override
     public List<FlowSegmentRequestFactory> buildAll(
             CommandContext context, Flow flow, FlowPath forwardPath, FlowPath reversePath) {
         return buildAll(context, flow, forwardPath, reversePath, SpeakerRequestBuildContext.EMPTY);
@@ -77,6 +88,11 @@ public class SpeakerFlowSegmentRequestBuilder implements FlowCommandBuilder {
     }
 
     @Override
+    public List<FlowSegmentRequestFactory> buildAllExceptIngress(CommandContext context, Flow flow, FlowPath path) {
+        return buildAllExceptIngress(context, flow, path, null);
+    }
+
+    @Override
     public List<FlowSegmentRequestFactory> buildAllExceptIngress(
             CommandContext context, Flow flow, FlowPath path, FlowPath oppositePath) {
         return makeRequests(context, flow, path, oppositePath, false, true, true,
@@ -86,6 +102,11 @@ public class SpeakerFlowSegmentRequestBuilder implements FlowCommandBuilder {
     @Override
     public List<FlowSegmentRequestFactory> buildIngressOnly(CommandContext context, @NonNull Flow flow) {
         return buildIngressOnly(context, flow, flow.getForwardPath(), flow.getReversePath());
+    }
+
+    @Override
+    public List<FlowSegmentRequestFactory> buildIngressOnly(CommandContext context, Flow flow, FlowPath path) {
+        return buildIngressOnly(context, flow, path, null);
     }
 
     @Override

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowCommandBuilder.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowCommandBuilder.java
@@ -24,6 +24,17 @@ import org.openkilda.wfm.share.model.SpeakerRequestBuildContext;
 import java.util.List;
 
 public interface FlowCommandBuilder {
+    /**
+     * Build install commands for ingress, transit(if needed) and egress rules for provided path only.
+     */
+    List<FlowSegmentRequestFactory> buildAll(CommandContext context, Flow flow, FlowPath path);
+
+    /**
+     * Build install commands for ingress, transit(if needed) and egress rules for provided path only.
+     */
+    List<FlowSegmentRequestFactory> buildAll(CommandContext context, Flow flow, FlowPath path,
+                                             SpeakerRequestBuildContext speakerRequestBuildContext);
+
     List<FlowSegmentRequestFactory> buildAll(
             CommandContext context, Flow flow, FlowPath forwardPath, FlowPath reversePath);
 
@@ -37,6 +48,11 @@ public interface FlowCommandBuilder {
     List<FlowSegmentRequestFactory> buildAllExceptIngress(CommandContext context, Flow flow);
 
     /**
+     * Build install commands for transit(if needed) and egress rules for provided path only.
+     */
+    List<FlowSegmentRequestFactory> buildAllExceptIngress(CommandContext context, Flow flow, FlowPath path);
+
+    /**
      * Build install commands for transit(if needed) and egress rules for provided paths.
      */
     List<FlowSegmentRequestFactory> buildAllExceptIngress(
@@ -46,6 +62,11 @@ public interface FlowCommandBuilder {
      * Build install commands for ingress rules for active forward and reverse paths.
      */
     List<FlowSegmentRequestFactory> buildIngressOnly(CommandContext context, Flow flow);
+
+    /**
+     * Build install commands for ingress rules for provided path only.
+     */
+    List<FlowSegmentRequestFactory> buildIngressOnly(CommandContext context, Flow flow, FlowPath path);
 
     /**
      * Build install commands for ingress rules for provided paths.

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseFlowPathRemovalAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseFlowPathRemovalAction.java
@@ -44,6 +44,12 @@ public abstract class BaseFlowPathRemovalAction<T extends FlowProcessingFsm<T, S
         islRepository = persistenceManager.getRepositoryFactory().createIslRepository();
     }
 
+    protected void deleteFlowPath(FlowPath flowPath) {
+        flowPathRepository.delete(flowPath);
+
+        updateIslsForFlowPath(flowPath);
+    }
+
     protected void deleteFlowPaths(FlowPathPair pathPair) {
         flowPathRepository.delete(pathPair.getForward());
         flowPathRepository.delete(pathPair.getReverse());
@@ -68,6 +74,13 @@ public abstract class BaseFlowPathRemovalAction<T extends FlowProcessingFsm<T, S
         log.debug("Updating ISL {}_{} - {}_{} with used bandwidth {}", srcSwitch, srcPort, dstSwitch, dstPort,
                 usedBandwidth);
         islRepository.updateAvailableBandwidth(srcSwitch, srcPort, dstSwitch, dstPort, usedBandwidth);
+    }
+
+    protected void saveRemovalActionWithDumpToHistory(T stateMachine, Flow flow, FlowPath flowPath) {
+        // TODO: History dumps require paired paths, fix it to support any (without opposite one).
+        FlowPathPair pathsToDelete = FlowPathPair.builder().forward(flowPath).reverse(flowPath).build();
+
+        saveRemovalActionWithDumpToHistory(stateMachine, flow, pathsToDelete);
     }
 
     protected void saveRemovalActionWithDumpToHistory(T stateMachine, Flow flow, FlowPathPair pathPair) {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseResourceAllocationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseResourceAllocationAction.java
@@ -186,7 +186,9 @@ public abstract class BaseResourceAllocationAction<T extends FlowPathSwappingFsm
     }
 
     protected boolean isNotSamePath(PathPair pathPair, FlowPathPair flowPathPair) {
-        return !flowPathBuilder.isSamePath(pathPair.getForward(), flowPathPair.getForward())
+        return flowPathPair.getForward() == null
+                || !flowPathBuilder.isSamePath(pathPair.getForward(), flowPathPair.getForward())
+                || flowPathPair.getReverse() == null
                 || !flowPathBuilder.isSamePath(pathPair.getReverse(), flowPathPair.getReverse());
     }
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/delete/actions/RemoveRulesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/delete/actions/RemoveRulesAction.java
@@ -37,12 +37,12 @@ import org.openkilda.wfm.topology.flowhs.utils.SpeakerRemoveSegmentEmitter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 public class RemoveRulesAction extends BaseFlowRuleRemovalAction<FlowDeleteFsm, State, Event, FlowDeleteContext> {
@@ -60,9 +60,7 @@ public class RemoveRulesAction extends BaseFlowRuleRemovalAction<FlowDeleteFsm, 
         FlowCommandBuilder commandBuilder = commandBuilderFactory.getBuilder(flow.getEncapsulationType());
         Collection<FlowSegmentRequestFactory> commands = new ArrayList<>();
 
-        Set<PathId> protectedPaths = Arrays.stream(
-                new PathId[]{
-                        flow.getProtectedForwardPathId(), flow.getProtectedReversePathId()})
+        Set<PathId> protectedPaths = Stream.of(flow.getProtectedForwardPathId(), flow.getProtectedReversePathId())
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
         Set<PathId> processed = new HashSet<>();
@@ -74,7 +72,6 @@ public class RemoveRulesAction extends BaseFlowRuleRemovalAction<FlowDeleteFsm, 
                 if (oppositePath != null) {
                     processed.add(oppositePath.getPathId());
                 }
-
 
                 if (oppositePath != null) {
                     stateMachine.getFlowResources().add(buildResources(flow, path, oppositePath));
@@ -114,7 +111,13 @@ public class RemoveRulesAction extends BaseFlowRuleRemovalAction<FlowDeleteFsm, 
                 stateMachine.getCarrier(), commands, stateMachine.getRemoveCommands());
         stateMachine.getPendingCommands().addAll(stateMachine.getRemoveCommands().keySet());
 
-        stateMachine.saveActionToHistory("Remove commands for rules have been sent");
+        if (commands.isEmpty()) {
+            stateMachine.saveActionToHistory("No need to remove rules");
+
+            stateMachine.fire(Event.RULES_REMOVED);
+        } else {
+            stateMachine.saveActionToHistory("Remove commands for rules have been sent");
+        }
     }
 
     private FlowResources buildResources(Flow flow, FlowPath path, FlowPath oppositePath) {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/CompleteFlowPathRemovalAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/CompleteFlowPathRemovalAction.java
@@ -56,37 +56,48 @@ public class CompleteFlowPathRemovalAction extends
     private void removeFlowPaths(FlowRerouteFsm stateMachine) {
         Flow flow = getFlow(stateMachine.getFlowId());
 
-        FlowPath oldPrimaryForward = null;
-        FlowPath oldPrimaryReverse = null;
-        if (stateMachine.getOldPrimaryForwardPath() != null && stateMachine.getOldPrimaryReversePath() != null) {
-            oldPrimaryForward = getFlowPath(flow, stateMachine.getOldPrimaryForwardPath());
-            oldPrimaryReverse = getFlowPath(flow, stateMachine.getOldPrimaryReversePath());
-        }
-        FlowPath oldProtectedForward = null;
-        FlowPath oldProtectedReverse = null;
-        if (stateMachine.getOldProtectedForwardPath() != null
-                && stateMachine.getOldProtectedReversePath() != null) {
-            oldProtectedForward = getFlowPath(flow, stateMachine.getOldProtectedForwardPath());
-            oldProtectedReverse = getFlowPath(flow, stateMachine.getOldProtectedReversePath());
-        }
+        FlowPath oldPrimaryForward = flow.getPath(stateMachine.getOldPrimaryForwardPath()).orElse(null);
+        FlowPath oldPrimaryReverse = flow.getPath(stateMachine.getOldPrimaryReversePath()).orElse(null);
+        FlowPath oldProtectedForward = flow.getPath(stateMachine.getOldProtectedForwardPath()).orElse(null);
+        FlowPath oldProtectedReverse = flow.getPath(stateMachine.getOldProtectedReversePath()).orElse(null);
 
         flowPathRepository.lockInvolvedSwitches(Stream.of(oldPrimaryForward, oldPrimaryReverse,
                 oldProtectedForward, oldProtectedReverse).filter(Objects::nonNull).toArray(FlowPath[]::new));
 
-        if (oldPrimaryForward != null && oldPrimaryReverse != null) {
-            log.debug("Completing removal of the flow path {} / {}", oldPrimaryForward, oldPrimaryReverse);
-            FlowPathPair pathsToDelete =
-                    FlowPathPair.builder().forward(oldPrimaryForward).reverse(oldPrimaryReverse).build();
-            deleteFlowPaths(pathsToDelete);
-            saveRemovalActionWithDumpToHistory(stateMachine, flow, pathsToDelete);
+        if (oldPrimaryForward != null) {
+            if (oldPrimaryReverse != null) {
+                log.debug("Completing removal of the flow paths {} / {}", oldPrimaryForward, oldPrimaryReverse);
+                FlowPathPair pathsToDelete =
+                        FlowPathPair.builder().forward(oldPrimaryForward).reverse(oldPrimaryReverse).build();
+                deleteFlowPaths(pathsToDelete);
+                saveRemovalActionWithDumpToHistory(stateMachine, flow, pathsToDelete);
+            } else {
+                log.debug("Completing removal of the flow path {} (no reverse pair)", oldPrimaryForward);
+                deleteFlowPath(oldPrimaryForward);
+                saveRemovalActionWithDumpToHistory(stateMachine, flow, oldPrimaryForward);
+            }
+        } else if (oldPrimaryReverse != null) {
+            log.debug("Completing removal of the flow path {} (no forward pair)", oldPrimaryReverse);
+            deleteFlowPath(oldPrimaryReverse);
+            saveRemovalActionWithDumpToHistory(stateMachine, flow, oldPrimaryReverse);
         }
 
-        if (oldProtectedForward != null && oldProtectedReverse != null) {
-            log.debug("Completing removal of the flow path {} / {}", oldProtectedForward, oldProtectedReverse);
-            FlowPathPair pathsToDelete =
-                    FlowPathPair.builder().forward(oldProtectedForward).reverse(oldProtectedReverse).build();
-            deleteFlowPaths(pathsToDelete);
-            saveRemovalActionWithDumpToHistory(stateMachine, flow, pathsToDelete);
+        if (oldProtectedForward != null) {
+            if (oldProtectedReverse != null) {
+                log.debug("Completing removal of the flow paths {} / {}", oldProtectedForward, oldProtectedReverse);
+                FlowPathPair pathsToDelete =
+                        FlowPathPair.builder().forward(oldProtectedForward).reverse(oldProtectedReverse).build();
+                deleteFlowPaths(pathsToDelete);
+                saveRemovalActionWithDumpToHistory(stateMachine, flow, pathsToDelete);
+            } else {
+                log.debug("Completing removal of the flow path {} (no reverse pair)", oldProtectedForward);
+                deleteFlowPath(oldProtectedForward);
+                saveRemovalActionWithDumpToHistory(stateMachine, flow, oldProtectedForward);
+            }
+        } else if (oldProtectedReverse != null) {
+            log.debug("Completing removal of the flow path {} (no forward pair)", oldProtectedReverse);
+            deleteFlowPath(oldProtectedReverse);
+            saveRemovalActionWithDumpToHistory(stateMachine, flow, oldProtectedReverse);
         }
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/HandleNotRemovedPathsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/HandleNotRemovedPathsAction.java
@@ -30,14 +30,21 @@ public class HandleNotRemovedPathsAction extends
         HistoryRecordingAction<FlowRerouteFsm, State, Event, FlowRerouteContext> {
     @Override
     public void perform(State from, State to, Event event, FlowRerouteContext context, FlowRerouteFsm stateMachine) {
-        if (stateMachine.getOldPrimaryForwardPath() != null && stateMachine.getOldPrimaryReversePath() != null) {
-            stateMachine.saveErrorToHistory(format("Failed to remove paths %s / %s",
-                    stateMachine.getOldPrimaryForwardPath(), stateMachine.getOldPrimaryReversePath()));
+        if (stateMachine.getOldPrimaryForwardPath() != null) {
+            stateMachine.saveErrorToHistory(format("Failed to remove the path %s",
+                    stateMachine.getOldPrimaryForwardPath()));
         }
-        if (stateMachine.getOldProtectedForwardPath() != null
-                && stateMachine.getOldProtectedReversePath() != null) {
-            stateMachine.saveErrorToHistory(format("Failed to remove paths %s / %s",
-                    stateMachine.getOldProtectedForwardPath(), stateMachine.getOldProtectedReversePath()));
+        if (stateMachine.getOldPrimaryReversePath() != null) {
+            stateMachine.saveErrorToHistory(format("Failed to remove the path %s",
+                    stateMachine.getOldPrimaryReversePath()));
+        }
+        if (stateMachine.getOldProtectedForwardPath() != null) {
+            stateMachine.saveErrorToHistory(format("Failed to remove the path %s",
+                    stateMachine.getOldProtectedForwardPath()));
+        }
+        if (stateMachine.getOldProtectedReversePath() != null) {
+            stateMachine.saveErrorToHistory(format("Failed to remove the path %s",
+                    stateMachine.getOldProtectedReversePath()));
         }
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/OnNoPathFoundAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/OnNoPathFoundAction.java
@@ -57,8 +57,12 @@ public class OnNoPathFoundAction extends FlowProcessingAction<FlowRerouteFsm, St
                 } else {
                     log.debug("Set the flow path status of {}/{} to inactive",
                             flow.getForwardPathId(), flow.getReversePathId());
-                    flowPathRepository.updateStatus(flow.getForwardPathId(), FlowPathStatus.INACTIVE);
-                    flowPathRepository.updateStatus(flow.getReversePathId(), FlowPathStatus.INACTIVE);
+                    if (flow.getForwardPathId() != null) {
+                        flowPathRepository.updateStatus(flow.getForwardPathId(), FlowPathStatus.INACTIVE);
+                    }
+                    if (flow.getReversePathId() != null) {
+                        flowPathRepository.updateStatus(flow.getReversePathId(), FlowPathStatus.INACTIVE);
+                    }
                 }
             }
 
@@ -70,8 +74,12 @@ public class OnNoPathFoundAction extends FlowProcessingAction<FlowRerouteFsm, St
                 } else {
                     log.debug("Set the flow path status of {}/{} to inactive",
                             flow.getProtectedForwardPathId(), flow.getProtectedReversePathId());
-                    flowPathRepository.updateStatus(flow.getProtectedForwardPathId(), FlowPathStatus.INACTIVE);
-                    flowPathRepository.updateStatus(flow.getProtectedReversePathId(), FlowPathStatus.INACTIVE);
+                    if (flow.getProtectedForwardPathId() != null) {
+                        flowPathRepository.updateStatus(flow.getProtectedForwardPathId(), FlowPathStatus.INACTIVE);
+                    }
+                    if (flow.getProtectedReversePathId() != null) {
+                        flowPathRepository.updateStatus(flow.getProtectedReversePathId(), FlowPathStatus.INACTIVE);
+                    }
                 }
             }
         });

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/PostResourceAllocationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/PostResourceAllocationAction.java
@@ -66,7 +66,7 @@ public class PostResourceAllocationAction extends
             Flow flow = getFlow(flowId, FetchStrategy.NO_RELATIONS);
             currentForwardId = flow.getForwardPathId();
         }
-        FlowPath currentForwardPath = getFlowPath(currentForwardId);
+        FlowPath currentForwardPath = currentForwardId != null ? getFlowPath(currentForwardId) : null;
 
         if (stateMachine.getNewPrimaryForwardPath() == null && stateMachine.getNewPrimaryReversePath() == null
                 && stateMachine.getNewProtectedForwardPath() == null

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/RevertPathsSwapAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/RevertPathsSwapAction.java
@@ -47,59 +47,72 @@ public class RevertPathsSwapAction extends FlowProcessingAction<FlowRerouteFsm, 
             }
             flow.setPathComputationStrategy(stateMachine.getOriginalPathComputationStrategy());
 
-            if (stateMachine.getOldPrimaryForwardPath() != null && stateMachine.getOldPrimaryReversePath() != null) {
+            if (stateMachine.getOldPrimaryForwardPath() != null) {
                 FlowPath oldForward = getFlowPath(stateMachine.getOldPrimaryForwardPath());
                 if (oldForward.getStatus() != FlowPathStatus.ACTIVE) {
                     flowPathRepository.updateStatus(oldForward.getPathId(),
                             stateMachine.getOldPrimaryForwardPathStatus());
                 }
 
+                log.debug("Swapping back the primary forward path {} with {}",
+                        flow.getForwardPathId(), oldForward.getPathId());
+
+                flow.setForwardPath(oldForward.getPathId());
+
+                saveHistory(stateMachine, flow.getFlowId(), oldForward.getPathId());
+            }
+
+            if (stateMachine.getOldPrimaryReversePath() != null) {
                 FlowPath oldReverse = getFlowPath(stateMachine.getOldPrimaryReversePath());
                 if (oldReverse.getStatus() != FlowPathStatus.ACTIVE) {
                     flowPathRepository.updateStatus(oldReverse.getPathId(),
                             stateMachine.getOldPrimaryReversePathStatus());
                 }
 
-                log.debug("Swapping back the primary paths {}/{} with {}/{}",
-                        flow.getForwardPath().getPathId(), flow.getReversePath().getPathId(),
-                        oldForward.getPathId(), oldReverse.getPathId());
+                log.debug("Swapping back the primary reverse path {} with {}",
+                        flow.getReversePathId(), oldReverse.getPathId());
 
-                flow.setForwardPath(oldForward.getPathId());
                 flow.setReversePath(oldReverse.getPathId());
 
-                saveHistory(stateMachine, flow.getFlowId(), oldForward.getPathId(), oldReverse.getPathId());
+                saveHistory(stateMachine, flow.getFlowId(), oldReverse.getPathId());
             }
 
-            if (stateMachine.getOldProtectedForwardPath() != null
-                    && stateMachine.getOldProtectedReversePath() != null) {
+            if (stateMachine.getOldProtectedForwardPath() != null) {
                 FlowPath oldForward = getFlowPath(stateMachine.getOldProtectedForwardPath());
                 if (oldForward.getStatus() != FlowPathStatus.ACTIVE) {
                     flowPathRepository.updateStatus(oldForward.getPathId(),
                             stateMachine.getOldProtectedForwardPathStatus());
                 }
 
+                log.debug("Swapping back the protected forward path {} with {}",
+                        flow.getProtectedForwardPathId(), oldForward.getPathId());
+
+                flow.setProtectedForwardPath(oldForward.getPathId());
+
+                saveHistory(stateMachine, flow.getFlowId(), oldForward.getPathId());
+            }
+
+            if (stateMachine.getOldProtectedReversePath() != null) {
                 FlowPath oldReverse = getFlowPath(stateMachine.getOldProtectedReversePath());
                 if (oldReverse.getStatus() != FlowPathStatus.ACTIVE) {
                     flowPathRepository.updateStatus(oldReverse.getPathId(),
                             stateMachine.getOldProtectedReversePathStatus());
                 }
 
-                log.debug("Swapping back the protected paths {}/{} with {}/{}",
-                        flow.getProtectedForwardPath().getPathId(), flow.getProtectedReversePath().getPathId(),
-                        oldForward.getPathId(), oldReverse.getPathId());
+                log.debug("Swapping back the protected reverse path {} with {}",
+                        flow.getProtectedReversePathId(), oldReverse.getPathId());
 
-                flow.setProtectedForwardPath(oldForward.getPathId());
                 flow.setProtectedReversePath(oldReverse.getPathId());
 
-                saveHistory(stateMachine, flow.getFlowId(), oldForward.getPathId(), oldReverse.getPathId());
+                saveHistory(stateMachine, flow.getFlowId(), oldReverse.getPathId());
             }
 
             flowRepository.createOrUpdate(flow);
         });
     }
 
-    private void saveHistory(FlowRerouteFsm stateMachine, String flowId, PathId forwardPath, PathId reversePath) {
+    private void saveHistory(FlowRerouteFsm stateMachine, String flowId, PathId pathId) {
         stateMachine.saveActionToHistory("Flow was reverted to old paths",
-                format("The flow %s was updated with paths %s / %s", flowId, forwardPath, reversePath));
+                format("The flow %s was updated with the path %s", flowId, pathId));
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocateProtectedResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocateProtectedResourcesAction.java
@@ -77,9 +77,10 @@ public class AllocateProtectedResourcesAction extends
         log.debug("Finding a new protected path for flow {}", flowId);
         PathPair potentialPath = pathComputer.getPath(flow, pathsToReuse);
 
-        boolean overlappingProtectedPathFound =
-                flowPathBuilder.arePathsOverlapped(potentialPath.getForward(), primaryForwardPath)
-                        || flowPathBuilder.arePathsOverlapped(potentialPath.getReverse(), primaryReversePath);
+        boolean overlappingProtectedPathFound = primaryForwardPath != null
+                && flowPathBuilder.arePathsOverlapped(potentialPath.getForward(), primaryForwardPath)
+                || primaryReversePath != null
+                && flowPathBuilder.arePathsOverlapped(potentialPath.getReverse(), primaryReversePath);
         if (overlappingProtectedPathFound) {
             String message = "Couldn't find non overlapping protected path";
             stateMachine.saveActionToHistory(message);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/HandleNotRemovedPathsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/HandleNotRemovedPathsAction.java
@@ -30,14 +30,21 @@ public class HandleNotRemovedPathsAction extends
         HistoryRecordingAction<FlowUpdateFsm, State, Event, FlowUpdateContext> {
     @Override
     public void perform(State from, State to, Event event, FlowUpdateContext context, FlowUpdateFsm stateMachine) {
-        if (stateMachine.getOldPrimaryForwardPath() != null && stateMachine.getOldPrimaryReversePath() != null) {
-            stateMachine.saveErrorToHistory(format("Failed to remove paths %s / %s",
-                    stateMachine.getOldPrimaryForwardPath(), stateMachine.getOldPrimaryReversePath()));
+        if (stateMachine.getOldPrimaryForwardPath() != null) {
+            stateMachine.saveErrorToHistory(format("Failed to remove the path %s",
+                    stateMachine.getOldPrimaryForwardPath()));
         }
-        if (stateMachine.getOldProtectedForwardPath() != null
-                && stateMachine.getOldProtectedReversePath() != null) {
-            stateMachine.saveErrorToHistory(format("Failed to remove paths %s / %s",
-                    stateMachine.getOldProtectedForwardPath(), stateMachine.getOldProtectedReversePath()));
+        if (stateMachine.getOldPrimaryReversePath() != null) {
+            stateMachine.saveErrorToHistory(format("Failed to remove the path %s",
+                    stateMachine.getOldPrimaryReversePath()));
+        }
+        if (stateMachine.getOldProtectedForwardPath() != null) {
+            stateMachine.saveErrorToHistory(format("Failed to remove the path %s",
+                    stateMachine.getOldProtectedForwardPath()));
+        }
+        if (stateMachine.getOldProtectedReversePath() != null) {
+            stateMachine.saveErrorToHistory(format("Failed to remove the path %s",
+                    stateMachine.getOldProtectedReversePath()));
         }
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RevertPathsSwapAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RevertPathsSwapAction.java
@@ -23,7 +23,6 @@ import org.openkilda.model.FlowPathStatus;
 import org.openkilda.model.PathId;
 import org.openkilda.persistence.FetchStrategy;
 import org.openkilda.persistence.PersistenceManager;
-import org.openkilda.persistence.repositories.SwitchRepository;
 import org.openkilda.wfm.topology.flowhs.fsm.common.actions.FlowProcessingAction;
 import org.openkilda.wfm.topology.flowhs.fsm.update.FlowUpdateContext;
 import org.openkilda.wfm.topology.flowhs.fsm.update.FlowUpdateFsm;
@@ -34,11 +33,8 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class RevertPathsSwapAction extends FlowProcessingAction<FlowUpdateFsm, State, Event, FlowUpdateContext> {
-    private final SwitchRepository switchRepository;
-
     public RevertPathsSwapAction(PersistenceManager persistenceManager) {
         super(persistenceManager);
-        switchRepository = persistenceManager.getRepositoryFactory().createSwitchRepository();
     }
 
     @Override
@@ -46,59 +42,72 @@ public class RevertPathsSwapAction extends FlowProcessingAction<FlowUpdateFsm, S
         persistenceManager.getTransactionManager().doInTransaction(() -> {
             Flow flow = getFlow(stateMachine.getFlowId(), FetchStrategy.DIRECT_RELATIONS);
 
-            if (stateMachine.getOldPrimaryForwardPath() != null && stateMachine.getOldPrimaryReversePath() != null) {
+            if (stateMachine.getOldPrimaryForwardPath() != null) {
                 FlowPath oldForward = getFlowPath(stateMachine.getOldPrimaryForwardPath());
                 if (oldForward.getStatus() != FlowPathStatus.ACTIVE) {
                     flowPathRepository.updateStatus(oldForward.getPathId(),
                             stateMachine.getOldPrimaryForwardPathStatus());
                 }
 
+                log.debug("Swapping back the primary forward path {} with {}",
+                        flow.getForwardPathId(), oldForward.getPathId());
+
+                flow.setForwardPath(oldForward.getPathId());
+
+                saveHistory(stateMachine, flow.getFlowId(), oldForward.getPathId());
+            }
+
+            if (stateMachine.getOldPrimaryReversePath() != null) {
                 FlowPath oldReverse = getFlowPath(stateMachine.getOldPrimaryReversePath());
                 if (oldReverse.getStatus() != FlowPathStatus.ACTIVE) {
                     flowPathRepository.updateStatus(oldReverse.getPathId(),
                             stateMachine.getOldPrimaryReversePathStatus());
                 }
 
-                log.debug("Swapping back the primary paths {}/{} with {}/{}",
-                        flow.getForwardPath().getPathId(), flow.getReversePath().getPathId(),
-                        oldForward.getPathId(), oldReverse.getPathId());
+                log.debug("Swapping back the primary reverse path {} with {}",
+                        flow.getReversePathId(), oldReverse.getPathId());
 
-                flow.setForwardPath(oldForward.getPathId());
                 flow.setReversePath(oldReverse.getPathId());
 
-                saveHistory(stateMachine, flow.getFlowId(), oldForward.getPathId(), oldReverse.getPathId());
+                saveHistory(stateMachine, flow.getFlowId(), oldReverse.getPathId());
             }
 
-            if (stateMachine.getOldProtectedForwardPath() != null
-                    && stateMachine.getOldProtectedReversePath() != null) {
+            if (stateMachine.getOldProtectedForwardPath() != null) {
                 FlowPath oldForward = getFlowPath(stateMachine.getOldProtectedForwardPath());
                 if (oldForward.getStatus() != FlowPathStatus.ACTIVE) {
                     flowPathRepository.updateStatus(oldForward.getPathId(),
                             stateMachine.getOldProtectedForwardPathStatus());
                 }
 
+                log.debug("Swapping back the protected forward path {} with {}",
+                        flow.getProtectedForwardPathId(), oldForward.getPathId());
+
+                flow.setProtectedForwardPath(oldForward.getPathId());
+
+                saveHistory(stateMachine, flow.getFlowId(), oldForward.getPathId());
+            }
+
+            if (stateMachine.getOldProtectedReversePath() != null) {
                 FlowPath oldReverse = getFlowPath(stateMachine.getOldProtectedReversePath());
                 if (oldReverse.getStatus() != FlowPathStatus.ACTIVE) {
                     flowPathRepository.updateStatus(oldReverse.getPathId(),
                             stateMachine.getOldProtectedReversePathStatus());
                 }
 
-                log.debug("Swapping back the protected paths {}/{} with {}/{}",
-                        flow.getProtectedForwardPath().getPathId(), flow.getProtectedReversePath().getPathId(),
-                        oldForward.getPathId(), oldReverse.getPathId());
+                log.debug("Swapping back the protected reverse path {} with {}",
+                        flow.getProtectedReversePathId(), oldReverse.getPathId());
 
-                flow.setProtectedForwardPath(oldForward.getPathId());
                 flow.setProtectedReversePath(oldReverse.getPathId());
 
-                saveHistory(stateMachine, flow.getFlowId(), oldForward.getPathId(), oldReverse.getPathId());
+                saveHistory(stateMachine, flow.getFlowId(), oldReverse.getPathId());
             }
 
             flowRepository.createOrUpdate(flow);
         });
     }
 
-    private void saveHistory(FlowUpdateFsm stateMachine, String flowId, PathId forwardPath, PathId reversePath) {
+    private void saveHistory(FlowUpdateFsm stateMachine, String flowId, PathId pathId) {
         stateMachine.saveActionToHistory("Flow was reverted to old paths",
-                format("The flow %s was updated with paths %s / %s", flowId, forwardPath, reversePath));
+                format("The flow %s was updated with the path %s", flowId, pathId));
     }
 }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
@@ -117,7 +117,6 @@ class SwitchFailuresSpec extends HealthCheckSpecification {
         database.resetCosts()
     }
 
-    @Ignore("https://github.com/telstra/open-kilda/issues/2954, https://github.com/telstra/open-kilda/issues/3028")
     def "System can handle situation when switch reconnects while flow is being created"() {
         when: "Start creating a flow between switches and lose connection to src before rules are set"
         def (Switch srcSwitch, Switch dstSwitch) = topology.activeSwitches


### PR DESCRIPTION
The changes:

- Proper handling of a flow with no paths or with incomplete pairs.

Closes #2954, #3028, #3467 