### PR TITLE
Retry reroute with max_latency strategy

### DIFF
--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowPathSwappingFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowPathSwappingFsm.java
@@ -19,6 +19,7 @@ import org.openkilda.floodlight.api.request.factory.FlowSegmentRequestFactory;
 import org.openkilda.floodlight.api.response.SpeakerFlowSegmentResponse;
 import org.openkilda.floodlight.flow.response.FlowErrorResponse;
 import org.openkilda.model.FlowPathStatus;
+import org.openkilda.model.PathComputationStrategy;
 import org.openkilda.model.PathId;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.CommandContext;
@@ -48,6 +49,8 @@ public abstract class FlowPathSwappingFsm<T extends NbTrackableFsm<T, S, E, C>, 
     protected PathId newPrimaryReversePath;
     protected PathId newProtectedForwardPath;
     protected PathId newProtectedReversePath;
+    protected PathComputationStrategy newPrimaryPathComputationStrategy;
+    protected PathComputationStrategy newProtectedPathComputationStrategy;
 
     protected final Collection<FlowResources> oldResources = new ArrayList<>();
     protected PathId oldPrimaryForwardPath;

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseResourceAllocationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseResourceAllocationAction.java
@@ -25,13 +25,14 @@ import org.openkilda.model.FlowPathDirection;
 import org.openkilda.model.FlowPathStatus;
 import org.openkilda.model.Isl;
 import org.openkilda.model.IslStatus;
+import org.openkilda.model.PathComputationStrategy;
 import org.openkilda.model.PathId;
 import org.openkilda.model.PathSegment;
 import org.openkilda.model.SwitchId;
 import org.openkilda.model.cookie.FlowSegmentCookie;
 import org.openkilda.model.cookie.FlowSegmentCookie.FlowSegmentCookieBuilder;
+import org.openkilda.pce.GetPathsResult;
 import org.openkilda.pce.PathComputer;
-import org.openkilda.pce.PathPair;
 import org.openkilda.pce.exception.RecoverableException;
 import org.openkilda.pce.exception.UnroutableFlowException;
 import org.openkilda.persistence.PersistenceManager;
@@ -210,7 +211,7 @@ public abstract class BaseResourceAllocationAction<T extends FlowPathSwappingFsm
         }
     }
 
