### PR TITLE
Use the same consumer group for both northbound colors

### DIFF
--- a/confd/templates/docker-compose/docker-compose.tmpl
+++ b/confd/templates/docker-compose/docker-compose.tmpl
@@ -489,7 +489,7 @@ services:
       context: docker
       dockerfile: northbound/Dockerfile
     ports:
-      - "8787:8080"
+      - "8080:8080"
     environment:
       REST_USERNAME: 'kilda'
       REST_PASSWORD: 'kilda'

--- a/confd/templates/makefile/makefile.tmpl
+++ b/confd/templates/makefile/makefile.tmpl
@@ -49,19 +49,22 @@ up-test-mode:
 
 up-stable:
 	cp -n .env.example .env
+	docker-compose stop northbound-blue-green
 	TAG=$(STABLE_TAG) WFM_TOPOLOGIES_MODE=blue docker-compose up -d --scale northbound-blue-green=0 {{if not (exists "/no_grpc_speaker")}}--scale grpc-speaker-blue-green=0{{end}}
 	docker-compose logs -f wfm
 	$(MAKE) -C tools/elk-dashboards
 
 up-green:
 	cp -n .env.example .env
-	WFM_TOPOLOGIES_MODE=green docker-compose up -d floodlight_2 northbound-blue-green wfm {{if not (exists "/no_grpc_speaker")}}grpc-speaker-blue-green{{end}}
+	docker-compose stop northbound
+	WFM_TOPOLOGIES_MODE=green docker-compose up -d --scale northbound=0 floodlight_2 northbound-blue-green wfm {{if not (exists "/no_grpc_speaker")}}grpc-speaker-blue-green{{end}}
 	docker-compose logs -f wfm
 	$(MAKE) -C tools/elk-dashboards
 
 up-blue:
 	cp -n .env.example .env
-	TAG=$(STABLE_TAG) WFM_TOPOLOGIES_MODE=blue docker-compose up -d floodlight_1 wfm
+	docker-compose stop northbound-blue-green
+	TAG=$(STABLE_TAG) WFM_TOPOLOGIES_MODE=blue docker-compose up -d --scale northbound-blue-green=0 floodlight_1 wfm
 	docker-compose logs -f wfm
 	$(MAKE) -C tools/elk-dashboards
 

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/config/MessageConsumerConfig.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/config/MessageConsumerConfig.java
@@ -105,7 +105,7 @@ public class MessageConsumerConfig {
     private Map<String, Object> consumerConfigs() {
         return ImmutableMap.<String, Object>builder()
                 .put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaHosts)
-                .put(ConsumerConfig.GROUP_ID_CONFIG, buildGroupId())
+                .put(ConsumerConfig.GROUP_ID_CONFIG, groupId)
                 .put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, true)
                 .put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, kafkaSessionTimeout)
                 .put(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, VersioningConsumerInterceptor.class.getName())
@@ -156,9 +156,5 @@ public class MessageConsumerConfig {
     @Bean
     public MessagingChannel messagingChannel() {
         return new KafkaMessagingChannel();
-    }
-
-    private String buildGroupId() {
-        return String.format("%s-%s", groupId, blueGreenMode);
     }
 }


### PR DESCRIPTION
this patch removes color for nb in different envs, since it's a
singleton anyway. So it's reduce operations part on cleaning group
offset