### PR TITLE
Remove stale option

### DIFF
--- a/confd/templates/base-storm-topology/topology.properties.tmpl
+++ b/confd/templates/base-storm-topology/topology.properties.tmpl
@@ -88,7 +88,6 @@ discovery.db.write.repeats.time.frame = {{ getv "/kilda_discovery_db_write_repea
 # multi-FL
 floodlight.alive.timeout = {{ getv "/kilda_floodlight_alive_timeout" }}
 floodlight.alive.interval = {{ getv "/kilda_floodlight_alive_interval" }}
-message.blacklist.timeout = {{ getv "/kilda_message_blacklist_timeout" }}
 floodlight.regions = {{ getv "/kilda_floodlight_regions" }}
 # floodlight.switch.mapping.remove.delay.seconds = 900
 

--- a/confd/vars/main.yaml
+++ b/confd/vars/main.yaml
@@ -110,7 +110,6 @@ kilda_pce_network_strategy: "SYMMETRIC_COST"
 
 kilda_floodlight_alive_timeout: 10
 kilda_floodlight_alive_interval: 2
-kilda_message_blacklist_timeout: 180
 
 kilda_logging_json_file: False
 kilda_logging_logstash: True

--- a/src-java/base-topology/base-storm-topology/src/release/resources/topology.properties.example
+++ b/src-java/base-topology/base-storm-topology/src/release/resources/topology.properties.example
@@ -86,7 +86,6 @@ discovery.db.write.repeats.time.frame = 30
 # multi-FL
 floodlight.alive.timeout = 10
 floodlight.alive.interval = 2
-message.blacklist.timeout = 180
 floodlight.regions = 1,1.stats,2
 # floodlight.switch.mapping.remove.delay.seconds = 900
 


### PR DESCRIPTION
Option "message.blacklist.timeout" was used long time ago somewhere in
floodlightrouter. It was removed in e1e25ff85120487feceee462d9ad1abcec4603cd.