### PR TITLE
Fix reroute flows on ISL

### DIFF
--- a/src-java/reroute-topology/reroute-storm-topology/src/main/java/org/openkilda/wfm/topology/reroute/service/RerouteQueueService.java
+++ b/src-java/reroute-topology/reroute-storm-topology/src/main/java/org/openkilda/wfm/topology/reroute/service/RerouteQueueService.java
@@ -1,4 +1,4 @@
-/* Copyright 2020 Telstra Open Source
+/* Copyright 2021 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -72,6 +72,15 @@ public class RerouteQueueService {
      * @param throttlingData reroute request params
      */
     public void processAutomaticRequest(String flowId, FlowThrottlingData throttlingData) {
+        Optional<Flow> flow = flowRepository.findById(flowId);
+        if (!flow.isPresent()) {
+            log.warn(format("Flow %s not found. Skip the reroute operation of this flow.", flowId));
+            return;
+        } else if (flow.get().isPinned()) {
+            log.info(format("Flow %s is pinned. Skip the reroute operation of this flow.", flowId));
+            return;
+        }
+
         log.info("Puts reroute request for flow {} with correlationId {}.", flowId, throttlingData.getCorrelationId());
         RerouteQueue rerouteQueue = getRerouteQueue(flowId);
         rerouteQueue.putToThrottling(throttlingData);

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PinnedFlowV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PinnedFlowV2Spec.groovy
@@ -2,7 +2,6 @@ package org.openkilda.functionaltests.spec.flows
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static org.openkilda.model.MeterId.MAX_SYSTEM_RULE_METER_ID
-import static org.openkilda.testing.Constants.RULES_INSTALLATION_TIME
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
@@ -17,7 +16,6 @@ import org.openkilda.testing.model.topology.TopologyDefinition.Switch
 
 import org.springframework.http.HttpStatus
 import org.springframework.web.client.HttpClientErrorException
-import spock.lang.Ignore
 import spock.lang.Narrative
 
 import java.time.Instant
@@ -177,7 +175,6 @@ class PinnedFlowV2Spec extends HealthCheckSpecification {
     }
 
     @Tidy
-    @Ignore("https://github.com/telstra/open-kilda/issues/4290")
     def "System is not rerouting pinned flow when 'reroute link flows' is called"() {
         given: "A pinned flow with alt path available"
         def switchPair = topologyHelper.getAllNeighboringSwitchPairs().find { it.paths.size() > 1 } ?:


### PR DESCRIPTION
- pinned flows no longer reroute when calling `PATCH /api/v1/links/flows/reroute`

Closes: #4290