### PR TITLE
Added kafka message versioning with ZooKeeper

### DIFF
--- a/confd/templates/server42/server42-control.application.properties.tmpl
+++ b/confd/templates/server42/server42-control.application.properties.tmpl
@@ -47,3 +47,8 @@ spring.kafka.producer.properties.interceptor.classes=org.openkilda.bluegreen.kaf
 spring.kafka.producer.properties.kafka.producer.messaging.zookeeper.connecting.string.property={{ getv "/kilda_zookeeper_hosts"}}/{{ getv "/kilda_zookeeper_state_root" }}
 spring.kafka.producer.properties.kafka.producer.messaging.component.name.property={{ getv "/kilda_server42_control_component_name" }}
 spring.kafka.producer.properties.kafka.producer.messaging.run.id.property={{ getv "/kilda_server42_control_run_id" }}
+
+spring.kafka.consumer.properties.interceptor.classes=org.openkilda.bluegreen.kafka.interceptors.VersioningConsumerInterceptor
+spring.kafka.consumer.properties.kafka.consumer.messaging.zookeeper.connecting.string.property={{ getv "/kilda_zookeeper_hosts"}}/{{ getv "/kilda_zookeeper_state_root" }}
+spring.kafka.consumer.properties.kafka.consumer.messaging.component.name.property={{ getv "/kilda_server42_control_component_name" }}
+spring.kafka.consumer.properties.kafka.consumer.messaging.run.id.property={{ getv "/kilda_server42_control_run_id" }}

--- a/confd/templates/server42/server42-stats.application.properties.tmpl
+++ b/confd/templates/server42/server42-stats.application.properties.tmpl
@@ -39,3 +39,8 @@ spring.kafka.producer.properties.interceptor.classes=org.openkilda.bluegreen.kaf
 spring.kafka.producer.properties.kafka.producer.messaging.zookeeper.connecting.string.property={{ getv "/kilda_zookeeper_hosts"}}/{{ getv "/kilda_zookeeper_state_root" }}
 spring.kafka.producer.properties.kafka.producer.messaging.component.name.property={{ getv "/kilda_server42_stats_component_name" }}
 spring.kafka.producer.properties.kafka.producer.messaging.run.id.property={{ getv "/kilda_server42_stats_run_id" }}
+
+spring.kafka.consumer.properties.interceptor.classes=org.openkilda.bluegreen.kafka.interceptors.VersioningConsumerInterceptor
+spring.kafka.consumer.properties.kafka.consumer.messaging.zookeeper.connecting.string.property={{ getv "/kilda_zookeeper_hosts"}}/{{ getv "/kilda_zookeeper_state_root" }}
+spring.kafka.consumer.properties.kafka.consumer.messaging.component.name.property={{ getv "/kilda_server42_stats_component_name" }}
+spring.kafka.consumer.properties.kafka.consumer.messaging.run.id.property={{ getv "/kilda_server42_stats_run_id" }}

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/topology/AbstractTopology.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/topology/AbstractTopology.java
@@ -18,10 +18,14 @@ package org.openkilda.wfm.topology;
 import static java.lang.String.format;
 import static org.openkilda.bluegreen.kafka.Utils.COMMON_COMPONENT_NAME;
 import static org.openkilda.bluegreen.kafka.Utils.COMMON_COMPONENT_RUN_ID;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_COMPONENT_NAME_PROPERTY;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_RUN_ID_PROPERTY;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY;
 import static org.openkilda.bluegreen.kafka.Utils.PRODUCER_COMPONENT_NAME_PROPERTY;
 import static org.openkilda.bluegreen.kafka.Utils.PRODUCER_RUN_ID_PROPERTY;
 import static org.openkilda.bluegreen.kafka.Utils.PRODUCER_ZOOKEEPER_CONNECTION_STRING_PROPERTY;
 
+import org.openkilda.bluegreen.kafka.interceptors.VersioningConsumerInterceptor;
 import org.openkilda.bluegreen.kafka.interceptors.VersioningProducerInterceptor;
 import org.openkilda.config.KafkaConfig;
 import org.openkilda.config.ZookeeperConfig;
@@ -278,12 +282,35 @@ public abstract class AbstractTopology<T extends AbstractTopologyConfig> impleme
         return topologyConfig;
     }
 
+    /**
+     * //TODO(zero_down_time) Remove when zero down time feature will be completed.
+     *
+     * @deprecated use declareKafkaSpout with parameters (component name, run id)
+     */
+    @Deprecated
     protected SpoutDeclarer declareKafkaSpout(TopologyBuilder builder, String topic, String spoutId) {
-        return declareKafkaSpout(builder, Collections.singletonList(topic), spoutId);
+        return declareKafkaSpout(builder, topic, spoutId, COMMON_COMPONENT_NAME, COMMON_COMPONENT_RUN_ID);
     }
 
