### PR TITLE
remove ignore annotation for "Traffic counters in ingress rule are reset on flow rerouting"

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/FlowRulesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/FlowRulesSpec.groovy
@@ -641,7 +641,6 @@ class FlowRulesSpec extends HealthCheckSpecification {
         flowHelperV2.deleteFlow(flow.flowId)
     }
 
-    @Ignore
     @Tidy
     @Tags([SMOKE, SMOKE_SWITCHES])
     def "Traffic counters in ingress rule are reset on flow rerouting(singleTable mode)"() {


### PR DESCRIPTION
This test is fixed by PR #3641

**This PR should be merged after #3641**