### PR TITLE
Update eth src/dst for looped VXLAN packets

### DIFF
--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/TransitFlowLoopSegmentInstallRequest.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/TransitFlowLoopSegmentInstallRequest.java
@@ -33,21 +33,23 @@ import java.util.UUID;
 @Getter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class TransitFlowLoopSegmentInstallRequest extends TransitFlowSegmentRequest {
+public class TransitFlowLoopSegmentInstallRequest extends TransitFlowLoopSegmentRequest {
     @JsonCreator
     @Builder(toBuilder = true)
     public TransitFlowLoopSegmentInstallRequest(
             @JsonProperty("message_context") MessageContext messageContext,
             @JsonProperty("switch_id") SwitchId switchId,
+            @JsonProperty("egress_switch_id") SwitchId egressSwitchId,
             @JsonProperty("command_id") UUID commandId,
             @JsonProperty("metadata") FlowSegmentMetadata metadata,
             @JsonProperty("ingress_isl_port") int ingressIslPort,
             @JsonProperty("egress_isl_port") int egressIslPort,
             @JsonProperty("encapsulation") FlowTransitEncapsulation encapsulation) {
-        super(messageContext, switchId, commandId, metadata, ingressIslPort, egressIslPort, encapsulation);
+        super(messageContext, switchId, egressSwitchId, commandId, metadata, ingressIslPort, egressIslPort,
+                encapsulation);
     }
 
-    public TransitFlowLoopSegmentInstallRequest(TransitFlowSegmentRequest other, UUID commandId) {
+    public TransitFlowLoopSegmentInstallRequest(TransitFlowLoopSegmentRequest other, UUID commandId) {
         super(other, commandId);
     }
 

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/TransitFlowLoopSegmentRemoveRequest.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/TransitFlowLoopSegmentRemoveRequest.java
@@ -33,21 +33,23 @@ import java.util.UUID;
 @Getter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class TransitFlowLoopSegmentRemoveRequest extends TransitFlowSegmentRequest {
+public class TransitFlowLoopSegmentRemoveRequest extends TransitFlowLoopSegmentRequest {
     @JsonCreator
     @Builder(toBuilder = true)
     public TransitFlowLoopSegmentRemoveRequest(
             @JsonProperty("message_context") MessageContext messageContext,
             @JsonProperty("switch_id") SwitchId switchId,
+            @JsonProperty("egress_switch_id") SwitchId egressSwitchId,
             @JsonProperty("command_id") UUID commandId,
             @JsonProperty("metadata") FlowSegmentMetadata metadata,
             @JsonProperty("ingress_isl_port") int ingressIslPort,
             @JsonProperty("egress_isl_port") int egressIslPort,
             @JsonProperty("encapsulation") FlowTransitEncapsulation encapsulation) {
-        super(messageContext, switchId, commandId, metadata, ingressIslPort, egressIslPort, encapsulation);
+        super(messageContext, switchId, egressSwitchId, commandId, metadata, ingressIslPort, egressIslPort,
+                encapsulation);
     }
 
-    public TransitFlowLoopSegmentRemoveRequest(TransitFlowSegmentRequest other, UUID commandId) {
+    public TransitFlowLoopSegmentRemoveRequest(TransitFlowLoopSegmentRequest other, UUID commandId) {
         super(other, commandId);
     }
 

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/TransitFlowLoopSegmentRequest.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/TransitFlowLoopSegmentRequest.java
@@ -1,0 +1,50 @@
+/* Copyright 2021 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.floodlight.api.request;
+
+import org.openkilda.floodlight.model.FlowSegmentMetadata;
+import org.openkilda.messaging.MessageContext;
+import org.openkilda.model.FlowTransitEncapsulation;
+import org.openkilda.model.SwitchId;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.UUID;
+
+@Getter
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class TransitFlowLoopSegmentRequest extends TransitFlowSegmentRequest {
+
+    @JsonProperty("egress_switch_id")
+    protected final SwitchId egressSwitchId;
+
+    public TransitFlowLoopSegmentRequest(
+            MessageContext messageContext, SwitchId switchId, SwitchId egressSwitchId, UUID commandId,
+            FlowSegmentMetadata metadata, int ingressIslPort, int egressIslPort,
+            FlowTransitEncapsulation encapsulation) {
+        super(messageContext, switchId, commandId, metadata, ingressIslPort, egressIslPort, encapsulation);
+        this.egressSwitchId = egressSwitchId;
+    }
+
+    public TransitFlowLoopSegmentRequest(TransitFlowLoopSegmentRequest other, UUID commandId) {
+        super(other, commandId);
+        this.egressSwitchId = other.egressSwitchId;
+    }
+}

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/TransitFlowLoopSegmentVerifyRequest.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/TransitFlowLoopSegmentVerifyRequest.java
@@ -33,21 +33,23 @@ import java.util.UUID;
 @Getter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class TransitFlowLoopSegmentVerifyRequest extends TransitFlowSegmentRequest {
+public class TransitFlowLoopSegmentVerifyRequest extends TransitFlowLoopSegmentRequest {
     @JsonCreator
     @Builder(toBuilder = true)
     public TransitFlowLoopSegmentVerifyRequest(
             @JsonProperty("message_context") MessageContext messageContext,
             @JsonProperty("switch_id") SwitchId switchId,
+            @JsonProperty("egress_switch_id") SwitchId egressSwitchId,
             @JsonProperty("command_id") UUID commandId,
             @JsonProperty("metadata") FlowSegmentMetadata metadata,
             @JsonProperty("ingress_isl_port") int ingressIslPort,
             @JsonProperty("egress_isl_port") int egressIslPort,
             @JsonProperty("encapsulation") FlowTransitEncapsulation encapsulation) {
-        super(messageContext, switchId, commandId, metadata, ingressIslPort, egressIslPort, encapsulation);
+        super(messageContext, switchId, egressSwitchId, commandId, metadata, ingressIslPort, egressIslPort,
+                encapsulation);
     }
 
-    public TransitFlowLoopSegmentVerifyRequest(TransitFlowSegmentRequest other, UUID commandId) {
+    public TransitFlowLoopSegmentVerifyRequest(TransitFlowLoopSegmentRequest other, UUID commandId) {
         super(other, commandId);
     }
 

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/factory/TransitFlowLoopSegmentRequestFactory.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/request/factory/TransitFlowLoopSegmentRequestFactory.java
@@ -17,8 +17,8 @@ package org.openkilda.floodlight.api.request.factory;
 
 import org.openkilda.floodlight.api.request.TransitFlowLoopSegmentInstallRequest;
 import org.openkilda.floodlight.api.request.TransitFlowLoopSegmentRemoveRequest;
+import org.openkilda.floodlight.api.request.TransitFlowLoopSegmentRequest;
 import org.openkilda.floodlight.api.request.TransitFlowLoopSegmentVerifyRequest;
-import org.openkilda.floodlight.api.request.TransitFlowSegmentRequest;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowTransitEncapsulation;
@@ -29,16 +29,16 @@ import lombok.Builder;
 import java.util.UUID;
 
 public class TransitFlowLoopSegmentRequestFactory extends FlowSegmentRequestFactory {
-    private final TransitFlowSegmentRequest requestBlank;
+    private final TransitFlowLoopSegmentRequest requestBlank;
 
     @Builder
     public TransitFlowLoopSegmentRequestFactory(
-            MessageContext messageContext, SwitchId switchId, FlowSegmentMetadata metadata,
+            MessageContext messageContext, SwitchId switchId, SwitchId egressSwitchId, FlowSegmentMetadata metadata,
             int port, FlowTransitEncapsulation encapsulation) {
-        this(new RequestBlank(messageContext, switchId, metadata, port, encapsulation));
+        this(new RequestBlank(messageContext, switchId, egressSwitchId, metadata, port, encapsulation));
     }
 
-    private TransitFlowLoopSegmentRequestFactory(TransitFlowSegmentRequest requestBlank) {
+    private TransitFlowLoopSegmentRequestFactory(TransitFlowLoopSegmentRequest requestBlank) {
         super(requestBlank);
         this.requestBlank = requestBlank;
     }
@@ -58,11 +58,11 @@ public class TransitFlowLoopSegmentRequestFactory extends FlowSegmentRequestFact
         return new TransitFlowLoopSegmentVerifyRequest(requestBlank, commandId);
     }
 
-    private static class RequestBlank extends TransitFlowSegmentRequest {
+    private static class RequestBlank extends TransitFlowLoopSegmentRequest {
         RequestBlank(
-                MessageContext context, SwitchId switchId, FlowSegmentMetadata metadata, int port,
-                FlowTransitEncapsulation encapsulation) {
-            super(context, switchId, dummyCommandId, metadata, port, port, encapsulation);
+                MessageContext context, SwitchId switchId, SwitchId egressSwitchId, FlowSegmentMetadata metadata,
+                int port, FlowTransitEncapsulation encapsulation) {
+            super(context, switchId, egressSwitchId, dummyCommandId, metadata, port, port, encapsulation);
         }
     }
 }

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/transit/TransitFlowLoopSegmentCommand.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/transit/TransitFlowLoopSegmentCommand.java
@@ -1,0 +1,56 @@
+/* Copyright 2021 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.floodlight.command.flow.transit;
+
+import org.openkilda.floodlight.model.FlowSegmentMetadata;
+import org.openkilda.floodlight.switchmanager.SwitchManager;
+import org.openkilda.floodlight.utils.OfFlowModBuilderFactory;
+import org.openkilda.messaging.MessageContext;
+import org.openkilda.model.FlowTransitEncapsulation;
+import org.openkilda.model.SwitchId;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+abstract class TransitFlowLoopSegmentCommand extends TransitFlowSegmentCommand {
+    protected final SwitchId egressSwitchId;
+
+    @SuppressWarnings("squid:S00107")
+    TransitFlowLoopSegmentCommand(
+            MessageContext messageContext, SwitchId switchId, SwitchId egressSwitchId, UUID commandId,
+            FlowSegmentMetadata metadata, int ingressIslPort, FlowTransitEncapsulation encapsulation, int egressIslPort,
+            OfFlowModBuilderFactory flowModBuilderFactory) {
+        super(messageContext, switchId, commandId, metadata, ingressIslPort, encapsulation, egressIslPort,
+                flowModBuilderFactory, null);
+        this.egressSwitchId = egressSwitchId;
+    }
+
+    @Override
+    protected int getTableId() {
+        return SwitchManager.EGRESS_TABLE_ID;
+    }
+
+    public String toString() {
+        return String.format(
+                "<transit-flow-loop-segment-%s{"
+                        + "id=%s, metadata=%s, ingress_isl_port=%s, egress_isl_port=%s, encapsulation=%s, switchId=%s, "
+                        + "egressSwitchId=%s}>",
+                getSegmentAction(), commandId, metadata, ingressIslPort, egressIslPort, encapsulation, switchId,
+                egressSwitchId);
+    }
+}

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/transit/TransitFlowLoopSegmentRemoveCommand.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/transit/TransitFlowLoopSegmentRemoveCommand.java
@@ -33,7 +33,7 @@ import org.projectfloodlight.openflow.protocol.instruction.OFInstruction;
 import java.util.List;
 import java.util.UUID;
 
-public class TransitFlowLoopSegmentRemoveCommand extends TransitFlowSegmentCommand {
+public class TransitFlowLoopSegmentRemoveCommand extends TransitFlowLoopSegmentCommand {
     private static OfFlowModBuilderFactory makeFlowModBuilderFactory(boolean isMultiTable) {
         if (isMultiTable) {
             return new OfFlowModDelMultiTableMessageBuilderFactory(SwitchManager.FLOW_LOOP_PRIORITY);
@@ -46,24 +46,20 @@ public class TransitFlowLoopSegmentRemoveCommand extends TransitFlowSegmentComma
     public TransitFlowLoopSegmentRemoveCommand(
             @JsonProperty("message_context") MessageContext context,
             @JsonProperty("switch_id") SwitchId switchId,
+            @JsonProperty("egress_switch_id") SwitchId egressSwitchId,
             @JsonProperty("command_id") UUID commandId,
             @JsonProperty("metadata") FlowSegmentMetadata metadata,
             @JsonProperty("ingress_isl_port") int ingressIslPort,
             @JsonProperty("encapsulation") FlowTransitEncapsulation encapsulation,
             @JsonProperty("egress_isl_port") int egressIslPort) {
         super(
-                context, switchId, commandId, metadata, ingressIslPort, encapsulation, egressIslPort,
-                makeFlowModBuilderFactory(metadata.isMultiTable()), null);
+                context, switchId, egressSwitchId, commandId, metadata, ingressIslPort, encapsulation, egressIslPort,
+                makeFlowModBuilderFactory(metadata.isMultiTable()));
     }
 
     @Override
     protected List<OFInstruction> makeTransitModMessageInstructions(OFFactory of) {
         return ImmutableList.of();  // do not add instructions into delete request
-    }
-
-    @Override
-    protected int getTableId() {
-        return SwitchManager.EGRESS_TABLE_ID;
     }
 
     @Override

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/transit/TransitFlowLoopSegmentVerifyCommand.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/transit/TransitFlowLoopSegmentVerifyCommand.java
@@ -18,7 +18,6 @@ package org.openkilda.floodlight.command.flow.transit;
 import org.openkilda.floodlight.command.SpeakerCommandProcessor;
 import org.openkilda.floodlight.command.flow.FlowSegmentReport;
 import org.openkilda.floodlight.model.FlowSegmentMetadata;
-import org.openkilda.floodlight.switchmanager.SwitchManager;
 import org.openkilda.messaging.MessageContext;
 import org.openkilda.model.FlowTransitEncapsulation;
 import org.openkilda.model.SwitchId;
@@ -35,22 +34,18 @@ public class TransitFlowLoopSegmentVerifyCommand extends TransitFlowLoopSegmentI
     public TransitFlowLoopSegmentVerifyCommand(
             @JsonProperty("message_context") MessageContext context,
             @JsonProperty("switch_id") SwitchId switchId,
+            @JsonProperty("egress_switch_id") SwitchId egressSwitchId,
             @JsonProperty("command_id") UUID commandId,
             @JsonProperty("metadata") FlowSegmentMetadata metadata,
             @JsonProperty("ingress_isl_port") int ingressIslPort,
             @JsonProperty("encapsulation") FlowTransitEncapsulation encapsulation,
             @JsonProperty("egress_isl_port") int egressIslPort) {
-        super(context, switchId, commandId, metadata, ingressIslPort, encapsulation, egressIslPort);
+        super(context, switchId, egressSwitchId, commandId, metadata, ingressIslPort, encapsulation, egressIslPort);
     }
 
     @Override
     protected CompletableFuture<FlowSegmentReport> makeExecutePlan(SpeakerCommandProcessor commandProcessor) {
         return makeVerifyPlan(ImmutableList.of(makeTransitModMessage()));
-    }
-
-    @Override
-    protected int getTableId() {
-        return SwitchManager.EGRESS_TABLE_ID;
     }
 
     @Override

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
@@ -1862,8 +1862,9 @@ class RecordHandler implements Runnable {
     private FlowSegmentWrapperCommand makeTransitLoopWrappedCommand(
             InstallTransitLoopFlow request, MessageContext messageContext, FlowSegmentResponseFactory responseFactory) {
         TransitFlowLoopSegmentInstallCommand command = new TransitFlowLoopSegmentInstallCommand(
-                messageContext, request.getSwitchId(), EMPTY_COMMAND_ID, makeSegmentMetadata(request),
-                request.getInputPort(), makeTransitEncapsulation(request), request.getOutputPort());
+                messageContext, request.getSwitchId(), request.getIngressEndpoint().getSwitchId(),
+                EMPTY_COMMAND_ID, makeSegmentMetadata(request), request.getInputPort(),
+                makeTransitEncapsulation(request), request.getOutputPort());
 
         return new FlowSegmentWrapperCommand(command, responseFactory);
     }


### PR DESCRIPTION
After turning of VXLAN packet we must update eth_dst header
because egress rule on the last switch will match the packet by this field.

Closes #4072