### PR TITLE
Fix multi-reroute spec

### DIFF
--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/extension/fixture/CleanupVerifierExtension.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/extension/fixture/CleanupVerifierExtension.groovy
@@ -1,10 +1,11 @@
 package org.openkilda.functionaltests.extension.fixture
 
 import org.openkilda.functionaltests.extension.spring.ContextAwareGlobalExtension
-import org.openkilda.messaging.info.event.IslChangeType
+import org.openkilda.model.IslStatus
 import org.openkilda.model.cookie.Cookie
 import org.openkilda.testing.Constants
 import org.openkilda.testing.model.topology.TopologyDefinition
+import org.openkilda.testing.service.database.Database
 import org.openkilda.testing.service.floodlight.FloodlightsHelper
 import org.openkilda.testing.service.northbound.NorthboundService
 import org.openkilda.testing.service.northbound.NorthboundServiceV2
@@ -40,6 +41,8 @@ class CleanupVerifierExtension extends ContextAwareGlobalExtension {
     TopologyDefinition topology
     @Autowired
     FloodlightsHelper flHelper
+    @Autowired
+    Database database
 
     @Override
     void delayedVisitSpec(SpecInfo spec) {
@@ -89,10 +92,13 @@ class CleanupVerifierExtension extends ContextAwareGlobalExtension {
             }
         }
         regionVerifications.verify()
-        northbound.getAllLinks().each {
-            assert it.state == IslChangeType.DISCOVERED
-            assert it.cost == Constants.DEFAULT_COST || it.cost == 0
+        database.getAllIsls().each {
+            assert it.timeUnstable == null
+            assert it.actualStatus == IslStatus.ACTIVE
+            assert it.status == IslStatus.ACTIVE
             assert it.availableBandwidth == it.maxBandwidth
+            assert it.availableBandwidth == it.speed
+            assert it.cost == Constants.DEFAULT_COST || it.cost == 0
         }
     }
 }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV2Spec.groovy
@@ -502,8 +502,8 @@ class FlowCrudV2Spec extends HealthCheckSpecification {
         topology.getBusyPortsForSwitch(isolatedSwitch).each { port ->
             antiflap.portUp(isolatedSwitch.dpId, port)
         }
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            northbound.getAllLinks().each { assert it.state == IslChangeType.DISCOVERED }
+        wait(discoveryInterval + WAIT_OFFSET) {
+            northbound.getAllLinks().each { assert it.state == DISCOVERED }
         }
         database.resetCosts()
 
@@ -1138,7 +1138,7 @@ class FlowCrudV2Spec extends HealthCheckSpecification {
 
         and: "Update the flow: vlanId on the src endpoint"
         def updatedFlowSrcEndpoint = flow.jacksonCopy().tap {
-            it.source.vlanId = flow.destination.vlanId + 1
+            it.source.vlanId = flow.destination.vlanId - 1
         }
         flowHelperV2.updateFlow(flow.flowId, updatedFlowSrcEndpoint)
 
@@ -1155,7 +1155,7 @@ class FlowCrudV2Spec extends HealthCheckSpecification {
 
         when: "Update the flow: vlanId on the dst endpoint"
         def updatedFlowDstEndpoint = flow.jacksonCopy().tap {
-            it.destination.vlanId = flow.source.vlanId + 1
+            it.destination.vlanId = flow.source.vlanId - 1
         }
         flowHelperV2.updateFlow(flow.flowId, updatedFlowDstEndpoint)
 
@@ -1173,9 +1173,9 @@ class FlowCrudV2Spec extends HealthCheckSpecification {
         then: "Update the flow: port number and vlanId on the src/dst endpoints"
         def updatedFlow = flow.jacksonCopy().tap {
             it.source.portNumber = activeTraffGens.find { it.switchConnected.dpId == switchPair.src.dpId}.switchPort
-            it.source.vlanId = updatedFlowDstEndpoint.source.vlanId + 1
+            it.source.vlanId = updatedFlowDstEndpoint.source.vlanId - 1
             it.destination.portNumber = activeTraffGens.find { it.switchConnected.dpId == switchPair.dst.dpId}.switchPort
-            it.destination.vlanId = updatedFlowDstEndpoint.destination.vlanId + 1
+            it.destination.vlanId = updatedFlowDstEndpoint.destination.vlanId - 1
         }
         flowHelperV2.updateFlow(flow.flowId, updatedFlow)
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
@@ -266,9 +266,9 @@ class ProtectedPathSpec extends HealthCheckSpecification {
             Wrappers.wait(WAIT_OFFSET + discoveryInterval) {
                 assert islUtils.getIslInfo(islToBreak).get().state == IslChangeType.DISCOVERED
             }
+            database.resetCosts()
         }
         northbound.deleteLinkProps(northbound.getAllLinkProps())
-        database.resetCosts()
 
         where:
         flowDescription | bandwidth
@@ -398,9 +398,9 @@ class ProtectedPathSpec extends HealthCheckSpecification {
             Wrappers.wait(WAIT_OFFSET + discoveryInterval) {
                 assert islUtils.getIslInfo(islToBreak).get().state == IslChangeType.DISCOVERED
             }
+            database.resetCosts()
         }
         northbound.deleteLinkProps(northbound.getAllLinkProps())
-        database.resetCosts()
 
         where:
         flowDescription | bandwidth
@@ -624,8 +624,8 @@ class ProtectedPathSpec extends HealthCheckSpecification {
             Wrappers.wait(WAIT_OFFSET + discoveryInterval) {
                 assert islUtils.getIslInfo(islToBreakProtectedPath).get().state == IslChangeType.DISCOVERED
             }
+            database.resetCosts()
         }
-        database.resetCosts()
     }
 
     @Tidy

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathV2Spec.groovy
@@ -451,6 +451,7 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
         flowHelperV2.deleteFlow(flow.flowId)
         mainIsl && antiflap.portUp(mainIsl.srcSwitch.dpId, mainIsl.srcPort)
         otherIsls && otherIsls.collectMany{[it, it.reversed]}.each { database.resetIslBandwidth(it) }
+        Wrappers.wait(WAIT_OFFSET) { assert northbound.getLink(mainIsl).state == IslChangeType.DISCOVERED }
         database.resetCosts()
     }
 
@@ -1138,6 +1139,7 @@ class ProtectedPathV2Spec extends HealthCheckSpecification {
                 northboundV2.partialSwitchUpdate(swId, new SwitchPatchDto().tap { it.pop = "" })
             }
         }
+        broughtDownPorts && database.resetCosts()
     }
 
     @Tidy

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
@@ -232,6 +232,7 @@ class LinkSpec extends HealthCheckSpecification {
             assert islUtils.getIslInfo(links, isl).get().state == DISCOVERED
             assert islUtils.getIslInfo(links, isl.reversed).get().state == DISCOVERED
         }
