### PR TITLE
Increased storm slots for storm workers from 15 to 30

### DIFF
--- a/confd/templates/storm/storm.yaml.tmpl
+++ b/confd/templates/storm/storm.yaml.tmpl
@@ -23,6 +23,21 @@ supervisor.slots.ports:
   - 6712
   - 6713
   - 6714
+  - 6715
+  - 6716
+  - 6717
+  - 6718
+  - 6719
+  - 6720
+  - 6721
+  - 6722
+  - 6723
+  - 6724
+  - 6725
+  - 6726
+  - 6727
+  - 6728
+  - 6729
 
 ## Metrics Consumers
 # topology.metrics.consumer.register:


### PR DESCRIPTION
Zero Downtime feature requires to run 2 sets of topologies.
Need to increase slots count for second set of topologies