### PR TITLE
minor improvements in fucn-tests

### DIFF
--- a/confd/templates/atdd-staging/kilda.properties.tmpl
+++ b/confd/templates/atdd-staging/kilda.properties.tmpl
@@ -44,6 +44,7 @@ reroute.hardtimeout={{ getv "/kilda_reroute_throttling_delay_max" }}
 discovery.generic.interval={{ getv "/kilda_discovery_generic_interval" }}
 discovery.timeout={{ getv "/kilda_discovery_timeout" }}
 discovery.exhausted.interval={{ getv "/kilda_discovery_exhausted_interval" }}
+discovery.auxiliary.interval={{ getv "/kilda_discovery_auxiliary_interval" }}
 
 antiflap.min={{ getv "/kilda_port_up_down_throttling_delay_seconds_min" }}
 antiflap.warmup={{ getv "/kilda_port_up_down_throttling_delay_seconds_warm_up" }}

--- a/src-java/testing/functional-tests/kilda.properties.example
+++ b/src-java/testing/functional-tests/kilda.properties.example
@@ -41,6 +41,7 @@ reroute.hardtimeout=8
 discovery.generic.interval=3
 discovery.timeout=15
 discovery.exhausted.interval=60
+discovery.auxiliary.interval=30
 
 antiflap.min=1
 antiflap.warmup=3

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/BaseSpecification.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/BaseSpecification.groovy
@@ -73,6 +73,8 @@ class BaseSpecification extends Specification implements SetupOnce {
     int discoveryTimeout
     @Value('${discovery.exhausted.interval}')
     int discoveryExhaustedInterval
+    @Value('${discovery.auxiliary.interval}')
+    int discoveryAuxiliaryInterval
     @Value('${antiflap.cooldown}')
     int antiflapCooldown
     @Value('${antiflap.min}')

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
@@ -937,7 +937,10 @@ class FlowCrudSpec extends HealthCheckSpecification {
             assert northbound.getActiveLinks().size() == topology.islsForActiveSwitches.size() * 2
         }
         database.resetCosts()
-        islsToModify.each { database.resetIslBandwidth(it) }
+        islsToModify.each {
+            database.resetIslBandwidth(it)
+            database.resetIslBandwidth(it.reversed)
+        }
     }
 
     //this is for v1 mapped to h&s

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
@@ -1307,8 +1307,11 @@ switches"() {
         error.errorDescription == sprintf("Reverted flows: [%s, %s]", flow2.flowId, flow1.flowId)
 
         and: "First flow is reverted to Down"
