### PR TITLE
Improve get paths api response

### DIFF
--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/network/Path.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/network/Path.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.io.Serializable;
+import java.time.Duration;
 import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -31,13 +32,13 @@ public class Path implements Serializable {
     private Long bandwidth;
 
     @JsonProperty("latency")
-    private Long latency;
+    private Duration latency;
 
     @JsonProperty("nodes")
     private List<PathNodePayload> nodes;
 
     public Path(@JsonProperty("bandwidth") Long bandwidth,
-                @JsonProperty("latency") Long latency,
+                @JsonProperty("latency") Duration latency,
                 @JsonProperty("nodes") List<PathNodePayload> nodes) {
         this.bandwidth = bandwidth;
         this.latency = latency;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/network/PathDto.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/network/PathDto.java
@@ -17,10 +17,12 @@ package org.openkilda.messaging.payload.network;
 
 import org.openkilda.messaging.payload.flow.PathNodePayload;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Value;
 
+import java.time.Duration;
 import java.util.List;
 
 @Value
@@ -32,14 +34,29 @@ public class PathDto {
     @JsonProperty("latency")
     private Long latency;
 
+    @JsonProperty("latency_ns")
+    private Long latencyNs;
+
+    @JsonProperty("latency_ms")
+    private Long latencyMs;
+
     @JsonProperty("nodes")
     private List<PathNodePayload> nodes;
 
+    public PathDto(Long bandwidth, Duration latency, List<PathNodePayload> nodes) {
+        this(bandwidth, latency.toNanos(), latency.toNanos(), latency.toMillis(), nodes);
+    }
+
+    @JsonCreator
     public PathDto(@JsonProperty("bandwidth") Long bandwidth,
                    @JsonProperty("latency") Long latency,
+                   @JsonProperty("latency_ns") Long latencyNs,
+                   @JsonProperty("latency_ms") Long latencyMs,
                    @JsonProperty("nodes") List<PathNodePayload> nodes) {
         this.bandwidth = bandwidth;
         this.latency = latency;
+        this.latencyNs = latencyNs;
+        this.latencyMs = latencyMs;
         this.nodes = nodes;
     }
 }

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/mappers/PathMapper.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/mappers/PathMapper.java
@@ -22,6 +22,7 @@ import org.openkilda.pce.Path.Segment;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,7 +39,7 @@ public abstract class PathMapper {
      */
     public org.openkilda.messaging.info.network.Path map(org.openkilda.pce.Path path) {
         if (path == null || path.getSegments().isEmpty()) {
-            return new org.openkilda.messaging.info.network.Path(0L, 0L, new ArrayList<>());
+            return new org.openkilda.messaging.info.network.Path(0L, Duration.ZERO, new ArrayList<>());
         }
 
         List<PathNodePayload> nodes = new ArrayList<>();
@@ -61,6 +62,6 @@ public abstract class PathMapper {
         }
 
         return new org.openkilda.messaging.info.network.Path(path.getMinAvailableBandwidth(),
-                path.getLatency(), nodes);
+                Duration.ofNanos(path.getLatency()), nodes);
     }
 }

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/cookie/CookieBase.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/cookie/CookieBase.java
@@ -149,6 +149,7 @@ public abstract class CookieBase implements Serializable {
         MULTI_TABLE_ISL_VXLAN_TRANSIT_RULES(0x004),
         MULTI_TABLE_INGRESS_RULES(0x005),
         ARP_INPUT_CUSTOMER_TYPE(0x006),
+        // FIXME(surabujin) not used
         INGRESS_SEGMENT(0x007),   // used for ingress flow segment and for one switch flow segments
         SHARED_OF_FLOW(0x008),
         SERVER_42_INPUT(0x009),

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/PathComputer.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/PathComputer.java
@@ -23,6 +23,7 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.pce.exception.RecoverableException;
 import org.openkilda.pce.exception.UnroutableFlowException;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -66,6 +67,6 @@ public interface PathComputer {
      */
     List<Path> getNPaths(SwitchId srcSwitch, SwitchId dstSwitch, int count,
                          FlowEncapsulationType flowEncapsulationType, PathComputationStrategy pathComputationStrategy,
-                         Long maxLatency, Long maxLatencyTier2)
+                         Duration maxLatency, Duration maxLatencyTier2)
             throws RecoverableException, UnroutableFlowException;
 }

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/InMemoryPathComputerBaseTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/InMemoryPathComputerBaseTest.java
@@ -74,6 +74,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -355,7 +356,7 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
     @Test
     public void getNPathsCostSortByBandwidth() throws RecoverableException, UnroutableFlowException {
         List<Path> foundPaths = mockPathComputerWithoutMaxWeight().getNPaths(SWITCH_1, SWITCH_2, 10, null, COST,
-                0L, 0L);
+                Duration.ZERO, Duration.ZERO);
 
         assertEquals(5, foundPaths.size());
         assertSortedByBandwidthAndLatency(foundPaths);
@@ -365,7 +366,7 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
     public void getNPathsCostAndAvailableBandwidthSortByBandwidth()
             throws RecoverableException, UnroutableFlowException {
         List<Path> foundPaths = mockPathComputerWithoutMaxWeight().getNPaths(
-                SWITCH_1, SWITCH_2, 10, null, COST_AND_AVAILABLE_BANDWIDTH, 0L, 0L);
+                SWITCH_1, SWITCH_2, 10, null, COST_AND_AVAILABLE_BANDWIDTH, Duration.ZERO, Duration.ZERO);
 
         assertEquals(5, foundPaths.size());
         assertSortedByBandwidthAndLatency(foundPaths);
@@ -374,7 +375,7 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
     @Test
     public void getNPathsLatencySortByLatency() throws RecoverableException, UnroutableFlowException {
         List<Path> foundPaths = mockPathComputerWithoutMaxWeight().getNPaths(
-                SWITCH_1, SWITCH_2, 10, null, LATENCY, 0L, 0L);
+                SWITCH_1, SWITCH_2, 10, null, LATENCY, Duration.ZERO, Duration.ZERO);
 
         assertEquals(5, foundPaths.size());
         assertSortedByLatencyAndBandwidth(foundPaths);
@@ -398,7 +399,7 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
         // We used MAX_LATENCY strategy with 0 max latency param. In this case LATENCY strategy must be used
         // We check it by using PathComputerWithoutMaxWeight() mock instead of mockPathComputerWithMaxWeight()
         List<Path> foundPaths = mockPathComputerWithoutMaxWeight().getNPaths(
-                SWITCH_1, SWITCH_2, 10, null, MAX_LATENCY, 0L, null);
+                SWITCH_1, SWITCH_2, 10, null, MAX_LATENCY, Duration.ZERO, null);
 
         assertEquals(5, foundPaths.size());
         assertSortedByLatencyAndBandwidth(foundPaths);
