### PR TITLE
Use custom OrientDB user (Kilda) for all-in-one configuration.

### DIFF
--- a/confd/vars/main.yaml
+++ b/confd/vars/main.yaml
@@ -12,8 +12,8 @@ kilda_neo4j_password: "temppass"
 kilda_neo4j_cypher_path: "/db/data/cypher"
 
 kilda_orientdb_hosts: "odb1.pendev,odb2.pendev,odb3.pendev"
-kilda_orientdb_user: "root"
-kilda_orientdb_password: "root"
+kilda_orientdb_user: "kilda"
+kilda_orientdb_password: "kilda"
 kilda_orientdb_database: "kilda"
 
 kilda_kafka_hosts: "kafka.pendev:9092"

--- a/docker/orientdb/init/create-db-with-schema.osql
+++ b/docker/orientdb/init/create-db-with-schema.osql
@@ -1,5 +1,14 @@
 CREATE DATABASE remote:localhost/kilda root root PLOCAL GRAPH;
 
+INSERT INTO ORole SET name = 'kilda-role', mode = 0, inheritedRole = (SELECT FROM ORole WHERE name = 'writer');
+GRANT READ ON database.cluster.internal TO `kilda-role`;
+GRANT CREATE ON database.cluster.internal TO `kilda-role`;
+GRANT UPDATE ON database.cluster.internal TO `kilda-role`;
+GRANT ALL ON database.schema TO `kilda-role`;
+GRANT READ ON database.systemclusters TO `kilda-role`;
+
+CREATE USER kilda IDENTIFIED BY kilda ROLE `kilda-role`;
+
 CREATE CLASS kilda_configuration IF NOT EXISTS EXTENDS V;
 CREATE PROPERTY kilda_configuration.unique IF NOT EXISTS STRING;
 CREATE INDEX kilda_configuration.unique UNIQUE_HASH_INDEX;

--- a/src-java/base-topology/base-storm-topology/src/release/resources/topology.properties.example
+++ b/src-java/base-topology/base-storm-topology/src/release/resources/topology.properties.example
@@ -63,8 +63,8 @@ opentsdb.client.chunked-requests.enabled = true
 opentsdb.metric.prefix = kilda.
 
 orientdb.url = remote:odb1.pendev,odb2.pendev,odb3.pendev/kilda
-orientdb.user = root
-orientdb.password = root
+orientdb.user = kilda
+orientdb.password = kilda
 
 logger.level = INFO
 

--- a/src-java/northbound-service/northbound/src/main/resources/northbound.properties.example
+++ b/src-java/northbound-service/northbound/src/main/resources/northbound.properties.example
@@ -19,5 +19,5 @@ northbound.kafka.listener.threads=10
 northbound.kafka.session.timeout=30000
 
 orientdb.url = remote:odb1.pendev,odb2.pendev,odb3.pendev/kilda
-orientdb.user = root
-orientdb.password = root
+orientdb.user = kilda
+orientdb.password = kilda

--- a/src-java/testing/functional-tests/kilda.properties.example
+++ b/src-java/testing/functional-tests/kilda.properties.example
@@ -13,8 +13,8 @@ floodlight.alive.timeout=10
 floodlight.alive.interval=2
 
 orientdb.url = remote:localhost:2424,localhost:2425,localhost:2426/kilda
-orientdb.user = root
-orientdb.password = root
+orientdb.user = kilda
+orientdb.password = kilda
 
 elasticsearch.endpoint=http://localhost:9200
 elasticsearch.username=kilda

--- a/src-java/testing/performance-tests/kilda.properties.example
+++ b/src-java/testing/performance-tests/kilda.properties.example
@@ -13,8 +13,8 @@ floodlight.alive.timeout=10
 floodlight.alive.interval=2
 
 orientdb.url = remote:localhost:2424,localhost:2425,localhost:2426/kilda
-orientdb.user = root
-orientdb.password = root
+orientdb.user = kilda
+orientdb.password = kilda
 
 elasticsearch.endpoint=http://localhost:9200
 elasticsearch.username=kilda


### PR DESCRIPTION
The changes:
- Change OrientDB init script (create-db-with-schema.osql) to create a dedicated role and user for Kilda access.
- Update Kilda all-in-one configuration files to use the Kilda user.