### PR TITLE
Added/updated requirements for lab service and traff exam

### DIFF
--- a/src-python/lab-service/lab/requirements.txt
+++ b/src-python/lab-service/lab/requirements.txt
@@ -1,4 +1,4 @@
 python-logstash
-flask
+flask<2.0.0 # flask 2.0.0 is incompatible with click==7.0 from traffexam/requirements.txt
 docker<=4.4.4
 requests

--- a/src-python/lab-service/traffexam/requirements.txt
+++ b/src-python/lab-service/traffexam/requirements.txt
@@ -2,4 +2,4 @@ click==7.0
 bottle>=0.12.16,<=0.12.18
 pyroute2==0.5.5
 nsenter==0.2
-scapy>=2.4.2,<2.4.3
+scapy>=2.4.3,<2.4.4


### PR DESCRIPTION
* scapy==2.4.2 has bug in package https://github.com/secdev/scapy/issues/1783
so we need to update this packet
* flask 2.0.0 was just released (2021-05-11) and it is incompatible
with click==7.0 from traffexam/requirements.txt