### PR TITLE
Fix the way how lab service starts traffexam

### DIFF
--- a/src-python/lab-service/lab/service/service.py
+++ b/src-python/lab-service/lab/service/service.py
@@ -14,6 +14,7 @@
 #
 
 import os
+import pathlib
 import traceback
 import logging
 
@@ -27,9 +28,12 @@ logger = logging.getLogger()
 
 LAB_ID = os.environ.get("LAB_ID", 1)
 API_HOST = os.environ.get("API_HOST", 'lab-api:8288')
+APP_ROOT = "/opt/lab-service"
 
 
 def main():
+    setup_app_home(APP_ROOT)
+
     base_url = "http://{}/api/{}/".format(API_HOST, LAB_ID)
     definition_url = base_url + 'definition'
     activate_url = base_url + 'activate'
@@ -56,3 +60,12 @@ def main():
         lockkeeper_proc.terminate()
         lockkeeper_proc.join()
     loop_forever(teardown)
+
+
+def setup_app_home(root):
+    root = pathlib.Path(root)
+    root.mkdir(parents=True, exist_ok=True)
+    os.chdir(root)
+
+    for p in ["log"]:
+        pathlib.Path(p).mkdir(parents=True, exist_ok=True)

--- a/src-python/lab-service/lab/service/test/test_topology.py
+++ b/src-python/lab-service/lab/service/test/test_topology.py
@@ -18,9 +18,11 @@ from service.topology import Topology
 
 
 def test_smoke(mocker):
+    mocker.patch('service.topology.daemon_start')
     mocker.patch('service.topology.run_cmd')
     mocker.patch('service.topology.vsctl')
     mocker.patch('service.topology.ofctl')
+    mocker.patch('service.service.setup_app_home')
 
     with open("./service/test/res/topology.json", "r") as f:
         topo = Topology.create(json.loads(f.read()))

--- a/src-python/lab-service/lab/service/topology.py
+++ b/src-python/lab-service/lab/service/topology.py
@@ -12,7 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-from service.cmd import vsctl, ofctl, run_cmd
+
+from service.cmd import vsctl, ofctl, run_cmd, daemon_start
 from urllib.parse import urlparse
 import socket
 import logging
@@ -170,6 +171,8 @@ class Link:
 
 
 class Traffgen:
+    proc = None
+
     def __init__(self, tgen_def):
         self.name = tgen_def['name']
         self.iface = tgen_def['iface_name']
@@ -179,13 +182,14 @@ class Traffgen:
 
         # listen rest on all interfaces
         self.endpoint = '%s:%s' % ('0.0.0.0', str(ctrl_url.port))
-        self.proc = None
 
     def make_link(self):
         return Link.create(self.sw, self.sw_port, self.name, self.iface, is_isl=False)
 
     def run(self):
-        self.proc = run_cmd('kilda-traffexam {} {}'.format(pname(self.name, self.iface), self.endpoint), sync=False)
+        self.proc = daemon_start(
+            ['kilda-traffexam', pname(self.name, str(self.iface)), self.endpoint],
+            self.name)
 
     def destroy(self):
         if self.proc:

--- a/src-python/lab-service/traffexam/kilda/traffexam/__init__.py
+++ b/src-python/lab-service/traffexam/kilda/traffexam/__init__.py
@@ -13,4 +13,4 @@
 #   limitations under the License.
 #
 
-__version__ = '0.1.dev15'
+__version__ = '0.1.dev16'

--- a/src-python/lab-service/traffexam/kilda/traffexam/common.py
+++ b/src-python/lab-service/traffexam/kilda/traffexam/common.py
@@ -59,21 +59,6 @@ class Registry(object):
         return value
 
 
-class ProcMonitor(collections.Iterable):
-    def __init__(self):
-        self.proc_set = weakref.WeakSet()
-
-    def __iter__(self):
-        return iter(self.proc_set)
-
-    def add(self, proc):
-        self.proc_set.add(proc)
-
-    def check_status(self):
-        for proc in self.proc_set:
-            proc.poll()
-
-
 class AbstractSignal(object):
     def __init__(self, signum):
         self.signum = signum

--- a/src-python/lab-service/traffexam/kilda/traffexam/context.py
+++ b/src-python/lab-service/traffexam/kilda/traffexam/context.py
@@ -34,7 +34,6 @@ class Context(object):
         self.iface = iface
         self.rest_bind = rest_bind
 
-        self.children = common.ProcMonitor()
         self.shared_registry = common.Registry()
         self._acquired_resources = []
 

--- a/src-python/lab-service/traffexam/kilda/traffexam/core.py
+++ b/src-python/lab-service/traffexam/kilda/traffexam/core.py
@@ -65,7 +65,6 @@ def main(iface, bind, **args):
 
                 context.set_service_adapter(service.Adapter(context))
                 context.set_action_adapter(action.Adapter(context))
-                SigCHLD(context.children)
 
                 rest.init(bind, context)
         finally:
@@ -102,13 +101,3 @@ def setup_environment(context):
             system.NSNetworksCleanUp,
             system.NSGatewaySetUp,
             system.TargetIfaceSetUp)
-
-
-class SigCHLD(common.AbstractSignal):
-    def __init__(self, children):
-        super().__init__(signal.SIGCHLD)
-        self.children = children
-
-    def handle(self):
-        for child in self.children:
-            child.poll()

--- a/src-python/lab-service/traffexam/kilda/traffexam/service.py
+++ b/src-python/lab-service/traffexam/kilda/traffexam/service.py
@@ -275,7 +275,6 @@ class EndpointService(Abstract):
         proc = subprocess.Popen(cmd, stdout=report, stderr=err)
 
         subject.set_proc(proc)
-        self.context.children.add(proc)
 
     def make_report_file_name(self, subject):
         return self.context.path('{}.json'.format(subject.idnr))

--- a/src-python/lab-service/traffexam/requirements.txt
+++ b/src-python/lab-service/traffexam/requirements.txt
@@ -1,5 +1,5 @@
 click==7.0
-bottle==0.12.16
+bottle>=0.12.16,<=0.12.18
 pyroute2==0.5.5
 nsenter==0.2
 scapy>=2.4.2,<2.4.3


### PR DESCRIPTION
Because traffexam stdout and stderr are redirected into lab-service via
pipe(s) and because lab-service do not read data from these pipes
traffexam became blocked forever after some requests to it (without
logging config it redirects access log to stdout).

Redirect traffexam output into a generic file. So we do not lose it and
do not block traffexam processes.