### PR TITLE
More accurate handling of newrok dumps for region mappings

### DIFF
--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchConnectMonitor.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchConnectMonitor.java
@@ -88,11 +88,17 @@ public abstract class SwitchConnectMonitor {
      */
     public void handleNetworkDumpResponse(NetworkDumpSwitchData switchData, String region) {
         ensureSwitchIdMatch(switchData.getSwitchId());
-        handleConnect(switchData, region);
+        if (isReadWriteMode() == switchData.isWriteMode()) {
+            handlePeriodicDump(switchData, region);
+        }
     }
 
     public boolean isAvailable() {
         return ! availableInRegions.isEmpty();
+    }
+
+    protected void handlePeriodicDump(NetworkDumpSwitchData switchData, String region) {
+        handleConnect(switchData, region);
     }
 
     protected void handleConnect(InfoData notification, String region) {
@@ -153,6 +159,10 @@ public abstract class SwitchConnectMonitor {
     protected abstract boolean isConnectNotification(SwitchInfoData notification);
 
     protected abstract boolean isDisconnectNotification(SwitchInfoData notification);
+
+    protected void reportNotificationDrop(InfoData notification) {
+        log.debug("Drop speaker switch {} notification: {}", switchId, notification);
+    }
 
     protected String formatConnectMode() {
         return isReadWriteMode() ? "RW" : "RO";

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchReadOnlyConnectMonitor.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchReadOnlyConnectMonitor.java
@@ -16,7 +16,6 @@
 package org.openkilda.wfm.topology.floodlightrouter.service.monitor;
 
 import org.openkilda.messaging.info.InfoData;
-import org.openkilda.messaging.info.discovery.NetworkDumpSwitchData;
 import org.openkilda.messaging.info.event.SwitchChangeType;
 import org.openkilda.messaging.info.event.SwitchInfoData;
 import org.openkilda.model.SwitchId;
@@ -33,24 +32,15 @@ public class SwitchReadOnlyConnectMonitor extends SwitchConnectMonitor {
     }
 
     @Override
-    public void handleNetworkDumpResponse(NetworkDumpSwitchData switchData, String region) {
-        if (! switchData.isWriteMode()) {
-            super.handleNetworkDumpResponse(switchData, region);
-        }
-    }
-
-    @Override
     protected void becomeAvailable(InfoData notification, String region) {
         super.becomeAvailable(notification, region);
-        // TODO(surabujin): network topology do not handle this event, so we can drop it here
-        carrier.switchStatusUpdateNotification(switchId, notification);
+        reportNotificationDrop(notification);
     }
 
     @Override
     protected void becomeUnavailable(InfoData notification) {
         super.becomeUnavailable(notification);
-        // TODO(surabujin): network topology do not handle this event, so we can drop it here
-        carrier.switchStatusUpdateNotification(switchId, notification);
+        reportNotificationDrop(notification);
     }
 
     @Override

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchReadWriteConnectMonitor.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchReadWriteConnectMonitor.java
@@ -40,13 +40,11 @@ public class SwitchReadWriteConnectMonitor extends SwitchConnectMonitor {
     }
 
     @Override
-    public void handleNetworkDumpResponse(NetworkDumpSwitchData switchData, String region) {
-        if (switchData.isWriteMode()) {
-            super.handleNetworkDumpResponse(switchData, region);
-            if (Objects.equals(activeRegion, region)) {
-                // proxy network dump for active region only
-                carrier.switchStatusUpdateNotification(switchId, switchData);
-            }
+    protected void handlePeriodicDump(NetworkDumpSwitchData switchData, String region) {
+        super.handlePeriodicDump(switchData, region);
+        if (Objects.equals(activeRegion, region)) {
+            // proxy network dump for active region only
+            carrier.switchStatusUpdateNotification(switchId, switchData);
         }
     }
 

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchMonitorServiceTest.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchMonitorServiceTest.java
@@ -57,7 +57,6 @@ public class SwitchMonitorServiceTest {
 
         SwitchInfoData swAdd = new SwitchInfoData(SWITCH_ALPHA, SwitchChangeType.ADDED);
         subject.handleStatusUpdateNotification(swAdd, REGION_ALPHA);
-        verify(carrier).switchStatusUpdateNotification(eq(swAdd.getSwitchId()), eq(swAdd));
         verify(carrier).regionUpdateNotification(
                 eq(new RegionMappingAdd(swAdd.getSwitchId(), REGION_ALPHA, false)));
         verifyNoMoreInteractions(carrier);


### PR DESCRIPTION
Add read-write mode check for network dumps data. Helps to decrease harm in the case of 2 FL with different roles (stats and management) in the same region.