+        database.resetCosts()
     }
 
     @Tidy

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortHistorySpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortHistorySpec.groovy
@@ -115,6 +115,7 @@ class PortHistorySpec extends HealthCheckSpecification {
             Wrappers.wait(WAIT_OFFSET + discoveryInterval) {
                 assert islUtils.getIslInfo(isl).get().state == IslChangeType.DISCOVERED
             }
+            database.resetCosts()
         }
 
         where:
@@ -158,6 +159,7 @@ class PortHistorySpec extends HealthCheckSpecification {
             Wrappers.wait(WAIT_OFFSET + discoveryInterval) {
                 assert islUtils.getIslInfo(isl).get().state == IslChangeType.DISCOVERED
             }
+            database.resetCosts()
         }
     }
 
@@ -201,6 +203,7 @@ class PortHistorySpec extends HealthCheckSpecification {
             Wrappers.wait(WAIT_OFFSET + discoveryInterval) {
                 assert islUtils.getIslInfo(isl).get().state == IslChangeType.DISCOVERED
             }
+            database.resetCosts()
         }
         switchToDisconnect && switchHelper.reviveSwitch(switchToDisconnect, blockData)
     }
@@ -268,6 +271,7 @@ class PortHistorySpec extends HealthCheckSpecification {
         Wrappers.wait(antiflapCooldown + WAIT_OFFSET) {
             antiflap.assertPortIsStable(isl.srcSwitch.dpId, isl.srcPort)
         }
+        database.resetCosts()
     }
 
     @Ignore("https://github.com/telstra/open-kilda/issues/3007")
@@ -315,6 +319,7 @@ class PortHistorySpec extends HealthCheckSpecification {
         Wrappers.wait(WAIT_OFFSET + discoveryInterval + antiflapCooldown) {
             assert islUtils.getIslInfo(isl).get().state == IslChangeType.DISCOVERED
         }
+        database.resetCosts()
     }
 
     void checkPortHistory(PortHistoryResponse portHistory, SwitchId switchId, Integer port, PortHistoryEvent event) {

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/database/Database.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/database/Database.java
@@ -53,6 +53,8 @@ public interface Database {
 
     Instant getIslTimeUnstable(Isl isl);
 
+    List<org.openkilda.model.Isl> getAllIsls();
+
     // Switches
 
     Switch getSwitch(SwitchId switchId);

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/database/DatabaseSupportImpl.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/database/DatabaseSupportImpl.java
@@ -416,6 +416,11 @@ public class DatabaseSupportImpl implements Database {
     }
 
     @Override
+    public List<org.openkilda.model.Isl> getAllIsls() {
+        return new ArrayList<>(transactionManager.doInTransaction(islRepository::findAll));
+    }
+
+    @Override
     public List<Object> dumpAllNodes() {
         return transactionManager.doInTransaction(() ->
                 repositoryFactory.getGraphFactory().getGraph()


### PR DESCRIPTION
- Cleanup verifier now also checks 'timeUnstable' on isls