### PR TITLE
Fix path(s) and status cleanup in Flow H&S operations

### DIFF
--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowPathSwappingFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowPathSwappingFsm.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 @Getter
@@ -90,4 +91,44 @@ public abstract class FlowPathSwappingFsm<T extends NbTrackableFsm<T, S, E, C>, 
     }
 
     public abstract void fireNoPathFound(String errorReason);
+
+    public void clearPendingCommands() {
+        pendingCommands.clear();
+    }
+
+    public Optional<SwitchId> getPendingCommand(UUID key) {
+        return Optional.ofNullable(pendingCommands.get(key));
+    }
+
+    public void addPendingCommand(UUID key, SwitchId switchId) {
+        pendingCommands.put(key, switchId);
+    }
+
+    public Optional<SwitchId> removePendingCommand(UUID key) {
+        return Optional.ofNullable(pendingCommands.remove(key));
+    }
+
+    public void clearRetriedCommands() {
+        retriedCommands.clear();
+    }
+
+    public int doRetryForCommand(UUID key) {
+        int attempt = retriedCommands.getOrDefault(key, 0) + 1;
+        retriedCommands.put(key, attempt);
+        return attempt;
+    }
+
+    public void clearFailedCommands() {
+        failedCommands.clear();
+    }
+
+    public void addFailedCommand(UUID key, FlowErrorResponse errorResponse) {
+        failedCommands.put(key, errorResponse);
+    }
+
+    public void clearPendingAndRetriedAndFailedCommands() {
+        clearPendingCommands();
+        clearRetriedCommands();
+        clearFailedCommands();
+    }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/delete/actions/HandleNotCompletedCommandsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/delete/actions/HandleNotCompletedCommandsAction.java
@@ -44,6 +44,6 @@ public class HandleNotCompletedCommandsAction extends
         }
 
         log.debug("Abandoning all pending commands: {}", stateMachine.getPendingCommands());
-        stateMachine.getPendingCommands().clear();
+        stateMachine.clearPendingCommands();
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/delete/actions/OnReceivedResponseAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/delete/actions/OnReceivedResponseAction.java
@@ -42,7 +42,7 @@ public class OnReceivedResponseAction extends
         }
 
         UUID commandId = response.getCommandId();
-        if (!stateMachine.getPendingCommands().remove(commandId)) {
+        if (!stateMachine.removePendingCommand(commandId)) {
             log.info("Received a response for unexpected command: {}", response);
             return;
         }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/delete/actions/RemoveRulesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/delete/actions/RemoveRulesAction.java
@@ -111,15 +111,17 @@ public class RemoveRulesAction extends BaseFlowRuleRemovalAction<FlowDeleteFsm, 
             }
         }
 
-        SpeakerRemoveSegmentEmitter.INSTANCE.emitBatch(
-                stateMachine.getCarrier(), commands, stateMachine.getRemoveCommands());
-        stateMachine.getPendingCommands().addAll(stateMachine.getRemoveCommands().keySet());
+        stateMachine.clearPendingAndRetriedCommands();
 
         if (commands.isEmpty()) {
             stateMachine.saveActionToHistory("No need to remove rules");
 
             stateMachine.fire(Event.RULES_REMOVED);
         } else {
+            SpeakerRemoveSegmentEmitter.INSTANCE.emitBatch(
+                    stateMachine.getCarrier(), commands, stateMachine.getRemoveCommands());
+            stateMachine.getPendingCommands().addAll(stateMachine.getRemoveCommands().keySet());
+
             stateMachine.saveActionToHistory("Remove commands for rules have been sent");
         }
     }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/pathswap/action/AbandonPendingCommandsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/pathswap/action/AbandonPendingCommandsAction.java
@@ -28,6 +28,6 @@ public class AbandonPendingCommandsAction extends AnonymousAction<FlowPathSwapFs
     @Override
     public void execute(State from, State to, Event event, FlowPathSwapContext context, FlowPathSwapFsm stateMachine) {
         log.debug("Abandoning all pending commands: {}", stateMachine.getPendingCommands());
-        stateMachine.getPendingCommands().clear();
+        stateMachine.clearPendingCommands();
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/pathswap/action/EmitIngressRulesVerifyRequestsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/pathswap/action/EmitIngressRulesVerifyRequestsAction.java
@@ -38,9 +38,9 @@ public class EmitIngressRulesVerifyRequestsAction
         ArrayList<FlowSegmentRequestFactory> requestFactories = new ArrayList<>(requestsStorage.values());
         requestsStorage.clear();
 
+        stateMachine.clearPendingAndRetriedAndFailedCommands();
         SpeakerVerifySegmentEmitter.INSTANCE.emitBatch(stateMachine.getCarrier(), requestFactories, requestsStorage);
-        requestsStorage.forEach((key, value) -> stateMachine.getPendingCommands().put(key, value.getSwitchId()));
-        stateMachine.getRetriedCommands().clear();
+        requestsStorage.forEach((key, value) -> stateMachine.addPendingCommand(key, value.getSwitchId()));
 
         stateMachine.saveActionToHistory("Started validation of installed ingress rules");
     }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/pathswap/action/HandleNotCompletedCommandsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/pathswap/action/HandleNotCompletedCommandsAction.java
@@ -49,6 +49,6 @@ public class HandleNotCompletedCommandsAction extends
             }
         }
         log.debug("Abandoning all pending commands: {}", stateMachine.getPendingCommands());
-        stateMachine.getPendingCommands().clear();
+        stateMachine.clearPendingCommands();
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/pathswap/action/InstallIngressRulesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/pathswap/action/InstallIngressRulesAction.java
@@ -71,17 +71,12 @@ public class InstallIngressRulesAction extends FlowProcessingAction<FlowPathSwap
 
         // Installation of ingress rules for protected paths is skipped. These paths are activated on swap.
 
