### PR TITLE
Adjustments to allow running tests in non-default situations

### DIFF
--- a/src-java/testing/functional-tests/README.md
+++ b/src-java/testing/functional-tests/README.md
@@ -44,6 +44,15 @@ execution of subsequent tests.
 - Run tests `make func-tests`
 > Note that the above command will overwrite any existing kilda.properties and topology.yaml 
 files with default ones
+>
+##### Partial Kilda deployment
+If you have limited resources available, it is possible to not deploy some optional Kilda components, for example
+deploy 1 Floodlight instead of 3 (default). Though this will disable some of the tests. 
+In order to achieve this look into `confd/vars/docker-compose.yaml`. If you deploy only 1 Floodlight make sure to:
+- adjust `kilda.properties` values for `floodlight.controllers` and `floodlight.regions`
+- in `topology.yaml` check that no switches try to connect to 'region: 2'  
+
+Make relative changes for any other properties related to not deployed components.
 
 ### Hardware (remote Kilda, Staging)
 - Ensure that `topology.yaml` and
@@ -54,7 +63,8 @@ Note that other properties should
 correspond to actual Kilda properties that were used for deployment of the target env.
 - Check your `topology.yaml`. It should represent your actual expected hardware topology. You can automatically generate 
 `topology.yaml` based on currently discovered topology, but be aware that this will prevent you from catching
-some switch/isl discovery-related issues: `make test-topology PARAMS="--tests GenerateTopologyConfig"` && `cp functional-tests/build/topology.yaml functional-tests/`
+some switch/isl discovery-related issues: `make test-topology PARAMS="--tests GenerateTopologyConfig"` && `cp functional-tests/build/topology.yaml functional-tests/`.
+ This will also not generate information about 'a-switch' and traffgens.
 - Now you can run tests by executing the following command in the terminal:  
 `make func-tests`.
 

--- a/src-java/testing/functional-tests/build.gradle
+++ b/src-java/testing/functional-tests/build.gradle
@@ -67,3 +67,7 @@ task runTest(type: Test) {
     include '**/functionaltests/**'
     systemProperty 'tags', System.getProperty('tags')
 }
+
+tasks.withType(Test) {
+    outputs.upToDateWhen { false } //never cache results of functional tests
+}

--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/config/TopologyConfig.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/config/TopologyConfig.groovy
@@ -70,7 +70,8 @@ class TopologyConfig {
                 throw new RuntimeException("Switch $sw has an unknown region '${sw.getRegion()}'. All regions should" +
                         "be specified in kilda.properties.")
             }
-            sw.setController(managementControllers[regionIndex] + " " + statControllers[regionIndex])
+            sw.setController(managementControllers[regionIndex] +
+                    (statControllers[regionIndex] ? " " + statControllers[regionIndex] : ""))
         }
         return topologyDefinition
     }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ConnectedDevicesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ConnectedDevicesSpec.groovy