-        Wrappers.wait(PATH_INSTALLATION_TIME) {
+        Wrappers.wait(PATH_INSTALLATION_TIME + WAIT_OFFSET) {
             assert northboundV2.getFlowStatus(flow1.flowId).status == FlowState.DOWN
+            assert northbound.getFlowHistory(flow1.flowId).find {
+                it.action == "Flow rerouting" && it.taskId =~ (/.+ : retry #1/)
+            }
         }
         with(northboundV2.getFlow(flow1.flowId)) {
             source == flow1.source

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/BfdSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/BfdSpec.groovy
@@ -66,7 +66,7 @@ class BfdSpec extends HealthCheckSpecification {
         lockKeeper.addFlows([isl.aswitch])
 
         then: "ISL is rediscovered"
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
+        Wrappers.wait(discoveryAuxiliaryInterval + WAIT_OFFSET) {
             assert northbound.getLink(isl).state == IslChangeType.DISCOVERED
             assert northbound.getLink(isl.reversed).state == IslChangeType.DISCOVERED
         }
@@ -133,7 +133,7 @@ class BfdSpec extends HealthCheckSpecification {
         when: "Set BFD toggle back to 'on' state and restore the ISL"
         lockKeeper.addFlows([isl.aswitch])
         def toggleOn = northbound.toggleFeature(FeatureTogglesDto.builder().useBfdForIslIntegrityCheck(true).build())
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
+        Wrappers.wait(discoveryAuxiliaryInterval + WAIT_OFFSET) {
             assert northbound.getLink(isl).state == IslChangeType.DISCOVERED
             assert northbound.getLink(isl.reversed).state == IslChangeType.DISCOVERED
         }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslReplugSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslReplugSpec.groovy
@@ -139,6 +139,13 @@ class IslReplugSpec extends HealthCheckSpecification {
 
         cleanup:
         database.resetCosts()
+        // next 3 lines(workaround) should be removed once the 3677 issue is fixed
+        antiflap.portDown(isl.srcSwitch.dpId, isl.srcPort)
+        antiflap.portUp(isl.srcSwitch.dpId, isl.srcPort)
+        Wrappers.wait(discoveryExhaustedInterval + WAIT_OFFSET) {
+            [isl, isl.reversed].each { assert northbound.getLink(it).state == DISCOVERED }
+        }
+
     }
 
     def "New potential self-loop ISL (the same port on the same switch) is not getting discovered when replugging"() {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchActivationSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchActivationSpec.groovy
@@ -2,7 +2,6 @@ package org.openkilda.functionaltests.spec.switches
 
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE_SWITCHES
-import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.messaging.info.event.SwitchChangeType.ACTIVATED
 import static org.openkilda.messaging.info.event.SwitchChangeType.DEACTIVATED
 import static org.openkilda.model.MeterId.MAX_SYSTEM_RULE_METER_ID
@@ -154,7 +153,7 @@ class SwitchActivationSpec extends HealthCheckSpecification {
         }
 
         and: "Related ISLs are discovered"
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET / 2 + antiflapCooldown) {
+        Wrappers.wait(discoveryExhaustedInterval + WAIT_OFFSET / 2 + antiflapCooldown) {
             def allIsls = northbound.getAllLinks()
             isls.each {
                 assert islUtils.getIslInfo(allIsls, it).get().actualState == IslChangeType.DISCOVERED

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
@@ -1,9 +1,11 @@
 package org.openkilda.functionaltests.spec.switches
 
+import static groovyx.gpars.GParsPool.withPool
 import static org.junit.Assume.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE_SWITCHES
+import static org.openkilda.functionaltests.helpers.thread.FlowHistoryConstants.REROUTE_ACTION
 import static org.openkilda.functionaltests.helpers.thread.FlowHistoryConstants.REROUTE_FAIL
 import static org.openkilda.testing.Constants.NON_EXISTENT_SWITCH_ID
 import static org.openkilda.testing.Constants.WAIT_OFFSET
@@ -149,19 +151,26 @@ class SwitchesSpec extends HealthCheckSpecification {
 
         when: "Bring down all ports on src switch to make flow DOWN"
         def doPortDowns = true //helper var for cleanup
-        topology.getBusyPortsForSwitch(switchPair.src).each {
-            antiflap.portDown(switchPair.src.dpId, it)
+        def portsToDown = topology.getBusyPortsForSwitch(switchPair.src)
+        withPool {
+            portsToDown.eachParallel { // issue 3665
+                antiflap.portDown(switchPair.src.dpId, it)
+            }
         }
         Wrappers.wait(WAIT_OFFSET) {
             assert northbound.getAllLinks().findAll {
                 it.state == IslChangeType.FAILED
-            }.size() == topology.getBusyPortsForSwitch(switchPair.src).size() * 2
+            }.size() == portsToDown.size() * 2
         }
 
         and: "Get all flows going through the src switch"
-        Wrappers.wait(WAIT_OFFSET) {
+        Wrappers.wait(WAIT_OFFSET * 2) {
             assert northboundV2.getFlowStatus(protectedFlow.flowId).status == FlowState.DOWN
             assert northbound.getFlowHistory(protectedFlow.flowId).last().histories.find { it.action == REROUTE_FAIL }
+            assert northboundV2.getFlowStatus(defaultFlow.flowId).status == FlowState.DOWN
+            def deafultFlowHistory = northbound.getFlowHistory(defaultFlow.flowId).findAll { it.action == REROUTE_ACTION }
+            assert deafultFlowHistory.last().histories.find { it.action == REROUTE_FAIL }
+            assert deafultFlowHistory.find { it.taskId =~ /.+ : retry #1/ }
         }
         def getSwitchFlowsResponse6 = northbound.getSwitchFlows(switchPair.src.dpId)
 
@@ -170,7 +179,7 @@ class SwitchesSpec extends HealthCheckSpecification {
 
         cleanup: "Delete the flows"
         [protectedFlow, singleFlow, defaultFlow].each { flowHelperV2.deleteFlow(it.flowId) }
-        doPortDowns && topology.getBusyPortsForSwitch(switchPair.src).each { antiflap.portUp(switchPair.src.dpId, it) }
+        doPortDowns && portsToDown.each { antiflap.portUp(switchPair.src.dpId, it) }
         Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
             northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
         }


### PR DESCRIPTION
- fix func-test: "Systems allows to get a flow that goes through a switch" 
- adjust BfdSpec to work with discovery.auxiliary.interval
- fix 'System doesn't create flow when reverse path has different bandwidth than forward path on the second link'
- fix "Reroute is not performed while new reroutes are being issued"
- add workaround into fucn test according to #3677 
- fix "New connected switch is properly discovered with related ISLs in a reasonable time"
- fix "System reverts both flows if fails during rule installation when swapping endpoints"