### PR TITLE
check status_info field in func tests

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteV2Spec.groovy
@@ -83,7 +83,9 @@ class AutoRerouteV2Spec extends HealthCheckSpecification {
 
         then: "Flow becomes 'Down'"
         Wrappers.wait(WAIT_OFFSET) {
-            assert northboundV2.getFlowStatus(flow.flowId).status == FlowState.DOWN
+            def flowInfo =  northboundV2.getFlow(flow.flowId)
+            assert flowInfo.status == FlowState.DOWN.toString()
+            assert flowInfo.statusInfo == "Switch $sw.dpId is inactive"
         }
 
         when: "The switch is connected back"
@@ -348,7 +350,10 @@ class AutoRerouteV2Spec extends HealthCheckSpecification {
 
         then: "Flow state is changed to DOWN"
         Wrappers.wait(WAIT_OFFSET) {
-            assert northboundV2.getFlowStatus(flow.flowId).status == FlowState.DOWN
+            def flowInfo = northboundV2.getFlow(flow.flowId)
+            assert flowInfo.status == FlowState.DOWN.toString()
+            assert flowInfo.statusInfo == "Not enough bandwidth or no path found. Failed to\
+ find path with requested bandwidth=$flow.maximumBandwidth: Switch $flow.source.switchId doesn't have links with enough bandwidth"
             assert northbound.getFlowHistory(flow.flowId).last().histories.find { it.action == REROUTE_FAIL }
         }
 
@@ -480,6 +485,10 @@ class AutoRerouteV2Spec extends HealthCheckSpecification {
                     }
                }
             }
+            assert northboundV2.getFlow(firstFlow.flowId).statusInfo =~ /ISL (.*) become INACTIVE because of FAIL TIMEOUT (.*)/
+            assert northboundV2.getFlow(secondFlow.flowId).statusInfo == "Not enough bandwidth or no path found.\
+ Failed to find path with requested bandwidth=$secondFlow.maximumBandwidth: Switch $secondFlow.source.switchId doesn't \
+have links with enough bandwidth"
         }
 
         when: "Connect the switch back to the controller"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PinnedFlowV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PinnedFlowV2Spec.groovy
@@ -115,7 +115,9 @@ class PinnedFlowV2Spec extends HealthCheckSpecification {
         then: "Flow is not rerouted and marked as DOWN when the first ISL is broken"
         Wrappers.wait(WAIT_OFFSET) {
             Wrappers.timedLoop(2) {
-                assert northboundV2.getFlowStatus(flow.flowId).status == FlowState.DOWN
+                def flowInfo = northboundV2.getFlow(flow.flowId)
+                assert flowInfo.status == FlowState.DOWN.toString()
+                assert flowInfo.statusInfo =~ /ISL (.*) become INACTIVE due to physical link DOWN event on (.*)/
                 assert pathHelper.convert(northbound.getFlowPath(flow.flowId)) == currentPath
             }
         }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
@@ -134,7 +134,9 @@ class SwitchFailuresSpec extends HealthCheckSpecification {
             assert northbound.getSwitch(srcSwitch.dpId).state == SwitchChangeType.DEACTIVATED
         }
         Wrappers.wait(WAIT_OFFSET) {
-            assert northboundV2.getFlowStatus(flow.flowId).status == FlowState.DOWN
+            def flowInfo = northboundV2.getFlow(flow.flowId)
+            assert flowInfo.status == FlowState.DOWN.toString()
+            assert flowInfo.statusInfo == "Failed to create flow $flow.flowId"
         }
 
         and: "Flow has no path associated"


### PR DESCRIPTION
Tests are covered the following cases:


Reason why flow is not UP | statusInfo message | Obvious?
-- | -- | --
can't reroute(not enough bandwidth) | ```"Not enough bandwidth or no path found. Failed to find path with requested bandwidth=$flow.maximumBandwidth: Switch $flow.source.switchId doesn't have links with enough bandwidth"``` | PASS
islDiscoveryTimeout | ```"ISL 00:00:00:00:00:00:00:02_3 <===> 00:00:00:00:00:00:00:03_1 become INACTIVE because of FAIL TIMEOUT (endpoint:00:00:00:00:00:00:00:03_1)"``` | PASS
1)create simpleFlow<br>2)break all alt paths<br>3)enable protectedPath<br>4) flow is DEGRADED | ```"Couldn't find non overlapping protected path"``` | PASS
1)create protectedPath<br>2) break all altPath and protectedPath | ```"Reroute is unsuccessful. Couldn't find new path(s)"``` | PASS
1)create protectedFlow<br>2)break all alt paths, protectedPath and mainPath<br>3)make sure flowStatus is DOWN<br>4) fix mainPath<br>5) flow is DEGRADED | ```"Couldn't find non overlapping protected path"``` | PASS
1)singleSwitchFlow<br>2)disconnect switch | ```"Switch $sw.dpId is inactive"``` | PASS
pinnedFlow, break flowPath | ```"ISL 00:00:00:00:00:00:00:02_6 <===> 00:00:00:00:00:00:00:07_19 become INACTIVE due to physical link DOWN event on 00:00:00:00:00:00:00:07_19"``` | PASS
disconnect switch while creating a flow | ```"Failed to create flow $flow.flowId"``` | PASS

