### PR TITLE
Use method instead of constant for empty speaker context.

### DIFF
--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/model/SpeakerRequestBuildContext.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/model/SpeakerRequestBuildContext.java
@@ -27,10 +27,15 @@ import lombok.EqualsAndHashCode;
 @AllArgsConstructor
 @EqualsAndHashCode
 public class SpeakerRequestBuildContext {
-    public static final SpeakerRequestBuildContext EMPTY = SpeakerRequestBuildContext.builder()
-            .forward(PathContext.builder().build())
-            .reverse(PathContext.builder().build())
-            .build();
+    /**
+     * Returns empty build context.
+     */
+    public static SpeakerRequestBuildContext getEmpty() {
+        return SpeakerRequestBuildContext.builder()
+                .forward(PathContext.builder().build())
+                .reverse(PathContext.builder().build())
+                .build();
+    }
 
     private PathContext forward;
     private PathContext reverse;

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/service/SpeakerFlowSegmentRequestBuilder.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/service/SpeakerFlowSegmentRequestBuilder.java
@@ -98,7 +98,7 @@ public class SpeakerFlowSegmentRequestBuilder implements FlowCommandBuilder {
     public List<FlowSegmentRequestFactory> buildAllExceptIngress(
             CommandContext context, Flow flow, FlowPath path, FlowPath oppositePath) {
         return makeRequests(context, flow, path, oppositePath, false, true, true,
-                SpeakerRequestBuildContext.EMPTY);
+                SpeakerRequestBuildContext.getEmpty());
     }
 
     @Override
@@ -127,7 +127,8 @@ public class SpeakerFlowSegmentRequestBuilder implements FlowCommandBuilder {
     @Override
     public List<FlowSegmentRequestFactory> buildEgressOnly(
             CommandContext context, Flow flow, FlowPath path, FlowPath oppositePath) {
-        return makeRequests(context, flow, path, oppositePath, false, false, true, SpeakerRequestBuildContext.EMPTY);
+        return makeRequests(context, flow, path, oppositePath, false, false, true,
+                SpeakerRequestBuildContext.getEmpty());
     }
 
     @Override
@@ -135,7 +136,7 @@ public class SpeakerFlowSegmentRequestBuilder implements FlowCommandBuilder {
             CommandContext context, Flow flow, FlowPath path, FlowPath oppositePath) {
 
         return makeRequests(context, flow, path, oppositePath, false, false, true,
-                SpeakerRequestBuildContext.EMPTY.getForward());
+                SpeakerRequestBuildContext.getEmpty().getForward());
 
     }
 

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/service/SpeakerFlowSegmentRequestBuilderTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/service/SpeakerFlowSegmentRequestBuilderTest.java
@@ -137,7 +137,7 @@ public class SpeakerFlowSegmentRequestBuilderTest extends InMemoryGraphBasedTest
         Flow flow = buildFlow(sw, 1, 10, sw, 2, 12, 1000);
         List<FlowSegmentRequestFactory> commands = target.buildAll(
                 COMMAND_CONTEXT, flow, flow.getForwardPath(), flow.getReversePath(),
-                SpeakerRequestBuildContext.EMPTY);
+                SpeakerRequestBuildContext.getEmpty());
 
         assertEquals(2, commands.size());
 
@@ -184,7 +184,7 @@ public class SpeakerFlowSegmentRequestBuilderTest extends InMemoryGraphBasedTest
 
         // then produce path segment request factories
         List<FlowSegmentRequestFactory> commands = target.buildIngressOnly(
-                COMMAND_CONTEXT, goal, goalForwardPath, goalReversePath, SpeakerRequestBuildContext.EMPTY);
+                COMMAND_CONTEXT, goal, goalForwardPath, goalReversePath, SpeakerRequestBuildContext.getEmpty());
         boolean haveMatch = false;
         for (FlowSegmentRequestFactory entry : commands) {
             // search command for flow source side
@@ -210,7 +210,7 @@ public class SpeakerFlowSegmentRequestBuilderTest extends InMemoryGraphBasedTest
                 Objects.requireNonNull(flow.getForwardPath()), Objects.requireNonNull(flow.getReversePath()));
 
         List<FlowSegmentRequestFactory> commands = target.buildIngressOnly(
-                COMMAND_CONTEXT, flow, SpeakerRequestBuildContext.EMPTY);
+                COMMAND_CONTEXT, flow, SpeakerRequestBuildContext.getEmpty());
         assertEquals(2, commands.size());
 
         verifyForwardIngressRequest(flow, commands.get(0).makeInstallRequest(commandIdGenerator.generate()));

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/FlowProcessingAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/FlowProcessingAction.java
@@ -203,7 +203,7 @@ public abstract class FlowProcessingAction<T extends FlowProcessingFsm<T, S, E, 
         if (Objects.equals(srcSwitchId, dstSwitchId)) {
             // At this moment all context props in buildBasePathContextForInstall() are about server42.
             // But server42 is not used for single switch flow.
-            return SpeakerRequestBuildContext.EMPTY;
+            return SpeakerRequestBuildContext.getEmpty();
         }
 
         return SpeakerRequestBuildContext.builder()

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/RemoveOldRulesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/RemoveOldRulesAction.java
@@ -56,7 +56,7 @@ public class RemoveOldRulesAction extends
 
         Flow originalFlow = getOriginalFlowWithPaths(stateMachine, stateMachine.getOriginalFlow());
 
-        SpeakerRequestBuildContext speakerContext = SpeakerRequestBuildContext.EMPTY;
+        SpeakerRequestBuildContext speakerContext = SpeakerRequestBuildContext.getEmpty();
 
         if (stateMachine.getOldPrimaryForwardPath() != null) {
             FlowPath oldForward = getFlowPath(stateMachine.getOldPrimaryForwardPath());


### PR DESCRIPTION
It needed to do not share same class instance between many parts of code
because fields of this constant can be changed by some part of the code.