### PR TITLE
Docker version prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The followings are required for building Kilda controller:
  - JDK8
  - Python 2.7+
  - Python 3.5+
+ - Docker 19.03.3+
  - Docker Compose 1.20.0+
  - GNU Make 4.1+
  - Open vSwitch 2.9+


### PR DESCRIPTION
Due to the usage of `--chown` argument for 'ADD' instruction into our
Doeckerfiles we need to raise minimal docker version prerequisite.