### PR TITLE
Reorder switch events inside network topology

### DIFF
--- a/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/controller/sw/SwitchFsm.java
+++ b/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/controller/sw/SwitchFsm.java
@@ -146,10 +146,11 @@ public final class SwitchFsm extends AbstractBaseFsm<SwitchFsm, SwitchFsmState, 
         logWrapper.onSwitchOnline(switchId);
 
         transactionManager.doInTransaction(transactionRetryPolicy, () -> updatePersistentStatus(SwitchStatus.ACTIVE));
-        context.getOutput().sendSwitchStateChanged(switchId, SwitchStatus.ACTIVE);
 
         updatePorts(context, speakerData, true);
         speakerData = null;
+
+        context.getOutput().sendSwitchStateChanged(switchId, SwitchStatus.ACTIVE);
         context.getOutput().sendAffectedFlowRerouteRequest(switchId);
     }
 


### PR DESCRIPTION
To avoid excess/unneeded BFD logical ports create requests service
responsible for BFD logical ports management must receive port add/del
event before switch online event.