### PR TITLE
Replace EMPTY fields with getEmpty() methods

### DIFF
--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/SwitchFlowTuple.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/SwitchFlowTuple.java
@@ -26,7 +26,9 @@ import org.projectfloodlight.openflow.protocol.OFMeterMod;
 @Builder
 public class SwitchFlowTuple {
 
-    public static final SwitchFlowTuple EMPTY = SwitchFlowTuple.builder().build();
+    public static SwitchFlowTuple getEmpty() {
+        return SwitchFlowTuple.builder().build();
+    }
 
     private IOFSwitch sw;
     private OFFlowMod flow;

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/BfdCatchFlowGenerator.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/BfdCatchFlowGenerator.java
@@ -50,7 +50,7 @@ public class BfdCatchFlowGenerator implements SwitchFlowGenerator {
     public SwitchFlowTuple generateFlow(IOFSwitch sw) {
         Set<SwitchFeature> features = featureDetectorService.detectSwitch(sw);
         if (!features.contains(SwitchFeature.BFD)) {
-            return SwitchFlowTuple.EMPTY;
+            return SwitchFlowTuple.getEmpty();
         }
 
         OFFactory ofFactory = sw.getOFFactory();

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/DropFlowGenerator.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/DropFlowGenerator.java
@@ -37,7 +37,7 @@ public class DropFlowGenerator implements SwitchFlowGenerator {
         OFFactory ofFactory = sw.getOFFactory();
 
         if (ofFactory.getVersion() == OF_12) {
-            return SwitchFlowTuple.EMPTY;
+            return SwitchFlowTuple.getEmpty();
         }
 
         OFFlowMod flowMod = prepareFlowModBuilder(ofFactory, cookie, MINIMAL_POSITIVE_PRIORITY, tableId)

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/DropLoopFlowGenerator.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/DropLoopFlowGenerator.java
@@ -41,7 +41,7 @@ public class DropLoopFlowGenerator implements SwitchFlowGenerator {
     public SwitchFlowTuple generateFlow(IOFSwitch sw) {
         OFFactory ofFactory = sw.getOFFactory();
         if (ofFactory.getVersion() == OF_12) {
-            return SwitchFlowTuple.EMPTY;
+            return SwitchFlowTuple.getEmpty();
         }
 
         Match.Builder builder = ofFactory.buildMatch();

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/RoundTripLatencyFlowGenerator.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/RoundTripLatencyFlowGenerator.java
@@ -56,7 +56,7 @@ public class RoundTripLatencyFlowGenerator implements SwitchFlowGenerator {
     @Override
     public SwitchFlowTuple generateFlow(IOFSwitch sw) {
         if (!featureDetectorService.detectSwitch(sw).contains(NOVIFLOW_COPY_FIELD)) {
-            return SwitchFlowTuple.EMPTY;
+            return SwitchFlowTuple.getEmpty();
         }
 
         OFFactory ofFactory = sw.getOFFactory();

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/UnicastVerificationVxlanRuleGenerator.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/UnicastVerificationVxlanRuleGenerator.java
@@ -64,7 +64,7 @@ public class UnicastVerificationVxlanRuleGenerator extends MeteredFlowGenerator 
     public SwitchFlowTuple generateFlow(IOFSwitch sw) {
         // should be replaced with fair feature detection based on ActionId's during handshake
         if (!featureDetectorService.detectSwitch(sw).contains(NOVIFLOW_PUSH_POP_VXLAN)) {
-            return SwitchFlowTuple.EMPTY;
+            return SwitchFlowTuple.getEmpty();
         }
 
         ArrayList<OFAction> actionList = new ArrayList<>();

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/arp/ArpFlowGenerator.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/arp/ArpFlowGenerator.java
@@ -53,7 +53,7 @@ public abstract class ArpFlowGenerator extends MeteredFlowGenerator {
 
         OFFlowMod flowMod = getArpFlowMod(sw, ofInstructionMeter, actionList);
         if (flowMod == null) {
-            return SwitchFlowTuple.EMPTY;
+            return SwitchFlowTuple.getEmpty();
         }
 
         return SwitchFlowTuple.builder()

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/lldp/LldpFlowGenerator.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/lldp/LldpFlowGenerator.java
@@ -53,7 +53,7 @@ public abstract class LldpFlowGenerator extends MeteredFlowGenerator {
 
         OFFlowMod flowMod = getLldpFlowMod(sw, ofInstructionMeter, actionList);
         if (flowMod == null) {
-            return SwitchFlowTuple.EMPTY;
+            return SwitchFlowTuple.getEmpty();
         }
 
         return SwitchFlowTuple.builder()

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/server42/Server42InputFlowGenerator.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/server42/Server42InputFlowGenerator.java
@@ -111,7 +111,7 @@ public class Server42InputFlowGenerator implements SwitchFlowGenerator {
                 server42Port, server42macAddress);
 
         if (!flowMod.isPresent()) {
-            return SwitchFlowTuple.EMPTY;
+            return SwitchFlowTuple.getEmpty();
         }
 
         return SwitchFlowTuple.builder()

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/server42/Server42OutputVxlanFlowGenerator.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/server42/Server42OutputVxlanFlowGenerator.java
@@ -78,7 +78,7 @@ public class Server42OutputVxlanFlowGenerator implements SwitchFlowGenerator {
     public SwitchFlowTuple generateFlow(IOFSwitch sw) {
         Set<SwitchFeature> features = featureDetectorService.detectSwitch(sw);
         if (!features.contains(NOVIFLOW_PUSH_POP_VXLAN)) {
-            return SwitchFlowTuple.EMPTY;
+            return SwitchFlowTuple.getEmpty();
         }
 
         OFFactory ofFactory = sw.getOFFactory();

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/server42/Server42TurningFlowGenerator.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/factory/generator/server42/Server42TurningFlowGenerator.java
@@ -57,7 +57,7 @@ public class Server42TurningFlowGenerator implements SwitchFlowGenerator {
     @Override
     public SwitchFlowTuple generateFlow(IOFSwitch sw) {
         if (!featureDetectorService.detectSwitch(sw).contains(NOVIFLOW_SWAP_ETH_SRC_ETH_DST)) {
-            return SwitchFlowTuple.EMPTY;
+            return SwitchFlowTuple.getEmpty();
         }
 
         OFFactory ofFactory = sw.getOFFactory();

--- a/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/controller/bfd/BfdLogicalPortFsm.java
+++ b/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/controller/bfd/BfdLogicalPortFsm.java
@@ -379,7 +379,9 @@ public class BfdLogicalPortFsm extends AbstractBaseFsm<BfdLogicalPortFsm, State,
     @Value
     @Builder
     public static class BfdLogicalPortFsmContext {
-        public static BfdLogicalPortFsmContext EMPTY = BfdLogicalPortFsmContext.builder().build();
+        public static BfdLogicalPortFsmContext getEmpty() {
+            return BfdLogicalPortFsmContext.builder().build();
+        }
 
         BfdSessionData sessionData;
 

--- a/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/service/NetworkBfdLogicalPortService.java
+++ b/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/service/NetworkBfdLogicalPortService.java
@@ -135,7 +135,7 @@ public class NetworkBfdLogicalPortService {
     }
 
     private void handle(BfdLogicalPortFsm controller, Event event) {
-        handle(controller, event, BfdLogicalPortFsmContext.EMPTY);
+        handle(controller, event, BfdLogicalPortFsmContext.getEmpty());
     }
 
     private void handle(BfdLogicalPortFsm controller, Event event, BfdLogicalPortFsmContext context) {


### PR DESCRIPTION
Several classes use EMPTY const too return empty value.
But fields this constant can be changed.
It caused a problem like in #4275
To prevent same problems constants were replaced with methods.
Method getEmpty() will return new object each time.