+        stateMachine.clearPendingAndRetriedAndFailedCommands();
         SpeakerInstallSegmentEmitter.INSTANCE.emitBatch(
                 stateMachine.getCarrier(), commands, stateMachine.getIngressCommands());
         stateMachine.getIngressCommands().forEach(
-                (key, value) -> stateMachine.getPendingCommands().put(key, value.getSwitchId()));
-        stateMachine.getRetriedCommands().clear();
+                (key, value) -> stateMachine.addPendingCommand(key, value.getSwitchId()));
 
-        if (commands.isEmpty()) {
-            stateMachine.saveActionToHistory("No need to install ingress rules");
-            stateMachine.fire(Event.INGRESS_IS_SKIPPED);
-        } else {
-            stateMachine.saveActionToHistory("Commands for installing ingress rules have been sent");
-        }
+        stateMachine.saveActionToHistory("Commands for installing ingress rules have been sent");
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/pathswap/action/OnReceivedInstallResponseAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/pathswap/action/OnReceivedInstallResponseAction.java
@@ -51,7 +51,7 @@ public class OnReceivedInstallResponseAction extends
         }
 
         if (response.isSuccess()) {
-            stateMachine.getPendingCommands().remove(commandId);
+            stateMachine.removePendingCommand(commandId);
 
             stateMachine.saveActionToHistory("Rule was installed",
                     format("The rule was installed: switch %s, cookie %s",
@@ -59,24 +59,22 @@ public class OnReceivedInstallResponseAction extends
         } else {
             FlowErrorResponse errorResponse = (FlowErrorResponse) response;
 
-            int retries = stateMachine.getRetriedCommands().getOrDefault(commandId, 0);
-            if (retries < speakerCommandRetriesLimit) {
-                stateMachine.getRetriedCommands().put(commandId, ++retries);
-
+            int attempt = stateMachine.doRetryForCommand(commandId);
+            if (attempt <= speakerCommandRetriesLimit) {
                 stateMachine.saveErrorToHistory("Failed to install rule", format(
                         "Failed to install the rule: commandId %s, switch %s, cookie %s. Error %s. "
                                 + "Retrying (attempt %d)",
-                        commandId, errorResponse.getSwitchId(), command.getCookie(), errorResponse, retries));
+                        commandId, errorResponse.getSwitchId(), command.getCookie(), errorResponse, attempt));
 
                 stateMachine.getCarrier().sendSpeakerRequest(command.makeInstallRequest(commandId));
             } else {
-                stateMachine.getPendingCommands().remove(commandId);
+                stateMachine.removePendingCommand(commandId);
 
                 stateMachine.saveErrorToHistory("Failed to install rule", format(
                         "Failed to install the rule: commandId %s, switch %s, cookie %s. Error: %s",
                         commandId, errorResponse.getSwitchId(), command.getCookie(), errorResponse));
 
-                stateMachine.getFailedCommands().put(commandId, errorResponse);
+                stateMachine.addFailedCommand(commandId, errorResponse);
             }
         }
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/pathswap/action/RemoveOldRulesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/pathswap/action/RemoveOldRulesAction.java
@@ -57,11 +57,11 @@ public class RemoveOldRulesAction
         Collection<FlowSegmentRequestFactory> commands = new ArrayList<>(commandBuilder.buildIngressOnly(
                 stateMachine.getCommandContext(), flow, oldPrimaryForward, oldPrimaryReverse, speakerContext));
 
+        stateMachine.clearPendingAndRetriedAndFailedCommands();
         SpeakerRemoveSegmentEmitter.INSTANCE.emitBatch(
                 stateMachine.getCarrier(), commands, stateMachine.getRemoveCommands());
         stateMachine.getRemoveCommands().forEach(
-                (key, value) -> stateMachine.getPendingCommands().put(key, value.getSwitchId()));
-        stateMachine.getRetriedCommands().clear();
+                (key, value) -> stateMachine.addPendingCommand(key, value.getSwitchId()));
 
         stateMachine.saveActionToHistory("Remove commands for old rules have been sent");
     }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/pathswap/action/RevertPathsSwapAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/pathswap/action/RevertPathsSwapAction.java
@@ -47,10 +47,10 @@ public class RevertPathsSwapAction extends FlowProcessingAction<FlowPathSwapFsm,
 
             FlowPath oldPrimaryForward = flow.getForwardPath();
             FlowPath oldPrimaryReverse = flow.getReversePath();
-            flow.setForwardPath(flow.getProtectedForwardPath());
-            flow.setReversePath(flow.getProtectedReversePath());
-            flow.setProtectedForwardPath(oldPrimaryForward);
-            flow.setProtectedReversePath(oldPrimaryReverse);
+            flow.setForwardPathId(flow.getProtectedForwardPathId());
+            flow.setReversePathId(flow.getProtectedReversePathId());
+            flow.setProtectedForwardPathId(oldPrimaryForward.getPathId());
+            flow.setProtectedReversePathId(oldPrimaryReverse.getPathId());
             return new FlowPathPair(oldPrimaryForward, oldPrimaryReverse);
         });
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/FlowRerouteFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/FlowRerouteFsm.java
@@ -370,9 +370,8 @@ public final class FlowRerouteFsm extends FlowPathSwappingFsm<FlowRerouteFsm, St
 
             builder.onEntry(State.PATHS_SWAP_REVERTED)
                     .perform(reportErrorAction);
-            builder.transitions().from(State.PATHS_SWAP_REVERTED)
-                    .toAmong(State.REVERTING_NEW_RULES, State.REVERTING_NEW_RULES)
-                    .onEach(Event.NEXT, Event.ERROR)
+            builder.transition().from(State.PATHS_SWAP_REVERTED)
+                    .to(State.REVERTING_NEW_RULES).on(Event.NEXT)
                     .perform(new RevertNewRulesAction(persistenceManager, resourcesManager));
 
             builder.internalTransition().within(State.REVERTING_NEW_RULES).on(Event.RESPONSE_RECEIVED)
