### PR TITLE
Improve performance of H&S flow operations: data model and graph super-nodes

### DIFF
--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/service/IntersectionComputer.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/service/IntersectionComputer.java
@@ -54,8 +54,8 @@ public class IntersectionComputer {
                                 Collection<FlowPath> paths) {
         List<Edge> targetPath = paths.stream()
                 .flatMap(path -> path.getSegments().stream())
-                .filter(e -> e.getPath().getPathId().equals(targetForwardPathId)
-                        || e.getPath().getPathId().equals(targetReversePathId))
+                .filter(e -> e.getPathId().equals(targetForwardPathId)
+                        || e.getPathId().equals(targetReversePathId))
                 .map(Edge::fromPathSegment)
                 .collect(Collectors.toList());
 
@@ -68,7 +68,7 @@ public class IntersectionComputer {
                 .filter(e -> !e.getFlow().getFlowId().equals(targetFlowId))
                 .flatMap(path -> path.getSegments().stream())
                 .collect(Collectors.groupingBy(
-                        ps -> ps.getPath().getPathId(),
+                        PathSegment::getPathId,
                         Collectors.mapping(Edge::fromPathSegment, Collectors.toSet())
                 ));
     }

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowPathBuilder.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowPathBuilder.java
@@ -195,6 +195,7 @@ public class FlowPathBuilder {
                     }
 
                     return PathSegment.builder()
+                            .pathId(flowPath.getPathId())
                             .srcSwitch(segmentSrcSwitch)
                             .srcWithMultiTable(segmentSrcSwitchProperties.isMultiTable())
                             .srcPort(segment.getSrcPort())

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/service/IntersectionComputerTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/service/IntersectionComputerTest.java
@@ -99,7 +99,7 @@ public class IntersectionComputerTest {
                 .srcSwitch(makeSwitch(SWITCH_ID_D))
                 .destSwitch(makeSwitch(SWITCH_ID_E))
                 .segments(Lists.newArrayList(
-                        buildPathSegment(SWITCH_ID_D, SWITCH_ID_E, 10, 10)))
+                        buildPathSegment(NEW_PATH_ID, SWITCH_ID_D, SWITCH_ID_E, 10, 10)))
                 .build();
         flow.addPaths(path);
 
@@ -108,7 +108,7 @@ public class IntersectionComputerTest {
                 .srcSwitch(makeSwitch(SWITCH_ID_E))
                 .destSwitch(makeSwitch(SWITCH_ID_D))
                 .segments(Lists.newArrayList(
-                        buildPathSegment(SWITCH_ID_E, SWITCH_ID_D, 10, 10)))
+                        buildPathSegment(NEW_PATH_ID_REVERSE, SWITCH_ID_E, SWITCH_ID_D, 10, 10)))
                 .build();
         flow2.addPaths(revPath);
         paths.addAll(Lists.newArrayList(path, revPath));
@@ -128,7 +128,7 @@ public class IntersectionComputerTest {
                 .srcSwitch(makeSwitch(SWITCH_ID_A))
                 .destSwitch(makeSwitch(SWITCH_ID_D))
                 .segments(Lists.newArrayList(
-                        buildPathSegment(SWITCH_ID_A, SWITCH_ID_D, 10, 10)))
+                        buildPathSegment(NEW_PATH_ID, SWITCH_ID_A, SWITCH_ID_D, 10, 10)))
                 .build();
         flow.addPaths(newPath);
         paths.add(newPath);
@@ -167,7 +167,7 @@ public class IntersectionComputerTest {
                 .srcSwitch(makeSwitch(SWITCH_ID_A))
                 .destSwitch(makeSwitch(SWITCH_ID_D))
                 .segments(Lists.newArrayList(
-                        buildPathSegment(SWITCH_ID_A, SWITCH_ID_D, 10, 10)))
+                        buildPathSegment(NEW_PATH_ID, SWITCH_ID_A, SWITCH_ID_D, 10, 10)))
                 .build();
         flow2.addPaths(newPath);
         paths.add(newPath);
@@ -187,7 +187,7 @@ public class IntersectionComputerTest {
                 .srcSwitch(makeSwitch(SWITCH_ID_A))
                 .destSwitch(makeSwitch(SWITCH_ID_B))
                 .segments(Lists.newArrayList(
-                        buildPathSegment(SWITCH_ID_A, SWITCH_ID_B, 1, 1)))
+                        buildPathSegment(NEW_PATH_ID, SWITCH_ID_A, SWITCH_ID_B, 1, 1)))
                 .build();
         flow2.addPaths(newPath);
         paths.add(newPath);
@@ -215,7 +215,7 @@ public class IntersectionComputerTest {
 
         List<PathSegment> primarySegments = getFlowPathSegments(paths);
         List<PathSegment> protectedSegmets = Collections.singletonList(
-                buildPathSegment(SWITCH_ID_A, SWITCH_ID_B, 1, 1));
+                buildPathSegment(PATH_ID, SWITCH_ID_A, SWITCH_ID_B, 1, 1));
 
         assertTrue(IntersectionComputer.isProtectedPathOverlaps(primarySegments, protectedSegmets));
     }
@@ -226,7 +226,7 @@ public class IntersectionComputerTest {
 
         List<PathSegment> primarySegments = getFlowPathSegments(paths);
         List<PathSegment> protectedSegmets = Collections.singletonList(
-                buildPathSegment(SWITCH_ID_A, SWITCH_ID_C, 3, 3));
+                buildPathSegment(PATH_ID, SWITCH_ID_A, SWITCH_ID_C, 3, 3));
 
         assertFalse(IntersectionComputer.isProtectedPathOverlaps(primarySegments, protectedSegmets));
     }
@@ -250,8 +250,8 @@ public class IntersectionComputerTest {
                 .srcSwitch(srcSwitch)
                 .destSwitch(dstSwitch)
                 .segments(Lists.newArrayList(
-                        buildPathSegment(SWITCH_ID_A, SWITCH_ID_B, 1, 1),
-                        buildPathSegment(SWITCH_ID_B, SWITCH_ID_C, 2, 2)))
+                        buildPathSegment(pathId, SWITCH_ID_A, SWITCH_ID_B, 1, 1),
+                        buildPathSegment(pathId, SWITCH_ID_B, SWITCH_ID_C, 2, 2)))
                 .build();
         flow.addPaths(path);
 
@@ -260,16 +260,17 @@ public class IntersectionComputerTest {
                 .srcSwitch(srcSwitch)
                 .destSwitch(dstSwitch)
                 .segments(Lists.newArrayList(
-                        buildPathSegment(SWITCH_ID_C, SWITCH_ID_B, 2, 2),
-                        buildPathSegment(SWITCH_ID_B, SWITCH_ID_A, 1, 1)))
+                        buildPathSegment(pathId, SWITCH_ID_C, SWITCH_ID_B, 2, 2),
+                        buildPathSegment(pathId, SWITCH_ID_B, SWITCH_ID_A, 1, 1)))
                 .build();
         flow.addPaths(revPath);
 
         return Lists.newArrayList(path, revPath);
     }
 