+    protected SpoutDeclarer declareKafkaSpout(
+            TopologyBuilder builder, String topic, String spoutId, String componentName, String runId) {
+        return declareKafkaSpout(builder, Collections.singletonList(topic), spoutId, componentName, runId);
+    }
+
+    /**
+     * //TODO(zero_down_time) Remove when zero down time feature will be completed.
+     *
+     * @deprecated use declareKafkaSpout with parameters (component name, run id)
+     */
+    @Deprecated
     protected SpoutDeclarer declareKafkaSpout(TopologyBuilder builder, List<String> topics, String spoutId) {
-        KafkaSpoutConfig<String, Message> config = getKafkaSpoutConfigBuilder(topics, spoutId).build();
+        return declareKafkaSpout(builder, topics, spoutId, COMMON_COMPONENT_NAME, COMMON_COMPONENT_RUN_ID);
+    }
+
+    protected SpoutDeclarer declareKafkaSpout(
+            TopologyBuilder builder, List<String> topics, String spoutId, String componentName, String runId) {
+        KafkaSpoutConfig<String, Message> config = getKafkaSpoutConfigBuilder(topics, spoutId, componentName, runId)
+                .build();
         logger.info("Setup kafka spout: id={}, group={}, subscriptions={}",
                 spoutId, config.getConsumerGroupId(), config.getSubscription().getTopicsString());
         return declareSpout(builder, new KafkaSpout<>(config), spoutId);
@@ -317,12 +344,37 @@ public abstract class AbstractTopology<T extends AbstractTopologyConfig> impleme
     }
 
     /**
+     * //TODO(zero_down_time) Remove when zero down time feature will be completed.
+     *
+     * @deprecated use declareKafkaSpoutForAbstractMessage with parameters (component name, run id)
+     */
+    @Deprecated
+    protected SpoutDeclarer declareKafkaSpoutForAbstractMessage(TopologyBuilder builder, String topic, String spoutId) {
+        return declareKafkaSpoutForAbstractMessage(builder, topic, spoutId,
+                COMMON_COMPONENT_NAME, COMMON_COMPONENT_RUN_ID);
+    }
+
+    /**
      * Creates Kafka spout. Transforms received value to {@link AbstractMessage}.
      *
      * @param topic Kafka topic
      */