@@ -385,15 +384,14 @@ public final class FlowRerouteFsm extends FlowPathSwappingFsm<FlowRerouteFsm, St
                     .on(Event.ERROR)
                     .perform(new HandleNotCompletedCommandsAction());
 
-            builder.transitions().from(State.NEW_RULES_REVERTED)
-                    .toAmong(State.REVERTING_ALLOCATED_RESOURCES, State.REVERTING_ALLOCATED_RESOURCES)
-                    .onEach(Event.NEXT, Event.ERROR);
+            builder.transition().from(State.NEW_RULES_REVERTED)
+                    .to(State.REVERTING_ALLOCATED_RESOURCES).on(Event.NEXT);
 
             builder.onEntry(State.REVERTING_ALLOCATED_RESOURCES)
                     .perform(reportErrorAction);
-            builder.transitions().from(State.REVERTING_ALLOCATED_RESOURCES)
-                    .toAmong(State.RESOURCES_ALLOCATION_REVERTED, State.RESOURCES_ALLOCATION_REVERTED)
-                    .onEach(Event.NEXT, Event.ERROR)
+            builder.transition().from(State.REVERTING_ALLOCATED_RESOURCES)
+                    .to(State.RESOURCES_ALLOCATION_REVERTED)
+                    .on(Event.NEXT)
                     .perform(new RevertResourceAllocationAction(persistenceManager, resourcesManager));
             builder.transition().from(State.RESOURCES_ALLOCATION_REVERTED)
                     .to(State.REVERTING_FLOW_STATUS).on(Event.NEXT);
@@ -403,9 +401,9 @@ public final class FlowRerouteFsm extends FlowPathSwappingFsm<FlowRerouteFsm, St
 
             builder.onEntry(State.REVERTING_FLOW_STATUS)
                     .perform(reportErrorAction);
-            builder.transitions().from(State.REVERTING_FLOW_STATUS)
-                    .toAmong(State.NOTIFY_FLOW_MONITOR_WITH_ERROR, State.NOTIFY_FLOW_MONITOR_WITH_ERROR)
-                    .onEach(Event.NEXT, Event.ERROR)
+            builder.transition().from(State.REVERTING_FLOW_STATUS)
+                    .to(State.NOTIFY_FLOW_MONITOR_WITH_ERROR)
+                    .on(Event.NEXT)
                     .perform(new RevertFlowStatusAction(persistenceManager));
 
             builder.transition()

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/EmitIngressRulesVerifyRequestsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/EmitIngressRulesVerifyRequestsAction.java
@@ -42,13 +42,16 @@ public class EmitIngressRulesVerifyRequestsAction
         Map<UUID, FlowSegmentRequestFactory> requestsStorage = stateMachine.getIngressCommands();
         List<FlowSegmentRequestFactory> requestFactories = new ArrayList<>(requestsStorage.values());
         requestsStorage.clear();
+
+        stateMachine.clearPendingAndRetriedAndFailedCommands();
+
         for (FlowSegmentRequestFactory factory : requestFactories) {
             FlowSegmentRequest request = factory.makeVerifyRequest(commandIdGenerator.generate());
             // TODO ensure no conflicts
             requestsStorage.put(request.getCommandId(), factory);
             stateMachine.getCarrier().sendSpeakerRequest(request);
         }
-        requestsStorage.forEach((key, value) -> stateMachine.getPendingCommands().put(key, value.getSwitchId()));
+        requestsStorage.forEach((key, value) -> stateMachine.addPendingCommand(key, value.getSwitchId()));
 
         stateMachine.saveActionToHistory("Started validation of installed ingress rules");
     }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/EmitNonIngressRulesVerifyRequestsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/EmitNonIngressRulesVerifyRequestsAction.java
@@ -43,6 +43,8 @@ public class EmitNonIngressRulesVerifyRequestsAction extends
         List<FlowSegmentRequestFactory> requestFactories = new ArrayList<>(requestsStorage.values());
         requestsStorage.clear();
 
+        stateMachine.clearPendingAndRetriedAndFailedCommands();
+
         if (requestFactories.isEmpty()) {
             stateMachine.saveActionToHistory("No need to validate non ingress rules");
 
@@ -54,10 +56,9 @@ public class EmitNonIngressRulesVerifyRequestsAction extends
                 requestsStorage.put(request.getCommandId(), factory);
                 stateMachine.getCarrier().sendSpeakerRequest(request);
             }
+            requestsStorage.forEach((key, value) -> stateMachine.addPendingCommand(key, value.getSwitchId()));
 
             stateMachine.saveActionToHistory("Started validation of installed non ingress rules");
         }
-
-        requestsStorage.forEach((key, value) -> stateMachine.getPendingCommands().put(key, value.getSwitchId()));
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/HandleNotCompletedCommandsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/HandleNotCompletedCommandsAction.java
@@ -60,6 +60,6 @@ public class HandleNotCompletedCommandsAction extends
         }
 
         log.debug("Abandoning all pending commands: {}", stateMachine.getPendingCommands());
