### PR TITLE
Rework LATENCY path computation strategy

### DIFF
--- a/docs/design/pce/design.md
+++ b/docs/design/pce/design.md
@@ -64,7 +64,7 @@ To calculate a path with a weight less than max weight and as close to it as pos
 + current desired path is what we were looking for
 + if current desired path is empty then no path is found
 
-### Weight function
+### Path computation strategies
 
 Weight function is defined by path computation strategy.
 For now four strategies are available:
@@ -72,7 +72,8 @@ For now four strategies are available:
 
 Manually assigned value for each link. If link is under maintenance and/or link is unstable then it's cost is increased by preconfigured value.
 
-`Link weight = cost + underMaintenance * underMaintenanceCostRise + unstable * unstableCostRise` where underMaintenance and unstable are 0 when false and 1 when true.
+Weight function:
+`Link weight = cost + underMaintenance * underMaintenanceCostRise + unstable * unstableCostRise` where `underMaintenance` and `unstable` are 0 when false and 1 when true.
 
 * Cost and available bandwidth
 
@@ -82,7 +83,10 @@ The same as Cost strategy but if two paths has the same cost then the one with m
 
 Automatically calculated value for each link. Separate maintenance/unstable penalties is used when calculating link weight based on latency in a similar way as for cost.
 
-`Link weight = latency + underMaintenance * underMaintenanceLatencyRise + unstable * unstableLatencyRise` where underMaintenance and unstable are 0 when false and 1 when true. Exact value for `underMaintenanceLatencyRise` and `unstableLatencyRise` should be estimated with respect to average and maximal latency in the network. To avoid using unstable links in best path it's possible to choose 1 to 10 seconds latency penalties.
+Weight function:
+`Link weight = latency + underMaintenance * underMaintenanceLatencyRise + unstable * unstableLatencyRise` where `underMaintenance` and `unstable` are 0 when false and 1 when true. Exact value for `underMaintenanceLatencyRise` and `unstableLatencyRise` should be estimated with respect to average and maximal latency in the network. To avoid using unstable links in best path it's possible to choose 1 to 10 seconds latency penalties.
+
+`maxLatency` and `maxLatencyTier2` params are used to limit latency for found path. PCE will return `backUpPathComputationWayUsed = true` flag if found path has latency greater than `maxLatency`. Flows with such paths should be treated as DEGRADED because found path violates latency SLA. PCE will not return path with latency greater than `maxLatencyTier2`.
 
 * Max latency
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteServiceTest.java
@@ -102,7 +102,7 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         testExpectedFailure(dummyRequestKey, request, commandContext, origin, FlowStatus.DOWN, ErrorType.NOT_FOUND);
 
         verify(pathComputer, times(11))
-                .getPath(makeFlowArgumentMatch(origin.getFlowId()), any(), any());
+                .getPath(makeFlowArgumentMatch(origin.getFlowId()), any());
     }
 
     @Test
@@ -115,7 +115,7 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         testExpectedFailure(dummyRequestKey, request, commandContext, origin, FlowStatus.UP, ErrorType.INTERNAL_ERROR);
 
         verify(pathComputer, times(PATH_ALLOCATION_RETRIES_LIMIT + 1))
-                .getPath(makeFlowArgumentMatch(origin.getFlowId()), any(), any());
+                .getPath(makeFlowArgumentMatch(origin.getFlowId()), any());
     }
 
     @Test
@@ -499,7 +499,7 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         transactionManager.doInTransaction(() ->
                 repositoryFactory.createFlowRepository().updateStatus(origin.getFlowId(), FlowStatus.DOWN));
 
-        when(pathComputer.getPath(makeFlowArgumentMatch(origin.getFlowId()), any(), any()))
+        when(pathComputer.getPath(makeFlowArgumentMatch(origin.getFlowId()), any()))
                 .thenReturn(make2SwitchAltPathPair())
                 .thenReturn(make3SwitchesPathPair());
 
