### PR TITLE
Use right encapsulation type during reroute if encapsulation was changed

### DIFF
--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/service/SpeakerFlowSegmentRequestBuilder.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/service/SpeakerFlowSegmentRequestBuilder.java
@@ -460,7 +460,8 @@ public class SpeakerFlowSegmentRequestBuilder implements FlowCommandBuilder {
         EncapsulationResources resources = resourcesManager
                 .getEncapsulationResources(pathId, oppositePathId, encapsulation)
                 .orElseThrow(() -> new IllegalStateException(format(
-                        "No encapsulation resources found for flow path %s (opposite: %s)", pathId, oppositePathId)));
+                        "No %s encapsulation resources found for flow path %s (opposite: %s).",
+                        encapsulation, pathId, oppositePathId)));
         return new FlowTransitEncapsulation(resources.getTransitEncapsulationId(), resources.getEncapsulationType());
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/InstallIngressRulesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/InstallIngressRulesAction.java
@@ -18,7 +18,6 @@ package org.openkilda.wfm.topology.flowhs.fsm.reroute.actions;
 import org.openkilda.floodlight.api.request.FlowSegmentRequest;
 import org.openkilda.floodlight.api.request.factory.FlowSegmentRequestFactory;
 import org.openkilda.model.Flow;
-import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.FlowPath;
 import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
@@ -52,9 +51,14 @@ public class InstallIngressRulesAction extends FlowProcessingAction<FlowRerouteF
         String flowId = stateMachine.getFlowId();
         Flow flow = getFlow(flowId);
 
-        FlowEncapsulationType encapsulationType = stateMachine.getNewEncapsulationType() != null
-                ? stateMachine.getNewEncapsulationType() : flow.getEncapsulationType();
-        FlowCommandBuilder commandBuilder = commandBuilderFactory.getBuilder(encapsulationType);
+        // Detach the entity to avoid propagation to the database.
+        flowRepository.detach(flow);
+        if (stateMachine.getNewEncapsulationType() != null) {
+            // This is for commandBuilder.buildIngressOnly() to use proper (updated) encapsulation type.
+            flow.setEncapsulationType(stateMachine.getNewEncapsulationType());
+        }
+
+        FlowCommandBuilder commandBuilder = commandBuilderFactory.getBuilder(flow.getEncapsulationType());
 
         Collection<FlowSegmentRequestFactory> requestFactories = new ArrayList<>();
         if (stateMachine.getNewPrimaryForwardPath() != null && stateMachine.getNewPrimaryReversePath() != null) {


### PR DESCRIPTION
Closes #4267

The problem was in `FlowCommandBuilder` class. It gets encapsulation type from Flow object, but Flow object contains current encapsulation. New (target) encapsulation we store in FSM