-        stateMachine.getPendingCommands().clear();
+        stateMachine.clearPendingCommands();
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/OnReceivedRemoveOrRevertResponseAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/OnReceivedRemoveOrRevertResponseAction.java
@@ -52,7 +52,7 @@ public class OnReceivedRemoveOrRevertResponseAction extends
         }
 
         if (response.isSuccess()) {
-            stateMachine.getPendingCommands().remove(commandId);
+            stateMachine.removePendingCommand(commandId);
 
             if (removeCommand != null) {
                 stateMachine.saveActionToHistory("Rule was deleted",
@@ -66,27 +66,25 @@ public class OnReceivedRemoveOrRevertResponseAction extends
         } else {
             FlowErrorResponse errorResponse = (FlowErrorResponse) response;
 
-            int retries = stateMachine.getRetriedCommands().getOrDefault(commandId, 0);
-            if (retries < speakerCommandRetriesLimit) {
-                stateMachine.getRetriedCommands().put(commandId, ++retries);
-
+            int attempt = stateMachine.doRetryForCommand(commandId);
+            if (attempt <= speakerCommandRetriesLimit) {
                 if (removeCommand != null) {
                     stateMachine.saveErrorToHistory("Failed to remove rule", format(
                             "Failed to remove the rule: commandId %s, switch %s, cookie %s. Error %s. "
                                     + "Retrying (attempt %d)",
-                            commandId, errorResponse.getSwitchId(), removeCommand.getCookie(), errorResponse, retries));
+                            commandId, errorResponse.getSwitchId(), removeCommand.getCookie(), errorResponse, attempt));
 
                     stateMachine.getCarrier().sendSpeakerRequest(removeCommand.makeRemoveRequest(commandId));
                 } else {
                     stateMachine.saveErrorToHistory("Failed to re-install (revert) rule", format(
                             "Failed to install the rule: commandId %s, switch %s, cookie %s. Error %s. "
                                     + "Retrying (attempt %d)", commandId, errorResponse.getSwitchId(),
-                            installCommand.getCookie(), errorResponse, retries));
+                            installCommand.getCookie(), errorResponse, attempt));
 
                     stateMachine.getCarrier().sendSpeakerRequest(installCommand.makeInstallRequest(commandId));
                 }
             } else {
-                stateMachine.getPendingCommands().remove(commandId);
+                stateMachine.removePendingCommand(commandId);
 
                 if (removeCommand != null) {
                     stateMachine.saveErrorToHistory("Failed to remove rule", format(
@@ -97,7 +95,7 @@ public class OnReceivedRemoveOrRevertResponseAction extends
                             "Failed to install the rule: commandId %s, switch %s, cookie %s. Error: %s",
                             commandId, errorResponse.getSwitchId(), installCommand.getCookie(), errorResponse));
                 }
-                stateMachine.getFailedCommands().put(commandId, errorResponse);
+                stateMachine.addFailedCommand(commandId, errorResponse);
             }
         }
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/error/SetInstallRuleErrorAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/error/SetInstallRuleErrorAction.java
@@ -40,6 +40,6 @@ public class SetInstallRuleErrorAction extends AnonymousAction<FlowRerouteFsm, S
                 .collect(Collectors.toSet());
         stateMachine.setRerouteError(new SpeakerRequestError("Failed to install rules", switches));
         log.debug("Abandoning all pending commands: {}", stateMachine.getPendingCommands());
-        stateMachine.getPendingCommands().clear();
+        stateMachine.clearPendingCommands();
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/error/SetValidateRuleErrorAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/error/SetValidateRuleErrorAction.java
@@ -41,6 +41,6 @@ public class SetValidateRuleErrorAction extends AnonymousAction<FlowRerouteFsm, 
                 .collect(Collectors.toSet());
         stateMachine.setRerouteError(new SpeakerRequestError("Failed to validate rules", switches));
         log.debug("Abandoning all pending commands: {}", stateMachine.getPendingCommands());
