### PR TITLE
Increased port count in metadata from 128 to 4096

### DIFF
--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/utils/metadata/RoutingMetadata.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/utils/metadata/RoutingMetadata.java
@@ -34,7 +34,10 @@ public class RoutingMetadata extends MetadataBase {
     private static final BitField ARP_MARKER_FLAG          = new BitField(0x0000_0000_0000_0004L);
     private static final BitField OUTER_VLAN_PRESENCE_FLAG = new BitField(0x0000_0000_0000_0008L);
     private static final BitField OUTER_VLAN_FIELD         = new BitField(0x0000_0000_0000_fff0L);
-    private static final BitField INPUT_PORT_FIELD         = new BitField(0x0000_0000_007F_0000L);
+    // NOTE: port count was increased from 128 to 4096. At this moment only 1000 ports can be used
+    // on Noviflow switches. But according to open flow specs port count could be up to 65536.
+    // So we increased port count to maximum possible value.
+    private static final BitField INPUT_PORT_FIELD         = new BitField(0x0000_0000_0FFF_0000L);
 
     static final long MAX_INPUT_PORT = INPUT_PORT_FIELD.getMask() >> INPUT_PORT_FIELD.getOffset();
 

--- a/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/utils/metadata/RoutingMetadataTest.java
+++ b/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/utils/metadata/RoutingMetadataTest.java
@@ -31,7 +31,7 @@ public class RoutingMetadataTest extends MetadataBaseTest {
     @Test
     public void testInputPortMetadata() {
         int offset = 16;
-        for (int port = 0; port <= 127; port++) {
+        for (int port = 0; port <= 4095; port++) {
             RoutingMetadata metadata = RoutingMetadata.builder().inputPort(port).build(new HashSet<>());
             long withoutType = ~TYPE_FIELD.getMask() & metadata.getValue().getValue();
             assertEquals(port, withoutType >> offset);


### PR DESCRIPTION
port count was increased from 128 to 4096. At this moment only 1000 ports can be used
on Noviflow switches. But according to open flow specs port count could be up to 65536.
So we increased port count to maximum possible value.