### PR TITLE
Add flow-id for attendant traffic stat entries

### DIFF
--- a/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/MeasurePoint.java
+++ b/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/MeasurePoint.java
@@ -17,6 +17,7 @@ package org.openkilda.wfm.topology.stats;
 
 public enum MeasurePoint {
     INGRESS,
+    INGRESS_ATTENDANT,
     EGRESS,
     ONE_SWITCH,
     TRANSIT

--- a/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/metrics/FlowMetricGenBolt.java
+++ b/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/metrics/FlowMetricGenBolt.java
@@ -106,6 +106,8 @@ public class FlowMetricGenBolt extends MetricGenBolt {
         tags.put("direction", FlowDirectionHelper.findDirectionSafe(entry.getCookie())
                 .orElse(Direction.UNKNOWN)
                 .name().toLowerCase());
+        CookieType cookieType = new Cookie(entry.getCookie()).getType();
+        tags.put("type", cookieType.name().toLowerCase());
 
         emitMetric("flow.raw.packets", timestamp, entry.getPacketCount(), tags);
         emitMetric("flow.raw.bytes", timestamp, entry.getByteCount(), tags);


### PR DESCRIPTION
Add new tag "type" for flow.raw.{packets,bytes,bits} metrics. And manage
to fill of `flowid` tag for these metrics for flow attendant
cookies/rules (server42 ingress rule).