@@ -664,12 +664,12 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
     private void preparePathComputation(String flowId, Throwable error)
             throws RecoverableException, UnroutableFlowException {
         doThrow(error).when(pathComputer)
-                .getPath(makeFlowArgumentMatch(flowId), any(), any());
+                .getPath(makeFlowArgumentMatch(flowId), any());
     }
 
     private void preparePathComputation(String flowId, GetPathsResult pathPair)
             throws RecoverableException, UnroutableFlowException {
-        when(pathComputer.getPath(makeFlowArgumentMatch(flowId), any(), any())).thenReturn(pathPair);
+        when(pathComputer.getPath(makeFlowArgumentMatch(flowId), any())).thenReturn(pathPair);
     }
 
     @Override

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowUpdateServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowUpdateServiceTest.java
@@ -94,7 +94,7 @@ public class FlowUpdateServiceTest extends AbstractFlowTest {
     @Test
     public void shouldFailUpdateFlowIfNoPathAvailable() throws RecoverableException, UnroutableFlowException {
         Flow origin = makeFlow();
-        when(pathComputer.getPath(makeFlowArgumentMatch(origin.getFlowId()), anyCollection(), any()))
+        when(pathComputer.getPath(makeFlowArgumentMatch(origin.getFlowId()), anyCollection()))
                 .thenThrow(new UnroutableFlowException(injectedErrorMessage));
 
         FlowRequest request = makeRequest()
@@ -105,13 +105,13 @@ public class FlowUpdateServiceTest extends AbstractFlowTest {
         Flow result = testExpectedFailure(request, origin, ErrorType.NOT_FOUND);
         Assert.assertEquals(origin.getBandwidth(), result.getBandwidth());
 
-        verify(pathComputer, times(11)).getPath(makeFlowArgumentMatch(origin.getFlowId()), any(), any());
+        verify(pathComputer, times(11)).getPath(makeFlowArgumentMatch(origin.getFlowId()), any());
     }
 
     @Test
     public void shouldFailUpdateFlowIfRecoverableException() throws RecoverableException, UnroutableFlowException {
         Flow origin = makeFlow();
-        when(pathComputer.getPath(makeFlowArgumentMatch(origin.getFlowId()), anyCollection(), any()))
+        when(pathComputer.getPath(makeFlowArgumentMatch(origin.getFlowId()), anyCollection()))
                 .thenThrow(new RecoverableException(injectedErrorMessage));
 
         FlowRequest request = makeRequest()
@@ -121,7 +121,7 @@ public class FlowUpdateServiceTest extends AbstractFlowTest {
         testExpectedFailure(request, origin, ErrorType.INTERNAL_ERROR);
 
         verify(pathComputer, times(PATH_ALLOCATION_RETRIES_LIMIT + 1))
-                .getPath(makeFlowArgumentMatch(origin.getFlowId()), any(), any());
+                .getPath(makeFlowArgumentMatch(origin.getFlowId()), any());
     }
 
     @Test
@@ -661,7 +661,7 @@ public class FlowUpdateServiceTest extends AbstractFlowTest {
 
     private void preparePathComputation(String flowId, GetPathsResult pathPair)
             throws RecoverableException, UnroutableFlowException {
-        when(pathComputer.getPath(makeFlowArgumentMatch(flowId), any(), any())).thenReturn(pathPair);
+        when(pathComputer.getPath(makeFlowArgumentMatch(flowId), any())).thenReturn(pathPair);
     }
 
     private FlowUpdateService makeService() {

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/PathComputer.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/PathComputer.java
@@ -39,9 +39,8 @@ public interface PathComputer {
      * @param flow the {@link Flow} instance
      * @return {@link PathPair} instances
      */
-    default GetPathsResult getPath(Flow flow, PathComputationStrategy... backUpStrategies)
-            throws UnroutableFlowException, RecoverableException {
-        return getPath(flow, Collections.emptyList(), backUpStrategies);
+    default GetPathsResult getPath(Flow flow) throws UnroutableFlowException, RecoverableException {
+        return getPath(flow, Collections.emptyList());
     }
 
     /**
@@ -52,8 +51,7 @@ public interface PathComputer {
      *                               be reused in new path computation.
      * @return {@link PathPair} instances
      */
-    GetPathsResult getPath(Flow flow, Collection<PathId> reusePathsResources,
-                           PathComputationStrategy... backUpStrategies)
+    GetPathsResult getPath(Flow flow, Collection<PathId> reusePathsResources)
             throws UnroutableFlowException, RecoverableException;
 
     /**

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/finder/PathFinder.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/finder/PathFinder.java
@@ -29,13 +29,26 @@ import java.util.List;
  */
 public interface PathFinder {
     /**
-     * Find a path from the start to the end switch.
+     * Find a path from the start to the end switch with min weight.
      *
      * @return a pair of ordered lists that represents the path from start to end, or an empty list if no path found.
      */
-    FindPathResult findPathInNetwork(AvailableNetwork network,
-                                     SwitchId startSwitchId, SwitchId endSwitchId,
-                                     WeightFunction weightFunction)
+    FindPathResult findPathWithMinWeight(AvailableNetwork network,
+                                         SwitchId startSwitchId, SwitchId endSwitchId,
+                                         WeightFunction weightFunction)
+            throws UnroutableFlowException;
+
+    /**
+     * Find a path from the start to the end switch with min weight and latency limits.
+     *
+     * @return a pair of ordered lists that represents the path from start to end, or an empty list if no path found.
+     *     Returns backUpPathComputationWayUsed = true if found path has latency greater than maxLatency.
+     *     Returns empty path if found path has latency greater than latencyLimit.
+     */
+    FindPathResult findPathWithMinWeightAndLatencyLimits(AvailableNetwork network,
+                                                         SwitchId startSwitchId, SwitchId endSwitchId,
+                                                         WeightFunction weightFunction,
+                                                         long maxLatency, long latencyLimit)
             throws UnroutableFlowException;
 
     /**
@@ -44,9 +57,10 @@ public interface PathFinder {
      *
      * @return a pair of ordered lists that represents the path from start to end, or an empty list if no path found.
      */
-    FindPathResult findPathInNetwork(AvailableNetwork network,
-                                     SwitchId startSwitchId, SwitchId endSwitchId,
-                                     WeightFunction weightFunction, long maxWeight, long backUpMaxWeight)
+    FindPathResult findPathWithWeightCloseToMaxWeight(AvailableNetwork network,
+                                                      SwitchId startSwitchId, SwitchId endSwitchId,
+                                                      WeightFunction weightFunction,
+                                                      long maxWeight, long backUpMaxWeight)
             throws UnroutableFlowException;
 
     /**

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/impl/InMemoryPathComputer.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/impl/InMemoryPathComputer.java
@@ -39,8 +39,6 @@ import org.openkilda.pce.model.WeightFunction;
 
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -69,25 +67,11 @@ public class InMemoryPathComputer implements PathComputer {
     }
 
     @Override
-    public GetPathsResult getPath(
-            Flow flow, Collection<PathId> reusePathsResources, PathComputationStrategy... backUpStrategies)
+    public GetPathsResult getPath(Flow flow, Collection<PathId> reusePathsResources)
             throws UnroutableFlowException, RecoverableException {
-        List<PathComputationStrategy> strategies = new ArrayList<>();
-        strategies.add(flow.getPathComputationStrategy());
-        strategies.addAll(Arrays.asList(backUpStrategies));
-
         AvailableNetwork network = availableNetworkFactory.getAvailableNetwork(flow, reusePathsResources);
 
-        for (int i = 0; i < strategies.size() - 1; i++) {
-            try {
-                return getPath(network, flow, strategies.get(i));
-            } catch (UnroutableFlowException e) {
-                log.warn(String.format("No path found for flow '%s' with '%s' strategy. Will try with "
-                        + "'%s' strategy.", flow.getFlowId(), strategies.get(i), strategies.get(i + 1)), e);
-            }
-        }
-
-        return getPath(network, flow, strategies.get(strategies.size() - 1));
+        return getPath(network, flow, flow.getPathComputationStrategy());
     }
 
     private GetPathsResult getPath(AvailableNetwork network, Flow flow, PathComputationStrategy strategy)

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/BestWeightAndShortestPathFinderTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/BestWeightAndShortestPathFinderTest.java
@@ -75,7 +75,7 @@ public class BestWeightAndShortestPathFinderTest {
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(2);
         Pair<List<Edge>, List<Edge>> pairPath =
-                pathFinder.findPathInNetwork(network, SWITCH_ID_1, SWITCH_ID_4, WEIGHT_FUNCTION).getFoundPath();
+                pathFinder.findPathWithMinWeight(network, SWITCH_ID_1, SWITCH_ID_4, WEIGHT_FUNCTION).getFoundPath();
         List<Edge> fpath = pairPath.getLeft();
         assertThat(fpath, Matchers.hasSize(2));
         assertEquals(SWITCH_ID_2, fpath.get(1).getSrcSwitch().getSwitchId());
@@ -92,7 +92,7 @@ public class BestWeightAndShortestPathFinderTest {
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(2);
         Pair<List<Edge>, List<Edge>> pairPath =
-                pathFinder.findPathInNetwork(network, SWITCH_ID_4, SWITCH_ID_1, WEIGHT_FUNCTION).getFoundPath();
+                pathFinder.findPathWithMinWeight(network, SWITCH_ID_4, SWITCH_ID_1, WEIGHT_FUNCTION).getFoundPath();
         List<Edge> fpath = pairPath.getLeft();
         assertThat(fpath, Matchers.hasSize(2));
         assertEquals(SWITCH_ID_2, fpath.get(1).getSrcSwitch().getSwitchId());
@@ -108,7 +108,7 @@ public class BestWeightAndShortestPathFinderTest {
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(4);
         Pair<List<Edge>, List<Edge>> pairPath =
-                pathFinder.findPathInNetwork(network, SWITCH_ID_1, SWITCH_ID_4, WEIGHT_FUNCTION).getFoundPath();
+                pathFinder.findPathWithMinWeight(network, SWITCH_ID_1, SWITCH_ID_4, WEIGHT_FUNCTION).getFoundPath();
         List<Edge> fpath = pairPath.getLeft();
         assertThat(fpath, Matchers.hasSize(4));
         assertEquals(SWITCH_ID_5, fpath.get(3).getSrcSwitch().getSwitchId());
@@ -124,7 +124,7 @@ public class BestWeightAndShortestPathFinderTest {
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(3);
         Pair<List<Edge>, List<Edge>> pairPath =
-                pathFinder.findPathInNetwork(network, SWITCH_ID_1, SWITCH_ID_5, WEIGHT_FUNCTION).getFoundPath();
+                pathFinder.findPathWithMinWeight(network, SWITCH_ID_1, SWITCH_ID_5, WEIGHT_FUNCTION).getFoundPath();
         List<Edge> fpath = pairPath.getLeft();
         assertThat(fpath, Matchers.hasSize(3));
         assertEquals(SWITCH_ID_3, fpath.get(2).getSrcSwitch().getSwitchId());
@@ -140,7 +140,7 @@ public class BestWeightAndShortestPathFinderTest {
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(2);
         Pair<List<Edge>, List<Edge>> pairPath =
-                pathFinder.findPathInNetwork(network, SWITCH_ID_1, SWITCH_ID_3, WEIGHT_FUNCTION,
+                pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_1, SWITCH_ID_3, WEIGHT_FUNCTION,
                         Long.MAX_VALUE, Long.MAX_VALUE).getFoundPath();
         List<Edge> fpath = pairPath.getLeft();
         assertThat(fpath, Matchers.hasSize(2));
@@ -158,7 +158,7 @@ public class BestWeightAndShortestPathFinderTest {
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(2);
         Pair<List<Edge>, List<Edge>> pairPath =
-                pathFinder.findPathInNetwork(network, SWITCH_ID_3, SWITCH_ID_1, WEIGHT_FUNCTION,
+                pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_3, SWITCH_ID_1, WEIGHT_FUNCTION,
                         Long.MAX_VALUE, Long.MAX_VALUE).getFoundPath();
         List<Edge> fpath = pairPath.getLeft();
         assertThat(fpath, Matchers.hasSize(2));
@@ -175,7 +175,7 @@ public class BestWeightAndShortestPathFinderTest {
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(4);
         Pair<List<Edge>, List<Edge>> pairPath =
-                pathFinder.findPathInNetwork(network, SWITCH_ID_1, SWITCH_ID_3, WEIGHT_FUNCTION,
+                pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_1, SWITCH_ID_3, WEIGHT_FUNCTION,
                         Long.MAX_VALUE, Long.MAX_VALUE).getFoundPath();
         List<Edge> fpath = pairPath.getLeft();
         assertThat(fpath, Matchers.hasSize(4));
@@ -192,7 +192,7 @@ public class BestWeightAndShortestPathFinderTest {
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(3);
         Pair<List<Edge>, List<Edge>> pairPath =
-                pathFinder.findPathInNetwork(network, SWITCH_ID_1, SWITCH_ID_5, WEIGHT_FUNCTION,
+                pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_1, SWITCH_ID_5, WEIGHT_FUNCTION,
                         Long.MAX_VALUE, Long.MAX_VALUE).getFoundPath();
         List<Edge> fpath = pairPath.getLeft();
         assertThat(fpath, Matchers.hasSize(3));
@@ -229,7 +229,7 @@ public class BestWeightAndShortestPathFinderTest {
         AvailableNetwork network = buildTestNetwork();
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(1);
-        pathFinder.findPathInNetwork(network, SWITCH_ID_D, SWITCH_ID_F, WEIGHT_FUNCTION);
+        pathFinder.findPathWithMinWeight(network, SWITCH_ID_D, SWITCH_ID_F, WEIGHT_FUNCTION);
     }
 
     @Test(expected = UnroutableFlowException.class)
@@ -237,7 +237,7 @@ public class BestWeightAndShortestPathFinderTest {
         AvailableNetwork network = buildTestNetwork();
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(1);
-        pathFinder.findPathInNetwork(network, SWITCH_ID_D, SWITCH_ID_F, WEIGHT_FUNCTION,
+        pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_D, SWITCH_ID_F, WEIGHT_FUNCTION,
                 Long.MAX_VALUE, Long.MAX_VALUE);
     }
 
@@ -247,7 +247,7 @@ public class BestWeightAndShortestPathFinderTest {
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
         Pair<List<Edge>, List<Edge>> pairPath =
-                pathFinder.findPathInNetwork(network, SWITCH_ID_E, SWITCH_ID_F, WEIGHT_FUNCTION).getFoundPath();
+                pathFinder.findPathWithMinWeight(network, SWITCH_ID_E, SWITCH_ID_F, WEIGHT_FUNCTION).getFoundPath();
         List<Edge> fpath = pairPath.getLeft();
         assertThat(fpath, Matchers.hasSize(2));
         assertEquals(SWITCH_ID_E, fpath.get(0).getSrcSwitch().getSwitchId());
@@ -286,8 +286,8 @@ public class BestWeightAndShortestPathFinderTest {
         AvailableNetwork network = buildThreePathsNetwork();
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
         //when: request a path with maxWeight 201
-        FindPathResult pathResult = pathFinder.findPathInNetwork(network, SWITCH_ID_1, SWITCH_ID_5, WEIGHT_FUNCTION,
-                maxWeight, backUpMaxWeight);
+        FindPathResult pathResult = pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_1, SWITCH_ID_5,
+                WEIGHT_FUNCTION, maxWeight, backUpMaxWeight);
         Pair<List<Edge>, List<Edge>> pairPath = pathResult.getFoundPath();
 
         //then: system picks 200 path
@@ -326,8 +326,8 @@ public class BestWeightAndShortestPathFinderTest {
         AvailableNetwork network = buildThreePathsNetwork();
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
         //when: request a path with maxWeight 200
-        FindPathResult pathResult = pathFinder.findPathInNetwork(network, SWITCH_ID_1, SWITCH_ID_5, WEIGHT_FUNCTION,
-                maxWeight, backUpMaxWeight);
+        FindPathResult pathResult = pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_1, SWITCH_ID_5,
+                WEIGHT_FUNCTION, maxWeight, backUpMaxWeight);
         Pair<List<Edge>, List<Edge>> pairPath = pathResult.getFoundPath();
 
         //then: system picks 198 path
@@ -370,8 +370,8 @@ public class BestWeightAndShortestPathFinderTest {
         addLink(network, SWITCH_ID_2, SWITCH_ID_1, 2, 2, 100, 0, false, false);
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
         //when: request a path with maxWeight 103
-        FindPathResult pathResult = pathFinder.findPathInNetwork(network, SWITCH_ID_1, SWITCH_ID_2, WEIGHT_FUNCTION,
-                maxWeight, backUpMaxWeight);
+        FindPathResult pathResult = pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_1, SWITCH_ID_2,
+                WEIGHT_FUNCTION, maxWeight, backUpMaxWeight);
         Pair<List<Edge>, List<Edge>> pairPath = pathResult.getFoundPath();
         //then: pick path1, because its reverse cost is 102 which is the closest to 103
         //system skips path2 even though its forward cost is 101, which is closer to 103 than 100 (path1 forward)
@@ -395,7 +395,7 @@ public class BestWeightAndShortestPathFinderTest {
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
         //when: request a best-latency path
         Pair<List<Edge>, List<Edge>> pairPath =
-                pathFinder.findPathInNetwork(network, SWITCH_ID_1, SWITCH_ID_2, WEIGHT_FUNCTION).getFoundPath();
+                pathFinder.findPathWithMinWeight(network, SWITCH_ID_1, SWITCH_ID_2, WEIGHT_FUNCTION).getFoundPath();
         //then: pick path2, because its forward cost is 100 which is less than forward 101 of path1
         //system ignores that path1 reverse cost is actually the best of all (99), since it only uses forward
         assertThat(pairPath.getLeft().get(0).getSrcPort(), equalTo(2));
@@ -411,7 +411,7 @@ public class BestWeightAndShortestPathFinderTest {
         AvailableNetwork network = buildThreePathsNetwork();
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
         //when: request a path with maxWeight 198
-        pathFinder.findPathInNetwork(network, SWITCH_ID_1, SWITCH_ID_5, WEIGHT_FUNCTION, 198L, 198L);
+        pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_1, SWITCH_ID_5, WEIGHT_FUNCTION, 198L, 198L);
         //then: no path found
     }
 
@@ -422,7 +422,7 @@ public class BestWeightAndShortestPathFinderTest {
         SwitchId srcDpid = new SwitchId("00:00:00:00:00:00:00:ff");
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
-        pathFinder.findPathInNetwork(network, srcDpid, SWITCH_ID_F, WEIGHT_FUNCTION);
+        pathFinder.findPathWithMinWeight(network, srcDpid, SWITCH_ID_F, WEIGHT_FUNCTION);
     }
 
     @Test(expected = UnroutableFlowException.class)
@@ -432,7 +432,7 @@ public class BestWeightAndShortestPathFinderTest {
         SwitchId srcDpid = new SwitchId("00:00:00:00:00:00:00:ff");
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
-        pathFinder.findPathInNetwork(network, srcDpid, SWITCH_ID_F, WEIGHT_FUNCTION,
+        pathFinder.findPathWithWeightCloseToMaxWeight(network, srcDpid, SWITCH_ID_F, WEIGHT_FUNCTION,
                 Long.MAX_VALUE, Long.MAX_VALUE);
     }
 
@@ -441,7 +441,7 @@ public class BestWeightAndShortestPathFinderTest {
         AvailableNetwork network = buildEqualCostsNetwork();
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
         Pair<List<Edge>, List<Edge>> paths =
-                pathFinder.findPathInNetwork(network, SWITCH_ID_1, SWITCH_ID_5, WEIGHT_FUNCTION).getFoundPath();
+                pathFinder.findPathWithMinWeight(network, SWITCH_ID_1, SWITCH_ID_5, WEIGHT_FUNCTION).getFoundPath();
 
         List<SwitchId> forwardSwitchPath = getSwitchIdsFlowPath(paths.getLeft());
         List<SwitchId> backwardSwitchPath = Lists.reverse(getSwitchIdsFlowPath(paths.getRight()));
@@ -456,7 +456,7 @@ public class BestWeightAndShortestPathFinderTest {
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
         Pair<List<Edge>, List<Edge>> paths =
-                pathFinder.findPathInNetwork(network, SWITCH_ID_D, SWITCH_ID_F, WEIGHT_FUNCTION).getFoundPath();
+                pathFinder.findPathWithMinWeight(network, SWITCH_ID_D, SWITCH_ID_F, WEIGHT_FUNCTION).getFoundPath();
 
         assertEquals(Arrays.asList(SWITCH_ID_D, SWITCH_ID_A, SWITCH_ID_F), getSwitchIdsFlowPath(paths.getLeft()));
     }
@@ -484,8 +484,8 @@ public class BestWeightAndShortestPathFinderTest {
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
         //when: request a path with maxWeight 201
-        FindPathResult pathResult = pathFinder.findPathInNetwork(network, SWITCH_ID_1, SWITCH_ID_5, WEIGHT_FUNCTION,
-                maxWeight, backUpMaxWeight);
+        FindPathResult pathResult = pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_1, SWITCH_ID_5,
+                WEIGHT_FUNCTION, maxWeight, backUpMaxWeight);
         Pair<List<Edge>, List<Edge>> pairPath = pathResult.getFoundPath();
 
         //then: system picks 198 path (since 200 path is no longer '200' due to diversity weight rise)
@@ -502,7 +502,7 @@ public class BestWeightAndShortestPathFinderTest {
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(2);
 
         Pair<List<Edge>, List<Edge>> pathPair =
-                pathFinder.findPathInNetwork(network, SWITCH_ID_1, SWITCH_ID_3, WEIGHT_FUNCTION).getFoundPath();
+                pathFinder.findPathWithMinWeight(network, SWITCH_ID_1, SWITCH_ID_3, WEIGHT_FUNCTION).getFoundPath();
         List<Edge> forward = pathPair.getLeft();
         List<Edge> reverse = Lists.reverse(pathPair.getRight());
 
@@ -558,7 +558,7 @@ public class BestWeightAndShortestPathFinderTest {
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
         Pair<List<Edge>, List<Edge>> paths =
-                pathFinder.findPathInNetwork(network, SWITCH_ID_1, SWITCH_ID_5, WEIGHT_FUNCTION).getFoundPath();
+                pathFinder.findPathWithMinWeight(network, SWITCH_ID_1, SWITCH_ID_5, WEIGHT_FUNCTION).getFoundPath();
 
         List<SwitchId> forwardSwitchPath = getSwitchIdsFlowPath(paths.getLeft());
         List<SwitchId> backwardSwitchPath = Lists.reverse(getSwitchIdsFlowPath(paths.getRight()));
@@ -584,8 +584,8 @@ public class BestWeightAndShortestPathFinderTest {
         AvailableNetwork network = buildNetworkWithCostInReversePathBiggerThanForward();
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
-        FindPathResult pathResult = pathFinder.findPathInNetwork(network, SWITCH_ID_1, SWITCH_ID_5, WEIGHT_FUNCTION,
-                maxWeight, backUpMaxWeight);
+        FindPathResult pathResult = pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_1, SWITCH_ID_5,
+                WEIGHT_FUNCTION, maxWeight, backUpMaxWeight);
         Pair<List<Edge>, List<Edge>> paths = pathResult.getFoundPath();
 
         List<Edge> fpath = paths.getLeft();
@@ -631,7 +631,7 @@ public class BestWeightAndShortestPathFinderTest {
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
         Pair<List<Edge>, List<Edge>> paths =
-                pathFinder.findPathInNetwork(network, SWITCH_ID_1, SWITCH_ID_3, WEIGHT_FUNCTION).getFoundPath();
+                pathFinder.findPathWithMinWeight(network, SWITCH_ID_1, SWITCH_ID_3, WEIGHT_FUNCTION).getFoundPath();
 
         List<SwitchId> forwardSwitchPath = getSwitchIdsFlowPath(paths.getLeft());
         List<SwitchId> reverseSwitchPath = Lists.reverse(getSwitchIdsFlowPath(paths.getRight()));
@@ -757,7 +757,7 @@ public class BestWeightAndShortestPathFinderTest {
 
         BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
         Pair<List<Edge>, List<Edge>> pairPath =
-                pathFinder.findPathInNetwork(network, SWITCH_ID_A, SWITCH_ID_B, WEIGHT_FUNCTION).getFoundPath();
+                pathFinder.findPathWithMinWeight(network, SWITCH_ID_A, SWITCH_ID_B, WEIGHT_FUNCTION).getFoundPath();
         List<Edge> forwardPath = pairPath.getLeft();
         assertThat(forwardPath, Matchers.hasSize(1));
         assertEquals(SWITCH_ID_A, forwardPath.get(0).getSrcSwitch().getSwitchId());
@@ -771,7 +771,7 @@ public class BestWeightAndShortestPathFinderTest {
         // Network where shortest path has under maintenance link.
         network = buildTestNetworkForVerifyIslConfig(true, false);
 
-        pairPath = pathFinder.findPathInNetwork(network, SWITCH_ID_A, SWITCH_ID_B, WEIGHT_FUNCTION).getFoundPath();
+        pairPath = pathFinder.findPathWithMinWeight(network, SWITCH_ID_A, SWITCH_ID_B, WEIGHT_FUNCTION).getFoundPath();
         forwardPath = pairPath.getLeft();
         assertThat(forwardPath, Matchers.hasSize(2));
         assertEquals(SWITCH_ID_A, forwardPath.get(0).getSrcSwitch().getSwitchId());
@@ -789,7 +789,7 @@ public class BestWeightAndShortestPathFinderTest {
         // Network where shortest path has under maintenance link and another short path has unstable link.
         network = buildTestNetworkForVerifyIslConfig(true, true);
 
-        pairPath = pathFinder.findPathInNetwork(network, SWITCH_ID_A, SWITCH_ID_B, WEIGHT_FUNCTION).getFoundPath();
+        pairPath = pathFinder.findPathWithMinWeight(network, SWITCH_ID_A, SWITCH_ID_B, WEIGHT_FUNCTION).getFoundPath();
         forwardPath = pairPath.getLeft();
         assertThat(forwardPath, Matchers.hasSize(3));
         assertEquals(SWITCH_ID_A, forwardPath.get(0).getSrcSwitch().getSwitchId());

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/InMemoryPathComputerBaseTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/InMemoryPathComputerBaseTest.java
@@ -307,30 +307,6 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
     }
 
     @Test
-    public void shouldUseBackupStrategiesWhenNoPathFound() throws RecoverableException, UnroutableFlowException {
-        createDiamond(IslStatus.ACTIVE, IslStatus.ACTIVE, 10, 20, "00:", 1, 150, 200);
-
-        Switch srcSwitch = getSwitchById("00:01");
-        Switch destSwitch = getSwitchById("00:04");
-
-        Flow flow = new TestFlowBuilder()
-                .srcSwitch(srcSwitch)
-                .destSwitch(destSwitch)
-                .maxLatency(100)
-                .maxLatencyTier2(101)
-                .pathComputationStrategy(PathComputationStrategy.MAX_LATENCY)
-                .build();
-
-        PathComputer pathComputer = new InMemoryPathComputer(availableNetworkFactory,
-                new BestWeightAndShortestPathFinder(5), config);
-        GetPathsResult path = pathComputer.getPath(flow, PathComputationStrategy.LATENCY);
-
-        assertTrue(path.isBackUpPathComputationWayUsed());
-        assertNotNull(path.getForward());
-        assertNotNull(path.getReverse());
-    }
-
-    @Test
     public void shouldUseBackUpWeightWhenNoPathFoundInMaxLatencyStrat()
             throws RecoverableException, UnroutableFlowException {
         // 1 - 2 - 4


### PR DESCRIPTION
Add support of maxLatency and maxLatencyTier2 params to LATENCY path computation strategy. Flow operations should move flow to DEGRADED state If found path has latency more than maxLatency and to DOWN state if found path has latency more than maxLatencyTier2.

Related to #3968 