### PR TITLE
Make traffexam to not hide into network namespace

### DIFF
--- a/src-python/lab-service/README.md
+++ b/src-python/lab-service/README.md
@@ -13,4 +13,4 @@ curl localhost:8288/api
 ```
 
 ## Traffic Examination
-A REST API wrapper above iperf. [Read more](https://github.com/telstra/open-kilda/blob/develop/services/lab-service/traffexam/README.rst)
+A REST API wrapper above iperf. [Read more](traffexam/README.rst)

--- a/src-python/lab-service/traffexam/kilda/traffexam/context.py
+++ b/src-python/lab-service/traffexam/kilda/traffexam/context.py
@@ -24,6 +24,7 @@ from kilda.traffexam import exc
 
 class Context(object):
     is_debug = False
+    is_allocate_network_namespace = True
 
     root = os.path.join(os.sep, 'var', 'run', const.PROJECT_NAME)
     service = None
@@ -39,6 +40,7 @@ class Context(object):
 
         self.set_root(self.root)
         self.set_debug_mode(self.is_debug)
+        self.set_allocate_namespace(self.is_allocate_network_namespace)
 
         self._init_done = True
 
@@ -92,6 +94,10 @@ class Context(object):
 
     def set_debug_mode(self, mode):
         self.is_debug = mode
+        return self
+
+    def set_allocate_namespace(self, need_allocate):
+        self.is_allocate_network_namespace = need_allocate
         return self
 
     def set_service_adapter(self, adapter):


### PR DESCRIPTION
To avoid issues with mac address filtering on some hardware ethernet
cards, making traffexam to be able to keep the original mac address of
produced IP packets.

To reach that goal we need to get rid of all intermediate "components"
between traffexam and hardware/virtual ethernet card. So there must be
no linux-bridge used now to pass traffic into the network namespace.
Also, the network namespace becomes excess in this case too.