-    protected boolean isNotSamePath(PathPair pathPair, FlowPathPair flowPathPair) {
+    protected boolean isNotSamePath(GetPathsResult pathPair, FlowPathPair flowPathPair) {
         return flowPathPair.getForward() == null
                 || !flowPathBuilder.isSamePath(pathPair.getForward(), flowPathPair.getForward())
                 || flowPathPair.getReverse() == null
@@ -218,7 +219,7 @@ public abstract class BaseResourceAllocationAction<T extends FlowPathSwappingFsm
     }
 
     protected FlowPathPair createFlowPathPair(Flow flow, List<FlowPath> pathsToReuseBandwidth,
-                                              PathPair pathPair, FlowResources flowResources,
+                                              GetPathsResult pathPair, FlowResources flowResources,
                                               boolean forceToIgnoreBandwidth) {
         final FlowSegmentCookieBuilder cookieBuilder = FlowSegmentCookie.builder()
                 .flowEffectiveId(flowResources.getUnmaskedCookie());
@@ -337,5 +338,12 @@ public abstract class BaseResourceAllocationAction<T extends FlowPathSwappingFsm
         Optional.ofNullable(stateMachine.getNewProtectedForwardPath()).ifPresent(pathIds::add);
         Optional.ofNullable(stateMachine.getNewProtectedReversePath()).ifPresent(pathIds::add);
         return pathIds;
+    }
+
+    protected PathComputationStrategy[] getBackUpStrategies(PathComputationStrategy strategy) {
+        if (PathComputationStrategy.MAX_LATENCY.equals(strategy)) {
+            return new PathComputationStrategy[] {PathComputationStrategy.LATENCY};
+        }
+        return new PathComputationStrategy[0];
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/create/action/ResourcesAllocationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/create/action/ResourcesAllocationAction.java
@@ -29,8 +29,8 @@ import org.openkilda.model.Isl;
 import org.openkilda.model.SwitchId;
 import org.openkilda.model.cookie.FlowSegmentCookie;
 import org.openkilda.model.cookie.FlowSegmentCookie.FlowSegmentCookieBuilder;
+import org.openkilda.pce.GetPathsResult;
 import org.openkilda.pce.PathComputer;
-import org.openkilda.pce.PathPair;
 import org.openkilda.pce.exception.RecoverableException;
 import org.openkilda.pce.exception.UnroutableFlowException;
 import org.openkilda.persistence.PersistenceManager;
@@ -227,19 +227,19 @@ public class ResourcesAllocationAction extends NbTrackableAction<FlowCreateFsm, 
 
     private void allocateMainPath(FlowCreateFsm fsm, Flow flow) throws UnroutableFlowException,
             RecoverableException, ResourceAllocationException {
-        PathPair pathPair = pathComputer.getPath(flow);
+        GetPathsResult paths = pathComputer.getPath(flow);
         FlowResources flowResources = resourcesManager.allocateFlowResources(flow);
         final FlowSegmentCookieBuilder cookieBuilder = FlowSegmentCookie.builder()
                 .flowEffectiveId(flowResources.getUnmaskedCookie());
 
         FlowPath forward = flowPathBuilder.buildFlowPath(
-                flow, flowResources.getForward(), pathPair.getForward(),
+                flow, flowResources.getForward(), paths.getForward(),
                 cookieBuilder.direction(FlowPathDirection.FORWARD).build(), false);
         forward.setStatus(FlowPathStatus.IN_PROGRESS);
         flow.setForwardPath(forward);
 
         FlowPath reverse = flowPathBuilder.buildFlowPath(
-                flow, flowResources.getReverse(), pathPair.getReverse(),
+                flow, flowResources.getReverse(), paths.getReverse(),
                 cookieBuilder.direction(FlowPathDirection.REVERSE).build(), false);
         reverse.setStatus(FlowPathStatus.IN_PROGRESS);
         flow.setReversePath(reverse);
@@ -260,7 +260,7 @@ public class ResourcesAllocationAction extends NbTrackableAction<FlowCreateFsm, 
     private void allocateProtectedPath(FlowCreateFsm fsm, Flow flow) throws UnroutableFlowException,
             RecoverableException, ResourceAllocationException, FlowNotFoundException {
         flow.setGroupId(getGroupId(flow.getFlowId()));
-        PathPair protectedPath = pathComputer.getPath(flow);
+        GetPathsResult protectedPath = pathComputer.getPath(flow);
 
         boolean overlappingProtectedPathFound =
                 flowPathBuilder.arePathsOverlapped(protectedPath.getForward(), flow.getForwardPath())

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/FlowRerouteFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/FlowRerouteFsm.java
@@ -92,6 +92,7 @@ public final class FlowRerouteFsm extends FlowPathSwappingFsm<FlowRerouteFsm, St
     private String originalFlowStatusInfo;
     private FlowEncapsulationType originalEncapsulationType;
     private PathComputationStrategy originalPathComputationStrategy;
+    private PathComputationStrategy targetPathComputationStrategy;
 
     private FlowStatus newFlowStatus;
     private FlowEncapsulationType newEncapsulationType;

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/ValidateFlowAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/ValidateFlowAction.java
@@ -95,8 +95,11 @@ public class ValidateFlowAction extends NbTrackableAction<FlowRerouteFsm, State,
             stateMachine.setPeriodicPingsEnabled(foundFlow.isPeriodicPings());
 
             if (foundFlow.getTargetPathComputationStrategy() != null) {
+                stateMachine.setTargetPathComputationStrategy(foundFlow.getTargetPathComputationStrategy());
                 foundFlow.setPathComputationStrategy(foundFlow.getTargetPathComputationStrategy());
                 foundFlow.setTargetPathComputationStrategy(null);
+            } else {
+                stateMachine.setTargetPathComputationStrategy(foundFlow.getPathComputationStrategy());
             }
             foundFlow.setStatus(FlowStatus.IN_PROGRESS);
             flowRepository.createOrUpdate(foundFlow);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocatePrimaryResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocatePrimaryResourcesAction.java
@@ -18,8 +18,8 @@ package org.openkilda.wfm.topology.flowhs.fsm.update.actions;
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowPath;
 import org.openkilda.model.PathId;
+import org.openkilda.pce.GetPathsResult;
 import org.openkilda.pce.PathComputer;
-import org.openkilda.pce.PathPair;
 import org.openkilda.pce.exception.RecoverableException;
 import org.openkilda.pce.exception.UnroutableFlowException;
 import org.openkilda.persistence.PersistenceManager;
@@ -76,7 +76,7 @@ public class AllocatePrimaryResourcesAction extends
         Flow flow = getFlow(flowId);
         log.debug("Finding a new primary path for flow {}", flowId);
         List<PathId> pathIdsToReuse = pathsToReuse.stream().map(FlowPath::getPathId).collect(Collectors.toList());
-        final PathPair potentialPath = pathComputer.getPath(flow, pathIdsToReuse);
+        final GetPathsResult potentialPath = pathComputer.getPath(flow, pathIdsToReuse);
 
         log.debug("Allocating resources for a new primary path of flow {}", flowId);
         FlowResources flowResources = resourcesManager.allocateFlowResources(flow);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocateProtectedResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocateProtectedResourcesAction.java
@@ -18,8 +18,8 @@ package org.openkilda.wfm.topology.flowhs.fsm.update.actions;
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowPath;
 import org.openkilda.model.PathId;
+import org.openkilda.pce.GetPathsResult;
 import org.openkilda.pce.PathComputer;
-import org.openkilda.pce.PathPair;
 import org.openkilda.pce.exception.RecoverableException;
 import org.openkilda.pce.exception.UnroutableFlowException;
 import org.openkilda.persistence.PersistenceManager;
@@ -75,7 +75,7 @@ public class AllocateProtectedResourcesAction extends
         Flow flow = getFlow(flowId);
         log.debug("Finding a new protected path for flow {}", flowId);
         List<PathId> pathIdsToReuse = pathsToReuse.stream().map(FlowPath::getPathId).collect(Collectors.toList());
-        PathPair potentialPath = pathComputer.getPath(flow, pathIdsToReuse);
+        GetPathsResult potentialPath = pathComputer.getPath(flow, pathIdsToReuse);
 
         PathId newPrimaryForwardPathId = stateMachine.getNewPrimaryForwardPath();
         FlowPath primaryForwardPath = getFlowPath(flow, newPrimaryForwardPathId);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/AbstractFlowTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/AbstractFlowTest.java
@@ -40,12 +40,13 @@ import org.openkilda.model.FlowPath;
 import org.openkilda.model.FlowPathStatus;
 import org.openkilda.model.FlowStatus;
 import org.openkilda.model.IslEndpoint;
+import org.openkilda.model.PathComputationStrategy;
 import org.openkilda.model.SwitchId;
 import org.openkilda.model.cookie.Cookie;
+import org.openkilda.pce.GetPathsResult;
 import org.openkilda.pce.Path;
 import org.openkilda.pce.Path.Segment;
 import org.openkilda.pce.PathComputer;
-import org.openkilda.pce.PathPair;
 import org.openkilda.persistence.Neo4jBasedTest;
 import org.openkilda.persistence.dummy.IslDirectionalReference;
 import org.openkilda.persistence.repositories.FeatureTogglesRepository;
@@ -294,8 +295,8 @@ public abstract class AbstractFlowTest extends Neo4jBasedTest {
                         flowDestination.getOuterVlanId()));
     }
 
-    protected PathPair makeOneSwitchPathPair() {
-        return PathPair.builder()
+    protected GetPathsResult makeOneSwitchPathPair() {
+        return GetPathsResult.builder()
                 .forward(Path.builder()
                         .srcSwitchId(SWITCH_SOURCE)
                         .destSwitchId(SWITCH_SOURCE)
@@ -309,21 +310,21 @@ public abstract class AbstractFlowTest extends Neo4jBasedTest {
                 .build();
     }
 
-    protected PathPair make2SwitchesPathPair() {
+    protected GetPathsResult make2SwitchesPathPair() {
         return makeSourceDestPathPair(islSourceDest);
     }
 
-    protected PathPair make2SwitchAltPathPair() {
+    protected GetPathsResult make2SwitchAltPathPair() {
         return makeSourceDestPathPair(islSourceDestAlt);
     }
 
-    private PathPair makeSourceDestPathPair(IslDirectionalReference islReference) {
+    private GetPathsResult makeSourceDestPathPair(IslDirectionalReference islReference) {
         List<Segment> forwardSegments = ImmutableList.of(
                 makePathSegment(islReference));
         List<Segment> reverseSegments = ImmutableList.of(
                 makePathSegment(islReference.makeOpposite()));
 
-        return PathPair.builder()
+        return GetPathsResult.builder()
                 .forward(Path.builder()
                         .srcSwitchId(SWITCH_SOURCE)
                         .destSwitchId(SWITCH_DEST)
@@ -334,10 +335,15 @@ public abstract class AbstractFlowTest extends Neo4jBasedTest {
                         .destSwitchId(SWITCH_SOURCE)
                         .segments(reverseSegments)
                         .build())
+                .usedStrategy(PathComputationStrategy.COST)
                 .build();
     }
 
-    protected PathPair make3SwitchesPathPair() {
+    protected GetPathsResult make3SwitchesPathPair() {
+        return make3SwitchesPathPair(PathComputationStrategy.COST);
+    }
+
+    protected GetPathsResult make3SwitchesPathPair(PathComputationStrategy pathComputationStrategy) {
         List<Segment> forwardSegments = ImmutableList.of(
                 makePathSegment(islSourceTransit),
                 makePathSegment(islTransitDest));
@@ -345,7 +351,7 @@ public abstract class AbstractFlowTest extends Neo4jBasedTest {
                 makePathSegment(islTransitDest.makeOpposite()),
                 makePathSegment(islSourceTransit.makeOpposite()));
 
-        return PathPair.builder()
+        return GetPathsResult.builder()
                 .forward(Path.builder()
                         .srcSwitchId(SWITCH_SOURCE)
                         .destSwitchId(SWITCH_DEST)
@@ -356,6 +362,7 @@ public abstract class AbstractFlowTest extends Neo4jBasedTest {
                         .destSwitchId(SWITCH_SOURCE)
                         .segments(reverseSegments)
                         .build())
+                .usedStrategy(pathComputationStrategy)
                 .build();
     }
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowCreateServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowCreateServiceTest.java
@@ -33,7 +33,7 @@ import org.openkilda.model.Flow;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowPathStatus;
 import org.openkilda.model.FlowStatus;
-import org.openkilda.pce.PathPair;
+import org.openkilda.pce.GetPathsResult;
 import org.openkilda.pce.exception.RecoverableException;
 import org.openkilda.pce.exception.UnroutableFlowException;
 import org.openkilda.wfm.CommandContext;
@@ -380,7 +380,7 @@ public class FlowCreateServiceTest extends AbstractFlowTest {
                 .build());
     }
 
-    private void preparePathComputation(String flowId, PathPair pathPair)
+    private void preparePathComputation(String flowId, GetPathsResult pathPair)
             throws RecoverableException, UnroutableFlowException {
         when(pathComputer.getPath(makeFlowArgumentMatch(flowId))).thenReturn(pathPair);
     }

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/GetPathsResult.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/GetPathsResult.java
@@ -1,0 +1,32 @@
+/* Copyright 2018 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.pce;
+
+import org.openkilda.model.PathComputationStrategy;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.io.Serializable;
+
+@Value
+@Builder
+public class GetPathsResult implements Serializable {
+    private static final long serialVersionUID = 2217277881039083324L;
+    Path forward;
+    Path reverse;
+    PathComputationStrategy usedStrategy;
+}

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/PathComputer.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/PathComputer.java
@@ -38,8 +38,9 @@ public interface PathComputer {
      * @param flow the {@link Flow} instance
      * @return {@link PathPair} instances
      */
-    default PathPair getPath(Flow flow) throws UnroutableFlowException, RecoverableException {
-        return getPath(flow, Collections.emptyList());
+    default GetPathsResult getPath(Flow flow, PathComputationStrategy... backUpStrategies)
+            throws UnroutableFlowException, RecoverableException {
+        return getPath(flow, Collections.emptyList(), backUpStrategies);
     }
 
     /**
@@ -50,7 +51,7 @@ public interface PathComputer {
      *                               be reused in new path computation.
      * @return {@link PathPair} instances
      */
-    PathPair getPath(Flow flow, List<PathId> reusePathsResources)
+    GetPathsResult getPath(Flow flow, List<PathId> reusePathsResources, PathComputationStrategy... backUpStrategies)
             throws UnroutableFlowException, RecoverableException;
 
     /**

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/CostAndBandwidthPathComputationStrategyTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/CostAndBandwidthPathComputationStrategyTest.java
@@ -29,8 +29,8 @@ import org.openkilda.model.PathComputationStrategy;
 import org.openkilda.model.PathId;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchId;
+import org.openkilda.pce.GetPathsResult;
 import org.openkilda.pce.PathComputer;
-import org.openkilda.pce.PathPair;
 import org.openkilda.pce.exception.RecoverableException;
 import org.openkilda.pce.exception.UnroutableFlowException;
 
@@ -56,7 +56,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
         Flow f = getTestFlowBuilder(srcSwitch, destSwitch).build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(f);
+        GetPathsResult path = pathComputer.getPath(f);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         assertEquals(new SwitchId("00:02"), path.getForward().getSegments().get(0).getDestSwitchId()); // chooses path B
@@ -73,7 +73,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
         Flow f = getTestFlowBuilder(srcSwitch, destSwitch).build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(f);
+        GetPathsResult path = pathComputer.getPath(f);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // ====> only difference is it should now have C as first hop .. since B is inactive
@@ -94,7 +94,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
         Flow f = getTestFlowBuilder(srcSwitch, destSwitch).build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(f);
+        GetPathsResult path = pathComputer.getPath(f);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // ====> only difference is it should now have C as first hop .. since B is inactive
@@ -114,7 +114,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
         Flow f = getTestFlowBuilder(srcSwitch, destSwitch).build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(f);
+        GetPathsResult path = pathComputer.getPath(f);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // ====> Should choose B .. because default cost (700) cheaper than 2000
@@ -151,7 +151,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
                 .build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(f1);
+        GetPathsResult path = pathComputer.getPath(f1);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(1));
 
@@ -189,7 +189,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
                 .build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(f1);
+        GetPathsResult path = pathComputer.getPath(f1);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(1));
 
@@ -221,7 +221,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
                 .pathComputationStrategy(PathComputationStrategy.COST)
                 .build();
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair diversePath = pathComputer.getPath(flow);
+        GetPathsResult diversePath = pathComputer.getPath(flow);
 
         diversePath.getForward().getSegments().forEach(
                 segment -> {
@@ -246,7 +246,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
                 .pathComputationStrategy(PathComputationStrategy.COST)
                 .build();
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair diversePath = pathComputer.getPath(flow);
+        GetPathsResult diversePath = pathComputer.getPath(flow);
 
         FlowPath forwardPath = FlowPath.builder()
                 .pathId(new PathId(UUID.randomUUID().toString()))
@@ -272,7 +272,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
 
         flowRepository.createOrUpdate(flow);
 
-        PathPair path2 = pathComputer.getPath(flow, flow.getFlowPathIds());
+        GetPathsResult path2 = pathComputer.getPath(flow, flow.getFlowPathIds());
         assertEquals(diversePath, path2);
     }
 
@@ -287,7 +287,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
         Flow f = getTestFlowBuilder(srcSwitch, destSwitch).build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(f);
+        GetPathsResult path = pathComputer.getPath(f);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         assertEquals(new SwitchId("00:03"), path.getForward().getSegments().get(0).getDestSwitchId());

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/CostPathComputationStrategyTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/CostPathComputationStrategyTest.java
@@ -28,8 +28,8 @@ import org.openkilda.model.PathComputationStrategy;
 import org.openkilda.model.PathId;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchId;
+import org.openkilda.pce.GetPathsResult;
 import org.openkilda.pce.PathComputer;
-import org.openkilda.pce.PathPair;
 import org.openkilda.pce.exception.RecoverableException;
 import org.openkilda.pce.exception.UnroutableFlowException;
 
@@ -59,7 +59,7 @@ public class CostPathComputationStrategyTest extends InMemoryPathComputerBaseTes
                 .build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(f);
+        GetPathsResult path = pathComputer.getPath(f);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         assertEquals(new SwitchId("00:02"), path.getForward().getSegments().get(0).getDestSwitchId()); // chooses path B
@@ -80,7 +80,7 @@ public class CostPathComputationStrategyTest extends InMemoryPathComputerBaseTes
                 .build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(f);
+        GetPathsResult path = pathComputer.getPath(f);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // ====> only difference is it should now have C as first hop .. since B is inactive
@@ -105,7 +105,7 @@ public class CostPathComputationStrategyTest extends InMemoryPathComputerBaseTes
                 .build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(f);
+        GetPathsResult path = pathComputer.getPath(f);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // ====> only difference is it should now have C as first hop .. since B is inactive
@@ -129,7 +129,7 @@ public class CostPathComputationStrategyTest extends InMemoryPathComputerBaseTes
                 .build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(f);
+        GetPathsResult path = pathComputer.getPath(f);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // ====> Should choose B .. because default cost (700) cheaper than 2000
@@ -172,7 +172,7 @@ public class CostPathComputationStrategyTest extends InMemoryPathComputerBaseTes
                 .build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(f1);
+        GetPathsResult path = pathComputer.getPath(f1);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(1));
 
@@ -214,7 +214,7 @@ public class CostPathComputationStrategyTest extends InMemoryPathComputerBaseTes
                 .build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(f1);
+        GetPathsResult path = pathComputer.getPath(f1);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(1));
 
@@ -248,7 +248,7 @@ public class CostPathComputationStrategyTest extends InMemoryPathComputerBaseTes
                 .pathComputationStrategy(PathComputationStrategy.COST)
                 .build();
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair diversePath = pathComputer.getPath(flow);
+        GetPathsResult diversePath = pathComputer.getPath(flow);
 
         diversePath.getForward().getSegments().forEach(
                 segment -> {
@@ -273,7 +273,7 @@ public class CostPathComputationStrategyTest extends InMemoryPathComputerBaseTes
                 .pathComputationStrategy(PathComputationStrategy.COST)
                 .build();
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair diversePath = pathComputer.getPath(flow);
+        GetPathsResult diversePath = pathComputer.getPath(flow);
 
         FlowPath forwardPath = FlowPath.builder()
                 .pathId(new PathId(UUID.randomUUID().toString()))
@@ -299,7 +299,7 @@ public class CostPathComputationStrategyTest extends InMemoryPathComputerBaseTes
 
         flowRepository.createOrUpdate(flow);
 
-        PathPair path2 = pathComputer.getPath(flow, flow.getFlowPathIds());
+        GetPathsResult path2 = pathComputer.getPath(flow, flow.getFlowPathIds());
         assertEquals(diversePath, path2);
     }
 }

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/LatencyPathComputationStrategyBaseTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/LatencyPathComputationStrategyBaseTest.java
@@ -29,8 +29,8 @@ import org.openkilda.model.PathComputationStrategy;
 import org.openkilda.model.PathId;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchId;
+import org.openkilda.pce.GetPathsResult;
 import org.openkilda.pce.PathComputer;
-import org.openkilda.pce.PathPair;
 import org.openkilda.pce.exception.RecoverableException;
 import org.openkilda.pce.exception.UnroutableFlowException;
 
@@ -59,7 +59,7 @@ public class LatencyPathComputationStrategyBaseTest extends InMemoryPathComputer
                 .build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(flow);
+        GetPathsResult path = pathComputer.getPath(flow);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // should choose path B because it has lower latency
@@ -82,7 +82,7 @@ public class LatencyPathComputationStrategyBaseTest extends InMemoryPathComputer
                 .build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(flow);
+        GetPathsResult path = pathComputer.getPath(flow);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // should have switch C as first hop since B is inactive
@@ -110,7 +110,7 @@ public class LatencyPathComputationStrategyBaseTest extends InMemoryPathComputer
                 .build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(flow);
+        GetPathsResult path = pathComputer.getPath(flow);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // should now have C as first hop since A - B link is under maintenance
@@ -138,7 +138,7 @@ public class LatencyPathComputationStrategyBaseTest extends InMemoryPathComputer
                 .build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(flow);
+        GetPathsResult path = pathComputer.getPath(flow);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // should now have C as first hop since A - B link is unstable
@@ -163,7 +163,7 @@ public class LatencyPathComputationStrategyBaseTest extends InMemoryPathComputer
                 .build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(flow);
+        GetPathsResult path = pathComputer.getPath(flow);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // it should now have C as first hop since A - B segment has high latency
@@ -189,7 +189,7 @@ public class LatencyPathComputationStrategyBaseTest extends InMemoryPathComputer
                 .build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair path = pathComputer.getPath(flow);
+        GetPathsResult path = pathComputer.getPath(flow);
         assertNotNull(path);
         assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // should choose B because default latency (500_000_000) is less then A-C latency (1_000_000_000)
@@ -252,7 +252,7 @@ public class LatencyPathComputationStrategyBaseTest extends InMemoryPathComputer
                 .pathComputationStrategy(PathComputationStrategy.LATENCY)
                 .build();
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair diversePath = pathComputer.getPath(flow);
+        GetPathsResult diversePath = pathComputer.getPath(flow);
 
         diversePath.getForward().getSegments().forEach(
                 segment -> {
@@ -277,7 +277,7 @@ public class LatencyPathComputationStrategyBaseTest extends InMemoryPathComputer
                 .pathComputationStrategy(PathComputationStrategy.LATENCY)
                 .build();
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        PathPair diversePath = pathComputer.getPath(flow);
+        GetPathsResult diversePath = pathComputer.getPath(flow);
 
         FlowPath forwardPath = FlowPath.builder()
                 .pathId(new PathId(UUID.randomUUID().toString()))
@@ -303,7 +303,7 @@ public class LatencyPathComputationStrategyBaseTest extends InMemoryPathComputer
 
         flowRepository.createOrUpdate(flow);
 
-        PathPair path2 = pathComputer.getPath(flow, flow.getFlowPathIds());
+        GetPathsResult path2 = pathComputer.getPath(flow, flow.getFlowPathIds());
         assertEquals(diversePath, path2);
     }
 

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/TestFlowBuilder.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/TestFlowBuilder.java
@@ -45,6 +45,7 @@ public class TestFlowBuilder {
     private long bandwidth;
     private boolean ignoreBandwidth = false;
     private PathComputationStrategy pathComputationStrategy = PathComputationStrategy.COST;
+    private long maxLatency;
 
     public TestFlowBuilder() {
     }
@@ -69,6 +70,7 @@ public class TestFlowBuilder {
                 .ignoreBandwidth(ignoreBandwidth)
                 .encapsulationType(FlowEncapsulationType.TRANSIT_VLAN)
                 .pathComputationStrategy(pathComputationStrategy)
+                .maxLatency(maxLatency)
                 .build();
 
         FlowPath forwardPath =


### PR DESCRIPTION
When flow with MAX_LATENCY path computation strategy is rerouted or updated and path with required latency and bandwidth is not found then system should try to build a path without latency restrictions. If flow has a path that violates latency or bandwidth requirements then the flow should be in DEGRADED state.