### PR TITLE
Upgrade gradle to 6.9 and test-logger plugin to 3.0.0

### DIFF
--- a/src-java/gradle/wrapper/gradle-wrapper.properties
+++ b/src-java/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src-java/testing/functional-tests/build.gradle
+++ b/src-java/testing/functional-tests/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'groovy'
-    id 'com.adarshr.test-logger' version '2.1.1'
+    id 'com.adarshr.test-logger' version '3.0.0'
     id "org.gradle.test-retry" version "1.2.1"
 }
 


### PR DESCRIPTION
This fixes test retries for Unrolled spock tests and failures to generate xml/html test reports