### PR TITLE
Raise moved discovery state priority

### DIFF
--- a/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/controller/isl/DiscoveryMovedMonitor.java
+++ b/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/controller/isl/DiscoveryMovedMonitor.java
@@ -1,0 +1,84 @@
+/* Copyright 2020 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.network.controller.isl;
+
+import org.openkilda.model.Isl;
+import org.openkilda.model.IslDownReason;
+import org.openkilda.model.IslStatus;
+import org.openkilda.wfm.share.model.Endpoint;
+import org.openkilda.wfm.share.model.IslReference;
+import org.openkilda.wfm.topology.network.controller.isl.IslFsm.IslFsmContext;
+import org.openkilda.wfm.topology.network.controller.isl.IslFsm.IslFsmEvent;
+
+import java.util.Optional;
+
+public class DiscoveryMovedMonitor extends DiscoveryMonitor<Boolean> {
+    protected DiscoveryMovedMonitor(IslReference reference) {
+        super(reference);
+    }
+
+    @Override
+    public Optional<IslStatus> evaluateStatus() {
+        boolean isMoved = discoveryData.stream()
+                .anyMatch(entry -> entry != null && entry);
+        if (isMoved) {
+            return Optional.of(IslStatus.MOVED);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public IslDownReason getDownReason() {
+        return null;  // this monitor can't produce down state
+    }
+
+    @Override
+    public void load(Endpoint endpoint, Isl persistentView) {
+        super.load(endpoint, persistentView);
+
+        boolean isMoved = persistentView.getActualStatus() == IslStatus.MOVED;
+        discoveryData.put(endpoint, isMoved);
+        cache.put(endpoint, isMoved);
+    }
+
+    @Override
+    protected void actualUpdate(IslFsmEvent event, IslFsmContext context) {
+        Endpoint endpoint = context.getEndpoint();
+        Boolean update = discoveryData.get(endpoint);
+        switch (event) {
+            case ISL_MOVE:
+                update = true;
+                break;
+
+            case ISL_UP:
+            case ISL_DOWN:
+                update = false;
+                break;
+
+            default:
+                // nothing to do here
+        }
+        discoveryData.put(endpoint, update);
+    }
+
+    @Override
+    protected void actualFlush(Endpoint endpoint, Isl persistentView) {
+        Boolean isMoved = discoveryData.get(endpoint);
+        if (isMoved != null && isMoved) {
+            persistentView.setActualStatus(IslStatus.MOVED);
+        }
+    }
+}

--- a/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/controller/isl/DiscoveryPollMonitor.java
+++ b/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/controller/isl/DiscoveryPollMonitor.java
@@ -52,15 +52,14 @@ public class DiscoveryPollMonitor extends DiscoveryMonitor<IslEndpointPollStatus
         IslStatus forward = discoveryData.getForward().getStatus();
         IslStatus reverse = discoveryData.getReverse().getStatus();
 
-        if (forward == IslStatus.MOVED || reverse == IslStatus.MOVED) {
-            return Optional.of(IslStatus.MOVED);
-        }
-
         if (forward == reverse) {
             return Optional.of(forward);
         }
+        if (forward == IslStatus.INACTIVE || reverse == IslStatus.INACTIVE) {
+            return Optional.of(IslStatus.INACTIVE);
+        }
 
-        return Optional.of(IslStatus.INACTIVE);
+        return Optional.empty();
     }
 
     @Override
@@ -83,6 +82,9 @@ public class DiscoveryPollMonitor extends DiscoveryMonitor<IslEndpointPollStatus
                 break;
 
             case ISL_MOVE:
+                // We must track MOVED state, because poll and moved monitor save it's status
+                // inside same field {@link Isl.actualStatus}. In other case we will rewrite MOVED state
+                // saved by {@link DiscoveryMovedMonitor} with our ovn "vision".
                 update = new IslEndpointPollStatus(update.getIslData(), IslStatus.MOVED);
                 break;
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
@@ -725,7 +725,7 @@ class FlowCrudSpec extends HealthCheckSpecification {
         Isl isl = topology.islsForActiveSwitches.find { it.aswitch && it.dstSwitch }
         assumeTrue("Unable to find required isl", isl as boolean)
         def notConnectedIsl = topology.notConnectedIsls.first()
-        def newIsl = islUtils.replug(isl, false, notConnectedIsl, true)
+        def newIsl = islUtils.replug(isl, false, notConnectedIsl, true, true)
 
         islUtils.waitForIslStatus([isl, isl.reversed], MOVED)
         islUtils.waitForIslStatus([newIsl, newIsl.reversed], DISCOVERED)
@@ -743,7 +743,7 @@ class FlowCrudSpec extends HealthCheckSpecification {
         errorDetails.errorDescription == getPortViolationError("source", isl.srcPort, isl.srcSwitch.dpId)
 
         and: "Cleanup: Restore status of the ISL and delete new created ISL"
-        islUtils.replug(newIsl, true, isl, false)
+        islUtils.replug(newIsl, true, isl, false, true)
         islUtils.waitForIslStatus([isl, isl.reversed], DISCOVERED)
         islUtils.waitForIslStatus([newIsl, newIsl.reversed], MOVED)
         northbound.deleteLink(islUtils.toLinkParameters(newIsl))

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV2Spec.groovy
@@ -679,7 +679,7 @@ class FlowCrudV2Spec extends HealthCheckSpecification {
         Isl isl = topology.islsForActiveSwitches.find { it.aswitch && it.dstSwitch }
         assumeTrue("Unable to find required isl", isl as boolean)
         def notConnectedIsl = topology.notConnectedIsls.first()
-        def newIsl = islUtils.replug(isl, false, notConnectedIsl, true)
+        def newIsl = islUtils.replug(isl, false, notConnectedIsl, true, true)
 
         islUtils.waitForIslStatus([isl, isl.reversed], MOVED)
         islUtils.waitForIslStatus([newIsl, newIsl.reversed], DISCOVERED)
@@ -697,7 +697,7 @@ class FlowCrudV2Spec extends HealthCheckSpecification {
         errorDetails.errorDescription == getPortViolationError("source", isl.srcPort, isl.srcSwitch.dpId)
 
         and: "Cleanup: Restore status of the ISL and delete new created ISL"
-        islUtils.replug(newIsl, true, isl, false)
+        islUtils.replug(newIsl, true, isl, false, true)
         islUtils.waitForIslStatus([isl, isl.reversed], DISCOVERED)
         islUtils.waitForIslStatus([newIsl, newIsl.reversed], MOVED)
         northbound.deleteLink(islUtils.toLinkParameters(newIsl))

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslMinPortSpeedSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslMinPortSpeedSpec.groovy
@@ -36,7 +36,7 @@ class IslMinPortSpeedSpec extends HealthCheckSpecification {
         def newDstPort = northbound.getPort(newDst.srcSwitch.dpId, newDst.srcPort)
 
         when: "Replug one end of the connected link to the destination switch(isl.srcSwitchId -> newDst.srcSwitchId)"
-        def newIsl = islUtils.replug(isl, false, newDst, true)
+        def newIsl = islUtils.replug(isl, false, newDst, true, true)
 
         islUtils.waitForIslStatus([newIsl, newIsl.reversed], DISCOVERED)
         islUtils.waitForIslStatus([isl, isl.reversed], MOVED)
@@ -47,7 +47,7 @@ class IslMinPortSpeedSpec extends HealthCheckSpecification {
         }
 
         and: "Cleanup: Replug the link back and delete the moved ISL"
-        islUtils.replug(newIsl, true, isl, false)
+        islUtils.replug(newIsl, true, isl, false, true)
         islUtils.waitForIslStatus([isl, isl.reversed], DISCOVERED)
         islUtils.waitForIslStatus([newIsl, newIsl.reversed], MOVED)
         northbound.deleteLink(islUtils.toLinkParameters(newIsl))

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/tools/IslUtils.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/tools/IslUtils.java
@@ -166,20 +166,23 @@ public class IslUtils {
     /**
      * Simulates a physical ISL replug from one switch-port to another switch-port. Uses a-switch.
      *
-     * @param srcIsl The initial ISL which is going to be replugged. Should go through a-switch!
+     * @param srcIsl The initial ISL which is going to be replugged. Should go through a-switch
      * @param replugSource replug source or destination end of the ISL
      * @param dstIsl The destination 'isl'. Usually a free link, which is connected to a-switch at one end
      * @param plugIntoSource Whether to connect to src or dst end of the dstIsl. Usually src end for not-connected ISLs
+     * @param portDown Whether to simulate a 'port down' event when unplugging
      * @return New ISL which is expected to be discovered after the replug
      */
     public TopologyDefinition.Isl replug(TopologyDefinition.Isl srcIsl, boolean replugSource,
-                                         TopologyDefinition.Isl dstIsl, boolean plugIntoSource) {
+                                         TopologyDefinition.Isl dstIsl, boolean plugIntoSource, boolean portDown) {
         ASwitchFlow srcASwitch = srcIsl.getAswitch();
         ASwitchFlow dstASwitch = dstIsl.getAswitch();
         //unplug
         List<Integer> portsToUnplug = Collections.singletonList(
                 replugSource ? srcASwitch.getInPort() : srcASwitch.getOutPort());
-        lockKeeper.portsDown(portsToUnplug);
+        if (portDown) {
+            lockKeeper.portsDown(portsToUnplug);
+        }
 
         //change flow on aSwitch
         //delete old flow
@@ -192,7 +195,9 @@ public class IslUtils {
         lockKeeper.addFlows(Arrays.asList(aswFlowForward, aswFlowForward.getReversed()));
 
         //plug back
-        lockKeeper.portsUp(portsToUnplug);
+        if (portDown) {
+            lockKeeper.portsUp(portsToUnplug);
+        }
 
         return TopologyDefinition.Isl.factory(
                 replugSource ? (plugIntoSource ? dstIsl.getSrcSwitch() : dstIsl.getDstSwitch()) : srcIsl.getSrcSwitch(),


### PR DESCRIPTION
Do not allow ACTIVE/DISCOVERED state from round-trip discovery monitor
to overcome MOVED state.