-    protected SpoutDeclarer declareKafkaSpoutForAbstractMessage(TopologyBuilder builder, String topic, String spoutId) {
-        return declareKafkaSpoutForAbstractMessage(builder, Collections.singletonList(topic), spoutId);
+    protected SpoutDeclarer declareKafkaSpoutForAbstractMessage(
+            TopologyBuilder builder, String topic, String spoutId, String componentName, String runId) {
+        return declareKafkaSpoutForAbstractMessage(
+                builder, Collections.singletonList(topic), spoutId, componentName, runId);
+    }
+
+    /**
+     * //TODO(zero_down_time) Remove when zero down time feature will be completed.
+     *
+     * @deprecated use declareKafkaSpoutForAbstractMessage with parameters (component name, run id)
+     */
+    @Deprecated
+        protected SpoutDeclarer declareKafkaSpoutForAbstractMessage(
+                TopologyBuilder builder, List<String> topics, String spoutId) {
+        return declareKafkaSpoutForAbstractMessage(
+                builder, topics, spoutId, COMMON_COMPONENT_NAME, COMMON_COMPONENT_RUN_ID);
     }
 
     /**
@@ -330,10 +382,10 @@ public abstract class AbstractTopology<T extends AbstractTopologyConfig> impleme
      *
      * @param topics Kafka topics
      */
-    protected SpoutDeclarer declareKafkaSpoutForAbstractMessage(TopologyBuilder builder,
-                                                                List<String> topics, String spoutId) {
+    protected SpoutDeclarer declareKafkaSpoutForAbstractMessage(
+            TopologyBuilder builder, List<String> topics, String spoutId, String componentName, String runId) {
         KafkaSpout<?, ?> spout = new KafkaSpout<>(
-                makeKafkaSpoutConfig(topics, spoutId, AbstractMessageDeserializer.class)
+                makeKafkaSpoutConfig(topics, spoutId, AbstractMessageDeserializer.class, componentName, runId)
                         .setRecordTranslator(new AbstractMessageTranslator())
                         .build());
         return declareSpout(builder, spout, spoutId);
@@ -347,9 +399,21 @@ public abstract class AbstractTopology<T extends AbstractTopologyConfig> impleme
      * @deprecated replaced by {@link AbstractTopology#buildKafkaBolt(String)}
      */
     @Deprecated
-    protected KafkaBolt<String, String> createKafkaBolt(final String topic) {
+    protected KafkaBolt<String, String> createKafkaBolt(String topic) {
+        return createKafkaBolt(topic, COMMON_COMPONENT_NAME, COMMON_COMPONENT_RUN_ID);
+    }
+
+    /**
+     * Creates Kafka bolt.
+     *
+     * @param topic Kafka topic
+     * @return {@link KafkaBolt}
+     * @deprecated replaced by {@link AbstractTopology#buildKafkaBolt(String, String, String)}
+     */
+    @Deprecated
+    protected KafkaBolt<String, String> createKafkaBolt(String topic, String componentName, String runId) {
         return new KafkaBolt<String, String>()
-                .withProducerProperties(getKafkaProducerProperties())
+                .withProducerProperties(getKafkaProducerProperties(componentName, runId))
                 .withTopicSelector(new DefaultTopicSelector(topic))
                 .withTupleToKafkaMapper(new FieldNameBasedTupleToKafkaMapper<>());
     }
@@ -393,17 +457,30 @@ public abstract class AbstractTopology<T extends AbstractTopologyConfig> impleme
                 .withTupleToKafkaMapper(new FieldNameBasedTupleToKafkaMapper<>());
     }
 
+    /**
+     * //TODO(zero_down_time) Remove when zero down time feature will be completed.
+     *
+     * @deprecated use getKafkaSpoutConfigBuilder with parameters (component name, run id)
+     */
+    @Deprecated
     protected KafkaSpoutConfig.Builder<String, Message> getKafkaSpoutConfigBuilder(String topic, String spoutId) {
-        return getKafkaSpoutConfigBuilder(Collections.singletonList(topic), spoutId);
+        return getKafkaSpoutConfigBuilder(topic, spoutId, COMMON_COMPONENT_NAME, COMMON_COMPONENT_RUN_ID);
     }
 
-    private KafkaSpoutConfig.Builder<String, Message> getKafkaSpoutConfigBuilder(List<String> topics, String spoutId) {
-        return makeKafkaSpoutConfig(topics, spoutId, MessageDeserializer.class)
+    protected KafkaSpoutConfig.Builder<String, Message> getKafkaSpoutConfigBuilder(
+            String topic, String spoutId, String componentName, String runId) {
+        return getKafkaSpoutConfigBuilder(Collections.singletonList(topic), spoutId, componentName, runId);
+    }
+
+    private KafkaSpoutConfig.Builder<String, Message> getKafkaSpoutConfigBuilder(
+            List<String> topics, String spoutId, String componentName, String runId) {
+        return makeKafkaSpoutConfig(topics, spoutId, MessageDeserializer.class, componentName, runId)
                 .setRecordTranslator(new MessageKafkaTranslator());
     }
 
     protected <V> KafkaSpoutConfig.Builder<String, V> makeKafkaSpoutConfig(
-            List<String> topics, String spoutId, Class<? extends Deserializer<V>> valueDecoder) {
+            List<String> topics, String spoutId, Class<? extends Deserializer<V>> valueDecoder, String componentName,
+            String runId) {
         KafkaSpoutConfig.Builder<String, V> config = new KafkaSpoutConfig.Builder<>(
                 kafkaConfig.getHosts(), new CustomNamedSubscription(topics));
 
@@ -412,6 +489,10 @@ public abstract class AbstractTopology<T extends AbstractTopologyConfig> impleme
                 .setProp(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, true)
                 .setProp(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
                 .setProp(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDecoder)
+                .setProp(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, VersioningConsumerInterceptor.class.getName())
+                .setProp(CONSUMER_COMPONENT_NAME_PROPERTY, componentName)
+                .setProp(CONSUMER_RUN_ID_PROPERTY, runId)
+                .setProp(CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY, getZookeeperConfig().getConnectString())
                 .setTupleTrackingEnforced(true);
 
         return config;

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/AbstractStormTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/AbstractStormTest.java
@@ -17,10 +17,14 @@ package org.openkilda.wfm;
 
 import static org.openkilda.bluegreen.kafka.Utils.COMMON_COMPONENT_NAME;
 import static org.openkilda.bluegreen.kafka.Utils.COMMON_COMPONENT_RUN_ID;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_COMPONENT_NAME_PROPERTY;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_RUN_ID_PROPERTY;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY;
 import static org.openkilda.bluegreen.kafka.Utils.PRODUCER_COMPONENT_NAME_PROPERTY;
 import static org.openkilda.bluegreen.kafka.Utils.PRODUCER_RUN_ID_PROPERTY;
 import static org.openkilda.bluegreen.kafka.Utils.PRODUCER_ZOOKEEPER_CONNECTION_STRING_PROPERTY;
 
+import org.openkilda.bluegreen.kafka.interceptors.VersioningConsumerInterceptor;
 import org.openkilda.bluegreen.kafka.interceptors.VersioningProducerInterceptor;
 import org.openkilda.config.KafkaConfig;
 import org.openkilda.wfm.config.ZookeeperConfig;
@@ -84,6 +88,11 @@ public abstract class AbstractStormTest {
         properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, STRING_DESERIALIZER);
         properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, STRING_DESERIALIZER);
         properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        properties.put(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, VersioningConsumerInterceptor.class.getName());
+        properties.put(CONSUMER_COMPONENT_NAME_PROPERTY, COMMON_COMPONENT_NAME);
+        properties.put(CONSUMER_RUN_ID_PROPERTY, COMMON_COMPONENT_RUN_ID);
+        properties.put(CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY,
+                makeUnboundConfig(ZookeeperConfig.class).getConnectString());
         return properties;
     }
 

--- a/src-java/blue-green/src/main/java/org/openkilda/bluegreen/kafka/Utils.java
+++ b/src-java/blue-green/src/main/java/org/openkilda/bluegreen/kafka/Utils.java
@@ -32,6 +32,19 @@ public final class Utils {
      */
     public static final String MESSAGE_VERSION_HEADER = "kafka.message.version.header";
     /**
+     * Property name for Kafka consumer to specify component name for consumer interceptor.
+     */
+    public static final String CONSUMER_COMPONENT_NAME_PROPERTY = "kafka.consumer.messaging.component.name.property";
+    /**
+     * Property name for Kafka consumer to specify run ID for consumer interceptor.
+     */
+    public static final String CONSUMER_RUN_ID_PROPERTY = "kafka.consumer.messaging.run.id.property";
+    /**
+     * Property name for Kafka consumer to specify zookeeper connection string.
+     */
+    public static final String CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY =
+            "kafka.consumer.messaging.zookeeper.connecting.string.property";
+    /**
      * Property name for Kafka producer to specify component name for producer interceptor.
      */
     public static final String PRODUCER_COMPONENT_NAME_PROPERTY = "kafka.producer.messaging.component.name.property";

--- a/src-java/blue-green/src/main/java/org/openkilda/bluegreen/kafka/interceptors/VersioningConsumerInterceptor.java
+++ b/src-java/blue-green/src/main/java/org/openkilda/bluegreen/kafka/interceptors/VersioningConsumerInterceptor.java
@@ -1,0 +1,143 @@
+/* Copyright 2020 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.bluegreen.kafka.interceptors;
+
+import static java.lang.String.format;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_COMPONENT_NAME_PROPERTY;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_RUN_ID_PROPERTY;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY;
+import static org.openkilda.bluegreen.kafka.Utils.MESSAGE_VERSION_HEADER;
+import static org.openkilda.bluegreen.kafka.Utils.getValue;
+
+import com.google.common.collect.Lists;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerInterceptor;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Header;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+public class VersioningConsumerInterceptor<K, V> extends VersioningInterceptorBase
+        implements ConsumerInterceptor<K, V> {
+
+    public VersioningConsumerInterceptor() {
+        log.debug("Initializing VersioningConsumerInterceptor");
+    }
+
+    @Override
+    public ConsumerRecords<K, V> onConsume(ConsumerRecords<K, V> records) {
+        if (!watchDog.isConnectedAndValidated()) {
+            if (isZooKeeperConnectTimeoutPassed()) {
+                log.error("Component {} with id {} tries to reconnect to ZooKeeper with connection string: {}",
+                        componentName, runId, connectionString);
+                cantConnectToZooKeeperTimestamp = Instant.now();
+            }
+            watchDog.safeRefreshConnection();
+        }
+
+        Map<TopicPartition, List<ConsumerRecord<K, V>>> filteredRecordMap = new HashMap<>();
+
+        for (TopicPartition partition : records.partitions()) {
+            List<ConsumerRecord<K, V>> filteredRecords = new ArrayList<>();
+
+            for (ConsumerRecord<K, V> record : records.records(partition)) {
+                if (checkRecordVersion(record)) {
+                    filteredRecords.add(record);
+                }
+            }
+
+            filteredRecordMap.put(partition, filteredRecords);
+        }
+        return new ConsumerRecords<>(filteredRecordMap);
+    }
+
+    private boolean checkRecordVersion(ConsumerRecord<K, V> record) {
+        List<Header> headers = Lists.newArrayList(record.headers().headers(MESSAGE_VERSION_HEADER));
+
+        if (version == null) {
+            if (isVersionTimeoutPassed()) {
+                // We will write this log every 60 seconds to do not spam in logs
+                log.warn("Messaging version is not set for component {} with id {}. Skip record {}",
+                        componentName, runId, record);
+                versionIsNotSetTimestamp = Instant.now();
+            }
+            return false;
+        }
+
+        if (headers.isEmpty()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Missed {} header for record {}", MESSAGE_VERSION_HEADER, record);
+            }
+            return false;
+        }
+
+        if (headers.size() > 1) {
+            log.warn("Found more than one {} headers for record {}", MESSAGE_VERSION_HEADER, record);
+            return false;
+        }
+
+        if (!Arrays.equals(version, headers.get(0).value())) {
+            if (log.isDebugEnabled()) {
+                log.debug("Skip record {} with version {}. Target version is {}",
+                        record, new String(headers.get(0).value()), getVersionAsString());
+            }
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        connectionString = getValue(configs, CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY, String.class);
+        runId = getValue(configs, CONSUMER_RUN_ID_PROPERTY, String.class);
+        componentName = getValue(configs, CONSUMER_COMPONENT_NAME_PROPERTY, String.class);
+        log.info("Configuring VersioningConsumerInterceptor for component {} with id {} and connection string {}",
+                componentName, runId, connectionString);
+        initWatchDog();
+    }
+
+    @Override
+    public void onCommit(Map<TopicPartition, OffsetAndMetadata> offsets) {
+        // nothing to do here
+    }
+
+    @Override
+    public void close() {
+        watchDog.unsubscribe(this);
+        try {
+            watchDog.close();
+        } catch (InterruptedException e) {
+            log.error(format("Could not close connection to zookeeper %s Error: %s",
+                    connectionString, e.getMessage()), e);
+        }
+    }
+
+    @Override
+    public void handle(String buildVersion) {
+        log.info("Updating consumer kafka messaging version from {} to {} for component {} with id {}",
+                getVersionAsString(), buildVersion, componentName, runId);
+        version = buildVersion.getBytes();
+    }
+}

--- a/src-java/blue-green/src/test/java/org/openkilda/bluegreen/kafka/interceptors/VersioningConsumerInterceptorTest.java
+++ b/src-java/blue-green/src/test/java/org/openkilda/bluegreen/kafka/interceptors/VersioningConsumerInterceptorTest.java
@@ -1,0 +1,142 @@
+/* Copyright 2020 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.bluegreen.kafka.interceptors;
+
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_COMPONENT_NAME_PROPERTY;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_RUN_ID_PROPERTY;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY;
+import static org.openkilda.bluegreen.kafka.Utils.MESSAGE_VERSION_HEADER;
+
+import com.google.common.collect.Lists;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class VersioningConsumerInterceptorTest {
+
+    public static final int PARTITION_1 = 1;
+    public static final int PARTITION_2 = 2;
+    public static final String TOPIC = "topic";
+    public static final String KEY_1 = "key1";
+    public static final String KEY_2 = "key2";
+    public static final String VALUE_1 = "value1";
+    public static final String VALUE_2 = "value2";
+    public static final String VALUE_3 = "value3";
+    public static final String VALUE_4 = "value4";
+    public static final String VERSION_1 = "version1";
+    public static final String VERSION_2 = "version2";
+
+    @Test
+    public void unsetVersionTest() {
+        VersioningConsumerInterceptor<String, String> interceptor = createInterceptor();
+        ConsumerRecords<String, String> records = getConsumerRecords(VERSION_1, VERSION_1, null, VERSION_2);
+        ConsumerRecords<String, String> result = interceptor.onConsume(records);
+
+        // interceptor with unset version skips all records
+        Assert.assertEquals(0, result.count());
+    }
+
+    @Test
+    public void differentVersionTest() {
+        VersioningConsumerInterceptor<String, String> interceptor = createInterceptor();
+        interceptor.handle(VERSION_1);
+        ConsumerRecords<String, String> records = getConsumerRecords(null, VERSION_1, VERSION_1, VERSION_2);
+        ConsumerRecords<String, String> result = interceptor.onConsume(records);
+
+        // interceptor will remove record with unset version and record with wrong version
+        Assert.assertEquals(2, result.count());
+        Set<String> values = getRecordValues(result);
+        Assert.assertTrue(values.contains(VALUE_2));
+        Assert.assertTrue(values.contains(VALUE_3));
+    }
+
+    @Test
+    public void severalHeadersTest() {
+        VersioningConsumerInterceptor<String, String> interceptor = createInterceptor();
+        interceptor.handle(VERSION_1);
+
+        // record with 2 same headers
+        ConsumerRecord<String, String> record = new ConsumerRecord<>(TOPIC, PARTITION_1, 0L, KEY_1, VALUE_1);
+        addVersion(record, VERSION_1);
+        addVersion(record, VERSION_1);
+
+        Map<TopicPartition, List<ConsumerRecord<String, String>>> recordMap = new HashMap<>();
+        recordMap.put(new TopicPartition(TOPIC, PARTITION_1), Lists.newArrayList(record));
+        ConsumerRecords<String, String> records = new ConsumerRecords<>(recordMap);
+
+        ConsumerRecords<String, String> result = interceptor.onConsume(records);
+
+        // interceptor will skip record because it has 2 headers, but must has one
+        Assert.assertEquals(0, result.count());
+    }
+
+    private ConsumerRecords<String, String> getConsumerRecords(String record1Version, String record2Version,
+                                                               String record3Version, String record4Version) {
+        ConsumerRecord<String, String> record1 = new ConsumerRecord<>(TOPIC, PARTITION_1, 0L, KEY_1, VALUE_1);
+        addVersion(record1, record1Version);
+
+        ConsumerRecord<String, String> record2 = new ConsumerRecord<>(TOPIC, PARTITION_1, 1L, KEY_1, VALUE_2);
+        addVersion(record2, record2Version);
+
+        ConsumerRecord<String, String> record3 = new ConsumerRecord<>(TOPIC, PARTITION_2, 2L, KEY_2, VALUE_3);
+        addVersion(record3, record3Version);
+
+        ConsumerRecord<String, String> record4 = new ConsumerRecord<>(TOPIC, PARTITION_2, 3L, KEY_2, VALUE_4);
+        addVersion(record4, record4Version);
+
+        TopicPartition topicPartition1 = new TopicPartition(TOPIC, PARTITION_1);
+        TopicPartition topicPartition2 = new TopicPartition(TOPIC, PARTITION_2);
+
+        Map<TopicPartition, List<ConsumerRecord<String, String>>> recordMap = new HashMap<>();
+        recordMap.put(topicPartition1, Lists.newArrayList(record1, record2));
+        recordMap.put(topicPartition2, Lists.newArrayList(record3, record4));
+
+        return new ConsumerRecords<>(recordMap);
+    }
+
+    private void addVersion(ConsumerRecord<String, String> record, String versionHeader) {
+        if (versionHeader != null) {
+            record.headers().add(MESSAGE_VERSION_HEADER, versionHeader.getBytes());
+        }
+    }
+
+    private Set<String> getRecordValues(ConsumerRecords<String, String> records) {
+        Set<String> values = new HashSet<>();
+        for (ConsumerRecord<String, String> record : records) {
+            values.add(record.value());
+        }
+        return values;
+    }
+
+    private VersioningConsumerInterceptor<String, String> createInterceptor() {
+        Map<String, String> config = new HashMap<>();
+        config.put(CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY, "test");
+        config.put(CONSUMER_RUN_ID_PROPERTY, "run_id");
+        config.put(CONSUMER_COMPONENT_NAME_PROPERTY, "name");
+
+        VersioningConsumerInterceptor<String, String> interceptor = new VersioningConsumerInterceptor<>();
+        interceptor.configure(config);
+        return interceptor;
+    }
+}

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/KafkaChannelConfig.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/KafkaChannelConfig.java
@@ -17,16 +17,21 @@ package org.openkilda.floodlight;
 
 import static org.openkilda.bluegreen.kafka.Utils.COMMON_COMPONENT_NAME;
 import static org.openkilda.bluegreen.kafka.Utils.COMMON_COMPONENT_RUN_ID;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_COMPONENT_NAME_PROPERTY;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_RUN_ID_PROPERTY;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY;
 import static org.openkilda.bluegreen.kafka.Utils.PRODUCER_COMPONENT_NAME_PROPERTY;
 import static org.openkilda.bluegreen.kafka.Utils.PRODUCER_RUN_ID_PROPERTY;
 import static org.openkilda.bluegreen.kafka.Utils.PRODUCER_ZOOKEEPER_CONNECTION_STRING_PROPERTY;
 
+import org.openkilda.bluegreen.kafka.interceptors.VersioningConsumerInterceptor;
 import org.openkilda.bluegreen.kafka.interceptors.VersioningProducerInterceptor;
 import org.openkilda.config.KafkaConsumerGroupConfig;
 import org.openkilda.config.mapping.Mapping;
 
 import com.sabre.oss.conf4j.annotation.Default;
 import com.sabre.oss.conf4j.annotation.Key;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 
 import java.util.Properties;
@@ -65,6 +70,11 @@ public interface KafkaChannelConfig extends KafkaConsumerGroupConfig {
 
         properties.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
         properties.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+
+        properties.put(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, VersioningConsumerInterceptor.class.getName());
+        properties.put(CONSUMER_COMPONENT_NAME_PROPERTY, COMMON_COMPONENT_NAME);
+        properties.put(CONSUMER_RUN_ID_PROPERTY, COMMON_COMPONENT_RUN_ID);
+        properties.put(CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY, getZooKeeperConnectString());
 
         return properties;
     }

--- a/src-java/grpc-speaker/grpc-service/src/main/java/org/openkilda/grpc/speaker/config/MessageConsumerConfig.java
+++ b/src-java/grpc-speaker/grpc-service/src/main/java/org/openkilda/grpc/speaker/config/MessageConsumerConfig.java
@@ -15,6 +15,13 @@
 
 package org.openkilda.grpc.speaker.config;
 
+import static org.openkilda.bluegreen.kafka.Utils.COMMON_COMPONENT_NAME;
+import static org.openkilda.bluegreen.kafka.Utils.COMMON_COMPONENT_RUN_ID;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_COMPONENT_NAME_PROPERTY;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_RUN_ID_PROPERTY;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY;
+
+import org.openkilda.bluegreen.kafka.interceptors.VersioningConsumerInterceptor;
 import org.openkilda.messaging.command.CommandMessage;
 
 import com.google.common.collect.ImmutableMap;
@@ -52,6 +59,12 @@ public class MessageConsumerConfig {
     private String kafkaHosts;
 
     /**
+     * ZooKeeper hosts.
+     */
+    @Value("${zookeeper.connect_string:'zookeeper.pendev/kilda'}")
+    private String zookeeperConnectString;
+
+    /**
      * Kafka group id.
      */
     @Value("#{kafkaGroupConfig.getGroupId()}")
@@ -83,6 +96,10 @@ public class MessageConsumerConfig {
                 .put(ConsumerConfig.GROUP_ID_CONFIG, groupId)
                 .put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, true)
                 .put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, kafkaSessionTimeout)
+                .put(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, VersioningConsumerInterceptor.class.getName())
+                .put(CONSUMER_COMPONENT_NAME_PROPERTY, COMMON_COMPONENT_NAME)
+                .put(CONSUMER_RUN_ID_PROPERTY, COMMON_COMPONENT_RUN_ID)
+                .put(CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY, zookeeperConnectString)
                 .build();
     }
 

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/config/MessageConsumerConfig.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/config/MessageConsumerConfig.java
@@ -15,6 +15,13 @@
 
 package org.openkilda.northbound.config;
 
+import static org.openkilda.bluegreen.kafka.Utils.COMMON_COMPONENT_NAME;
+import static org.openkilda.bluegreen.kafka.Utils.COMMON_COMPONENT_RUN_ID;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_COMPONENT_NAME_PROPERTY;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_RUN_ID_PROPERTY;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY;
+
+import org.openkilda.bluegreen.kafka.interceptors.VersioningConsumerInterceptor;
 import org.openkilda.messaging.Message;
 import org.openkilda.northbound.messaging.MessagingChannel;
 import org.openkilda.northbound.messaging.kafka.KafkaMessageListener;
@@ -55,6 +62,12 @@ public class MessageConsumerConfig {
     private String kafkaHosts;
 
     /**
+     * ZooKeeper hosts.
+     */
+    @Value("${zookeeper.connect_string}")
+    private String zookeeperConnectString;
+
+    /**
      * Kafka group id.
      */
     @Value("#{kafkaGroupConfig.getGroupId()}")
@@ -83,6 +96,10 @@ public class MessageConsumerConfig {
                 .put(ConsumerConfig.GROUP_ID_CONFIG, groupId)
                 .put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, true)
                 .put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, kafkaSessionTimeout)
+                .put(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, VersioningConsumerInterceptor.class.getName())
+                .put(CONSUMER_COMPONENT_NAME_PROPERTY, COMMON_COMPONENT_NAME)
+                .put(CONSUMER_RUN_ID_PROPERTY, COMMON_COMPONENT_RUN_ID)
+                .put(CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY, zookeeperConnectString)
                 .build();
     }
 

--- a/src-java/server42/server42-control/src/test/resources/test.properties
+++ b/src-java/server42/server42-control/src/test/resources/test.properties
@@ -46,3 +46,8 @@ spring.kafka.producer.properties.interceptor.classes=org.openkilda.bluegreen.kaf
 spring.kafka.producer.properties.kafka.producer.messaging.zookeeper.connecting.string.property=zookeeper.pendev/kilda
 spring.kafka.producer.properties.kafka.producer.messaging.component.name.property=server42-control
 spring.kafka.producer.properties.kafka.producer.messaging.run.id.property=server42-control-run-id
+
+spring.kafka.consumer.properties.interceptor.classes=org.openkilda.bluegreen.kafka.interceptors.VersioningConsumerInterceptor
+spring.kafka.consumer.properties.kafka.consumer.messaging.zookeeper.connecting.string.property=zookeeper.pendev/kilda
+spring.kafka.consumer.properties.kafka.consumer.messaging.component.name.property=server42-control
+spring.kafka.consumer.properties.kafka.consumer.messaging.run.id.property=server42-control-run-id

--- a/src-java/server42/server42-stats/src/test/resources/test.properties
+++ b/src-java/server42/server42-stats/src/test/resources/test.properties
@@ -35,3 +35,8 @@ spring.kafka.producer.properties.interceptor.classes=org.openkilda.bluegreen.kaf
 spring.kafka.producer.properties.kafka.producer.messaging.zookeeper.connecting.string.property=zookeeper.pendev/kilda
 spring.kafka.producer.properties.kafka.producer.messaging.component.name.property=server42-stats
 spring.kafka.producer.properties.kafka.producer.messaging.run.id.property=server42-stats-run-id
+
+spring.kafka.consumer.properties.interceptor.classes=org.openkilda.bluegreen.kafka.interceptors.VersioningConsumerInterceptor
+spring.kafka.consumer.properties.kafka.consumer.messaging.zookeeper.connecting.string.property=zookeeper.pendev/kilda
+spring.kafka.consumer.properties.kafka.consumer.messaging.component.name.property=server42-stats
+spring.kafka.consumer.properties.kafka.consumer.messaging.run.id.property=server42-stats-run-id

--- a/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/StatsTopology.java
+++ b/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/StatsTopology.java
@@ -15,6 +15,8 @@
 
 package org.openkilda.wfm.topology.stats;
 
+import static org.openkilda.bluegreen.kafka.Utils.COMMON_COMPONENT_NAME;
+import static org.openkilda.bluegreen.kafka.Utils.COMMON_COMPONENT_RUN_ID;
 import static org.openkilda.wfm.AbstractBolt.FIELD_ID_CONTEXT;
 import static org.openkilda.wfm.topology.stats.StatsComponentType.FLOW_STATS_METRIC_GEN;
 import static org.openkilda.wfm.topology.stats.StatsComponentType.METER_CFG_STATS_METRIC_GEN;
@@ -173,8 +175,8 @@ public class StatsTopology extends AbstractTopology<StatsTopologyConfig> {
         String id = STATS_KILDA_SPEAKER_SPOUT.name();
         KafkaTopicsConfig topics = topologyConfig.getKafkaTopics();
         KafkaSpoutConfig<String, String> config = makeKafkaSpoutConfig(
-                    ImmutableList.of(topics.getSpeakerFlowHsTopic()),
-                    id, StringDeserializer.class)
+                ImmutableList.of(topics.getSpeakerFlowHsTopic()), id, StringDeserializer.class, COMMON_COMPONENT_NAME,
+                COMMON_COMPONENT_RUN_ID)
                 .setRecordTranslator(new JsonKafkaTranslator())
                 .build();
         declareSpout(topology, new KafkaSpout<>(config), id);

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/kafka/KafkaConfig.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/kafka/KafkaConfig.java
@@ -17,10 +17,14 @@ package org.openkilda.testing.service.kafka;
 
 import static org.openkilda.bluegreen.kafka.Utils.COMMON_COMPONENT_NAME;
 import static org.openkilda.bluegreen.kafka.Utils.COMMON_COMPONENT_RUN_ID;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_COMPONENT_NAME_PROPERTY;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_RUN_ID_PROPERTY;
+import static org.openkilda.bluegreen.kafka.Utils.CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY;
 import static org.openkilda.bluegreen.kafka.Utils.PRODUCER_COMPONENT_NAME_PROPERTY;
 import static org.openkilda.bluegreen.kafka.Utils.PRODUCER_RUN_ID_PROPERTY;
 import static org.openkilda.bluegreen.kafka.Utils.PRODUCER_ZOOKEEPER_CONNECTION_STRING_PROPERTY;
 
+import org.openkilda.bluegreen.kafka.interceptors.VersioningConsumerInterceptor;
 import org.openkilda.bluegreen.kafka.interceptors.VersioningProducerInterceptor;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -36,13 +40,18 @@ import java.util.Properties;
 @Configuration
 public class KafkaConfig {
     @Bean(name = "kafkaConsumerProperties")
-    public Properties kafkaConsumerProperties(@Value("${kafka.bootstrap.server}") String bootstrapServer) {
+    public Properties kafkaConsumerProperties(@Value("${kafka.bootstrap.server}") String bootstrapServer,
+                                              @Value("${zookeeper.connect_string}") String zookeeperHosts) {
         Properties connectDefaults = new Properties();
         connectDefaults.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
         connectDefaults.put(ConsumerConfig.GROUP_ID_CONFIG, "autotest");
         connectDefaults.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
         connectDefaults.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         connectDefaults.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        connectDefaults.put(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, VersioningConsumerInterceptor.class.getName());
+        connectDefaults.put(CONSUMER_COMPONENT_NAME_PROPERTY, COMMON_COMPONENT_NAME);
+        connectDefaults.put(CONSUMER_RUN_ID_PROPERTY, COMMON_COMPONENT_RUN_ID);
+        connectDefaults.put(CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY, zookeeperHosts);
         return connectDefaults;
     }
 


### PR DESCRIPTION
This PR adds kafka Header to all Kafka messages in Kilda. This is needed to isolate components by version.
If a component read Kafka message without version or with different version - this message will be skipped. 

Each component gets current version from ZooKeeper during start up. If ZooKeeper has no version for component default version will be used.
At this moment all components will use default version. When Zero Downtime feature will be finished Kilda will use some other version.