### PR TITLE
Fixed Otsdb shouldSendDatapointRequestsTwice test.

### DIFF
--- a/src-java/opentsdb-topology/opentsdb-storm-topology/src/test/java/org/openkilda/wfm/topology/opentsdb/OpenTsdbTopologyTest.java
+++ b/src-java/opentsdb-topology/opentsdb-storm-topology/src/test/java/org/openkilda/wfm/topology/opentsdb/OpenTsdbTopologyTest.java
@@ -35,6 +35,7 @@ import org.mockserver.verify.VerificationTimes;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Properties;
 
 public class OpenTsdbTopologyTest extends StableAbstractStormTest {
     private static final long timestamp = System.currentTimeMillis();
@@ -109,7 +110,13 @@ public class OpenTsdbTopologyTest extends StableAbstractStormTest {
         MockedSources sources = new MockedSources();
 
         Testing.withTrackedCluster(clusterParam, (cluster) -> {
-            OpenTsdbTopology topology = new OpenTsdbTopology(makeLaunchEnvironment());
+            // This test expects to see 2 POST requests to OpenTsdb, but if batch.size > 1 OtsdbBolt will send
+            // 1 request with 2 metrics instead of 2 requests with 1 metric.
+            // So next property forces OtsdbBolt to send 2 requests.
+            Properties properties = new Properties();
+            properties.put("opentsdb.batch.size", "1");
+
+            OpenTsdbTopology topology = new OpenTsdbTopology(makeLaunchEnvironment(properties));
 
             sources.addMockData(OpenTsdbTopology.OTSDB_SPOUT_ID,
                     new Values(null, datapoint1), new Values(null, datapoint2));


### PR DESCRIPTION
This test expects to see 2 POST requests into OpenTsdb because we want to store 2 metrics. But if these 2 metrics will be in one batch only 1 HTTP request will be send (with 2 metrics inside). This test worked previously because parallelism of OtsdbBolt was 10 and we have 10 different batches. Now parallelism is only 1 so Bolt puts both metrics into one batch and send one request. To fix it batch size was reduced to 1 for this test.