### PR TITLE
Replace sun.misc.BASE64* with java.util.Base64

### DIFF
--- a/src-gui/src/main/java/org/openkilda/security/RsaEncryptionDescription.java
+++ b/src-gui/src/main/java/org/openkilda/security/RsaEncryptionDescription.java
@@ -101,9 +101,7 @@ public final class RsaEncryptionDescription {
          * StringBuilder sb = new StringBuilder(); for (byte b : data) {
          * sb.append((char)b); } return sb.toString();
          */
-        // return new sun.misc.BASE64Encoder().encode(data);
-        return new sun.misc.BASE64Encoder().encode(data);
-
+        return java.util.Base64.getEncoder().encodeToString(data);
     }
 
     /**
@@ -120,7 +118,7 @@ public final class RsaEncryptionDescription {
         Key priKey = readKeyFromFile("private.key");
         Cipher cipher = Cipher.getInstance("RSA");
         cipher.init(Cipher.DECRYPT_MODE, priKey);
-        byte[] data = cipher.doFinal(new sun.misc.BASE64Decoder().decodeBuffer(text));
+        byte[] data = cipher.doFinal(java.util.Base64.getDecoder().decode(text));
         // return new String(data);
         return new String(data, "UTF8");
     }


### PR DESCRIPTION
In JDK 9 sun.misc.BASE64* classes were removed.
To be able to compile GUI by JDK 9+ sun.misc.BASE64* classes were replaced with java.util.Base64

More info:
https://bugs.openjdk.java.net/browse/JDK-8097121
https://www.baeldung.com/java-9-migration-issue#jdk-internal-apis

