### PR TITLE
Set active=false for DatapointParseBolt by default

### DIFF
--- a/src-java/opentsdb-topology/opentsdb-storm-topology/src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTsdbTopology.java
+++ b/src-java/opentsdb-topology/opentsdb-storm-topology/src/main/java/org/openkilda/wfm/topology/opentsdb/OpenTsdbTopology.java
@@ -52,7 +52,8 @@ public class OpenTsdbTopology extends AbstractTopology<OpenTsdbTopologyConfig> {
     static final String OTSDB_SPOUT_ID = "kilda.otsdb-spout";
     private static final String OTSDB_BOLT_ID = "otsdb-bolt";
     private static final String OTSDB_FILTER_BOLT_ID = OpenTSDBFilterBolt.class.getSimpleName();
-    private static final String OTSDB_PARSE_BOLT_ID = DatapointParseBolt.class.getSimpleName();
+    @VisibleForTesting
+    static final String OTSDB_PARSE_BOLT_ID = DatapointParseBolt.class.getSimpleName();
 
     @Override
     public StormTopology createTopology() {

--- a/src-java/opentsdb-topology/opentsdb-storm-topology/src/main/java/org/openkilda/wfm/topology/opentsdb/bolts/DatapointParseBolt.java
+++ b/src-java/opentsdb-topology/opentsdb-storm-topology/src/main/java/org/openkilda/wfm/topology/opentsdb/bolts/DatapointParseBolt.java
@@ -27,6 +27,7 @@ import org.openkilda.wfm.share.zk.ZooKeeperBolt;
 import org.openkilda.wfm.share.zk.ZooKeeperSpout;
 import org.openkilda.wfm.topology.utils.MessageKafkaTranslator;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
@@ -47,8 +48,8 @@ public class DatapointParseBolt extends BaseRichBolt {
     private static final Logger LOGGER = LoggerFactory.getLogger(DatapointParseBolt.class);
     private transient OutputCollector collector;
 
-    // True for testing
-    private boolean active = true;
+    @VisibleForTesting
+    public boolean active;
 
     @Override
     public void prepare(Map map, TopologyContext topologyContext, OutputCollector collector) {


### PR DESCRIPTION
We have an activation check in DatapointParseBolt. This check do not allows bolt handle START signal if bolt is already active. But earlier we set active to true by default for testing. So first START signal will be ignored. This PR will fix it.  