### PR TITLE
Correct grpc speaker consumer group id

### DIFF
--- a/src-java/grpc-speaker/grpc-service/src/main/java/org/openkilda/grpc/speaker/messaging/KafkaMessageListener.java
+++ b/src-java/grpc-speaker/grpc-service/src/main/java/org/openkilda/grpc/speaker/messaging/KafkaMessageListener.java
@@ -33,7 +33,7 @@ import org.springframework.stereotype.Component;
  */
 @Slf4j
 @Component
-@KafkaListener(id = "grpc-listener", topics = "#{kafkaTopicsConfig.getGrpcSpeakerTopic()}")
+@KafkaListener(topics = "#{kafkaTopicsConfig.getGrpcSpeakerTopic()}")
 public class KafkaMessageListener {
 
     @Autowired


### PR DESCRIPTION
Do not pass "id" argument into @KafkaListener annotation into
grpc-speaker to disallow overriding of group-id passed into consumer
factory.