-    private PathSegment buildPathSegment(SwitchId srcDpid, SwitchId dstDpid, int srcPort, int dstPort) {
+    private PathSegment buildPathSegment(PathId pathId, SwitchId srcDpid, SwitchId dstDpid, int srcPort, int dstPort) {
         return PathSegment.builder()
+                .pathId(pathId)
                 .srcSwitch(makeSwitch(srcDpid))
                 .destSwitch(makeSwitch(dstDpid))
                 .srcPort(srcPort)

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/service/SpeakerFlowSegmentRequestBuilderTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/service/SpeakerFlowSegmentRequestBuilderTest.java
@@ -392,6 +392,7 @@ public class SpeakerFlowSegmentRequestBuilderTest extends InMemoryGraphBasedTest
 
     private void setSegmentsWithoutTransitSwitches(FlowPath forward, FlowPath reverse) {
         PathSegment switch1ToSwitch2 = PathSegment.builder()
+                .pathId(forward.getPathId())
                 .srcSwitch(forward.getSrcSwitch())
                 .srcPort(12)
                 .destSwitch(forward.getDestSwitch())
@@ -399,6 +400,7 @@ public class SpeakerFlowSegmentRequestBuilderTest extends InMemoryGraphBasedTest
                 .build();
         forward.setSegments(ImmutableList.of(switch1ToSwitch2));
         PathSegment switch2ToSwitch1 = PathSegment.builder()
+                .pathId(reverse.getPathId())
                 .srcSwitch(reverse.getSrcSwitch())
                 .srcPort(22)
                 .destSwitch(reverse.getDestSwitch())
@@ -409,12 +411,14 @@ public class SpeakerFlowSegmentRequestBuilderTest extends InMemoryGraphBasedTest
 
     private void setSegmentsWithTransitSwitches(FlowPath forward, FlowPath reverse) {
         PathSegment switch1ToSwitch2 = PathSegment.builder()
+                .pathId(forward.getPathId())
                 .srcSwitch(forward.getSrcSwitch())
                 .srcPort(12)
                 .destSwitch(Switch.builder().switchId(SWITCH_2).build())
                 .destPort(21)
                 .build();
         PathSegment switch2ToSwitch3 = PathSegment.builder()
+                .pathId(forward.getPathId())
                 .srcSwitch(Switch.builder().switchId(SWITCH_2).build())
                 .srcPort(23)
                 .destSwitch(forward.getDestSwitch())
@@ -423,12 +427,14 @@ public class SpeakerFlowSegmentRequestBuilderTest extends InMemoryGraphBasedTest
         forward.setSegments(ImmutableList.of(switch1ToSwitch2, switch2ToSwitch3));
 
         PathSegment switch3ToSwitch2 = PathSegment.builder()
+                .pathId(reverse.getPathId())
                 .srcSwitch(reverse.getSrcSwitch())
                 .srcPort(32)
                 .destSwitch(Switch.builder().switchId(SWITCH_2).build())
                 .destPort(23)
                 .build();
         PathSegment switch2ToSwitch1 = PathSegment.builder()
+                .pathId(reverse.getPathId())
                 .srcSwitch(Switch.builder().switchId(SWITCH_2).build())
                 .srcPort(21)
                 .destSwitch(reverse.getDestSwitch())

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/utils/rule/validation/SimpleSwitchRuleConverterTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/utils/rule/validation/SimpleSwitchRuleConverterTest.java
@@ -286,6 +286,7 @@ public class SimpleSwitchRuleConverterTest {
         flow.setForwardPath(forwardFlowPath);
 
         PathSegment forwardSegmentA = PathSegment.builder()
+                .pathId(forwardFlowPath.getPathId())
                 .srcSwitch(switchA)
                 .srcPort(FLOW_A_SEGMENT_A_SRC_PORT)
                 .destSwitch(switchB)
@@ -293,6 +294,7 @@ public class SimpleSwitchRuleConverterTest {
                 .build();
 
         PathSegment forwardSegmentB = PathSegment.builder()
+                .pathId(forwardFlowPath.getPathId())
                 .srcSwitch(switchB)
                 .srcPort(FLOW_A_SEGMENT_B_SRC_PORT)
                 .destSwitch(switchC)

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowPathBuilderTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowPathBuilderTest.java
@@ -126,11 +126,13 @@ public class FlowPathBuilderTest {
                         .build()))
                 .build();
 
+        PathId flowPathId = new PathId("test_path_id");
         FlowPath flowPath = FlowPath.builder()
                 .srcSwitch(switch1)
                 .destSwitch(switch2)
-                .pathId(new PathId("test_path_id"))
+                .pathId(flowPathId)
                 .segments(Collections.singletonList(PathSegment.builder()
+                        .pathId(flowPathId)
                         .srcSwitch(switch1).srcPort(1).destSwitch(switch2).destPort(2).build()))
                 .build();
 
@@ -156,11 +158,13 @@ public class FlowPathBuilderTest {
                         .build()))
                 .build();
 
+        PathId flowPathId = new PathId("test_path_id");
         FlowPath flowPath = FlowPath.builder()
                 .srcSwitch(switch1)
                 .destSwitch(switch2)
-                .pathId(new PathId("test_path_id"))
+                .pathId(flowPathId)
                 .segments(Collections.singletonList(PathSegment.builder()
+                        .pathId(flowPathId)
                         .srcSwitch(switch1).srcPort(2).destSwitch(switch2).destPort(3).build()))
                 .build();
 
@@ -194,13 +198,16 @@ public class FlowPathBuilderTest {
                         .build()))
                 .build();
 
+        PathId flowPathId = new PathId("test_path_id");
         FlowPath flowPath = FlowPath.builder()
                 .srcSwitch(switch1)
                 .destSwitch(switch2)
-                .pathId(new PathId("test_path_id"))
+                .pathId(flowPathId)
                 .segments(asList(
-                        PathSegment.builder().srcSwitch(switch1).srcPort(1).destSwitch(switch3).destPort(2).build(),
-                        PathSegment.builder().srcSwitch(switch3).srcPort(1).destSwitch(switch2).destPort(2).build()))
+                        PathSegment.builder().pathId(flowPathId)
+                                .srcSwitch(switch1).srcPort(1).destSwitch(switch3).destPort(2).build(),
+                        PathSegment.builder().pathId(flowPathId)
+                                .srcSwitch(switch3).srcPort(1).destSwitch(switch2).destPort(2).build()))
                 .build();
 
         assertTrue(builder.isSamePath(path, flowPath));

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseResourceAllocationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseResourceAllocationAction.java
@@ -244,9 +244,9 @@ public abstract class BaseResourceAllocationAction<T extends FlowPathSwappingFsm
                 for (FlowPath pathToReuseBandwidth : pathsToReuseBandwidth) {
                     if (pathToReuseBandwidth != null) {
                         for (PathSegment reuseSegment : pathToReuseBandwidth.getSegments()) {
-                            if (pathSegment.getSrcSwitch().equals(reuseSegment.getSrcSwitch())
+                            if (pathSegment.getSrcSwitchId().equals(reuseSegment.getSrcSwitchId())
                                     && pathSegment.getSrcPort() == reuseSegment.getSrcPort()
-                                    && pathSegment.getDestSwitch().equals(reuseSegment.getDestSwitch())
+                                    && pathSegment.getDestSwitchId().equals(reuseSegment.getDestSwitchId())
                                     && pathSegment.getDestPort() == reuseSegment.getDestPort()) {
                                 allowedOverprovisionedBandwidth += pathToReuseBandwidth.getBandwidth();
                             }

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/ApplicationRule.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/ApplicationRule.java
@@ -59,7 +59,7 @@ public class ApplicationRule implements CompositeDataEntity<ApplicationRule.Appl
      * @param entityToClone the entity to copy entity data from.
      */
     public ApplicationRule(@NonNull ApplicationRule entityToClone) {
-        data = ApplicationRuleCloner.INSTANCE.copy(entityToClone.getData());
+        data = ApplicationRuleCloner.INSTANCE.deepCopy(entityToClone.getData());
     }
 
     @Builder
@@ -193,7 +193,7 @@ public class ApplicationRule implements CompositeDataEntity<ApplicationRule.Appl
         /**
          * Performs deep copy of entity data.
          */
-        default ApplicationRuleData copy(ApplicationRuleData source) {
+        default ApplicationRuleData deepCopy(ApplicationRuleData source) {
             ApplicationRuleData result = new ApplicationRuleDataImpl();
             copy(source, result);
             return result;

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/BfdSession.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/BfdSession.java
@@ -167,7 +167,7 @@ public class BfdSession implements CompositeDataEntity<BfdSession.BfdSessionData
         /**
          * Performs deep copy of entity data.
          */
-        default BfdSessionData copy(BfdSessionData source) {
+        default BfdSessionData deepCopy(BfdSessionData source) {
             BfdSessionData result = new BfdSessionDataImpl();
             copy(source, result);
             return result;

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/ExclusionId.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/ExclusionId.java
@@ -60,7 +60,7 @@ public class ExclusionId implements CompositeDataEntity<ExclusionId.ExclusionIdD
      * @param entityToClone the entity to copy entity data from.
      */
     public ExclusionId(@NonNull ExclusionId entityToClone) {
-        data = ExclusionIdCloner.INSTANCE.copy(entityToClone.getData());
+        data = ExclusionIdCloner.INSTANCE.deepCopy(entityToClone.getData());
     }
 
     @Builder
@@ -133,7 +133,7 @@ public class ExclusionId implements CompositeDataEntity<ExclusionId.ExclusionIdD
         /**
          * Performs deep copy of entity data.
          */
-        default ExclusionIdData copy(ExclusionIdData source) {
+        default ExclusionIdData deepCopy(ExclusionIdData source) {
             ExclusionIdData result = new ExclusionIdDataImpl();
             copy(source, result);
             return result;

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/FeatureToggles.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/FeatureToggles.java
@@ -70,7 +70,7 @@ public class FeatureToggles implements CompositeDataEntity<FeatureToggles.Featur
      * @param entityToClone the entity to copy entity data from.
      */
     public FeatureToggles(@NonNull FeatureToggles entityToClone) {
-        data = FeatureTogglesCloner.INSTANCE.copy(entityToClone.getData());
+        data = FeatureTogglesCloner.INSTANCE.deepCopy(entityToClone.getData());
     }
 
     @Builder
@@ -202,7 +202,7 @@ public class FeatureToggles implements CompositeDataEntity<FeatureToggles.Featur
         /**
          * Performs deep copy of entity data.
          */
-        default FeatureTogglesData copy(FeatureTogglesData source) {
+        default FeatureTogglesData deepCopy(FeatureTogglesData source) {
             FeatureTogglesData result = new FeatureTogglesDataImpl();
             copyNonNull(source, result);
             return result;

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/FlowCookie.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/FlowCookie.java
@@ -121,7 +121,7 @@ public class FlowCookie implements CompositeDataEntity<FlowCookie.FlowCookieData
         /**
          * Performs deep copy of entity data.
          */
-        default FlowCookieData copy(FlowCookieData source) {
+        default FlowCookieData deepCopy(FlowCookieData source) {
             FlowCookieData result = new FlowCookieDataImpl();
             copy(source, result);
             return result;

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/FlowMeter.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/FlowMeter.java
@@ -134,7 +134,7 @@ public class FlowMeter implements CompositeDataEntity<FlowMeter.FlowMeterData> {
         /**
          * Performs deep copy of entity data.
          */
-        default FlowMeterData copy(FlowMeterData source) {
+        default FlowMeterData deepCopy(FlowMeterData source) {
             FlowMeterData result = new FlowMeterDataImpl();
             copy(source, result);
             return result;

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/FlowPath.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/FlowPath.java
@@ -17,8 +17,6 @@ package org.openkilda.model;
 
 import static java.lang.String.format;
 
-import org.openkilda.model.PathSegment.PathSegmentData;
-import org.openkilda.model.PathSegment.PathSegmentDataImpl;
 import org.openkilda.model.cookie.FlowSegmentCookie;
 
 import com.esotericsoftware.kryo.DefaultSerializer;
@@ -68,8 +66,6 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
      */
     private FlowPath() {
         data = new FlowPathDataImpl();
-        // The reference is used to link path segments back to the path. See {@link #setSegments(List)}.
-        ((FlowPathDataImpl) data).flowPath = this;
     }
 
     /**
@@ -79,9 +75,7 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
      * @param flow the flow to be referred ({@code FlowPath.getFlow()}) by the new path.
      */
     public FlowPath(@NonNull FlowPath entityToClone, Flow flow) {
-        this();
-        ((FlowPathDataImpl) data).flow = flow;
-        FlowPathCloner.INSTANCE.copy(entityToClone.getData(), data, this);
+        data = FlowPathCloner.INSTANCE.deepCopy(entityToClone.getData(), flow);
     }
 
     @Builder
@@ -95,9 +89,6 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
                 .latency(latency).bandwidth(bandwidth)
                 .ignoreBandwidth(ignoreBandwidth).status(status)
                 .applications(applications).build();
-        // The reference is used to link path segments back to the path. See {@link #setSegments(List)}.
-        ((FlowPathDataImpl) data).flowPath = this;
-
         if (segments != null && !segments.isEmpty()) {
             data.setSegments(segments);
         }
@@ -282,12 +273,14 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
         @EqualsAndHashCode.Exclude
         @NonNull List<PathSegment> segments = new ArrayList<>();
         Set<FlowApplication> applications;
-        // The reference is used to link path segments back to the path. See {@link #setSegments(List)}.
-        @Setter(AccessLevel.NONE)
-        @Getter(AccessLevel.NONE)
-        @ToString.Exclude
-        @EqualsAndHashCode.Exclude
-        FlowPath flowPath;
+
+        public void setPathId(PathId pathId) {
+            this.pathId = pathId;
+
+            if (segments != null) {
+                segments.forEach(segment -> segment.getData().setPathId(pathId));
+            }
+        }
 
         @Override
         public String getFlowId() {
@@ -308,7 +301,7 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
             this.bandwidth = bandwidth;
 
             if (segments != null) {
-                segments.forEach(segment -> segment.setBandwidth(bandwidth));
+                segments.forEach(segment -> segment.getData().setBandwidth(bandwidth));
             }
         }
 
@@ -316,7 +309,7 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
             this.ignoreBandwidth = ignoreBandwidth;
 
             if (segments != null) {
-                segments.forEach(segment -> segment.setIgnoreBandwidth(ignoreBandwidth));
+                segments.forEach(segment -> segment.getData().setIgnoreBandwidth(ignoreBandwidth));
             }
         }
 
@@ -332,13 +325,11 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
         public void setSegments(List<PathSegment> segments) {
             for (int idx = 0; idx < segments.size(); idx++) {
                 PathSegment segment = segments.get(idx);
-                segment.setSeqId(idx);
-                segment.setIgnoreBandwidth(ignoreBandwidth);
-                segment.setBandwidth(bandwidth);
-                PathSegmentData data = segment.getData();
-                if (data instanceof PathSegmentDataImpl) {
-                    ((PathSegmentDataImpl) data).path = flowPath;
-                }
+                PathSegment.PathSegmentData data = segment.getData();
+                data.setPathId(pathId);
+                data.setSeqId(idx);
+                data.setIgnoreBandwidth(ignoreBandwidth);
+                data.setBandwidth(bandwidth);
             }
 
             this.segments = new ArrayList<>(segments);
@@ -354,32 +345,27 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
 
         void copy(FlowPathData source, @MappingTarget FlowPathData target);
 
-        /**
-         * Performs deep copy of entity data.
-         */
-        default FlowPathData copy(FlowPathData source, FlowPath targetPath, Flow targetFlow) {
-            FlowPathDataImpl result = new FlowPathDataImpl();
-            result.flowPath = targetPath;
-            result.flow = targetFlow;
-            copy(source, result, targetPath);
-            return result;
-        }
-
-        /**
-         * Performs deep copy of entity data.
-         */
-        default void copy(FlowPathData source, FlowPathData target, FlowPath targetPath) {
-            copyWithoutSwitchesAndSegments(source, target);
-            target.setSrcSwitch(new Switch(source.getSrcSwitch()));
-            target.setDestSwitch(new Switch(source.getDestSwitch()));
-            target.setSegments(source.getSegments().stream()
-                    .map(segment -> new PathSegment(segment, targetPath))
-                    .collect(Collectors.toList()));
-        }
-
         @Mapping(target = "srcSwitch", ignore = true)
         @Mapping(target = "destSwitch", ignore = true)
         @Mapping(target = "segments", ignore = true)
         void copyWithoutSwitchesAndSegments(FlowPathData source, @MappingTarget FlowPathData target);
+
+        /**
+         * Performs deep copy of entity data.
+         *
+         * @param source the path data to copy from.
+         * @param targetFlow the flow to be referred ({@code FlowPathData.getFlow()}) by the new path data.
+         */
+        default FlowPathData deepCopy(FlowPathData source, Flow targetFlow) {
+            FlowPathDataImpl result = new FlowPathDataImpl();
+            result.flow = targetFlow;
+            copyWithoutSwitchesAndSegments(source, result);
+            result.setSrcSwitch(new Switch(source.getSrcSwitch()));
+            result.setDestSwitch(new Switch(source.getDestSwitch()));
+            result.setSegments(source.getSegments().stream()
+                    .map(PathSegment::new)
+                    .collect(Collectors.toList()));
+            return result;
+        }
     }
 }

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/Isl.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/Isl.java
@@ -66,7 +66,7 @@ public class Isl implements CompositeDataEntity<Isl.IslData> {
      * @param entityToClone the entity to copy entity data from.
      */
     public Isl(@NonNull Isl entityToClone) {
-        data = IslCloner.INSTANCE.copy(entityToClone.getData());
+        data = IslCloner.INSTANCE.deepCopy(entityToClone.getData());
     }
 
     @Builder
@@ -307,7 +307,7 @@ public class Isl implements CompositeDataEntity<Isl.IslData> {
         /**
          * Performs deep copy of entity data.
          */
-        default IslData copy(IslData source) {
+        default IslData deepCopy(IslData source) {
             IslData result = new IslDataImpl();
             copyWithoutSwitches(source, result);
             result.setSrcSwitch(new Switch(source.getSrcSwitch()));

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/KildaConfiguration.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/KildaConfiguration.java
@@ -64,7 +64,7 @@ public class KildaConfiguration implements CompositeDataEntity<KildaConfiguratio
      * @param entityToClone the entity to copy entity data from.
      */
     public KildaConfiguration(@NonNull KildaConfiguration entityToClone) {
-        data = KildaConfigurationCloner.INSTANCE.copy(entityToClone.getData());
+        data = KildaConfigurationCloner.INSTANCE.deepCopy(entityToClone.getData());
     }
 
     @Builder
@@ -147,7 +147,7 @@ public class KildaConfiguration implements CompositeDataEntity<KildaConfiguratio
         /**
          * Performs deep copy of entity data.
          */
-        default KildaConfigurationData copy(KildaConfigurationData source) {
+        default KildaConfigurationData deepCopy(KildaConfigurationData source) {
             KildaConfigurationData result = new KildaConfigurationDataImpl();
             copyNonNull(source, result);
             return result;

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/LinkProps.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/LinkProps.java
@@ -61,7 +61,7 @@ public class LinkProps implements CompositeDataEntity<LinkProps.LinkPropsData> {
      * @param entityToClone the entity to copy entity data from.
      */
     public LinkProps(@NonNull LinkProps entityToClone) {
-        data = LinkPropsCloner.INSTANCE.copy(entityToClone.getData());
+        data = LinkPropsCloner.INSTANCE.deepCopy(entityToClone.getData());
     }
 
     @Builder
@@ -170,7 +170,7 @@ public class LinkProps implements CompositeDataEntity<LinkProps.LinkPropsData> {
         /**
          * Performs deep copy of entity data.
          */
-        default LinkPropsData copy(LinkPropsData source) {
+        default LinkPropsData deepCopy(LinkPropsData source) {
             LinkPropsData result = new LinkPropsDataImpl();
             copy(source, result);
             return result;

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/MirrorGroup.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/MirrorGroup.java
@@ -60,7 +60,7 @@ public class MirrorGroup implements CompositeDataEntity<MirrorGroup.MirrorGroupD
      * @param entityToClone the entity to copy entity data from.
      */
     public MirrorGroup(@NonNull MirrorGroup entityToClone) {
-        data = MirrorGroupCloner.INSTANCE.copy(entityToClone.getData());
+        data = MirrorGroupCloner.INSTANCE.deepCopy(entityToClone.getData());
     }
 
     @Builder
@@ -167,7 +167,7 @@ public class MirrorGroup implements CompositeDataEntity<MirrorGroup.MirrorGroupD
         /**
          * Performs deep copy of entity data.
          */
-        default MirrorGroupData copy(MirrorGroupData source) {
+        default MirrorGroupData deepCopy(MirrorGroupData source) {
             MirrorGroupData result = new MirrorGroupDataImpl();
             copy(source, result);
             return result;

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/PortProperties.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/PortProperties.java
@@ -61,7 +61,7 @@ public class PortProperties implements CompositeDataEntity<PortProperties.PortPr
      * @param entityToClone the entity to copy properties data from.
      */
     public PortProperties(@NonNull PortProperties entityToClone) {
-        data = PortPropertiesCloner.INSTANCE.copy(entityToClone.getData());
+        data = PortPropertiesCloner.INSTANCE.deepCopy(entityToClone.getData());
     }
 
     @Builder
@@ -150,17 +150,17 @@ public class PortProperties implements CompositeDataEntity<PortProperties.PortPr
             target.setSwitchObj(new Switch(source.getSwitchObj()));
         }
 
+        @Mapping(target = "switchObj", ignore = true)
+        void copyWithoutSwitch(PortPropertiesData source, @MappingTarget PortPropertiesData target);
+
         /**
          * Performs deep copy of entity data.
          */
-        default PortPropertiesData copy(PortPropertiesData source) {
+        default PortPropertiesData deepCopy(PortPropertiesData source) {
             PortPropertiesData result = new PortPropertiesDataImpl();
             copyWithoutSwitch(source, result);
             result.setSwitchObj(new Switch(source.getSwitchObj()));
             return result;
         }
-
-        @Mapping(target = "switchObj", ignore = true)
-        void copyWithoutSwitch(PortPropertiesData source, @MappingTarget PortPropertiesData target);
     }
 }

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/Switch.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/Switch.java
@@ -71,7 +71,7 @@ public class Switch implements CompositeDataEntity<Switch.SwitchData> {
      * @param entityToClone the entity to copy entity data from.
      */
     public Switch(@NonNull Switch entityToClone) {
-        data = SwitchCloner.INSTANCE.copy(entityToClone.getData());
+        data = SwitchCloner.INSTANCE.deepCopy(entityToClone.getData());
     }
 
     @Builder
@@ -337,7 +337,7 @@ public class Switch implements CompositeDataEntity<Switch.SwitchData> {
         /**
          * Performs deep copy of entity data.
          */
-        default SwitchData copy(SwitchData source) {
+        default SwitchData deepCopy(SwitchData source) {
             SwitchDataImpl result = new SwitchDataImpl();
             copy(source, result);
             return result;

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/SwitchConnectedDevice.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/SwitchConnectedDevice.java
@@ -63,7 +63,7 @@ public class SwitchConnectedDevice implements CompositeDataEntity<SwitchConnecte
      * @param entityToClone the entity to copy entity data from.
      */
     public SwitchConnectedDevice(@NonNull SwitchConnectedDevice entityToClone) {
-        data = SwitchConnectedDeviceCloner.INSTANCE.copy(entityToClone.getData());
+        data = SwitchConnectedDeviceCloner.INSTANCE.deepCopy(entityToClone.getData());
     }
 
     @Builder
@@ -243,17 +243,17 @@ public class SwitchConnectedDevice implements CompositeDataEntity<SwitchConnecte
 
         void copy(SwitchConnectedDeviceData source, @MappingTarget SwitchConnectedDeviceData target);
 
+        @Mapping(target = "switchObj", ignore = true)
+        void copyWithoutSwitch(SwitchConnectedDeviceData source, @MappingTarget SwitchConnectedDeviceData target);
+
         /**
          * Performs deep copy of entity data.
          */
-        default SwitchConnectedDeviceData copy(SwitchConnectedDeviceData source) {
+        default SwitchConnectedDeviceData deepCopy(SwitchConnectedDeviceData source) {
             SwitchConnectedDeviceData result = new SwitchConnectedDeviceDataImpl();
             copyWithoutSwitch(source, result);
             result.setSwitchObj(new Switch(source.getSwitchObj()));
             return result;
         }
-
-        @Mapping(target = "switchObj", ignore = true)
-        void copyWithoutSwitch(SwitchConnectedDeviceData source, @MappingTarget SwitchConnectedDeviceData target);
     }
 }

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/SwitchProperties.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/SwitchProperties.java
@@ -68,7 +68,7 @@ public class SwitchProperties implements CompositeDataEntity<SwitchProperties.Sw
      * @param entityToClone the entity to copy entity data from.
      */
     public SwitchProperties(@NonNull SwitchProperties entityToClone) {
-        data = SwitchPropertiesCloner.INSTANCE.copy(entityToClone.getData());
+        data = SwitchPropertiesCloner.INSTANCE.deepCopy(entityToClone.getData());
     }
 
     @Builder
@@ -267,17 +267,17 @@ public class SwitchProperties implements CompositeDataEntity<SwitchProperties.Sw
 
         void copy(SwitchPropertiesData source, @MappingTarget SwitchPropertiesData target);
 
+        @Mapping(target = "switchObj", ignore = true)
+        void copyWithoutSwitch(SwitchPropertiesData source, @MappingTarget SwitchPropertiesData target);
+
         /**
          * Performs deep copy of entity data.
          */
-        default SwitchPropertiesData copy(SwitchPropertiesData source) {
+        default SwitchPropertiesData deepCopy(SwitchPropertiesData source) {
             SwitchPropertiesData result = new SwitchPropertiesDataImpl();
             result.setSwitchObj(new Switch(source.getSwitchObj()));
             copyWithoutSwitch(source, result);
             return result;
         }
-
-        @Mapping(target = "switchObj", ignore = true)
-        void copyWithoutSwitch(SwitchPropertiesData source, @MappingTarget SwitchPropertiesData target);
     }
 }

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/TransitVlan.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/TransitVlan.java
@@ -60,7 +60,7 @@ public class TransitVlan implements EncapsulationId, CompositeDataEntity<Transit
      * @param entityToClone the entity to copy entity data from.
      */
     public TransitVlan(@NonNull TransitVlan entityToClone) {
-        data = TransitVlanCloner.INSTANCE.copy(entityToClone.getData());
+        data = TransitVlanCloner.INSTANCE.deepCopy(entityToClone.getData());
     }
 
     @Builder
@@ -141,7 +141,7 @@ public class TransitVlan implements EncapsulationId, CompositeDataEntity<Transit
         /**
          * Performs deep copy of entity data.
          */
-        default TransitVlanData copy(TransitVlanData source) {
+        default TransitVlanData deepCopy(TransitVlanData source) {
             TransitVlanData result = new TransitVlanDataImpl();
             copy(source, result);
             return result;

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/Vxlan.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/Vxlan.java
@@ -60,7 +60,7 @@ public class Vxlan implements EncapsulationId, CompositeDataEntity<Vxlan.VxlanDa
      * @param entityToClone the entity to copy entity data from.
      */
     public Vxlan(@NonNull Vxlan entityToClone) {
-        data = VxlanCloner.INSTANCE.copy(entityToClone.getData());
+        data = VxlanCloner.INSTANCE.deepCopy(entityToClone.getData());
     }
 
     @Builder
@@ -141,7 +141,7 @@ public class Vxlan implements EncapsulationId, CompositeDataEntity<Vxlan.VxlanDa
         /**
          * Performs deep copy of entity data.
          */
-        default VxlanData copy(VxlanData source) {
+        default VxlanData deepCopy(VxlanData source) {
             VxlanData result = new VxlanDataImpl();
             copy(source, result);
             return result;

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/history/FlowDump.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/history/FlowDump.java
@@ -66,7 +66,7 @@ public class FlowDump implements CompositeDataEntity<FlowDump.FlowDumpData> {
      * @param entityToClone the entity to copy entity data from.
      */
     public FlowDump(@NonNull FlowDump entityToClone) {
-        data = FlowDumpCloner.INSTANCE.copy(entityToClone.getData());
+        data = FlowDumpCloner.INSTANCE.deepCopy(entityToClone.getData());
     }
 
     public FlowDump(@NonNull FlowDumpData data) {
@@ -309,7 +309,7 @@ public class FlowDump implements CompositeDataEntity<FlowDump.FlowDumpData> {
         /**
          * Performs deep copy of entity data.
          */
-        default FlowDumpData copy(FlowDumpData source) {
+        default FlowDumpData deepCopy(FlowDumpData source) {
             FlowDumpData result = new FlowDumpDataImpl();
             copy(source, result);
             return result;

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/history/FlowEvent.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/history/FlowEvent.java
@@ -68,7 +68,7 @@ public class FlowEvent implements CompositeDataEntity<FlowEvent.FlowEventData> {
      * @param entityToClone the entity to copy entity data from.
      */
     public FlowEvent(@NonNull FlowEvent entityToClone) {
-        data = FlowEventCloner.INSTANCE.copy(entityToClone.getData());
+        data = FlowEventCloner.INSTANCE.deepCopy(entityToClone.getData());
     }
 
     @Builder
@@ -172,7 +172,7 @@ public class FlowEvent implements CompositeDataEntity<FlowEvent.FlowEventData> {
         /**
          * Performs deep copy of entity data.
          */
-        default FlowEventData copy(FlowEventData source) {
+        default FlowEventData deepCopy(FlowEventData source) {
             FlowEventDataImpl result = new FlowEventDataImpl();
             copyWithoutRecordsAndDumps(source, result);
             result.setHistoryRecords(source.getHistoryRecords().stream()

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/history/FlowHistory.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/history/FlowHistory.java
@@ -60,7 +60,7 @@ public class FlowHistory implements CompositeDataEntity<FlowHistory.FlowHistoryD
      * @param entityToClone the entity to copy entity data from.
      */
     public FlowHistory(@NonNull FlowHistory entityToClone) {
-        data = FlowHistoryCloner.INSTANCE.copy(entityToClone.getData());
+        data = FlowHistoryCloner.INSTANCE.deepCopy(entityToClone.getData());
     }
 
     public FlowHistory(@NonNull FlowHistoryData data) {
@@ -110,7 +110,7 @@ public class FlowHistory implements CompositeDataEntity<FlowHistory.FlowHistoryD
         /**
          * Performs deep copy of entity data.
          */
-        default FlowHistoryData copy(FlowHistoryData source) {
+        default FlowHistoryData deepCopy(FlowHistoryData source) {
             FlowHistoryData result = new FlowHistoryDataImpl();
             copy(source, result);
             return result;

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/history/PortHistory.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/history/PortHistory.java
@@ -60,7 +60,7 @@ public class PortHistory implements CompositeDataEntity<PortHistory.PortHistoryD
      * @param entityToClone the entity to copy entity data from.
      */
     public PortHistory(@NonNull PortHistory entityToClone) {
-        data = PortHistoryCloner.INSTANCE.copy(entityToClone.getData());
+        data = PortHistoryCloner.INSTANCE.deepCopy(entityToClone.getData());
     }
 
     public PortHistory(@NonNull PortHistoryData data) {
@@ -151,7 +151,7 @@ public class PortHistory implements CompositeDataEntity<PortHistory.PortHistoryD
         /**
          * Performs deep copy of entity data.
          */
-        default PortHistoryData copy(PortHistoryData source) {
+        default PortHistoryData deepCopy(PortHistoryData source) {
             PortHistoryData result = new PortHistoryDataImpl();
             copy(source, result);
             return result;

--- a/src-java/kilda-model/src/test/java/org/openkilda/model/PathSegmentTest.java
+++ b/src-java/kilda-model/src/test/java/org/openkilda/model/PathSegmentTest.java
@@ -43,12 +43,14 @@ public class PathSegmentTest {
     public void setup() {
         flow = Flow.builder().flowId(FLOW_ID).srcSwitch(SWITCH_A)
                 .destSwitch(SWITCH_B).pinned(true).build();
-        FlowPath flowForwardPath = FlowPath.builder().pathId(new PathId("1"))
+        PathId forwardPathId = new PathId("1");
+        FlowPath flowForwardPath = FlowPath.builder().pathId(forwardPathId)
                 .srcSwitch(SWITCH_A).destSwitch(SWITCH_B)
                 .cookie(new FlowSegmentCookie(FlowPathDirection.FORWARD, 1))
                 .build();
         List<PathSegment> flowForwardSegments = new ArrayList<>();
         flowForwardSegments.add(PathSegment.builder()
+                .pathId(forwardPathId)
                 .srcSwitch(SWITCH_A)
                 .srcPort(1)
                 .destSwitch(SWITCH_B)
@@ -56,12 +58,14 @@ public class PathSegmentTest {
                 .build());
         flowForwardPath.setSegments(flowForwardSegments);
 
-        FlowPath flowReversePath = FlowPath.builder().pathId(new PathId("2"))
+        PathId reversePathId = new PathId("2");
+        FlowPath flowReversePath = FlowPath.builder().pathId(reversePathId)
                 .srcSwitch(SWITCH_B).destSwitch(SWITCH_A)
                 .cookie(new FlowSegmentCookie(FlowPathDirection.REVERSE, 2)).build();
         List<PathSegment> flowReverseSegments = new ArrayList<>();
 
         flowReverseSegments.add(PathSegment.builder()
+                .pathId(reversePathId)
                 .srcSwitch(SWITCH_B)
                 .srcPort(1)
                 .destSwitch(SWITCH_A)

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/AvailableNetworkFactoryTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/AvailableNetworkFactoryTest.java
@@ -130,7 +130,7 @@ public class AvailableNetworkFactoryTest {
                 .srcSwitch(switchB)
                 .destSwitch(switchD)
                 .pathId(FORWARD_PATH_ID)
-                .segments(Collections.singletonList(PathSegment.builder()
+                .segments(Collections.singletonList(PathSegment.builder().pathId(FORWARD_PATH_ID)
                         .srcSwitch(switchB).srcPort(SRC_PORT).destSwitch(switchD).destPort(DEST_PORT).build()))
                 .build();
         when(flowPathRepository.findById(FORWARD_PATH_ID)).thenReturn(java.util.Optional.of(forwardPath));
@@ -139,7 +139,7 @@ public class AvailableNetworkFactoryTest {
                 .srcSwitch(switchD)
                 .destSwitch(switchB)
                 .pathId(REVERSE_PATH_ID)
-                .segments(Collections.singletonList(PathSegment.builder()
+                .segments(Collections.singletonList(PathSegment.builder().pathId(REVERSE_PATH_ID)
                         .srcSwitch(switchD).srcPort(DEST_PORT).destSwitch(switchB).destPort(SRC_PORT).build()))
                 .build();
         when(flowPathRepository.findById(REVERSE_PATH_ID)).thenReturn(java.util.Optional.of(reversePath));

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/AvailableNetworkTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/AvailableNetworkTest.java
@@ -457,12 +457,13 @@ public class AvailableNetworkTest {
         Switch srcSwitch = Switch.builder().switchId(srcDpid).pop(srcPop).build();
         Switch dstSwitch = Switch.builder().switchId(dstDpid).pop(dstPop).build();
 
+        PathId pathId = new PathId(UUID.randomUUID().toString());
         FlowPath flowPath = FlowPath.builder()
-                .pathId(new PathId(UUID.randomUUID().toString()))
+                .pathId(pathId)
                 .srcSwitch(srcSwitch)
                 .destSwitch(dstSwitch)
                 .segments(IntStream.rangeClosed(0, seqId)
-                        .mapToObj(i -> PathSegment.builder()
+                        .mapToObj(i -> PathSegment.builder().pathId(pathId)
                                 .srcSwitch(srcSwitch).destSwitch(dstSwitch).srcPort(srcPort).destPort(dstPort).build())
                         .collect(toList()))
                 .build();

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/InMemoryPathComputerBaseTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/InMemoryPathComputerBaseTest.java
@@ -556,6 +556,7 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
 
     private void addPathSegment(FlowPath flowPath, Switch src, Switch dst, int srcPort, int dstPort) {
         PathSegment ps = PathSegment.builder()
+                .pathId(flowPath.getPathId())
                 .srcSwitch(src)
                 .destSwitch(dst)
                 .srcPort(srcPort)

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaApplicationRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaApplicationRepository.java
@@ -116,6 +116,6 @@ public class FermaApplicationRepository extends FermaGenericRepository<Applicati
 
     @Override
     protected ApplicationRuleData doDetach(ApplicationRule entity, ApplicationRuleFrame frame) {
-        return ApplicationRule.ApplicationRuleCloner.INSTANCE.copy(frame);
+        return ApplicationRule.ApplicationRuleCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaBfdSessionRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaBfdSessionRepository.java
@@ -93,7 +93,7 @@ public class FermaBfdSessionRepository extends FermaGenericRepository<BfdSession
 
     @Override
     protected BfdSessionData doDetach(BfdSession entity, BfdSessionFrame frame) {
-        return BfdSession.BfdSessionCloner.INSTANCE.copy(frame);
+        return BfdSession.BfdSessionCloner.INSTANCE.deepCopy(frame);
     }
 
     private Optional<BfdSession> makeOneOrZeroResults(List<? extends BfdSessionFrame> results) {

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaExclusionIdRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaExclusionIdRepository.java
@@ -112,6 +112,6 @@ public class FermaExclusionIdRepository extends FermaGenericRepository<Exclusion
 
     @Override
     protected ExclusionIdData doDetach(ExclusionId entity, ExclusionIdFrame frame) {
-        return ExclusionId.ExclusionIdCloner.INSTANCE.copy(frame);
+        return ExclusionId.ExclusionIdCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaFeatureTogglesRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaFeatureTogglesRepository.java
@@ -68,6 +68,6 @@ public class FermaFeatureTogglesRepository
 
     @Override
     protected FeatureTogglesData doDetach(FeatureToggles entity, FeatureTogglesFrame frame) {
-        return FeatureToggles.FeatureTogglesCloner.INSTANCE.copy(frame);
+        return FeatureToggles.FeatureTogglesCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaFlowCookieRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaFlowCookieRepository.java
@@ -124,6 +124,6 @@ public class FermaFlowCookieRepository extends FermaGenericRepository<FlowCookie
 
     @Override
     protected FlowCookieData doDetach(FlowCookie entity, FlowCookieFrame frame) {
-        return FlowCookie.FlowCookieCloner.INSTANCE.copy(frame);
+        return FlowCookie.FlowCookieCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaFlowDumpRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaFlowDumpRepository.java
@@ -48,6 +48,6 @@ public class FermaFlowDumpRepository extends FermaGenericRepository<FlowDump, Fl
 
     @Override
     protected FlowDumpData doDetach(FlowDump entity, FlowDumpFrame frame) {
-        return FlowDumpCloner.INSTANCE.copy(frame);
+        return FlowDumpCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaFlowEventRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaFlowEventRepository.java
@@ -105,6 +105,6 @@ public class FermaFlowEventRepository extends FermaGenericRepository<FlowEvent, 
 
     @Override
     protected FlowEventData doDetach(FlowEvent entity, FlowEventFrame frame) {
-        return FlowEvent.FlowEventCloner.INSTANCE.copy(frame);
+        return FlowEvent.FlowEventCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaFlowHistoryRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaFlowHistoryRepository.java
@@ -47,6 +47,6 @@ public class FermaFlowHistoryRepository extends FermaGenericRepository<FlowHisto
 
     @Override
     protected FlowHistoryData doDetach(FlowHistory entity, FlowHistoryFrame frame) {
-        return FlowHistory.FlowHistoryCloner.INSTANCE.copy(frame);
+        return FlowHistory.FlowHistoryCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaFlowMeterRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaFlowMeterRepository.java
@@ -144,6 +144,6 @@ public class FermaFlowMeterRepository extends FermaGenericRepository<FlowMeter, 
 
     @Override
     protected FlowMeterData doDetach(FlowMeter entity, FlowMeterFrame frame) {
-        return FlowMeter.FlowMeterCloner.INSTANCE.copy(frame);
+        return FlowMeter.FlowMeterCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaFlowRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaFlowRepository.java
@@ -26,7 +26,6 @@ import org.openkilda.persistence.ferma.FramedGraphFactory;
 import org.openkilda.persistence.ferma.frames.FlowFrame;
 import org.openkilda.persistence.ferma.frames.FlowPathFrame;
 import org.openkilda.persistence.ferma.frames.KildaBaseVertexFrame;
-import org.openkilda.persistence.ferma.frames.PathSegmentFrame;
 import org.openkilda.persistence.ferma.frames.converters.FlowStatusConverter;
 import org.openkilda.persistence.ferma.frames.converters.SwitchIdConverter;
 import org.openkilda.persistence.repositories.FlowPathRepository;
@@ -38,8 +37,6 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Direction;
-import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.util.Collection;
@@ -460,38 +457,6 @@ public class FermaFlowRepository extends FermaGenericRepository<Flow, FlowData, 
             throw new IllegalStateException("This implementation of remove requires no outside transaction");
         }
 
-        transactionManager.doInTransaction(() ->
-                framedGraph().traverse(g -> g.V()
-                        .hasLabel(FlowFrame.FRAME_LABEL)
-                        .has(FlowFrame.FLOW_ID_PROPERTY, flowId))
-                        .toListExplicit(FlowFrame.class)
-                        .forEach(flowFrame -> {
-                            // Unlink the flow endpoints
-                            flowFrame.getElement().edges(Direction.OUT,
-                                    FlowFrame.SOURCE_EDGE, FlowFrame.DESTINATION_EDGE)
-                                    .forEachRemaining(Edge::remove);
-
-                            flowFrame.traverse(v -> v.out(FlowFrame.OWNS_PATHS_EDGE)
-                                    .hasLabel(FlowPathFrame.FRAME_LABEL))
-                                    .toListExplicit(FlowPathFrame.class)
-                                    .forEach(pathFrame -> {
-                                        // Unlink the path endpoints
-                                        pathFrame.getElement().edges(Direction.OUT,
-                                                FlowPathFrame.SOURCE_EDGE, FlowPathFrame.DESTINATION_EDGE)
-                                                .forEachRemaining(Edge::remove);
-
-                                        pathFrame.traverse(v -> v.out(FlowPathFrame.OWNS_SEGMENTS_EDGE)
-                                                .hasLabel(PathSegmentFrame.FRAME_LABEL))
-                                                .toListExplicit(PathSegmentFrame.class)
-                                                .forEach(segmentFrame ->
-                                                        // Unlink the segments' endpoints
-                                                        segmentFrame.getElement().edges(Direction.OUT,
-                                                                PathSegmentFrame.SOURCE_EDGE,
-                                                                PathSegmentFrame.DESTINATION_EDGE)
-                                                                .forEachRemaining(Edge::remove));
-                                    });
-                        }));
-
         return transactionManager.doInTransaction(() ->
                 findById(flowId)
                         .map(flow -> {
@@ -567,10 +532,6 @@ public class FermaFlowRepository extends FermaGenericRepository<Flow, FlowData, 
 
     @Override
     protected FlowData doDetach(Flow entity, FlowFrame frame) {
-        FlowData data = Flow.FlowCloner.INSTANCE.copyWithoutPaths(frame, entity);
-        data.addPaths(frame.getPaths().stream()
-                .map(path -> new FlowPath(path, entity))
-                .toArray(FlowPath[]::new));
-        return data;
+        return Flow.FlowCloner.INSTANCE.deepCopy(frame, entity);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaIslRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaIslRepository.java
@@ -441,6 +441,6 @@ public class FermaIslRepository extends FermaGenericRepository<Isl, IslData, Isl
 
     @Override
     protected IslData doDetach(Isl entity, IslFrame frame) {
-        return Isl.IslCloner.INSTANCE.copy(frame);
+        return Isl.IslCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaKildaConfigurationRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaKildaConfigurationRepository.java
@@ -70,6 +70,6 @@ public class FermaKildaConfigurationRepository
 
     @Override
     protected KildaConfigurationData doDetach(KildaConfiguration entity, KildaConfigurationFrame frame) {
-        return KildaConfiguration.KildaConfigurationCloner.INSTANCE.copy(frame);
+        return KildaConfiguration.KildaConfigurationCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaLinkPropsRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaLinkPropsRepository.java
@@ -90,6 +90,6 @@ public class FermaLinkPropsRepository extends FermaGenericRepository<LinkProps, 
 
     @Override
     protected LinkPropsData doDetach(LinkProps entity, LinkPropsFrame frame) {
-        return LinkProps.LinkPropsCloner.INSTANCE.copy(frame);
+        return LinkProps.LinkPropsCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaMirrorGroupRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaMirrorGroupRepository.java
@@ -119,6 +119,6 @@ public class FermaMirrorGroupRepository extends FermaGenericRepository<MirrorGro
 
     @Override
     protected MirrorGroupData doDetach(MirrorGroup entity, MirrorGroupFrame frame) {
-        return MirrorGroup.MirrorGroupCloner.INSTANCE.copy(frame);
+        return MirrorGroup.MirrorGroupCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaPathSegmentRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaPathSegmentRepository.java
@@ -73,6 +73,6 @@ public class FermaPathSegmentRepository extends FermaGenericRepository<PathSegme
 
     @Override
     protected PathSegmentData doDetach(PathSegment entity, PathSegmentFrame frame) {
-        return PathSegment.PathSegmentCloner.INSTANCE.copy(frame);
+        return PathSegment.PathSegmentCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaPortHistoryRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaPortHistoryRepository.java
@@ -82,6 +82,6 @@ public class FermaPortHistoryRepository extends FermaGenericRepository<PortHisto
 
     @Override
     protected PortHistoryData doDetach(PortHistory entity, PortHistoryFrame frame) {
-        return PortHistory.PortHistoryCloner.INSTANCE.copy(frame);
+        return PortHistory.PortHistoryCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaPortPropertiesRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaPortPropertiesRepository.java
@@ -89,6 +89,6 @@ public class FermaPortPropertiesRepository
 
     @Override
     protected PortPropertiesData doDetach(PortProperties entity, PortPropertiesFrame frame) {
-        return PortProperties.PortPropertiesCloner.INSTANCE.copy(frame);
+        return PortProperties.PortPropertiesCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaSwitchConnectedDevicesRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaSwitchConnectedDevicesRepository.java
@@ -138,6 +138,6 @@ public class FermaSwitchConnectedDevicesRepository
 
     @Override
     protected SwitchConnectedDeviceData doDetach(SwitchConnectedDevice entity, SwitchConnectedDeviceFrame frame) {
-        return SwitchConnectedDevice.SwitchConnectedDeviceCloner.INSTANCE.copy(frame);
+        return SwitchConnectedDevice.SwitchConnectedDeviceCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaSwitchPropertiesRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaSwitchPropertiesRepository.java
@@ -75,6 +75,6 @@ public class FermaSwitchPropertiesRepository
 
     @Override
     protected SwitchPropertiesData doDetach(SwitchProperties entity, SwitchPropertiesFrame frame) {
-        return SwitchProperties.SwitchPropertiesCloner.INSTANCE.copy(frame);
+        return SwitchProperties.SwitchPropertiesCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaSwitchRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaSwitchRepository.java
@@ -101,10 +101,9 @@ public class FermaSwitchRepository extends FermaGenericRepository<Switch, Switch
         flowPathFrames.forEach(flowPath -> {
             Stream.of(flowPath.getSrcSwitch(), flowPath.getDestSwitch())
                     .forEach(sw -> result.put(sw.getSwitchId(), sw));
-            flowPath.getSegments().forEach(pathSegment -> {
-                Stream.of(pathSegment.getSrcSwitch(), pathSegment.getDestSwitch())
-                        .forEach(sw -> result.put(sw.getSwitchId(), sw));
-            });
+            flowPath.getSegments().forEach(pathSegment ->
+                    Stream.of(pathSegment.getSrcSwitch(), pathSegment.getDestSwitch())
+                            .forEach(sw -> result.put(sw.getSwitchId(), sw)));
         });
         return result.values();
     }
@@ -139,6 +138,6 @@ public class FermaSwitchRepository extends FermaGenericRepository<Switch, Switch
 
     @Override
     protected SwitchData doDetach(Switch entity, SwitchFrame frame) {
-        return Switch.SwitchCloner.INSTANCE.copy(frame);
+        return Switch.SwitchCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaTransitVlanRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaTransitVlanRepository.java
@@ -162,6 +162,6 @@ public class FermaTransitVlanRepository extends FermaGenericRepository<TransitVl
 
     @Override
     protected TransitVlanData doDetach(TransitVlan entity, TransitVlanFrame frame) {
-        return TransitVlan.TransitVlanCloner.INSTANCE.copy(frame);
+        return TransitVlan.TransitVlanCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaVxlanRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaVxlanRepository.java
@@ -133,6 +133,6 @@ public class FermaVxlanRepository extends FermaGenericRepository<Vxlan, VxlanDat
 
     @Override
     protected VxlanData doDetach(Vxlan entity, VxlanFrame frame) {
-        return Vxlan.VxlanCloner.INSTANCE.copy(frame);
+        return Vxlan.VxlanCloner.INSTANCE.deepCopy(frame);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaFlowPathRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaFlowPathRepositoryTest.java
@@ -360,10 +360,12 @@ public class FermaFlowPathRepositoryTest extends InMemoryGraphBasedTest {
         FlowPath flowPath = createTestFlowPath();
 
         List<PathSegment> segments = asList(PathSegment.builder()
+                        .pathId(flowPath.getPathId())
                         .srcSwitch(switchA)
                         .destSwitch(switchC)
                         .build(),
                 PathSegment.builder()
+                        .pathId(flowPath.getPathId())
                         .srcSwitch(switchC)
                         .destSwitch(switchB)
                         .build());
@@ -434,12 +436,14 @@ public class FermaFlowPathRepositoryTest extends InMemoryGraphBasedTest {
                 .build();
 
         PathSegment segment1 = PathSegment.builder()
+                .pathId(flowPath.getPathId())
                 .srcSwitch(switchA)
                 .srcPort(1)
                 .destSwitch(intSwitch)
                 .destPort(intPort)
                 .build();
         PathSegment segment2 = PathSegment.builder()
+                .pathId(flowPath.getPathId())
                 .srcSwitch(intSwitch)
                 .srcPort(intPort + 100)
                 .destSwitch(switchB)
@@ -476,6 +480,7 @@ public class FermaFlowPathRepositoryTest extends InMemoryGraphBasedTest {
         flow.setForwardPath(forwardFlowPath);
 
         PathSegment forwardSegment = PathSegment.builder()
+                .pathId(forwardFlowPath.getPathId())
                 .srcSwitch(srcSwitch)
                 .srcPort(srcPort)
                 .destSwitch(destSwitch)
@@ -494,6 +499,7 @@ public class FermaFlowPathRepositoryTest extends InMemoryGraphBasedTest {
         flow.setReversePath(reverseFlowPath);
 
         PathSegment reverseSegment = PathSegment.builder()
+                .pathId(reverseFlowPath.getPathId())
                 .srcSwitch(destSwitch)
                 .srcPort(destPort)
                 .destSwitch(srcSwitch)
@@ -518,6 +524,7 @@ public class FermaFlowPathRepositoryTest extends InMemoryGraphBasedTest {
         flow.setProtectedForwardPath(forwardProtectedFlowPath);
 
         PathSegment forwardSegment = PathSegment.builder()
+                .pathId(forwardProtectedFlowPath.getPathId())
                 .srcSwitch(srcSwitch)
                 .srcPort(srcPort)
                 .destSwitch(destSwitch)
@@ -535,6 +542,7 @@ public class FermaFlowPathRepositoryTest extends InMemoryGraphBasedTest {
         flow.setProtectedReversePath(reverseProtectedFlowPath);
 
         PathSegment reverseSegment = PathSegment.builder()
+                .pathId(reverseProtectedFlowPath.getPathId())
                 .srcSwitch(destSwitch)
                 .srcPort(destPort)
                 .destSwitch(srcSwitch)

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaFlowRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaFlowRepositoryTest.java
@@ -613,6 +613,7 @@ public class FermaFlowRepositoryTest extends InMemoryGraphBasedTest {
                 .build();
 
         PathSegment forwardSegment = PathSegment.builder()
+                .pathId(forwardFlowPath.getPathId())
                 .srcSwitch(srcSwitch)
                 .srcPort(srcPort)
                 .destSwitch(destSwitch)
@@ -633,6 +634,7 @@ public class FermaFlowRepositoryTest extends InMemoryGraphBasedTest {
                 .build();
 
         PathSegment reverseSegment = PathSegment.builder()
+                .pathId(reverseFlowPath.getPathId())
                 .srcSwitch(destSwitch)
                 .srcPort(destPort)
                 .destSwitch(srcSwitch)
@@ -671,6 +673,7 @@ public class FermaFlowRepositoryTest extends InMemoryGraphBasedTest {
         flow.setForwardPath(forwardFlowPath);
 
         PathSegment forwardSegment = PathSegment.builder()
+                .pathId(forwardFlowPath.getPathId())
                 .srcSwitch(srcSwitch)
                 .srcPort(1)
                 .destSwitch(intSwitch)
@@ -690,6 +693,7 @@ public class FermaFlowRepositoryTest extends InMemoryGraphBasedTest {
         flow.setReversePath(reverseFlowPath);
 
         PathSegment reverseSegment = PathSegment.builder()
+                .pathId(reverseFlowPath.getPathId())
                 .srcSwitch(intSwitch)
                 .srcPort(100)
                 .destSwitch(srcSwitch)

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaIslRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaIslRepositoryTest.java
@@ -436,6 +436,7 @@ public class FermaIslRepositoryTest extends InMemoryGraphBasedTest {
         flow.setForwardPath(forwardPath);
 
         PathSegment forwardSegment = PathSegment.builder()
+                .pathId(forwardPath.getPathId())
                 .srcSwitch(switchA)
                 .srcPort(1)
                 .destSwitch(switchB)
@@ -456,6 +457,7 @@ public class FermaIslRepositoryTest extends InMemoryGraphBasedTest {
         flow.setReversePath(reversePath);
 
         PathSegment reverseSegment = PathSegment.builder()
+                .pathId(reversePath.getPathId())
                 .srcSwitch(switchB)
                 .srcPort(2)
                 .destSwitch(switchA)

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaSwitchRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaSwitchRepositoryTest.java
@@ -199,6 +199,7 @@ public class FermaSwitchRepositoryTest extends InMemoryGraphBasedTest {
         flow.setForwardPath(forwardFlowPath);
 
         PathSegment forwardSegment = PathSegment.builder()
+                .pathId(forwardFlowPath.getPathId())
                 .srcSwitch(switchA)
                 .srcPort(2)
                 .destSwitch(switchB)
@@ -217,6 +218,7 @@ public class FermaSwitchRepositoryTest extends InMemoryGraphBasedTest {
         flow.setReversePath(reverseFlowPath);
 
         PathSegment reverseSegment = PathSegment.builder()
+                .pathId(reverseFlowPath.getPathId())
                 .srcSwitch(switchB)
                 .srcPort(3)
                 .destSwitch(switchA)
@@ -250,6 +252,7 @@ public class FermaSwitchRepositoryTest extends InMemoryGraphBasedTest {
         flow.setForwardPath(forwardFlowPath);
 
         PathSegment forwardSegmentA = PathSegment.builder()
+                .pathId(forwardFlowPath.getPathId())
                 .srcSwitch(switchA)
                 .srcPort(2)
                 .destSwitch(switchB)
@@ -257,6 +260,7 @@ public class FermaSwitchRepositoryTest extends InMemoryGraphBasedTest {
                 .build();
 
         PathSegment forwardSegmentB = PathSegment.builder()
+                .pathId(forwardFlowPath.getPathId())
                 .srcSwitch(switchB)
                 .srcPort(5)
                 .destSwitch(switchC)
@@ -275,6 +279,7 @@ public class FermaSwitchRepositoryTest extends InMemoryGraphBasedTest {
         flow.setReversePath(reverseFlowPath);
 
         PathSegment reverseSegmentA = PathSegment.builder()
+                .pathId(reverseFlowPath.getPathId())
                 .srcSwitch(switchC)
                 .srcPort(6)
                 .destSwitch(switchB)
@@ -282,6 +287,7 @@ public class FermaSwitchRepositoryTest extends InMemoryGraphBasedTest {
                 .build();
 
         PathSegment reverseSegmentB = PathSegment.builder()
+                .pathId(reverseFlowPath.getPathId())
                 .srcSwitch(switchB)
                 .srcPort(3)
                 .destSwitch(switchA)

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/topology/nbworker/services/FlowOperationsServiceTest.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/topology/nbworker/services/FlowOperationsServiceTest.java
@@ -501,16 +501,18 @@ public class FlowOperationsServiceTest extends InMemoryGraphBasedTest {
         if (!srcSwitch.getSwitchId().equals(dstSwitch.getSwitchId())) {
             if (transitSwitch == null) {
                 // direct paths between src and dst switches
-                forwardPath.setSegments(newArrayList(createPathSegment(srcSwitch, srcPort, dstSwitch, dstPort)));
-                reversePath.setSegments(newArrayList(createPathSegment(dstSwitch, dstPort, srcSwitch, srcPort)));
+                forwardPath.setSegments(newArrayList(createPathSegment(forwardPath.getPathId(),
+                        srcSwitch, srcPort, dstSwitch, dstPort)));
+                reversePath.setSegments(newArrayList(createPathSegment(reversePath.getPathId(),
+                        dstSwitch, dstPort, srcSwitch, srcPort)));
             } else {
                 // src switch ==> transit switch ==> dst switch
                 forwardPath.setSegments(newArrayList(
-                        createPathSegment(srcSwitch, srcPort, transitSwitch, srcPort),
-                        createPathSegment(transitSwitch, dstPort, dstSwitch, dstPort)));
+                        createPathSegment(forwardPath.getPathId(), srcSwitch, srcPort, transitSwitch, srcPort),
+                        createPathSegment(forwardPath.getPathId(), transitSwitch, dstPort, dstSwitch, dstPort)));
                 reversePath.setSegments(newArrayList(
-                        createPathSegment(dstSwitch, dstPort, transitSwitch, dstPort),
-                        createPathSegment(transitSwitch, srcPort, srcSwitch, srcPort)));
+                        createPathSegment(reversePath.getPathId(), dstSwitch, dstPort, transitSwitch, dstPort),
+                        createPathSegment(reversePath.getPathId(), transitSwitch, srcPort, srcSwitch, srcPort)));
 
             }
         }
@@ -551,16 +553,18 @@ public class FlowOperationsServiceTest extends InMemoryGraphBasedTest {
         if (!srcSwitch.getSwitchId().equals(dstSwitch.getSwitchId())) {
             if (transitSwitch == null) {
                 // direct paths between src and dst switches
-                forwardPath.setSegments(newArrayList(createPathSegment(srcSwitch, srcPort, dstSwitch, dstPort)));
-                reversePath.setSegments(newArrayList(createPathSegment(dstSwitch, dstPort, srcSwitch, srcPort)));
+                forwardPath.setSegments(newArrayList(createPathSegment(forwardPath.getPathId(),
+                        srcSwitch, srcPort, dstSwitch, dstPort)));
+                reversePath.setSegments(newArrayList(createPathSegment(reversePath.getPathId(),
+                        dstSwitch, dstPort, srcSwitch, srcPort)));
             } else {
                 // src switch ==> transit switch ==> dst switch
                 forwardPath.setSegments(newArrayList(
-                        createPathSegment(srcSwitch, srcPort, transitSwitch, srcPort),
-                        createPathSegment(transitSwitch, dstPort, dstSwitch, dstPort)));
+                        createPathSegment(forwardPath.getPathId(), srcSwitch, srcPort, transitSwitch, srcPort),
+                        createPathSegment(forwardPath.getPathId(), transitSwitch, dstPort, dstSwitch, dstPort)));
                 reversePath.setSegments(newArrayList(
-                        createPathSegment(dstSwitch, dstPort, transitSwitch, dstPort),
-                        createPathSegment(transitSwitch, srcPort, srcSwitch, srcPort)));
+                        createPathSegment(reversePath.getPathId(), dstSwitch, dstPort, transitSwitch, dstPort),
+                        createPathSegment(reversePath.getPathId(), transitSwitch, srcPort, srcSwitch, srcPort)));
 
             }
         }
@@ -571,8 +575,9 @@ public class FlowOperationsServiceTest extends InMemoryGraphBasedTest {
         return flow;
     }
 
-    private PathSegment createPathSegment(Switch srcSwitch, int srcPort, Switch dstSwitch, int dstPort) {
+    private PathSegment createPathSegment(PathId pathId, Switch srcSwitch, int srcPort, Switch dstSwitch, int dstPort) {
         PathSegment pathSegment = PathSegment.builder()
+                .pathId(pathId)
                 .srcSwitch(srcSwitch)
                 .srcPort(srcPort)
                 .destSwitch(dstSwitch)

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/topology/nbworker/services/FlowValidationTestBase.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/topology/nbworker/services/FlowValidationTestBase.java
@@ -188,6 +188,7 @@ public class FlowValidationTestBase extends InMemoryGraphBasedTest {
         flow.setForwardPath(forwardFlowPath);
 
         PathSegment forwardSegmentA = PathSegment.builder()
+                .pathId(forwardFlowPath.getPathId())
                 .srcSwitch(switchA)
                 .srcPort(FLOW_A_SEGMENT_A_SRC_PORT)
                 .destSwitch(switchB)
@@ -195,6 +196,7 @@ public class FlowValidationTestBase extends InMemoryGraphBasedTest {
                 .build();
 
         PathSegment forwardSegmentB = PathSegment.builder()
+                .pathId(forwardFlowPath.getPathId())
                 .srcSwitch(switchB)
                 .srcPort(FLOW_A_SEGMENT_B_SRC_PORT)
                 .destSwitch(switchC)
@@ -214,6 +216,7 @@ public class FlowValidationTestBase extends InMemoryGraphBasedTest {
         flow.setProtectedForwardPath(forwardProtectedFlowPath);
 
         PathSegment forwardProtectedSegmentA = PathSegment.builder()
+                .pathId(forwardProtectedFlowPath.getPathId())
                 .srcSwitch(switchA)
                 .srcPort(FLOW_A_SEGMENT_A_SRC_PORT_PROTECTED)
                 .destSwitch(switchE)
@@ -221,6 +224,7 @@ public class FlowValidationTestBase extends InMemoryGraphBasedTest {
                 .build();
 
         PathSegment forwardProtectedSegmentB = PathSegment.builder()
+                .pathId(forwardProtectedFlowPath.getPathId())
                 .srcSwitch(switchE)
                 .srcPort(FLOW_A_SEGMENT_B_SRC_PORT_PROTECTED)
                 .destSwitch(switchC)
@@ -240,6 +244,7 @@ public class FlowValidationTestBase extends InMemoryGraphBasedTest {
         flow.setReversePath(reverseFlowPath);
 
         PathSegment reverseSegmentA = PathSegment.builder()
+                .pathId(reverseFlowPath.getPathId())
                 .srcSwitch(switchC)
                 .srcPort(FLOW_A_SEGMENT_B_DST_PORT)
                 .destSwitch(switchB)
@@ -247,6 +252,7 @@ public class FlowValidationTestBase extends InMemoryGraphBasedTest {
                 .build();
 
         PathSegment reverseSegmentB = PathSegment.builder()
+                .pathId(reverseFlowPath.getPathId())
                 .srcSwitch(switchB)
                 .srcPort(FLOW_A_SEGMENT_A_DST_PORT)
                 .destSwitch(switchA)
@@ -266,6 +272,7 @@ public class FlowValidationTestBase extends InMemoryGraphBasedTest {
         flow.setProtectedReversePath(reverseProtectedFlowPath);
 
         PathSegment reverseProtectedSegmentA = PathSegment.builder()
+                .pathId(reverseProtectedFlowPath.getPathId())
                 .srcSwitch(switchC)
                 .srcPort(FLOW_A_SEGMENT_B_DST_PORT_PROTECTED)
                 .destSwitch(switchE)
@@ -273,6 +280,7 @@ public class FlowValidationTestBase extends InMemoryGraphBasedTest {
                 .build();
 
         PathSegment reverseProtectedSegmentB = PathSegment.builder()
+                .pathId(reverseProtectedFlowPath.getPathId())
                 .srcSwitch(switchE)
                 .srcPort(FLOW_A_SEGMENT_A_DST_PORT_PROTECTED)
                 .destSwitch(switchA)

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/topology/nbworker/services/LinkOperationsServiceTest.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/topology/nbworker/services/LinkOperationsServiceTest.java
@@ -304,8 +304,10 @@ public class LinkOperationsServiceTest extends InMemoryGraphBasedTest {
                 .cookie(new FlowSegmentCookie(1L))
                 .build();
 
-        forwardPath.setSegments(newArrayList(createPathSegment(srcSwitch, srcPort, dstSwitch, dstPort)));
-        reversePath.setSegments(newArrayList(createPathSegment(dstSwitch, dstPort, srcSwitch, srcPort)));
+        forwardPath.setSegments(newArrayList(createPathSegment(forwardPath.getPathId(),
+                srcSwitch, srcPort, dstSwitch, dstPort)));
+        reversePath.setSegments(newArrayList(createPathSegment(reversePath.getPathId(),
+                dstSwitch, dstPort, srcSwitch, srcPort)));
 
         flow.setForwardPath(forwardPath);
         flow.setReversePath(reversePath);
@@ -314,8 +316,9 @@ public class LinkOperationsServiceTest extends InMemoryGraphBasedTest {
         return flow;
     }
 
-    private PathSegment createPathSegment(Switch srcSwitch, int srcPort, Switch dstSwitch, int dstPort) {
+    private PathSegment createPathSegment(PathId pathId, Switch srcSwitch, int srcPort, Switch dstSwitch, int dstPort) {
         return PathSegment.builder()
+                .pathId(pathId)
                 .srcSwitch(srcSwitch)
                 .srcPort(srcPort)
                 .destSwitch(dstSwitch)

--- a/src-java/reroute-topology/reroute-storm-topology/src/test/java/org/openkilda/wfm/topology/reroute/service/RerouteServiceTest.java
+++ b/src-java/reroute-topology/reroute-storm-topology/src/test/java/org/openkilda/wfm/topology/reroute/service/RerouteServiceTest.java
@@ -119,12 +119,14 @@ public class RerouteServiceTest {
                 .build();
         List<PathSegment> pinnedFlowForwardSegments = new ArrayList<>();
         pinnedFlowForwardSegments.add(PathSegment.builder()
+                .pathId(pinnedFlowForwardPath.getPathId())
                 .srcSwitch(SWITCH_A)
                 .srcPort(1)
                 .destSwitch(SWITCH_B)
                 .destPort(1)
                 .build());
         pinnedFlowForwardSegments.add(PathSegment.builder()
+                .pathId(pinnedFlowForwardPath.getPathId())
                 .srcSwitch(SWITCH_B)
                 .srcPort(2)
                 .destSwitch(SWITCH_C)
@@ -138,12 +140,14 @@ public class RerouteServiceTest {
                 .build();
         List<PathSegment> pinnedFlowReverseSegments = new ArrayList<>();
         pinnedFlowReverseSegments.add(PathSegment.builder()
+                .pathId(pinnedFlowReversePath.getPathId())
                 .srcSwitch(SWITCH_C)
                 .srcPort(1)
                 .destSwitch(SWITCH_B)
                 .destPort(2)
                 .build());
         pinnedFlowReverseSegments.add(PathSegment.builder()
+                .pathId(pinnedFlowReversePath.getPathId())
                 .srcSwitch(SWITCH_B)
                 .srcPort(1)
                 .destSwitch(SWITCH_A)
@@ -164,12 +168,14 @@ public class RerouteServiceTest {
                 .build();
         List<PathSegment> unpinnedFlowForwardSegments = new ArrayList<>();
         unpinnedFlowForwardSegments.add(PathSegment.builder()
+                .pathId(regularFlowForwardPath.getPathId())
                 .srcSwitch(SWITCH_A)
                 .srcPort(1)
                 .destSwitch(SWITCH_B)
                 .destPort(1)
                 .build());
         unpinnedFlowForwardSegments.add(PathSegment.builder()
+                .pathId(regularFlowForwardPath.getPathId())
                 .srcSwitch(SWITCH_B)
                 .srcPort(2)
                 .destSwitch(SWITCH_C)
@@ -184,12 +190,14 @@ public class RerouteServiceTest {
                 .build();
         List<PathSegment> unpinnedFlowReverseSegments = new ArrayList<>();
         unpinnedFlowReverseSegments.add(PathSegment.builder()
+                .pathId(regularFlowReversePath.getPathId())
                 .srcSwitch(SWITCH_C)
                 .srcPort(1)
                 .destSwitch(SWITCH_B)
                 .destPort(2)
                 .build());
         unpinnedFlowReverseSegments.add(PathSegment.builder()
+                .pathId(regularFlowReversePath.getPathId())
                 .srcSwitch(SWITCH_B)
                 .srcPort(1)
                 .destSwitch(SWITCH_A)

--- a/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/bolts/CacheBoltTest.java
+++ b/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/bolts/CacheBoltTest.java
@@ -171,19 +171,22 @@ public class CacheBoltTest {
 
     private FlowPath getPath(Flow flow, Switch src, Switch dest, long cookie, long meterId) {
         Switch transitSwitch = Switch.builder().switchId(TRANSIT_SWITCH_ID).build();
+        PathId pathId = new PathId(uuid());
 
         List<PathSegment> segments = new ArrayList<>();
         segments.add(PathSegment.builder()
+                .pathId(pathId)
                 .srcSwitch(src)
                 .destSwitch(transitSwitch)
                 .build());
         segments.add(PathSegment.builder()
+                .pathId(pathId)
                 .srcSwitch(transitSwitch)
                 .destSwitch(dest)
                 .build());
 
         return FlowPath.builder()
-                .pathId(new PathId(uuid()))
+                .pathId(pathId)
                 .srcSwitch(src)
                 .destSwitch(dest)
                 .cookie(new FlowSegmentCookie(cookie))

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/service/impl/CommandBuilderImplTest.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/service/impl/CommandBuilderImplTest.java
@@ -169,8 +169,9 @@ public class CommandBuilderImplTest {
             return forwardPath;
         }
 
-        private PathSegment buildSegment(FlowPath path, SwitchId srcSwitchId, SwitchId destSwitchId) {
+        private PathSegment buildSegment(PathId pathId, SwitchId srcSwitchId, SwitchId destSwitchId) {
             return PathSegment.builder()
+                    .pathId(pathId)
                     .srcSwitch(Switch.builder().switchId(srcSwitchId).build())
                     .destSwitch(Switch.builder().switchId(destSwitchId).build())
                     .build();
@@ -178,17 +179,17 @@ public class CommandBuilderImplTest {
 
         private PersistenceManager build() {
             FlowPath flowPathA = buildFlowAndPath("A", SWITCH_ID_A, SWITCH_ID_B, 1, 1);
-            flowPathA.setSegments(asList(buildSegment(flowPathA, SWITCH_ID_A, SWITCH_ID_C),
-                    buildSegment(flowPathA, SWITCH_ID_C, SWITCH_ID_B)));
+            flowPathA.setSegments(asList(buildSegment(flowPathA.getPathId(), SWITCH_ID_A, SWITCH_ID_C),
+                    buildSegment(flowPathA.getPathId(), SWITCH_ID_C, SWITCH_ID_B)));
 
             FlowPath flowPathB = buildFlowAndPath("B", SWITCH_ID_A, SWITCH_ID_C, 2, 1);
-            flowPathB.setSegments(asList(buildSegment(flowPathB, SWITCH_ID_A, SWITCH_ID_B),
-                    buildSegment(flowPathB, SWITCH_ID_B, SWITCH_ID_C)));
+            flowPathB.setSegments(asList(buildSegment(flowPathB.getPathId(), SWITCH_ID_A, SWITCH_ID_B),
+                    buildSegment(flowPathB.getPathId(), SWITCH_ID_B, SWITCH_ID_C)));
 
             FlowPath flowPathC = buildFlowAndPath("C", SWITCH_ID_A, SWITCH_ID_A, 3, 1);
 
             FlowPath flowPathD = buildFlowAndPath("D", SWITCH_ID_B, SWITCH_ID_A, 4, 1);
-            flowPathD.setSegments(asList(buildSegment(flowPathD, SWITCH_ID_B, SWITCH_ID_A)));
+            flowPathD.setSegments(asList(buildSegment(flowPathD.getPathId(), SWITCH_ID_B, SWITCH_ID_A)));
 
             when(flowPathRepository.findBySegmentDestSwitch(eq(SWITCH_ID_B)))
                     .thenReturn(Arrays.asList(flowPathA, flowPathB));


### PR DESCRIPTION
The changes:
- Remove graph relations from paths and segments to switches. This addresses the issue with graph super-node conflicts.
- Revise lazy loading for path and segment entities. This optimizes data fetching and handling.
- Expose pathId property of segment entities. This optimizes data fetching.
- Revise the deep copy methods in data model entities. This optimizes data handling.