### PR TITLE
Don't drop group id when updating flow without diverse_flowid param

### DIFF
--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/UpdateFlowAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/UpdateFlowAction.java
@@ -88,13 +88,15 @@ public class UpdateFlowAction extends NbTrackableAction<FlowUpdateFsm, State, Ev
 
         stateMachine.setOriginalFlowGroup(flow.getGroupId());
         if (targetFlow.getDiverseFlowId() != null) {
-            flow.setGroupId(getOrCreateFlowGroupId(targetFlow.getDiverseFlowId()));
+            if (targetFlow.getDiverseFlowId().isEmpty()) {
+                flow.setGroupId(null);
+            } else {
+                flow.setGroupId(getOrCreateFlowGroupId(targetFlow.getDiverseFlowId()));
+            }
         } else if (targetFlow.isAllocateProtectedPath()) {
             if (flow.getGroupId() == null) {
                 flow.setGroupId(getOrCreateFlowGroupId(flow.getFlowId()));
             }
-        } else {
-            flow.setGroupId(null);
         }
 
         Switch srcSwitch = switchRepository.findById(targetFlow.getSrcSwitch())

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/ValidateFlowAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/ValidateFlowAction.java
@@ -68,11 +68,12 @@ public class ValidateFlowAction extends NbTrackableAction<FlowUpdateFsm, State, 
                                                     FlowUpdateFsm stateMachine) {
         String flowId = stateMachine.getFlowId();
         RequestedFlow targetFlow = context.getTargetFlow();
+        String diverseFlowId = targetFlow.getDiverseFlowId();
 
         dashboardLogger.onFlowUpdate(flowId,
                 targetFlow.getSrcSwitch(), targetFlow.getSrcPort(), targetFlow.getSrcVlan(),
                 targetFlow.getDestSwitch(), targetFlow.getDestPort(), targetFlow.getDestVlan(),
-                targetFlow.getDiverseFlowId(), targetFlow.getBandwidth());
+                diverseFlowId, targetFlow.getBandwidth());
 
         boolean isOperationAllowed = featureTogglesRepository.find()
                 .map(FeatureToggles::getUpdateFlowEnabled).orElse(Boolean.FALSE);
@@ -92,15 +93,15 @@ public class ValidateFlowAction extends NbTrackableAction<FlowUpdateFsm, State, 
             throw new FlowProcessingException(ErrorType.DATA_INVALID, e.getMessage(), e);
         }
 
-        if (targetFlow.getDiverseFlowId() != null
+        if (diverseFlowId != null
                 && targetFlow.getSrcSwitch().equals(targetFlow.getDestSwitch())) {
             throw new FlowProcessingException(ErrorType.DATA_INVALID,
                     "Couldn't add one-switch flow into diverse group");
         }
 
         persistenceManager.getTransactionManager().doInTransaction(() -> {
-            if (targetFlow.getDiverseFlowId() != null) {
-                Flow diverseFlow = getFlow(targetFlow.getDiverseFlowId());
+            if (diverseFlowId != null && !diverseFlowId.isEmpty()) {
+                Flow diverseFlow = getFlow(diverseFlowId);
                 if (diverseFlow.isOneSwitchFlow()) {
                     throw new FlowProcessingException(ErrorType.PARAMETERS_INVALID,
                             "Couldn't create diverse group with one-switch flow");

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowDiversityV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowDiversityV2Spec.groovy
@@ -144,7 +144,7 @@ class FlowDiversityV2Spec extends HealthCheckSpecification {
         assert allInvolvedIsls.unique(false) == allInvolvedIsls
 
         when: "Update the second flow to become not diverse"
-        flowHelperV2.updateFlow(flow2.flowId, flow2.tap { it.diverseFlowId = null })
+        flowHelperV2.updateFlow(flow2.flowId, flow2.tap { it.diverseFlowId = "" })
 
         then: "The flow became not diverse and rerouted to the more preferable path (path of the first flow)"
         def flow2PathUpdated = PathHelper.convert(northbound.getFlowPath(flow2.flowId))
@@ -155,7 +155,7 @@ class FlowDiversityV2Spec extends HealthCheckSpecification {
         !northboundV2.getFlow(flow2.flowId).diverseWith
 
         when: "Update the third flow to become not diverse"
-        flowHelperV2.updateFlow(flow3.flowId, flow3.tap { it.diverseFlowId = null })
+        flowHelperV2.updateFlow(flow3.flowId, flow3.tap { it.diverseFlowId = "" })
 
         then: "The flow became not diverse and rerouted to the more preferable path (path of the first flow)"
         def flow3PathUpdated = PathHelper.convert(northbound.getFlowPath(flow3.flowId))


### PR DESCRIPTION
Flow update requests without diverse_flowid param should not drop current group id for flow.