### PR TITLE
Disable IPv6 on interfaces(VLAN) created by traffexam

### DIFF
--- a/src-python/lab-service/traffexam/kilda/traffexam/__init__.py
+++ b/src-python/lab-service/traffexam/kilda/traffexam/__init__.py
@@ -13,4 +13,4 @@
 #   limitations under the License.
 #
 
-__version__ = '0.1.dev16'
+__version__ = '0.1.dev17'

--- a/src-python/lab-service/traffexam/kilda/traffexam/exc.py
+++ b/src-python/lab-service/traffexam/kilda/traffexam/exc.py
@@ -173,3 +173,12 @@ class SystemCompatibilityError(SystemResourceError):
     def __str__(self):
         return ('Unable to configure system resource kind={0} name={1!r}'
                 ' - {2}').format(*self.args)
+
+
+class SubprocessError(AbstractError):
+    def __init__(self, cmd, exit_code, output):
+        super().__init__(cmd, exit_code, output)
+
+    def __str__(self):
+        return ('Child process have failed - cmd={0!r} exit_code={1} '
+                'output={2!r}').format(*self.args)

--- a/src-python/lab-service/traffexam/kilda/traffexam/service.py
+++ b/src-python/lab-service/traffexam/kilda/traffexam/service.py
@@ -117,13 +117,7 @@ class VLANService(Abstract):
         else:
             link = self.get_gw_iface()
 
-        ip = self.get_ipdb()
-        with ip.create(
-                kind='vlan', ifname=ifname, vlan_id=tag,
-                link=link) as iface:
-            iface.up()
-
-        iface = ip.interfaces[ifname].ro
+        iface = self.make_vlan_iface(ifname, link, tag)
         subject.set_iface(model.NetworkIface(
                 ifname, index=iface.index, vlan=subject, vlan_tag=tag))
 
@@ -142,6 +136,14 @@ class VLANService(Abstract):
         else:
             vlan_stack = (raw,)
         return vlan_stack
+
+    def make_vlan_iface(self, name, link, vlan_id):
+        ip = self.get_ipdb()
+        with ip.create(
+                kind='vlan', ifname=name, vlan_id=vlan_id,
+                link=link) as iface:
+            iface.up()
+        return ip.interfaces[name].ro
 
     def make_iface_name(self, tag_raw):
         tag = self._unify_tag_definition(tag_raw)


### PR DESCRIPTION
IPv6 router autodiscovery and router solicitations packets pollute the
test environment and make rests unstable. To avoid such instability IPv6
on traffexam interfaces is being disabled.