### PR TITLE
Ignore round trip notifications for missing ISL

### DIFF
--- a/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/service/NetworkIslService.java
+++ b/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/service/NetworkIslService.java
@@ -127,11 +127,16 @@ public class NetworkIslService {
      */
     public void roundTripStatusNotification(IslReference reference, RoundTripStatus status) {
         log.debug("ISL service receive ROUND TRIP STATUS for {} (on {})", reference, status.getEndpoint());
-        IslFsm islFsm = locateController(reference).fsm;
+        IslController islController = controller.get(reference);
+        if (islController == null) {
+            log.debug("Ignore ROUND TRIP STATUS for for {} - ISL not found", reference);
+            return;
+        }
+
         IslFsmContext context = IslFsmContext.builder(carrier, status.getEndpoint())
                 .roundTripStatus(status)
                 .build();
-        controllerExecutor.fire(islFsm, IslFsmEvent.ROUND_TRIP_STATUS, context);
+        controllerExecutor.fire(islController.fsm, IslFsmEvent.ROUND_TRIP_STATUS, context);
     }
 
     /**

--- a/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/service/NetworkWatcherService.java
+++ b/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/service/NetworkWatcherService.java
@@ -194,8 +194,8 @@ public class NetworkWatcherService {
         if (roundTripPackets.remove(Packet.of(endpoint, packetId))) {
             lastSeenRoundTrip.put(endpoint, clock.instant());
         } else {
-            log.error("Receive invalid/stale/duplicate round trip discovery packet for {} id:{} task:{}",
-                      endpoint, packetId, taskId);
+            log.debug("Receive invalid/stale/duplicate round trip discovery packet for {} id:{} task:{}",
+                    endpoint, packetId, taskId);
         }
     }
 


### PR DESCRIPTION
Avoid error generation for missing ISL triggered by round-trip status
notifications. Round-trip notifications are produced by "switch-port"
periodically (each 1 second) starting at first received round-trip
notification from speaker. ISL can be removed at any time, but  network
topology will continue to generate round-trip status
notifications(internal for network-topology) for it. So we can/should
ignore such notification for  missing/removed ISLs.