@@ -269,6 +269,7 @@ srcDevices=#newSrcEnabled, dstDevices=#newDstEnabled"() {
     @Tags([SMOKE_SWITCHES])
     def "Able to detect devices on a single-switch different-port flow"() {
         given: "A flow between different ports on the same switch"
+        assumeTrue("Require at least 1 switch with connected traffgen", topology.activeTraffGens.size() > 0)
         def sw = topology.activeTraffGens*.switchConnected.first()
         def initialProps = enableMultiTableIfNeeded(true, sw.dpId)
 
@@ -578,6 +579,7 @@ srcDevices=#newSrcEnabled, dstDevices=#newDstEnabled"() {
     @Tidy
     def "System properly detects devices if feature is 'off' on switch level and 'on' on flow level"() {
         given: "A switch with devices feature turned off"
+        assumeTrue("Require at least 1 switch with connected traffgen", topology.activeTraffGens.size() > 0)
         def sw = topology.activeTraffGens[0].switchConnected
         def initialProps = enableMultiTableIfNeeded(true, sw.dpId)
         def swProps = northbound.getSwitchProperties(sw.dpId)
@@ -645,6 +647,7 @@ srcDevices=#newSrcEnabled, dstDevices=#newDstEnabled"() {
     @Tidy
     def "System properly detects devices if feature is 'on' on switch level and 'off' on flow level"() {
         given: "A switch with devices feature turned on"
+        assumeTrue("Require at least 1 switch with connected traffgen", topology.activeTraffGens.size() > 0)
         def tg = topology.activeTraffGens[0]
         def sw = tg.switchConnected
         def initialProps = northbound.getSwitchProperties(sw.dpId)
@@ -699,6 +702,7 @@ srcDevices=#newSrcEnabled, dstDevices=#newDstEnabled"() {
 
     def "Able to detect devices on free switch port (no flow or isl)"() {
         given: "A switch with devices feature turned on"
+        assumeTrue("Require at least 1 switch with connected traffgen", topology.activeTraffGens.size() > 0)
         def tg = topology.activeTraffGens[0]
         def sw = tg.switchConnected
         def initialProps = northbound.getSwitchProperties(sw.dpId)
@@ -737,6 +741,7 @@ srcDevices=#newSrcEnabled, dstDevices=#newDstEnabled"() {
     @Unroll
     def "Able to distinguish devices between default and non-default single-switch flows (#descr)"() {
         given: "A switch with devices feature turned on"
+        assumeTrue("Require at least 1 switch with connected traffgen", topology.activeTraffGens.size() > 0)
         def tg = topology.activeTraffGens[0]
         def sw = tg.switchConnected
         def initialProps = northbound.getSwitchProperties(sw.dpId)
@@ -1282,8 +1287,8 @@ srcDevices=#newSrcEnabled, dstDevices=#newDstEnabled"() {
 
     private FlowPayload getFlowWithConnectedDevices(
             boolean protectedFlow, boolean oneSwitch, boolean srcEnabled, boolean dstEnabled) {
-        def tgSwPair = getUniqueSwitchPairs()[0]
-        assert tgSwPair, "Unable to find a switchPair with traffgens for the requested flow arguments"
+        def tgSwPair = getUniqueSwitchPairs()?.first()
+        assumeTrue("Unable to find a switchPair with traffgens for the requested flow arguments", tgSwPair as boolean)
         getFlowWithConnectedDevices(protectedFlow, oneSwitch, srcEnabled, dstEnabled, tgSwPair)
     }
 
@@ -1321,6 +1326,7 @@ srcDevices=#newSrcEnabled, dstDevices=#newDstEnabled"() {
         List<SwitchPair> switchPairs = topologyHelper.switchPairs.collectMany { [it, it.reversed] }.findAll {
             it.src in tgSwitches && it.dst in tgSwitches
         }
+        assumeTrue("Unable to find a switchPair with traffgens on both sides", switchPairs.size() > 0)
         def result = []
         while (!unpickedTgSwitches.empty) {
             def pair = switchPairs.sort(false) { switchPair ->

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/DefaultFlowSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/DefaultFlowSpec.groovy
@@ -30,7 +30,7 @@ class DefaultFlowSpec extends HealthCheckSpecification {
     def "Systems allows to pass traffic via default and vlan flow when they are on the same port"() {
         given: "At least 3 traffGen switches"
         def allTraffGenSwitches = topology.activeTraffGens*.switchConnected
-        assumeTrue("Unable to find required switches in topology", (allTraffGenSwitches.size() > 2) as boolean)
+        assumeTrue("Unable to find required switches in topology", allTraffGenSwitches.size() > 2)
 
         when: "Create a vlan flow"
         def (Switch srcSwitch, Switch dstSwitch) = allTraffGenSwitches
@@ -108,7 +108,7 @@ class DefaultFlowSpec extends HealthCheckSpecification {
         // we can't test (0<->20, 20<->0) because iperf is not able to establish a connection
         given: "At least 2 traffGen switches"
         def allTraffGenSwitches = topology.activeTraffGens*.switchConnected
-        assumeTrue("Unable to find required switches in topology", (allTraffGenSwitches.size() > 1) as boolean)
+        assumeTrue("Unable to find required switches in topology", allTraffGenSwitches.size() > 1)
 
         when: "Create a default flow"
         def (Switch srcSwitch, Switch dstSwitch) = allTraffGenSwitches
@@ -139,7 +139,7 @@ class DefaultFlowSpec extends HealthCheckSpecification {
     def "Unable to send traffic from simple flow into default flow and vice versa"() {
         given: "At least 2 traffGen switches"
         def allTraffGenSwitches = topology.activeTraffGens*.switchConnected
-        assumeTrue("Unable to find required switches in topology", (allTraffGenSwitches.size() > 1) as boolean)
+        assumeTrue("Unable to find required switches in topology", allTraffGenSwitches.size() > 1)
 
         and: "A default flow"
         def (Switch srcSwitch, Switch dstSwitch) = allTraffGenSwitches

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/DefaultFlowV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/DefaultFlowV2Spec.groovy
@@ -35,7 +35,7 @@ class DefaultFlowV2Spec extends HealthCheckSpecification {
    def "Systems allows to pass traffic via default/vlan and qinq flow when they are on the same port"() {
         given: "At least 3 traffGen switches"
         def allTraffGenSwitches = topology.activeTraffGens*.switchConnected
-        assumeTrue("Unable to find required switches in topology", (allTraffGenSwitches.size() > 2) as boolean)
+        assumeTrue("Unable to find required switches in topology", allTraffGenSwitches.size() > 2)
 
         when: "Create a vlan flow"
         def (Switch srcSwitch, Switch dstSwitch) = allTraffGenSwitches
@@ -128,7 +128,7 @@ class DefaultFlowV2Spec extends HealthCheckSpecification {
         // we can't test (0<->20, 20<->0) because iperf is not able to establish a connection
         given: "At least 2 traffGen switches"
         def allTraffGenSwitches = topology.activeTraffGens*.switchConnected
-        assumeTrue("Unable to find required switches in topology", (allTraffGenSwitches.size() > 1) as boolean)
+        assumeTrue("Unable to find required switches in topology", allTraffGenSwitches.size() > 1)
 
         when: "Create a default flow"
         def (Switch srcSwitch, Switch dstSwitch) = allTraffGenSwitches
@@ -169,7 +169,7 @@ class DefaultFlowV2Spec extends HealthCheckSpecification {
     def "Unable to send traffic from simple flow into default flow and vice versa"() {
         given: "At least 2 traffGen switches"
         def allTraffGenSwitches = topology.activeTraffGens*.switchConnected
-        assumeTrue("Unable to find required switches in topology", (allTraffGenSwitches.size() > 1) as boolean)
+        assumeTrue("Unable to find required switches in topology", allTraffGenSwitches.size() > 1)
 
         and: "A default flow"
         def (Switch srcSwitch, Switch dstSwitch) = allTraffGenSwitches

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
@@ -254,8 +254,8 @@ switches"() {
             if (halfDifferent) result = [switchPair, halfDifferent]
             return result
         }] * 3
-        flow1 << [getFirstFlow(switchPairs[0], switchPairs[1])] * 3
-        flow2 << [getSecondFlow(switchPairs[0], switchPairs[1], flow1)] * 3
+        flow1 << [getFirstFlow(switchPairs?.get(0), switchPairs?.get(1))] * 3
+        flow2 << [getSecondFlow(switchPairs?.get(0), switchPairs?.get(1), flow1)] * 3
         [flow1Src, flow1Dst, flow2Src, flow2Dst] << [
                 [changePropertyValue(flow1.source, "vlanId", flow2.destination.vlanId),
                  changePropertyValue(flow1.destination, "vlanId", flow2.source.vlanId),
@@ -312,8 +312,8 @@ switches"() {
             if (halfDifferent) result = [switchPair, halfDifferent]
             return result
         }] * 4
-        flow1 << [getFirstFlow(switchPairs[0], switchPairs[1])] * 4
-        flow2 << [getSecondFlow(switchPairs[0], switchPairs[1], flow1)] * 4
+        flow1 << [getFirstFlow(switchPairs?.get(0), switchPairs?.get(1))] * 4
+        flow2 << [getSecondFlow(switchPairs?.get(0), switchPairs?.get(1), flow1)] * 4
         [flow1Src, flow1Dst, flow2Src, flow2Dst] << [
                 [flow2.source, flow1.destination, flow1.source, flow2.destination],
                 [flow1.source, flow2.destination, flow2.source, flow1.destination],
@@ -361,8 +361,8 @@ switches"() {
             if (halfDifferent) result = [switchPair, halfDifferent]
             return result
         }] * 3
-        flow1 << [getFirstFlow(switchPairs[0], switchPairs[1])] * 3
-        flow2 << [getSecondFlow(switchPairs[0], switchPairs[1], flow1)] * 3
+        flow1 << [getFirstFlow(switchPairs?.get(0), switchPairs?.get(1))] * 3
+        flow2 << [getSecondFlow(switchPairs?.get(0), switchPairs?.get(1), flow1)] * 3
         [flow1Src, flow1Dst, flow2Src, flow2Dst] << [
                 [changePropertyValue(flow1.source, "vlanId", flow2.destination.vlanId),
                  changePropertyValue(flow1.destination, "vlanId", flow2.source.vlanId),
@@ -1038,7 +1038,6 @@ switches"() {
         given: "Two protected flows with different source and destination switches"
         def tgSwitches = topology.getActiveTraffGens()*.getSwitchConnected()
         assumeTrue("Not enough traffgen switches found", tgSwitches.size() > 1)
-
         SwitchPair flow2SwitchPair = null
         SwitchPair flow1SwitchPair = topologyHelper.getAllNeighboringSwitchPairs().find { firstPair ->
             def firstOk = !(firstPair.src in tgSwitches) && firstPair.dst in tgSwitches
@@ -1362,6 +1361,7 @@ switches"() {
      * @return a FlowCreatePayload instance
      */
     def getFirstFlow(SwitchPair firstFlowSwitchPair, SwitchPair secondFlowSwitchPair, noVlans = false) {
+        assumeTrue("Required conditions for switch-pairs for this test are not met", firstFlowSwitchPair && secondFlowSwitchPair)
         def firstFlow = flowHelper.randomFlow(firstFlowSwitchPair)
         firstFlow.source.portNumber = (topology.getAllowedPortsForSwitch(firstFlowSwitchPair.src) -
                 topology.getBusyPortsForSwitch(secondFlowSwitchPair.src) -
@@ -1395,6 +1395,7 @@ switches"() {
      * @return a FlowCreatePayload instance
      */
     def getSecondFlow(firstFlowSwitchPair, secondFlowSwitchPair, firstFlow, noVlans = false) {
+        assumeTrue("Required conditions for switch-pairs for this test are not met", firstFlowSwitchPair && secondFlowSwitchPair)
         def secondFlow = flowHelper.randomFlow(secondFlowSwitchPair)
         secondFlow.source.portNumber = (topology.getAllowedPortsForSwitch(secondFlowSwitchPair.src) -
                 topology.getBusyPortsForSwitch(firstFlowSwitchPair.src) -

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/VxlanFlowV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/VxlanFlowV2Spec.groovy
@@ -545,9 +545,8 @@ class VxlanFlowV2Spec extends HealthCheckSpecification {
     def "System allows to create/update encapsulation type for a one-switch flow\
 (#encapsulationCreate.toString() -> #encapsulationUpdate.toString())"() {
         when: "Try to create a one-switch flow"
-        def sw = topology.activeTraffGens*.switchConnected.find {
-            it.noviflow && !it.wb5164
-        } ?: assumeTrue("Should be at least one active traffgen connected to NoviFlow switch", false)
+        def sw = topology.activeSwitches.find { it.noviflow && !it.wb5164 }
+        assumeTrue("Require at least 1 Noviflow non-WB switch", sw as boolean)
         def flow = flowHelperV2.singleSwitchFlow(sw)
         flow.encapsulationType = encapsulationCreate
         northboundV2.addFlow(flow)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/MflStatSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/MflStatSpec.groovy
@@ -1,5 +1,6 @@
 package org.openkilda.functionaltests.spec.stats
 
+import static org.junit.Assume.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 import static org.openkilda.functionaltests.extension.tags.Tag.VIRTUAL
 import static org.openkilda.testing.Constants.WAIT_OFFSET
@@ -44,6 +45,7 @@ class MflStatSpec extends HealthCheckSpecification {
     @Tags([VIRTUAL, LOW_PRIORITY])
     def "System is able to collect stats from the statistic and management controllers"() {
         given: "A flow"
+        assumeTrue("Require at least 2 switches with connected traffgen", topology.activeTraffGens.size() > 1)
         def (Switch srcSwitch, Switch dstSwitch) = topology.activeTraffGens*.switchConnected
         def flow = flowHelper.randomFlow(srcSwitch, dstSwitch)
         flow.maximumBandwidth = 100
@@ -139,6 +141,7 @@ class MflStatSpec extends HealthCheckSpecification {
     @Tags(VIRTUAL)
     def "System is able to collect stats from the statistic and management controllers (v2)"() {
         given: "A flow"
+        assumeTrue("Require at least 2 switches with connected traffgen", topology.activeTraffGens.size() > 1)
         def (Switch srcSwitch, Switch dstSwitch) = topology.activeTraffGens*.switchConnected
         def flow = flowHelperV2.randomFlow(srcSwitch, dstSwitch)
         flow.maximumBandwidth = 100


### PR DESCRIPTION
- never cache results of functional tests
- skip instead of fail if no traffgens found for test
- allow healthcheck to pass if no stats FL is deployed