### PR TITLE
Fight port vs switch dump events race condition

### DIFF
--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/FloodlightRouterTopology.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/FloodlightRouterTopology.java
@@ -37,6 +37,7 @@ import org.openkilda.wfm.topology.floodlightrouter.bolts.SwitchMonitorBolt;
 import joptsimple.internal.Strings;
 import lombok.Value;
 import org.apache.storm.generated.StormTopology;
+import org.apache.storm.kafka.bolt.mapper.FieldNameBasedTupleToKafkaMapper;
 import org.apache.storm.topology.BoltDeclarer;
 import org.apache.storm.topology.TopologyBuilder;
 import org.apache.storm.tuple.Fields;
@@ -275,7 +276,9 @@ public class FloodlightRouterTopology extends AbstractTopology<FloodlightRouterT
                         SpeakerToNetworkProxyBolt.BOLT_ID, SpeakerToNetworkProxyBolt.STREAM_CONNECT_NOTIFICATION_ID,
                         switchIdGrouping);
 
-        output.getKafkaGenericOutput().shuffleGrouping(SwitchMonitorBolt.BOLT_ID, SwitchMonitorBolt.STREAM_NETWORK_ID);
+        Fields keyGrouping = new Fields(FieldNameBasedTupleToKafkaMapper.BOLT_KEY);
+        output.getKafkaGenericOutput()
+                .fieldsGrouping(SwitchMonitorBolt.BOLT_ID, SwitchMonitorBolt.STREAM_NETWORK_ID, keyGrouping);
     }
 
     private void clock(TopologyBuilder topology) {

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/bolts/SpeakerToControllerProxyBolt.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/bolts/SpeakerToControllerProxyBolt.java
@@ -93,14 +93,16 @@ public class SpeakerToControllerProxyBolt extends AbstractBolt {
         InfoData payload = envelope.getData();
         if (payload instanceof IslInfoData) {
             proxyOnlyIfActiveRegion(key, envelope, (IslInfoData) payload);
-        } else if (payload instanceof PortInfoData) {
-            proxyOnlyIfActiveRegion(key, envelope, (PortInfoData) payload);
         } else if (payload instanceof IslOneWayLatency) {
             proxyOnlyIfActiveRegion(key, envelope, (IslOneWayLatency) payload);
         } else if (payload instanceof IslBaseLatency) {
             proxyOnlyIfActiveRegion(key, envelope, (IslBaseLatency) payload);
         } else if (payload instanceof ConnectedDevicePacketBase) {
             proxyOnlyIfActiveRegion(key, envelope, (ConnectedDevicePacketBase) payload);
+        } else if (payload instanceof PortInfoData) {
+            log.error(
+                    "Drop Port status update event {}, it must not be handled by generic proxy, it must be handled "
+                            + "by network specific handler", payload);
         } else {
             proxyOther(key, envelope);
         }
@@ -113,10 +115,6 @@ public class SpeakerToControllerProxyBolt extends AbstractBolt {
     private void proxyOnlyIfActiveRegion(String key, InfoMessage envelope, IslInfoData payload) {
         SwitchId switchId = payload.getDestination().getSwitchId();
         proxyOnlyIfActiveRegion(key, envelope, switchId);
-    }
-
-    private void proxyOnlyIfActiveRegion(String key, InfoMessage envelope, PortInfoData payload) {
-        proxyOnlyIfActiveRegion(key, envelope, payload.getSwitchId());
     }
 
     private void proxyOnlyIfActiveRegion(String key, InfoMessage envelope, IslOneWayLatency payload) {

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/bolts/SpeakerToNetworkProxyBolt.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/bolts/SpeakerToNetworkProxyBolt.java
@@ -19,6 +19,7 @@ import org.openkilda.messaging.AliveResponse;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.InfoMessage;
 import org.openkilda.messaging.info.discovery.NetworkDumpSwitchData;
+import org.openkilda.messaging.info.event.PortInfoData;
 import org.openkilda.messaging.info.event.SwitchInfoData;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.AbstractBolt;
@@ -64,9 +65,11 @@ public class SpeakerToNetworkProxyBolt extends SpeakerToControllerProxyBolt {
         if (payload instanceof AliveResponse) {
             emitRegionNotification(envelope.getRegion(), (AliveResponse) payload);
         } else if (payload instanceof SwitchInfoData) {
-            emitConnectNotification(envelope.getRegion(), (SwitchInfoData) payload);
+            emitNetworkNotification(envelope.getRegion(), (SwitchInfoData) payload);
         } else if (payload instanceof NetworkDumpSwitchData) {
-            emitConnectNotification(envelope.getRegion(), (NetworkDumpSwitchData) payload);
+            emitNetworkNotification(envelope.getRegion(), (NetworkDumpSwitchData) payload);
+        } else if (payload instanceof PortInfoData) {
+            emitNetworkNotification(envelope.getRegion(), (PortInfoData) payload);
         } else {
             super.proxyInfoMessage(key, envelope);
         }
@@ -84,15 +87,19 @@ public class SpeakerToNetworkProxyBolt extends SpeakerToControllerProxyBolt {
                 makeRegionNotificationTuple(region, response));
     }
 
-    private void emitConnectNotification(String region, SwitchInfoData payload) {
-        emitConnectNotification(region, payload.getSwitchId(), payload);
+    private void emitNetworkNotification(String region, SwitchInfoData payload) {
+        emitNetworkNotification(region, payload.getSwitchId(), payload);
     }
 
-    private void emitConnectNotification(String region, NetworkDumpSwitchData payload) {
-        emitConnectNotification(region, payload.getSwitchView().getDatapath(), payload);
+    private void emitNetworkNotification(String region, NetworkDumpSwitchData payload) {
+        emitNetworkNotification(region, payload.getSwitchView().getDatapath(), payload);
     }
 
-    private void emitConnectNotification(String region, SwitchId switchId, InfoData payload) {
+    private void emitNetworkNotification(String region, PortInfoData payload) {
+        emitNetworkNotification(region, payload.getSwitchId(), payload);
+    }
+
+    private void emitNetworkNotification(String region, SwitchId switchId, InfoData payload) {
         getOutput().emit(
                 STREAM_CONNECT_NOTIFICATION_ID, getCurrentTuple(),
                 makeConnectNotificationTuple(region, switchId, payload));

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/bolts/SwitchMonitorBolt.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/bolts/SwitchMonitorBolt.java
@@ -20,6 +20,7 @@ import org.openkilda.messaging.Message;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.InfoMessage;
 import org.openkilda.messaging.info.discovery.NetworkDumpSwitchData;
+import org.openkilda.messaging.info.event.PortInfoData;
 import org.openkilda.messaging.info.event.SwitchInfoData;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.AbstractBolt;
@@ -71,7 +72,7 @@ public class SwitchMonitorBolt extends AbstractBolt implements SwitchMonitorCarr
         } else if (RegionTrackerBolt.BOLT_ID.equals(source) && active) {
             handleRegionOfflineNotification(input);
         } else if (SpeakerToNetworkProxyBolt.BOLT_ID.equals(source) && active) {
-            handleSwitchConnectionNotification(input);
+            handleNetworkUpdateNotification(input);
         } else if (active) {
             unhandledInput(input);
         }
@@ -81,13 +82,15 @@ public class SwitchMonitorBolt extends AbstractBolt implements SwitchMonitorCarr
         service.handleRegionOfflineNotification(pullRegion(input));
     }
 
-    private void handleSwitchConnectionNotification(Tuple input) throws PipelineException {
+    private void handleNetworkUpdateNotification(Tuple input) throws PipelineException {
         String region = pullRegion(input);
         InfoData payload = pullValue(input, SpeakerToNetworkProxyBolt.FIELD_ID_PAYLOAD, InfoData.class);
         if (payload instanceof SwitchInfoData) {
             service.handleStatusUpdateNotification((SwitchInfoData) payload, region);
         } else if (payload instanceof NetworkDumpSwitchData) {
             service.handleNetworkDumpResponse((NetworkDumpSwitchData) payload, region);
+        } else if (payload instanceof PortInfoData) {
+            service.handlePortStatusUpdateNotification((PortInfoData) payload, region);
         } else {
             unhandledInput(input);
         }
@@ -102,7 +105,7 @@ public class SwitchMonitorBolt extends AbstractBolt implements SwitchMonitorCarr
     }
 
     @Override
-    public void switchStatusUpdateNotification(SwitchId switchId, InfoData notification) {
+    public void networkStatusUpdateNotification(SwitchId switchId, InfoData notification) {
         InfoMessage message = new InfoMessage(
                 notification, clock.instant().toEpochMilli(), getCommandContext().getCorrelationId());
         getOutput().emit(STREAM_NETWORK_ID, getCurrentTuple(), makeNetworkTuple(switchId.toString(), message));

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/SwitchMonitorCarrier.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/SwitchMonitorCarrier.java
@@ -22,5 +22,5 @@ import org.openkilda.wfm.topology.floodlightrouter.model.RegionMappingUpdate;
 public interface SwitchMonitorCarrier {
     void regionUpdateNotification(RegionMappingUpdate mappingUpdate);
 
-    void switchStatusUpdateNotification(SwitchId switchId, InfoData notification);
+    void networkStatusUpdateNotification(SwitchId switchId, InfoData notification);
 }

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchConnectMonitor.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchConnectMonitor.java
@@ -17,6 +17,7 @@ package org.openkilda.wfm.topology.floodlightrouter.service.monitor;
 
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.discovery.NetworkDumpSwitchData;
+import org.openkilda.messaging.info.event.PortInfoData;
 import org.openkilda.messaging.info.event.SwitchInfoData;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.topology.floodlightrouter.service.SwitchMonitorCarrier;
@@ -93,6 +94,11 @@ public abstract class SwitchConnectMonitor {
         }
     }
 
+    public void handlePortStatusUpdateNotification(PortInfoData notification, String region) {
+        ensureSwitchIdMatch(notification.getSwitchId());
+        proxyPortStatusUpdateNotification(notification, region);
+    }
+
     public boolean isAvailable() {
         return ! availableInRegions.isEmpty();
     }
@@ -144,6 +150,10 @@ public abstract class SwitchConnectMonitor {
         log.info(
                 "List of {} availability zones for {} has changed to: {}",
                 formatConnectMode(), switchId, formatAvailableRegionsSet());
+    }
+
+    protected void proxyPortStatusUpdateNotification(PortInfoData notification, String region) {
+        // noop
     }
 
     protected void ensureSwitchIdMatch(SwitchId affectedSwitchId) {

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchMonitorEntry.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchMonitorEntry.java
@@ -16,6 +16,7 @@
 package org.openkilda.wfm.topology.floodlightrouter.service.monitor;
 
 import org.openkilda.messaging.info.discovery.NetworkDumpSwitchData;
+import org.openkilda.messaging.info.event.PortInfoData;
 import org.openkilda.messaging.info.event.SwitchInfoData;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.topology.floodlightrouter.service.SwitchMonitorCarrier;
@@ -51,7 +52,7 @@ public class SwitchMonitorEntry {
         }
 
         if (! isHandled) {
-            carrier.switchStatusUpdateNotification(notification.getSwitchId(), notification);
+            carrier.networkStatusUpdateNotification(notification.getSwitchId(), notification);
         }
     }
 
@@ -70,6 +71,15 @@ public class SwitchMonitorEntry {
     public void handleNetworkDumpResponse(NetworkDumpSwitchData response, String region) {
         for (SwitchConnectMonitor entry : basicMonitors) {
             entry.handleNetworkDumpResponse(response, region);
+        }
+    }
+
+    /**
+     * Handle port status update notification.
+     */
+    public void handlePortStatusUpdateNotification(PortInfoData notification, String region) {
+        for (SwitchConnectMonitor entry : basicMonitors) {
+            entry.handlePortStatusUpdateNotification(notification, region);
         }
     }
 

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchMonitorService.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchMonitorService.java
@@ -16,6 +16,7 @@
 package org.openkilda.wfm.topology.floodlightrouter.service.monitor;
 
 import org.openkilda.messaging.info.discovery.NetworkDumpSwitchData;
+import org.openkilda.messaging.info.event.PortInfoData;
 import org.openkilda.messaging.info.event.SwitchInfoData;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.topology.floodlightrouter.service.SwitchMonitorCarrier;
@@ -87,6 +88,11 @@ public class SwitchMonitorService {
     public void handleNetworkDumpResponse(NetworkDumpSwitchData response, String region) {
         SwitchMonitorEntry entry = lookupOrCreateSwitchMonitor(response.getSwitchId());
         entry.handleNetworkDumpResponse(response, region);
+    }
+
+    public void handlePortStatusUpdateNotification(PortInfoData notification, String region) {
+        SwitchMonitorEntry entry = lookupOrCreateSwitchMonitor(notification.getSwitchId());
+        entry.handlePortStatusUpdateNotification(notification, region);
     }
 
     @VisibleForTesting

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchReadWriteConnectMonitor.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchReadWriteConnectMonitor.java
@@ -17,6 +17,7 @@ package org.openkilda.wfm.topology.floodlightrouter.service.monitor;
 
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.discovery.NetworkDumpSwitchData;
+import org.openkilda.messaging.info.event.PortInfoData;
 import org.openkilda.messaging.info.event.SwitchChangeType;
 import org.openkilda.messaging.info.event.SwitchInfoData;
 import org.openkilda.messaging.info.switches.UnmanagedSwitchNotification;
@@ -44,7 +45,7 @@ public class SwitchReadWriteConnectMonitor extends SwitchConnectMonitor {
         super.handlePeriodicDump(switchData, region);
         if (Objects.equals(activeRegion, region)) {
             // proxy network dump for active region only
-            carrier.switchStatusUpdateNotification(switchId, switchData);
+            carrier.networkStatusUpdateNotification(switchId, switchData);
         }
     }
 
@@ -56,7 +57,7 @@ public class SwitchReadWriteConnectMonitor extends SwitchConnectMonitor {
         log.info("Set {} active region for {} to \"{}\"", formatConnectMode(), switchId, activeRegion);
 
         carrier.regionUpdateNotification(new RegionMappingSet(switchId, activeRegion, isReadWriteMode()));
-        carrier.switchStatusUpdateNotification(switchId, notification);
+        carrier.networkStatusUpdateNotification(switchId, notification);
     }
 
     @Override
@@ -67,7 +68,7 @@ public class SwitchReadWriteConnectMonitor extends SwitchConnectMonitor {
         log.info("There is no any {} available regions for {} - switch is unavailable", formatConnectMode(), switchId);
 
         carrier.regionUpdateNotification(new RegionMappingRemove(switchId, null, isReadWriteMode()));
-        carrier.switchStatusUpdateNotification(switchId, notification);
+        carrier.networkStatusUpdateNotification(switchId, notification);
     }
 
     @Override
@@ -80,6 +81,15 @@ public class SwitchReadWriteConnectMonitor extends SwitchConnectMonitor {
         super.handleRegionLose(region);
         if (Objects.equals(activeRegion, region) && !availableInRegions.isEmpty()) {
             swapActiveRegion();
+        }
+    }
+
+    @Override
+    protected void proxyPortStatusUpdateNotification(PortInfoData notification, String region) {
+        super.proxyPortStatusUpdateNotification(notification, region);
+        if (Objects.equals(activeRegion, region)) {
+            // proxy port status update for active region only
+            carrier.networkStatusUpdateNotification(notification.getSwitchId(), notification);
         }
     }
 

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchMonitorServiceTest.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchMonitorServiceTest.java
@@ -63,7 +63,7 @@ public class SwitchMonitorServiceTest {
 
         SwitchInfoData swActivate = makeSwitchActivateNotification(swAdd.getSwitchId());
         subject.handleStatusUpdateNotification(swActivate, REGION_ALPHA);
-        verify(carrier).switchStatusUpdateNotification(eq(swActivate.getSwitchId()), eq(swActivate));
+        verify(carrier).networkStatusUpdateNotification(eq(swActivate.getSwitchId()), eq(swActivate));
         verify(carrier).regionUpdateNotification(
                 eq(new RegionMappingSet(swActivate.getSwitchId(), REGION_ALPHA, true)));
         verifyNoMoreInteractions(carrier);

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchReadWriteConnectMonitorTest.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchReadWriteConnectMonitorTest.java
@@ -60,13 +60,13 @@ public abstract class SwitchReadWriteConnectMonitorTest {
 
         subject.handleSwitchStatusNotification(connectEvent, REGION_A);
         verify(carrier, times(1))
-                .switchStatusUpdateNotification(eq(connectEvent.getSwitchId()), eq(connectEvent));
+                .networkStatusUpdateNotification(eq(connectEvent.getSwitchId()), eq(connectEvent));
         verify(carrier).regionUpdateNotification(
                 eq(new RegionMappingSet(connectEvent.getSwitchId(), REGION_A, subject.isReadWriteMode())));
 
         subject.handleSwitchStatusNotification(connectEvent, REGION_B);
         verify(carrier, times(1))
-                .switchStatusUpdateNotification(eq(connectEvent.getSwitchId()), eq(connectEvent));
+                .networkStatusUpdateNotification(eq(connectEvent.getSwitchId()), eq(connectEvent));
         verify(carrier, never()).regionUpdateNotification(
                 eq(new RegionMappingSet(connectEvent.getSwitchId(), REGION_B, subject.isReadWriteMode())));
     }
@@ -77,7 +77,7 @@ public abstract class SwitchReadWriteConnectMonitorTest {
         SwitchInfoData connectEvent = makeConnectNotification(SWITCH_ALPHA);
 
         subject.handleSwitchStatusNotification(connectEvent, REGION_A);
-        verify(carrier).switchStatusUpdateNotification(eq(connectEvent.getSwitchId()), eq(connectEvent));
+        verify(carrier).networkStatusUpdateNotification(eq(connectEvent.getSwitchId()), eq(connectEvent));
         verify(carrier).regionUpdateNotification(
                 eq(new RegionMappingSet(connectEvent.getSwitchId(), REGION_A, subject.isReadWriteMode())));
 
@@ -87,7 +87,7 @@ public abstract class SwitchReadWriteConnectMonitorTest {
 
         SwitchInfoData disconnectEvent = makeDisconnectNotification(connectEvent.getSwitchId());
         subject.handleSwitchStatusNotification(disconnectEvent, REGION_A);
-        verify(carrier).switchStatusUpdateNotification(
+        verify(carrier).networkStatusUpdateNotification(
                 eq(disconnectEvent.getSwitchId()), ArgumentMatchers.eq(disconnectEvent));
         Assert.assertFalse(subject.isAvailable());
         Assert.assertEquals(now, subject.getBecomeUnavailableAt());
@@ -116,7 +116,7 @@ public abstract class SwitchReadWriteConnectMonitorTest {
         Assert.assertFalse(subject.isAvailable());
         Assert.assertEquals(failedAt, subject.getBecomeUnavailableAt());
 
-        verify(carrier).switchStatusUpdateNotification(eq(disconnectEvent.getSwitchId()), eq(disconnectEvent));
+        verify(carrier).networkStatusUpdateNotification(eq(disconnectEvent.getSwitchId()), eq(disconnectEvent));
         verify(carrier).regionUpdateNotification(
                 eq(new RegionMappingRemove(disconnectEvent.getSwitchId(), null, subject.isReadWriteMode())));
         verifyNoMoreInteractions(carrier);


### PR DESCRIPTION
Due to different processing path of network(switch) dump and port status
update events inside floodlightrouter these events can switch their
order. As result ISL attached to such port can unexpectedly flap (on
time up to period of network dump).

Rework processing of port status update notification events "processing
path" into floodlightrouter to make it simmilar to network(switch) dump
"processing path".

Close #3990