### PR TITLE
Fixed incorrect constructor for FlowRerouteRequest

### DIFF
--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/flow/FlowRerouteRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/flow/FlowRerouteRequest.java
@@ -62,7 +62,7 @@ public class FlowRerouteRequest extends CommandData {
      * Create Simplified request usable only for northbound API.
      */
     public FlowRerouteRequest(String flowId, boolean force, boolean ignoreBandwidth, String reason) {
-        this(flowId, force,  ignoreBandwidth, false, Collections.emptySet(), reason);
+        this(flowId, force, false, ignoreBandwidth, Collections.emptySet(), reason);
     }
 
     @JsonCreator


### PR DESCRIPTION
PR #3598 added new field `ignoreBandwidth` into constructor. But this field was used in incorrect place in `this()` statement.
Code sets `ignoreBandwidth` parameter to `effectivelyDown` field.