### PR TITLE
fix "cleanup" in retries/swPortConfig specs

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ConnectedDevicesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ConnectedDevicesSpec.groovy
@@ -169,7 +169,10 @@ class ConnectedDevicesSpec extends HealthCheckSpecification {
                                 dstEnabled: true, encapsulation: FlowEncapsulationType.VXLAN)
                         //each of the above datapieces may repeat multiple times depending on amount of available TG switches
                 ].collectMany { dataPiece ->
-                    getUniqueSwitchPairs().collect {
+                    getUniqueSwitchPairs().findAll {
+                        //for protected flow
+                        it.paths.unique(false) { a, b -> a.intersect(b) == [] ? 1 : 0 }.size() >= 2
+                    }.collect {
                         def newDataPiece = dataPiece.clone()
                         newDataPiece.switchPair = it
                         newDataPiece

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/RetriesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/RetriesSpec.groovy
@@ -521,7 +521,7 @@ and at least 1 path must remain safe"
             database.setSwitchStatus(brokenSwitch.dpId, SwitchStatus.INACTIVE)
             switchHelper.reviveSwitch(brokenSwitch, blockData)
         }
-        originalMode && swPair.src.changeMultitable(originalMode)
+        (originalMode != null) && swPair.src.changeMultitable(originalMode)
         !done && currentSwitches && (currentSwitches + otherSwitches).unique { it.dpId }.each {
             northbound.synchronizeSwitch(it.dpId, true) }
         broughtDownIsls && broughtDownIsls.each { antiflap.portUp(it.srcSwitch.dpId, it.srcPort) }
@@ -607,7 +607,7 @@ and at least 1 path must remain safe"
             database.setSwitchStatus(brokenSwitch.dpId, SwitchStatus.INACTIVE)
             switchHelper.reviveSwitch(brokenSwitch, blockData)
         }
-        originalMode && swPair.src.changeMultitable(originalMode)
+        (originalMode != null) && swPair.src.changeMultitable(originalMode)
         broughtDownIsls && broughtDownIsls.each { antiflap.portUp(it.srcSwitch.dpId, it.srcPort) }
         isl && antiflap.portUp(isl.srcSwitch.dpId, isl.srcPort)
         wait(WAIT_OFFSET * 2) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/MflStatSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/MflStatSpec.groovy
@@ -300,10 +300,14 @@ class MflStatSpec extends HealthCheckSpecification {
 
         when: "Src switch is only left with the other management controller (no stats controllers)"
         lockKeeper.reviveSwitch(srcSwitch, blockData)
+        Wrappers.wait(WAIT_OFFSET / 2) {
+            assert northboundV2.getSwitchConnections(srcSwitch.dpId).connections.size() == 4
+        }
+        //TODO (andriidovhan) rework, regionToStay should be array or string during whole test
         regionToStay = findMgmtFls(northboundV2.getSwitchConnections(srcSwitch.dpId))*.regionName - regionToStay
         blockData = lockKeeper.knockoutSwitch(srcSwitch, srcSwitch.regions - regionToStay)
         Wrappers.wait(WAIT_OFFSET / 2) {
-            assert northboundV2.getSwitchConnections(srcSwitch.dpId).connections*.regionName == [regionToStay]
+            assert northboundV2.getSwitchConnections(srcSwitch.dpId).connections*.regionName == regionToStay
         }
 
         and: "Generate traffic on the given flow"
@@ -322,6 +326,9 @@ class MflStatSpec extends HealthCheckSpecification {
         when: "Set only 1 statistic controller on the src switch and disconnect from management"
         initStats = newStats
         lockKeeper.reviveSwitch(srcSwitch, blockData)
+        Wrappers.wait(WAIT_OFFSET / 2) {
+            assert northboundV2.getSwitchConnections(srcSwitch.dpId).connections.size() == 4
+        }
         regionToStay = findStatFls(northboundV2.getSwitchConnections(srcSwitch.dpId))*.regionName.first()
         blockData = lockKeeper.knockoutSwitch(srcSwitch, srcSwitch.regions - regionToStay)
         Wrappers.wait(WAIT_OFFSET / 2) {
@@ -342,10 +349,13 @@ class MflStatSpec extends HealthCheckSpecification {
         when: "Set only other statistic controller on the src switch and disconnect from management"
         initStats = newStats
         lockKeeper.reviveSwitch(srcSwitch, blockData)
+        Wrappers.wait(WAIT_OFFSET / 2) {
+            assert northboundV2.getSwitchConnections(srcSwitch.dpId).connections.size() == 4
+        }
         regionToStay = findStatFls(northboundV2.getSwitchConnections(srcSwitch.dpId))*.regionName - regionToStay
         blockData = lockKeeper.knockoutSwitch(srcSwitch, srcSwitch.regions - regionToStay)
         Wrappers.wait(WAIT_OFFSET / 2) {
-            assert northboundV2.getSwitchConnections(srcSwitch.dpId).connections*.regionName == [regionToStay]
+            assert northboundV2.getSwitchConnections(srcSwitch.dpId).connections*.regionName == regionToStay
         }
 
         and: "Generate traffic on the given flow"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/FlowRulesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/FlowRulesSpec.groovy
@@ -468,8 +468,15 @@ class FlowRulesSpec extends HealthCheckSpecification {
             def swProps = northbound.getSwitchProperties(switchId)
             def switchIdInSrcOrDst = (switchId in [switchPair.src.dpId, switchPair.dst.dpId])
             def defaultAmountOfFlowRules = 2 // ingress + egress
-            def rulesCount = defaultAmountOfFlowRules + (switchIdInSrcOrDst && swProps.multiTable ? 1 : 0) +
-                    (switchIdInSrcOrDst && swProps.server42FlowRtt ? 1 : 0)
+            def amountOfServer42Rules = (switchIdInSrcOrDst && swProps.server42FlowRtt ? 1 : 0)
+            if (swProps.multiTable && swProps.server42FlowRtt) {
+                if ((flow.destination.getSwitchId() == switchId && flow.destination.vlanId) || (
+                        flow.source.getSwitchId() == switchId && flow.source.vlanId))
+                    amountOfServer42Rules += 1
+            }
+            def rulesCount = defaultAmountOfFlowRules + amountOfServer42Rules +
+                    (switchIdInSrcOrDst && swProps.multiTable ? 1 : 0)
+
             [switchId, (rulesCount)]
         }
         involvedSwitches.each { switchId ->

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchPortConfigSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchPortConfigSpec.groovy
@@ -104,6 +104,7 @@ class SwitchPortConfigSpec extends HealthCheckSpecification {
 
         cleanup:
         !portUp && antiflap.portUp(sw.dpId, port)
+        database.resetCosts()
 
         where:
         // It is impossible to understand whether ISL-free port is UP/DOWN on OF_12 switches.


### PR DESCRIPTION
- fix "cleanup" in retries/swPortConfig specs
- fix "amountOfServer42Rules" in flowRulesSpec
- make  ConnectedDevicesSpec not dependable on topology