@@ -407,7 +408,7 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
     @Test
     public void getNPathsMaxLatencySortByLatency() throws RecoverableException, UnroutableFlowException {
         List<Path> foundPaths = mockPathComputerWithMaxWeight().getNPaths(
-                SWITCH_1, SWITCH_2, 10, null, MAX_LATENCY, 1000L, 0L);
+                SWITCH_1, SWITCH_2, 10, null, MAX_LATENCY, Duration.ofNanos(1000L), Duration.ZERO);
 
         assertEquals(5, foundPaths.size());
         assertSortedByLatencyAndBandwidth(foundPaths);

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetPathsRequest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetPathsRequest.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 
+import java.time.Duration;
+
 @EqualsAndHashCode(callSuper = true)
 @ReadRequest
 @Value
@@ -42,17 +44,17 @@ public class GetPathsRequest extends BaseRequest {
     PathComputationStrategy pathComputationStrategy;
 
     @JsonProperty("max_latency")
-    Long maxLatency;
+    Duration maxLatency;
 
     @JsonProperty("max_latency_tier2")
-    Long maxLatencyTier2;
+    Duration maxLatencyTier2;
 
     public GetPathsRequest(@JsonProperty("src_switch_id") SwitchId srcSwitchId,
                            @JsonProperty("dst_switch_id") SwitchId dstSwitchId,
                            @JsonProperty("encapsulation_type") FlowEncapsulationType encapsulationType,
                            @JsonProperty("path_computation_strategy") PathComputationStrategy pathComputationStrategy,
-                           @JsonProperty("max_latency") Long maxLatency,
-                           @JsonProperty("max_latency_tier2") Long maxLatencyTier2) {
+                           @JsonProperty("max_latency") Duration maxLatency,
+                           @JsonProperty("max_latency_tier2") Duration maxLatencyTier2) {
         this.srcSwitchId = srcSwitchId;
         this.dstSwitchId = dstSwitchId;
         this.encapsulationType = encapsulationType;

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/main/java/org/openkilda/wfm/topology/nbworker/services/PathsService.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/main/java/org/openkilda/wfm/topology/nbworker/services/PathsService.java
@@ -38,6 +38,7 @@ import org.openkilda.wfm.share.mappers.PathMapper;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -65,7 +66,7 @@ public class PathsService {
      */
     public List<PathsInfoData> getPaths(
             SwitchId srcSwitchId, SwitchId dstSwitchId, FlowEncapsulationType requestEncapsulationType,
-            PathComputationStrategy requestPathComputationStrategy, Long maxLatency, Long maxLatencyTier2)
+            PathComputationStrategy requestPathComputationStrategy, Duration maxLatency, Duration maxLatencyTier2)
             throws RecoverableException, SwitchNotFoundException, UnroutableFlowException {
         if (Objects.equals(srcSwitchId, dstSwitchId)) {
             throw new IllegalArgumentException(

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/controller/v1/NetworkController.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/controller/v1/NetworkController.java
@@ -36,6 +36,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -49,6 +50,9 @@ public class NetworkController extends BaseController {
     @Autowired
     private NetworkService networkService;
 
+    /**
+     * Handles paths between two endpoints requests.
+     */
     @GetMapping(path = "/paths")
     @ApiOperation(value = "Get paths between two switches", response = PathsDto.class)
     @ResponseStatus(HttpStatus.OK)
@@ -64,12 +68,16 @@ public class NetworkController extends BaseController {
             @ApiParam(value = "Maximum latency of flow path in milliseconds. Required for MAX_LATENCY strategy. "
                     + "Other strategies will ignore this parameter. If max_latency is 0 LATENCY strategy will be used "
                     + "instead of MAX_LATENCY")
-            @RequestParam(value = "max_latency", required = false) Long maxLatency,
+            @RequestParam(value = "max_latency", required = false) Long maxLatencyMs,
             @ApiParam(value = "Second tier for flow path latency in milliseconds. If there is no path with required "
                     + "max_latency, max_latency_tier2 with be used instead. Used only with MAX_LATENCY strategy. "
                     + "Other strategies will ignore this parameter.")
             @RequestParam(value = "max_latency_tier2", required = false)
-                    Long maxLatencyTier2) {
+                    Long maxLatencyTier2Ms) {
+
+        Duration maxLatency = maxLatencyMs != null ? Duration.ofMillis(maxLatencyMs) : null;
+        Duration maxLatencyTier2 = maxLatencyTier2Ms != null ? Duration.ofMillis(maxLatencyTier2Ms) : null;
+
         return networkService.getPaths(srcSwitchId, dstSwitchId, encapsulationType, pathComputationStrategy, maxLatency,
                 maxLatencyTier2);
     }

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/NetworkService.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/NetworkService.java
@@ -20,6 +20,7 @@ import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.PathComputationStrategy;
 import org.openkilda.model.SwitchId;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -32,5 +33,5 @@ public interface NetworkService {
      */
     CompletableFuture<PathsDto> getPaths(
             SwitchId srcSwitch, SwitchId dstSwitch, FlowEncapsulationType encapsulationType,
-            PathComputationStrategy pathComputationStrategy, Long maxLatency, Long maxLatencyTier2);
+            PathComputationStrategy pathComputationStrategy, Duration maxLatencyMs, Duration maxLatencyTier2);
 }

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/impl/NetworkServiceImpl.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/impl/NetworkServiceImpl.java
@@ -34,10 +34,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @Service
@@ -58,7 +57,7 @@ public class NetworkServiceImpl implements NetworkService {
     @Override
     public CompletableFuture<PathsDto> getPaths(
             SwitchId srcSwitch, SwitchId dstSwitch, FlowEncapsulationType encapsulationType,
-            PathComputationStrategy pathComputationStrategy, Long maxLatency, Long maxLatencyTier2) {
+            PathComputationStrategy pathComputationStrategy, Duration maxLatency, Duration maxLatencyTier2) {
         String correlationId = RequestCorrelationId.getId();
 
         if (PathComputationStrategy.MAX_LATENCY.equals(pathComputationStrategy) && maxLatency == null) {
@@ -67,10 +66,6 @@ public class NetworkServiceImpl implements NetworkService {
                     + "max_latency parameter. If max_latency will be equal to 0 LATENCY strategy will be used instead "
                     + "of MAX_LATENCY.");
         }
-
-        // convert milliseconds to nanoseconds
-        maxLatency = Optional.ofNullable(maxLatency).map(TimeUnit.MILLISECONDS::toNanos).orElse(null);
-        maxLatencyTier2 = Optional.ofNullable(maxLatencyTier2).map(TimeUnit.MILLISECONDS::toNanos).orElse(null);
 
         GetPathsRequest request = new GetPathsRequest(srcSwitch, dstSwitch, encapsulationType, pathComputationStrategy,
                 maxLatency, maxLatencyTier2);


### PR DESCRIPTION
Add time unit suffixes into time related fields into "get paths" API
call response.

Also improve internal communications replaceting unitless time fields
with untifull (java.time.Duration).