### PR TITLE
Added kafka consumer group id prefix

### DIFF
--- a/confd/templates/docker-compose/docker-compose.tmpl
+++ b/confd/templates/docker-compose/docker-compose.tmpl
@@ -448,6 +448,7 @@ services:
     environment:
       REST_USERNAME: 'kilda'
       REST_PASSWORD: 'kilda'
+      KAFKA_GROUP_ID_PREFIX: 'blue-green'
     depends_on:
       kafka:
         condition: service_healthy
@@ -489,6 +490,8 @@ services:
         dockerfile: grpc-service/Dockerfile
       ports:
       - "8092:8091"
+      environment:
+        KAFKA_GROUP_ID_PREFIX: 'blue-green'
       depends_on:
         kafka:
           condition: service_healthy

--- a/confd/templates/grpc-service/grpc-service.properties.tmpl
+++ b/confd/templates/grpc-service/grpc-service.properties.tmpl
@@ -11,6 +11,8 @@ service.version=@project.version@
 service.description=@project.description@
 
 kafka.hosts={{ getv "/kilda_kafka_hosts" }}
+kafka.groupid.prefix.env=KAFKA_GROUP_ID_PREFIX
+
 server.port={{ getv "/kilda_grpc_rest_port" }}
 
 grpc.speaker.kafka.listener.threads={{ getv "/kilda_grpc_speaker_kafka_listener_threads" }}

--- a/confd/templates/northbound/northbound.properties.tmpl
+++ b/confd/templates/northbound/northbound.properties.tmpl
@@ -12,6 +12,7 @@ security.rest.username.default={{ getv "/kilda_northbound_username" }}
 security.rest.password.default={{ getv "/kilda_northbound_password" }}
 
 kafka.hosts={{ getv "/kilda_kafka_hosts" }}
+kafka.groupid.prefix.env=KAFKA_GROUP_ID_PREFIX
 
 server.contextPath=/api
 

--- a/src-java/grpc-speaker/grpc-service/src/main/java/org/openkilda/grpc/speaker/config/KafkaGrpcSpeakerConfig.java
+++ b/src-java/grpc-speaker/grpc-service/src/main/java/org/openkilda/grpc/speaker/config/KafkaGrpcSpeakerConfig.java
@@ -16,7 +16,6 @@
 package org.openkilda.grpc.speaker.config;
 
 import org.openkilda.config.KafkaConsumerGroupConfig;
-import org.openkilda.config.mapping.Mapping;
 
 import com.sabre.oss.conf4j.annotation.Configuration;
 import com.sabre.oss.conf4j.annotation.Default;
@@ -26,6 +25,5 @@ import com.sabre.oss.conf4j.annotation.Key;
 public interface KafkaGrpcSpeakerConfig extends KafkaConsumerGroupConfig {
     @Key("kafka.groupid")
     @Default("grpc-speaker-consumer")
-    @Mapping(target = KAFKA_CONSUMER_GROUP_MAPPING)
     String getGroupId();
 }

--- a/src-java/grpc-speaker/grpc-service/src/main/resources/grpc-service.properties.example
+++ b/src-java/grpc-speaker/grpc-service/src/main/resources/grpc-service.properties.example
@@ -8,6 +8,8 @@ service.version=@project.version@
 service.description=@project.description@
 
 kafka.hosts=kafka.pendev:9092
+kafka.groupid.prefix.env=KAFKA_GROUP_ID_PREFIX
+
 server.port=8091
 
 grpc.speaker.kafka.listener.threads=1

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/config/KafkaNorthboundConfig.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/config/KafkaNorthboundConfig.java
@@ -16,7 +16,6 @@
 package org.openkilda.northbound.config;
 
 import org.openkilda.config.KafkaConsumerGroupConfig;
-import org.openkilda.config.mapping.Mapping;
 
 import com.sabre.oss.conf4j.annotation.Configuration;
 import com.sabre.oss.conf4j.annotation.Default;
@@ -26,6 +25,5 @@ import com.sabre.oss.conf4j.annotation.Key;
 public interface KafkaNorthboundConfig extends KafkaConsumerGroupConfig {
     @Key("kafka.groupid")
     @Default("northbound-consumer")
-    @Mapping(target = KAFKA_CONSUMER_GROUP_MAPPING)
     String getGroupId();
 }

--- a/src-java/northbound-service/northbound/src/main/resources/northbound.properties.example
+++ b/src-java/northbound-service/northbound/src/main/resources/northbound.properties.example
@@ -9,6 +9,7 @@ security.rest.username.default=kilda
 security.rest.password.default=kilda
 
 kafka.hosts=kafka.pendev:9092
+kafka.groupid.prefix.env=KAFKA_GROUP_ID_PREFIX
 
 server.contextPath=/api
 


### PR DESCRIPTION
This fix allows two northbounds read the same topic simultaneously.