### PR TITLE
Docker base image for Lab-Api bumped to Ubuntu Focal

### DIFF
--- a/docker/base/kilda-base-lab-service/Dockerfile
+++ b/docker/base/kilda-base-lab-service/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-ARG base_image=ubuntu:eoan
+ARG base_image=ubuntu:focal
 FROM ${base_image}
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Docker base image for Lab-Api bumped to Ubuntu Аocal due Ubuntu Eoan deletion.