-        stateMachine.getPendingCommands().clear();
+        stateMachine.clearPendingCommands();
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/swapendpoints/actions/RevertFlowStatusAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/swapendpoints/actions/RevertFlowStatusAction.java
@@ -1,0 +1,64 @@
+/* Copyright 2021 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.fsm.swapendpoints.actions;
+
+import static java.lang.String.format;
+
+import org.openkilda.model.Flow;
+import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.wfm.topology.flowhs.fsm.common.actions.FlowProcessingAction;
+import org.openkilda.wfm.topology.flowhs.fsm.swapendpoints.FlowSwapEndpointsContext;
+import org.openkilda.wfm.topology.flowhs.fsm.swapendpoints.FlowSwapEndpointsFsm;
+import org.openkilda.wfm.topology.flowhs.fsm.swapendpoints.FlowSwapEndpointsFsm.Event;
+import org.openkilda.wfm.topology.flowhs.fsm.swapendpoints.FlowSwapEndpointsFsm.State;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class RevertFlowStatusAction
+        extends FlowProcessingAction<FlowSwapEndpointsFsm, State, Event, FlowSwapEndpointsContext> {
+    public RevertFlowStatusAction(PersistenceManager persistenceManager) {
+        super(persistenceManager);
+    }
+
+    @Override
+    protected void perform(State from, State to, Event event, FlowSwapEndpointsContext context,
+                           FlowSwapEndpointsFsm stateMachine) {
+        Flow firstOriginalFlow = stateMachine.getFirstOriginalFlow();
+        if (firstOriginalFlow != null) {
+            log.debug("Reverting the flow status of {} to {}", firstOriginalFlow.getFlowId(),
+                    firstOriginalFlow.getStatus());
+
+            flowRepository.updateStatus(firstOriginalFlow.getFlowId(),
+                    firstOriginalFlow.getStatus());
+
+            stateMachine.saveActionToHistory(format("The flow status of %s was reverted to %s",
+                    firstOriginalFlow.getFlowId(), firstOriginalFlow.getStatus()));
+        }
+
+        Flow secondOriginalFlow = stateMachine.getSecondOriginalFlow();
+        if (secondOriginalFlow != null) {
+            log.debug("Reverting the flow status of {} to {}", secondOriginalFlow.getFlowId(),
+                    secondOriginalFlow.getStatus());
+
+            flowRepository.updateStatus(secondOriginalFlow.getFlowId(),
+                    secondOriginalFlow.getStatus());
+
+            stateMachine.saveActionToHistory(format("The flow status of %s was reverted to %s",
+                    secondOriginalFlow.getFlowId(), secondOriginalFlow.getStatus()));
+        }
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/FlowUpdateFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/FlowUpdateFsm.java
@@ -343,9 +343,9 @@ public final class FlowUpdateFsm extends FlowPathSwappingFsm<FlowUpdateFsm, Stat
 
             builder.onEntry(State.PATHS_SWAP_REVERTED)
                     .perform(reportErrorAction);
-            builder.transitions().from(State.PATHS_SWAP_REVERTED)
-                    .toAmong(State.REVERTING_NEW_RULES, State.REVERTING_NEW_RULES)
-                    .onEach(Event.NEXT, Event.ERROR)
+            builder.transition().from(State.PATHS_SWAP_REVERTED)
+                    .to(State.REVERTING_NEW_RULES)
+                    .on(Event.NEXT)
                     .perform(new RevertNewRulesAction(persistenceManager, resourcesManager));
 
             builder.internalTransition().within(State.REVERTING_NEW_RULES).on(Event.RESPONSE_RECEIVED)
@@ -360,15 +360,14 @@ public final class FlowUpdateFsm extends FlowPathSwappingFsm<FlowUpdateFsm, Stat
                     .perform(new HandleNotCompletedCommandsAction());
 
             builder.transitions().from(State.NEW_RULES_REVERTED)
-                    .toAmong(State.REVERTING_ALLOCATED_RESOURCES, State.REVERTING_ALLOCATED_RESOURCES,
-                            State.REVERTING_FLOW)
-                    .onEach(Event.NEXT, Event.ERROR, Event.UPDATE_ENDPOINT_RULES_ONLY);
+                    .toAmong(State.REVERTING_ALLOCATED_RESOURCES, State.REVERTING_FLOW)
+                    .onEach(Event.NEXT, Event.UPDATE_ENDPOINT_RULES_ONLY);
 
             builder.onEntry(State.REVERTING_ALLOCATED_RESOURCES)
                     .perform(reportErrorAction);
             builder.transitions().from(State.REVERTING_ALLOCATED_RESOURCES)
-                    .toAmong(State.RESOURCES_ALLOCATION_REVERTED, State.RESOURCES_ALLOCATION_REVERTED)
-                    .onEach(Event.NEXT, Event.ERROR)
+                    .toAmong(State.RESOURCES_ALLOCATION_REVERTED)
+                    .onEach(Event.NEXT)
                     .perform(new RevertResourceAllocationAction(persistenceManager, resourcesManager));
             builder.transition().from(State.RESOURCES_ALLOCATION_REVERTED).to(State.REVERTING_FLOW).on(Event.NEXT);
             builder.transition().from(State.RESOURCES_ALLOCATION_REVERTED).to(State.REVERTING_FLOW)
@@ -377,16 +376,16 @@ public final class FlowUpdateFsm extends FlowPathSwappingFsm<FlowUpdateFsm, Stat
 
             builder.onEntry(State.REVERTING_FLOW)
                     .perform(reportErrorAction);
-            builder.transitions().from(State.REVERTING_FLOW)
-                    .toAmong(State.REVERTING_FLOW_STATUS, State.REVERTING_FLOW_STATUS)
-                    .onEach(Event.NEXT, Event.ERROR)
+            builder.transition().from(State.REVERTING_FLOW)
+                    .to(State.REVERTING_FLOW_STATUS)
+                    .on(Event.NEXT)
                     .perform(new RevertFlowAction(persistenceManager));
 
             builder.onEntry(State.REVERTING_FLOW_STATUS)
                     .perform(reportErrorAction);
-            builder.transitions().from(State.REVERTING_FLOW_STATUS)
-                    .toAmong(State.NOTIFY_FLOW_MONITOR_WITH_ERROR, State.NOTIFY_FLOW_MONITOR_WITH_ERROR)
-                    .onEach(Event.NEXT, Event.ERROR)
+            builder.transition().from(State.REVERTING_FLOW_STATUS)
+                    .to(State.NOTIFY_FLOW_MONITOR_WITH_ERROR)
+                    .on(Event.NEXT)
                     .perform(new RevertFlowStatusAction(persistenceManager));
 
             builder.onEntry(State.FINISHED_WITH_ERROR)

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AbandonPendingCommandsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AbandonPendingCommandsAction.java
@@ -28,6 +28,6 @@ public class AbandonPendingCommandsAction extends AnonymousAction<FlowUpdateFsm,
     @Override
     public void execute(State from, State to, Event event, FlowUpdateContext context, FlowUpdateFsm stateMachine) {
         log.debug("Abandoning all pending commands: {}", stateMachine.getPendingCommands());
-        stateMachine.getPendingCommands().clear();
+        stateMachine.clearPendingCommands();
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/EmitIngressRulesVerifyRequestsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/EmitIngressRulesVerifyRequestsAction.java
@@ -38,9 +38,10 @@ public class EmitIngressRulesVerifyRequestsAction
         ArrayList<FlowSegmentRequestFactory> requestFactories = new ArrayList<>(requestsStorage.values());
         requestsStorage.clear();
 
+        stateMachine.clearPendingAndRetriedAndFailedCommands();
+
         SpeakerVerifySegmentEmitter.INSTANCE.emitBatch(stateMachine.getCarrier(), requestFactories, requestsStorage);
-        requestsStorage.forEach((key, value) -> stateMachine.getPendingCommands().put(key, value.getSwitchId()));
-        stateMachine.getRetriedCommands().clear();
+        requestsStorage.forEach((key, value) -> stateMachine.addPendingCommand(key, value.getSwitchId()));
 
         stateMachine.saveActionToHistory("Started validation of installed ingress rules");
     }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/HandleNotCompletedCommandsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/HandleNotCompletedCommandsAction.java
@@ -50,7 +50,7 @@ public class HandleNotCompletedCommandsAction extends
         }
 
         log.debug("Abandoning all pending commands: {}", stateMachine.getPendingCommands());
-        stateMachine.getPendingCommands().clear();
+        stateMachine.clearPendingCommands();
 
         if (stateMachine.getEndpointUpdate().isPartialUpdate()) {
             stateMachine.saveActionToHistory("Skip paths and resources allocation");

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/InstallIngressRulesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/InstallIngressRulesAction.java
@@ -96,16 +96,17 @@ public class InstallIngressRulesAction extends FlowProcessingAction<FlowUpdateFs
 
         // Installation of ingress rules for protected paths is skipped. These paths are activated on swap.
 
-        SpeakerInstallSegmentEmitter.INSTANCE.emitBatch(
-                stateMachine.getCarrier(), commands, stateMachine.getIngressCommands());
-        stateMachine.getIngressCommands().forEach(
-                (key, value) -> stateMachine.getPendingCommands().put(key, value.getSwitchId()));
-        stateMachine.getRetriedCommands().clear();
+        stateMachine.clearPendingAndRetriedAndFailedCommands();
 
         if (commands.isEmpty()) {
             stateMachine.saveActionToHistory("No need to install ingress rules");
             stateMachine.fire(Event.INGRESS_IS_SKIPPED);
         } else {
+            SpeakerInstallSegmentEmitter.INSTANCE.emitBatch(
+                    stateMachine.getCarrier(), commands, stateMachine.getIngressCommands());
+            stateMachine.getIngressCommands().forEach(
+                    (key, value) -> stateMachine.addPendingCommand(key, value.getSwitchId()));
+
             stateMachine.saveActionToHistory("Commands for installing ingress rules have been sent");
         }
     }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/InstallNonIngressRulesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/InstallNonIngressRulesAction.java
@@ -70,16 +70,18 @@ public class InstallNonIngressRulesAction
                     newProtectedForward, newProtectedReverse));
         }
 
-        // emitting
-        SpeakerInstallSegmentEmitter.INSTANCE.emitBatch(
-                stateMachine.getCarrier(), commands, stateMachine.getNonIngressCommands());
-        stateMachine.getNonIngressCommands().forEach(
-                (key, value) -> stateMachine.getPendingCommands().put(key, value.getSwitchId()));
+        stateMachine.clearPendingAndRetriedAndFailedCommands();
 
         if (commands.isEmpty()) {
             stateMachine.saveActionToHistory("No need to install non ingress rules");
             stateMachine.fire(Event.RULES_INSTALLED);
         } else {
+            // emitting
+            SpeakerInstallSegmentEmitter.INSTANCE.emitBatch(
+                    stateMachine.getCarrier(), commands, stateMachine.getNonIngressCommands());
+            stateMachine.getNonIngressCommands().forEach(
+                    (key, value) -> stateMachine.addPendingCommand(key, value.getSwitchId()));
+
             stateMachine.saveActionToHistory("Commands for installing non ingress rules have been sent");
         }
     }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/OnReceivedRemoveOrRevertResponseAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/OnReceivedRemoveOrRevertResponseAction.java
@@ -52,7 +52,7 @@ public class OnReceivedRemoveOrRevertResponseAction extends
         }
 
         if (response.isSuccess()) {
-            stateMachine.getPendingCommands().remove(commandId);
+            stateMachine.removePendingCommand(commandId);
 
             if (removeCommand != null) {
                 stateMachine.saveActionToHistory("Rule was deleted",
@@ -66,27 +66,25 @@ public class OnReceivedRemoveOrRevertResponseAction extends
         } else {
             FlowErrorResponse errorResponse = (FlowErrorResponse) response;
 
-            int retries = stateMachine.getRetriedCommands().getOrDefault(commandId, 0);
-            if (retries < speakerCommandRetriesLimit) {
-                stateMachine.getRetriedCommands().put(commandId, ++retries);
-
+            int attempt = stateMachine.doRetryForCommand(commandId);
+            if (attempt <= speakerCommandRetriesLimit) {
                 if (removeCommand != null) {
                     stateMachine.saveErrorToHistory("Failed to remove rule", format(
                             "Failed to remove the rule: commandId %s, switch %s, cookie %s. Error %s. "
                                     + "Retrying (attempt %d)",
-                            commandId, errorResponse.getSwitchId(), removeCommand.getCookie(), errorResponse, retries));
+                            commandId, errorResponse.getSwitchId(), removeCommand.getCookie(), errorResponse, attempt));
 
                     stateMachine.getCarrier().sendSpeakerRequest(removeCommand.makeRemoveRequest(commandId));
                 } else {
                     stateMachine.saveErrorToHistory("Failed to re-install (revert) rule", format(
                             "Failed to install the rule: commandId %s, switch %s, cookie %s. Error %s. "
                                     + "Retrying (attempt %d)", commandId, errorResponse.getSwitchId(),
-                            installCommand.getCookie(), errorResponse, retries));
+                            installCommand.getCookie(), errorResponse, attempt));
 
                     stateMachine.getCarrier().sendSpeakerRequest(installCommand.makeInstallRequest(commandId));
                 }
             } else {
-                stateMachine.getPendingCommands().remove(commandId);
+                stateMachine.removePendingCommand(commandId);
 
                 if (removeCommand != null) {
                     stateMachine.saveErrorToHistory("Failed to remove rule", format(
@@ -97,7 +95,7 @@ public class OnReceivedRemoveOrRevertResponseAction extends
                             "Failed to install the rule: commandId %s, switch %s, cookie %s. Error: %s",
                             commandId, errorResponse.getSwitchId(), installCommand.getCookie(), errorResponse));
                 }
-                stateMachine.getFailedCommands().put(commandId, errorResponse);
+                stateMachine.addFailedCommand(commandId, errorResponse);
             }
         }
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RemoveOldRulesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RemoveOldRulesAction.java
@@ -134,17 +134,19 @@ public class RemoveOldRulesAction extends
                         stateMachine.getCommandContext(), originalFlow, oldReverse));
             }
         }
-        SpeakerRemoveSegmentEmitter.INSTANCE.emitBatch(
-                stateMachine.getCarrier(), factories, stateMachine.getRemoveCommands());
-        stateMachine.getRemoveCommands().forEach(
-                (key, value) -> stateMachine.getPendingCommands().put(key, value.getSwitchId()));
-        stateMachine.getRetriedCommands().clear();
+
+        stateMachine.clearPendingAndRetriedAndFailedCommands();
 
         if (factories.isEmpty()) {
             stateMachine.saveActionToHistory("No need to remove old rules");
 
             stateMachine.fire(Event.RULES_REMOVED);
         } else {
+            SpeakerRemoveSegmentEmitter.INSTANCE.emitBatch(
+                    stateMachine.getCarrier(), factories, stateMachine.getRemoveCommands());
+            stateMachine.getRemoveCommands().forEach(
+                    (key, value) -> stateMachine.addPendingCommand(key, value.getSwitchId()));
+
             stateMachine.saveActionToHistory("Remove commands for old rules have been sent");
         }
     }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RevertPathsSwapAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/RevertPathsSwapAction.java
@@ -18,7 +18,6 @@ package org.openkilda.wfm.topology.flowhs.fsm.update.actions;
 import static java.lang.String.format;
 
 import org.openkilda.model.Flow;
-import org.openkilda.model.FlowPath;
 import org.openkilda.model.FlowPathStatus;
 import org.openkilda.model.PathId;
 import org.openkilda.persistence.PersistenceManager;
@@ -46,66 +45,93 @@ public class RevertPathsSwapAction extends FlowProcessingAction<FlowUpdateFsm, S
         transactionManager.doInTransaction(() -> {
             Flow flow = getFlow(stateMachine.getFlowId());
 
-            if (stateMachine.getOldPrimaryForwardPath() != null) {
-                FlowPath oldForward = getFlowPath(stateMachine.getOldPrimaryForwardPath());
-                if (oldForward.getStatus() != FlowPathStatus.ACTIVE) {
-                    oldForward.setStatus(stateMachine.getOldPrimaryForwardPathStatus());
+            if (stateMachine.getNewPrimaryForwardPath() != null) {
+                PathId oldPrimaryForward = stateMachine.getOldPrimaryForwardPath();
+                if (oldPrimaryForward != null) {
+                    flowPathRepository.findById(oldPrimaryForward)
+                            .ifPresent(path -> {
+                                if (path.getStatus() != FlowPathStatus.ACTIVE) {
+                                    path.setStatus(stateMachine.getOldPrimaryForwardPathStatus());
+                                }
+                            });
                 }
 
                 log.debug("Swapping back the primary forward path {} with {}",
-                        flow.getForwardPathId(), oldForward.getPathId());
+                        flow.getForwardPathId(), oldPrimaryForward != null ? oldPrimaryForward : "no path");
 
-                flow.setForwardPathId(oldForward.getPathId());
+                flow.setForwardPathId(oldPrimaryForward);
 
-                saveHistory(stateMachine, flow.getFlowId(), oldForward.getPathId());
+                saveHistory(stateMachine, flow.getFlowId(), oldPrimaryForward);
             }
 
-            if (stateMachine.getOldPrimaryReversePath() != null) {
-                FlowPath oldReverse = getFlowPath(stateMachine.getOldPrimaryReversePath());
-                if (oldReverse.getStatus() != FlowPathStatus.ACTIVE) {
-                    oldReverse.setStatus(stateMachine.getOldPrimaryReversePathStatus());
+            if (stateMachine.getNewPrimaryReversePath() != null) {
+                PathId oldPrimaryReverse = stateMachine.getOldPrimaryReversePath();
+                if (oldPrimaryReverse != null) {
+                    flowPathRepository.findById(oldPrimaryReverse)
+                            .ifPresent(path -> {
+                                if (path.getStatus() != FlowPathStatus.ACTIVE) {
+                                    path.setStatus(stateMachine.getOldPrimaryReversePathStatus());
+                                }
+                            });
                 }
 
                 log.debug("Swapping back the primary reverse path {} with {}",
-                        flow.getReversePathId(), oldReverse.getPathId());
+                        flow.getReversePathId(), oldPrimaryReverse != null ? oldPrimaryReverse : "no path");
 
-                flow.setReversePathId(oldReverse.getPathId());
+                flow.setReversePathId(oldPrimaryReverse);
 
-                saveHistory(stateMachine, flow.getFlowId(), oldReverse.getPathId());
+                saveHistory(stateMachine, flow.getFlowId(), oldPrimaryReverse);
             }
 
-            if (stateMachine.getOldProtectedForwardPath() != null) {
-                FlowPath oldForward = getFlowPath(stateMachine.getOldProtectedForwardPath());
-                if (oldForward.getStatus() != FlowPathStatus.ACTIVE) {
-                    oldForward.setStatus(stateMachine.getOldProtectedForwardPathStatus());
+            if (stateMachine.getNewProtectedForwardPath() != null) {
+                PathId oldProtectedForward = stateMachine.getOldProtectedForwardPath();
+                if (oldProtectedForward != null) {
+                    flowPathRepository.findById(oldProtectedForward)
+                            .ifPresent(path -> {
+                                if (path.getStatus() != FlowPathStatus.ACTIVE) {
+                                    path.setStatus(stateMachine.getOldProtectedForwardPathStatus());
+                                }
+                            });
                 }
 
                 log.debug("Swapping back the protected forward path {} with {}",
-                        flow.getProtectedForwardPathId(), oldForward.getPathId());
+                        flow.getProtectedForwardPathId(),
+                        oldProtectedForward != null ? oldProtectedForward : "no path");
 
-                flow.setProtectedForwardPathId(oldForward.getPathId());
+                flow.setProtectedForwardPathId(oldProtectedForward);
 
-                saveHistory(stateMachine, flow.getFlowId(), oldForward.getPathId());
+                saveHistory(stateMachine, flow.getFlowId(), oldProtectedForward);
             }
 
-            if (stateMachine.getOldProtectedReversePath() != null) {
-                FlowPath oldReverse = getFlowPath(stateMachine.getOldProtectedReversePath());
-                if (oldReverse.getStatus() != FlowPathStatus.ACTIVE) {
-                    oldReverse.setStatus(stateMachine.getOldProtectedReversePathStatus());
+            if (stateMachine.getNewProtectedReversePath() != null) {
+                PathId oldProtectedReverse = stateMachine.getOldProtectedReversePath();
+                if (oldProtectedReverse != null) {
+                    flowPathRepository.findById(oldProtectedReverse)
+                            .ifPresent(path -> {
+                                if (path.getStatus() != FlowPathStatus.ACTIVE) {
+                                    path.setStatus(stateMachine.getOldProtectedReversePathStatus());
+                                }
+                            });
                 }
 
                 log.debug("Swapping back the protected reverse path {} with {}",
-                        flow.getProtectedReversePathId(), oldReverse.getPathId());
+                        flow.getProtectedReversePathId(),
+                        oldProtectedReverse != null ? oldProtectedReverse : "no path");
 
-                flow.setProtectedReversePathId(oldReverse.getPathId());
+                flow.setProtectedReversePathId(oldProtectedReverse);
 
-                saveHistory(stateMachine, flow.getFlowId(), oldReverse.getPathId());
+                saveHistory(stateMachine, flow.getFlowId(), oldProtectedReverse);
             }
         });
     }
 
     private void saveHistory(FlowUpdateFsm stateMachine, String flowId, PathId pathId) {
-        stateMachine.saveActionToHistory("Flow was reverted to old paths",
-                format("The flow %s was updated with the path %s", flowId, pathId));
+        String description;
+        if (pathId != null) {
+            description = format("The flow %s was updated with the path %s", flowId, pathId);
+        } else {
+            description = format("The flow %s was updated with no path", flowId);
+        }
+        stateMachine.saveActionToHistory("Flow was reverted to old paths", description);
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/ValidateIngressRulesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/ValidateIngressRulesAction.java
@@ -53,26 +53,24 @@ public class ValidateIngressRulesAction extends
         }
 
         if (response.isSuccess()) {
-            stateMachine.getPendingCommands().remove(commandId);
+            stateMachine.removePendingCommand(commandId);
             stateMachine.saveActionToHistory("Rule was validated",
                     format("The ingress rule has been validated successfully: switch %s, cookie %s",
                             command.getSwitchId(), command.getCookie()));
         } else {
             FlowErrorResponse errorResponse = (FlowErrorResponse) response;
 
-            int retries = stateMachine.getRetriedCommands().getOrDefault(commandId, 0);
-            if (retries < speakerCommandRetriesLimit
+            int attempt = stateMachine.doRetryForCommand(commandId);
+            if (attempt <= speakerCommandRetriesLimit
                     && errorResponse.getErrorCode() != FlowErrorResponse.ErrorCode.MISSING_OF_FLOWS) {
-                stateMachine.getRetriedCommands().put(commandId, ++retries);
-
                 stateMachine.saveErrorToHistory(RULE_VALIDATION_FAILED_ACTION, format(
                         "Failed to validate the ingress rule: commandId %s, switch %s, cookie %s. Error %s. "
                                 + "Retrying (attempt %d)",
-                        commandId, errorResponse.getSwitchId(), command.getCookie(), errorResponse, retries));
+                        commandId, errorResponse.getSwitchId(), command.getCookie(), errorResponse, attempt));
 
                 stateMachine.getCarrier().sendSpeakerRequest(command.makeInstallRequest(commandId));
             } else if (stateMachine.isDoNotRevert()) {
-                stateMachine.getPendingCommands().remove(commandId);
+                stateMachine.removePendingCommand(commandId);
                 stateMachine.saveErrorToHistory(RULE_VALIDATION_FAILED_ACTION, format(
                                 "Failed to validate the ingress rule: commandId %s, switch %s, cookie %s. Error %s. "
                                         + "Skipping validation attempts",
@@ -80,7 +78,7 @@ public class ValidateIngressRulesAction extends
                 stateMachine.setNewFlowStatus(FlowStatus.DOWN);
                 stateMachine.setErrorReason(RULE_VALIDATION_FAILED_ACTION);
             } else {
-                stateMachine.getPendingCommands().remove(commandId);
+                stateMachine.removePendingCommand(commandId);
 
                 stateMachine.saveErrorToHistory(RULE_VALIDATION_FAILED_ACTION,
                         format("Failed to validate the ingress rule: commandId %s, switch %s, cookie %s. Error %s",


### PR DESCRIPTION
The changes:
- Fix RevertPathsSwapAction to prevent flows with excessive paths.
- Fix reverting of the flow status in a case of timeout or error. 
- Revise Flow FSMs to ensure that the error and timeout events are handled properly, and there're no dead ends.
- Unify how FSMs are working with pending, retried and failed command lists.
 
Related to #3090