### PR TITLE
Replace InetSocketAddress with own IpSocket objects

### DIFF
--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/event/SwitchInfoData.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/event/SwitchInfoData.java
@@ -44,9 +44,6 @@ public class SwitchInfoData extends CacheTimeTag {
     @JsonProperty("address")
     private String address;
 
-    @JsonProperty("hostname")
-    private String hostname;
-
     @JsonProperty("description")
     private String description;
 
@@ -73,7 +70,7 @@ public class SwitchInfoData extends CacheTimeTag {
 
     public SwitchInfoData(SwitchId switchId, SwitchChangeType state, String address, String hostname,
                           String description, String controller, boolean underMaintenance) {
-        this(switchId, state, address, hostname, description, controller, underMaintenance, null);
+        this(switchId, state, address, description, controller, underMaintenance, null);
     }
 
     /**
@@ -82,7 +79,6 @@ public class SwitchInfoData extends CacheTimeTag {
      * @param switchId    switch datapath id
      * @param state       switch state
      * @param address     switch ip address
-     * @param hostname    switch name
      * @param description switch description
      * @param controller  switch controller
      * @param switchView data for ISL/switch discovery
@@ -92,7 +88,6 @@ public class SwitchInfoData extends CacheTimeTag {
     public SwitchInfoData(@JsonProperty("switch_id") SwitchId switchId,
                           @JsonProperty("state") SwitchChangeType state,
                           @JsonProperty("address") String address,
-                          @JsonProperty("hostname") String hostname,
                           @JsonProperty("description") String description,
                           @JsonProperty("controller") String controller,
                           @JsonProperty("under_maintenance") boolean underMaintenance,
@@ -100,7 +95,6 @@ public class SwitchInfoData extends CacheTimeTag {
         this.switchId = switchId;
         this.state = state;
         this.address = address;
-        this.hostname = hostname;
         this.description = description;
         this.controller = controller;
         this.switchView = switchView;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/SpeakerSwitchView.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/SpeakerSwitchView.java
@@ -15,6 +15,7 @@
 
 package org.openkilda.messaging.model;
 
+import org.openkilda.model.IpSocketAddress;
 import org.openkilda.model.SwitchFeature;
 import org.openkilda.model.SwitchId;
 
@@ -27,7 +28,6 @@ import lombok.Singular;
 import lombok.Value;
 
 import java.io.Serializable;
-import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -39,10 +39,13 @@ public class SpeakerSwitchView implements Serializable {
     private SwitchId datapath;
 
     @JsonProperty(value = "switch-socket", required = true)
-    private InetSocketAddress switchSocketAddress;
+    private IpSocketAddress switchSocketAddress;
 
     @JsonProperty(value = "speaker-socket", required = true)
-    private InetSocketAddress speakerSocketAddress;
+    private IpSocketAddress speakerSocketAddress;
+
+    @JsonProperty(value = "hostname")
+    String hostname;
 
     // TODO: move to enum
     @JsonProperty(value = "OF-version")
@@ -61,8 +64,9 @@ public class SpeakerSwitchView implements Serializable {
     @JsonCreator
     public SpeakerSwitchView(
             @JsonProperty("datapath") SwitchId datapath,
-            @JsonProperty("switch-socket") InetSocketAddress switchSocketAddress,
-            @JsonProperty("speaker-socket") InetSocketAddress speakerSocketAddress,
+            @JsonProperty("switch-socket") IpSocketAddress switchSocketAddress,
+            @JsonProperty("speaker-socket") IpSocketAddress speakerSocketAddress,
+            @JsonProperty("hostname") String hostname,
             @JsonProperty("OF-version") String ofVersion,
             @JsonProperty("description") SpeakerSwitchDescription description,
             @JsonProperty("features") Set<SwitchFeature> features,
@@ -70,6 +74,7 @@ public class SpeakerSwitchView implements Serializable {
         this.datapath = datapath;
         this.switchSocketAddress = switchSocketAddress;
         this.speakerSocketAddress = speakerSocketAddress;
+        this.hostname = hostname;
         this.ofVersion = ofVersion;
         this.description = description;
 

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/model/SwitchTest.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/model/SwitchTest.java
@@ -17,6 +17,7 @@ package org.openkilda.messaging.model;
 
 import org.openkilda.messaging.StringSerializer;
 import org.openkilda.messaging.Utils;
+import org.openkilda.model.IpSocketAddress;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchFeature;
 import org.openkilda.model.SwitchId;
@@ -26,7 +27,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.Collections;
 
 public class SwitchTest {
@@ -52,7 +52,7 @@ public class SwitchTest {
                 .pop("test_pop")
                 .status(SwitchStatus.ACTIVE)
                 .underMaintenance(true)
-                .socketAddress(new InetSocketAddress(1))
+                .socketAddress(new IpSocketAddress("192.168.10.20", 1))
                 .features(Collections.singleton(SwitchFeature.GROUP_PACKET_OUT_CONTROLLER))
                 .build();
         serializer.serialize(origin);

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/converter/IofSwitchConverter.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/converter/IofSwitchConverter.java
@@ -50,7 +50,6 @@ public final class IofSwitchConverter {
                 String.format("%s:%d",
                         address.getHostString(),
                         address.getPort()),
-                address.getHostName(),
                 String.format("%s %s %s",
                         sw.getSwitchDescription().getManufacturerDescription(),
                         sw.getOFFactory().getVersion().toString(),

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/error/InvalidConnectionDataException.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/error/InvalidConnectionDataException.java
@@ -1,0 +1,39 @@
+/* Copyright 2021 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.floodlight.error;
+
+import lombok.Getter;
+import org.projectfloodlight.openflow.types.DatapathId;
+
+import java.net.SocketAddress;
+
+@Getter
+public final class InvalidConnectionDataException extends SwitchOperationException {
+    private final SocketAddress socketAddress;
+
+    public static InvalidConnectionDataException ofSpeakerSocket(DatapathId dpId, SocketAddress socketAddress) {
+        return new InvalidConnectionDataException(dpId, socketAddress, "speaker");
+    }
+
+    public static InvalidConnectionDataException ofSwitchSocket(DatapathId dpId, SocketAddress socketAddress) {
+        return new InvalidConnectionDataException(dpId, socketAddress, "switch");
+    }
+
+    private InvalidConnectionDataException(DatapathId dpId, SocketAddress socketAddress, String kind) {
+        super(dpId, String.format("Invalid %s ip socket address %s (dpid: %s)", kind, socketAddress, dpId));
+        this.socketAddress = socketAddress;
+    }
+}

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/model/SwitchConnect.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/model/SwitchConnect.java
@@ -15,9 +15,10 @@
 
 package org.openkilda.wfm.topology.floodlightrouter.model;
 
+import org.openkilda.model.IpSocketAddress;
+
 import lombok.Value;
 
-import java.net.InetSocketAddress;
 import java.time.Instant;
 
 @Value
@@ -26,9 +27,9 @@ public class SwitchConnect {
 
     Instant connectedAt;
 
-    InetSocketAddress switchAddress;
+    IpSocketAddress switchAddress;
 
-    InetSocketAddress speakerAddress;
+    IpSocketAddress speakerAddress;
 
     /**
      * Manages setting of isActive flag.

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchMonitor.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/main/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchMonitor.java
@@ -22,6 +22,7 @@ import org.openkilda.messaging.info.event.SwitchInfoData;
 import org.openkilda.messaging.model.SpeakerSwitchView;
 import org.openkilda.messaging.model.SwitchAvailabilityData;
 import org.openkilda.messaging.model.SwitchAvailabilityEntry;
+import org.openkilda.model.IpSocketAddress;
 import org.openkilda.model.SwitchConnectMode;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.topology.floodlightrouter.mapper.SwitchNotificationMapper;
@@ -34,7 +35,6 @@ import org.openkilda.wfm.topology.floodlightrouter.service.SwitchMonitorCarrier;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
-import java.net.InetSocketAddress;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -272,8 +272,8 @@ public class SwitchMonitor {
     }
 
     private SwitchConnect makeSwitchConnect(boolean isActive, SpeakerSwitchView speakerData) {
-        InetSocketAddress switchAddress = null;
-        InetSocketAddress speakerAddress = null;
+        IpSocketAddress switchAddress = null;
+        IpSocketAddress speakerAddress = null;
         if (speakerData != null) {
             switchAddress = speakerData.getSwitchSocketAddress();
             speakerAddress = speakerData.getSpeakerSocketAddress();

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchMonitorServiceTest.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchMonitorServiceTest.java
@@ -32,6 +32,7 @@ import org.openkilda.messaging.model.SpeakerSwitchPortView.State;
 import org.openkilda.messaging.model.SpeakerSwitchView;
 import org.openkilda.messaging.model.SwitchAvailabilityData;
 import org.openkilda.messaging.model.SwitchAvailabilityEntry;
+import org.openkilda.model.IpSocketAddress;
 import org.openkilda.model.SwitchConnectMode;
 import org.openkilda.model.SwitchId;
 import org.openkilda.stubs.ManualClock;
@@ -46,7 +47,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
@@ -509,8 +509,8 @@ public class SwitchMonitorServiceTest {
         String swAddress = String.format("127.0.%d.2", network);
         SpeakerSwitchView speakerView = SpeakerSwitchView.builder()
                 .datapath(switchId)
-                .switchSocketAddress(InetSocketAddress.createUnresolved(swAddress, 32769))
-                .speakerSocketAddress(InetSocketAddress.createUnresolved(String.format("127.0.%d.1", network), 6653))
+                .switchSocketAddress(new IpSocketAddress(swAddress, 32769))
+                .speakerSocketAddress(new IpSocketAddress(String.format("127.0.%d.1", network), 6653))
                 .ofVersion("OF_13")
                 .description(SpeakerSwitchDescription.builder()
                         .manufacturer("manufacturer")
@@ -525,7 +525,7 @@ public class SwitchMonitorServiceTest {
                 .build();
         return new SwitchInfoData(
                 SWITCH_ALPHA, SwitchChangeType.ACTIVATED,
-                swAddress, swAddress,
+                swAddress,
                 String.format("%s %s %s",
                         speakerView.getDescription().getManufacturer(),
                         speakerView.getOfVersion(),

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/IpSocketAddress.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/IpSocketAddress.java
@@ -13,28 +13,14 @@
  *   limitations under the License.
  */
 
-package org.openkilda.messaging.model;
+package org.openkilda.model;
 
-import org.openkilda.model.IpSocketAddress;
-import org.openkilda.model.SwitchConnectMode;
-
-import lombok.Builder;
+import lombok.NonNull;
 import lombok.Value;
 
-import java.io.Serializable;
-import java.time.Instant;
-
 @Value
-@Builder
-public class SwitchAvailabilityEntry implements Serializable {
-    String regionName;
-
-    SwitchConnectMode connectMode;
-
-    boolean master;
-
-    Instant connectedAt;
-
-    IpSocketAddress switchAddress;
-    IpSocketAddress speakerAddress;
+public class IpSocketAddress {
+    @NonNull
+    String address;
+    int port;
 }

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/Switch.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/Switch.java
@@ -35,7 +35,6 @@ import org.mapstruct.MappingTarget;
 import org.mapstruct.factory.Mappers;
 
 import java.io.Serializable;
-import java.net.InetSocketAddress;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.Objects;
@@ -75,7 +74,7 @@ public class Switch implements CompositeDataEntity<Switch.SwitchData> {
     }
 
     @Builder
-    public Switch(@NonNull SwitchId switchId, SwitchStatus status, InetSocketAddress socketAddress,
+    public Switch(@NonNull SwitchId switchId, SwitchStatus status, IpSocketAddress socketAddress,
                   String hostname, String controller, String description, String ofVersion,
                   String ofDescriptionManufacturer, String ofDescriptionHardware, String ofDescriptionSoftware,
                   String ofDescriptionSerialNumber, String ofDescriptionDatapath,
@@ -192,9 +191,9 @@ public class Switch implements CompositeDataEntity<Switch.SwitchData> {
 
         void setStatus(SwitchStatus status);
 
-        InetSocketAddress getSocketAddress();
+        IpSocketAddress getSocketAddress();
 
-        void setSocketAddress(InetSocketAddress socketAddress);
+        void setSocketAddress(IpSocketAddress socketAddress);
 
         String getHostname();
 
@@ -284,7 +283,7 @@ public class Switch implements CompositeDataEntity<Switch.SwitchData> {
         private static final long serialVersionUID = 1L;
         @NonNull SwitchId switchId;
         SwitchStatus status;
-        InetSocketAddress socketAddress;
+        IpSocketAddress socketAddress;
         String hostname;
         String controller;
         String description;

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/SwitchConnect.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/SwitchConnect.java
@@ -34,7 +34,6 @@ import org.mapstruct.MappingTarget;
 import org.mapstruct.factory.Mappers;
 
 import java.io.Serializable;
-import java.net.InetSocketAddress;
 import java.time.Instant;
 
 @DefaultSerializer(BeanSerializer.class)
@@ -56,7 +55,7 @@ public class SwitchConnect implements CompositeDataEntity<SwitchConnect.SwitchCo
     @Builder
     public SwitchConnect(
             @NonNull Speaker speaker, @NonNull Switch owner, SwitchConnectMode mode, boolean isMaster,
-            Instant connectedAt, InetSocketAddress switchAddress, InetSocketAddress speakerAddress) {
+            Instant connectedAt, IpSocketAddress switchAddress, IpSocketAddress speakerAddress) {
         this.data = SwitchConnectDataImpl.builder()
                 .speaker(speaker)
                 .owner(owner)
@@ -129,13 +128,13 @@ public class SwitchConnect implements CompositeDataEntity<SwitchConnect.SwitchCo
 
         void setConnectedAt(Instant connectedAt);
 
-        InetSocketAddress getSwitchAddress();
+        IpSocketAddress getSwitchAddress();
 
-        void setSwitchAddress(InetSocketAddress address);
+        void setSwitchAddress(IpSocketAddress address);
 
-        InetSocketAddress getSpeakerAddress();
+        IpSocketAddress getSpeakerAddress();
 
-        void setSpeakerAddress(InetSocketAddress address);
+        void setSpeakerAddress(IpSocketAddress address);
     }
 
     @Data
@@ -155,10 +154,10 @@ public class SwitchConnect implements CompositeDataEntity<SwitchConnect.SwitchCo
 
         boolean master;
 
-        Instant connectedAt;
+        private Instant connectedAt;
 
-        InetSocketAddress switchAddress;
-        InetSocketAddress speakerAddress;
+        private IpSocketAddress switchAddress;
+        private IpSocketAddress speakerAddress;
 
         public SwitchId getOwnerSwitchId() {
             return owner.getSwitchId();

--- a/src-java/kilda-persistence-api/src/test/java/org/openkilda/persistence/dummy/SwitchDefaults.java
+++ b/src-java/kilda-persistence-api/src/test/java/org/openkilda/persistence/dummy/SwitchDefaults.java
@@ -15,13 +15,13 @@
 
 package org.openkilda.persistence.dummy;
 
+import org.openkilda.model.IpSocketAddress;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchFeature;
 import org.openkilda.model.SwitchStatus;
 
 import lombok.Data;
 
-import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.Set;
 
@@ -29,7 +29,7 @@ import java.util.Set;
 public class SwitchDefaults {
     private SwitchStatus status = SwitchStatus.ACTIVE;
 
-    private InetSocketAddress socketAddress = new InetSocketAddress("127.0.0.1", 32768);
+    private IpSocketAddress socketAddress = new IpSocketAddress("127.0.0.1", 32768);
     private String hostname = "dummy.ofsw.local";
 
     Set<SwitchFeature> features = Collections.emptySet();

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/frames/SwitchConnectFrame.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/frames/SwitchConnectFrame.java
@@ -15,6 +15,7 @@
 
 package org.openkilda.persistence.ferma.frames;
 
+import org.openkilda.model.IpSocketAddress;
 import org.openkilda.model.Speaker;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchConnect.SwitchConnectData;
@@ -27,9 +28,6 @@ import org.openkilda.persistence.ferma.frames.converters.SwitchConnectModeConver
 import com.syncleus.ferma.annotations.Property;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 import java.time.Instant;
 import java.util.Iterator;
 
@@ -122,50 +120,42 @@ public abstract class SwitchConnectFrame extends KildaBaseEdgeFrame implements S
     public abstract void setConnectedAt(Instant connectedAt);
 
     @Override
-    public InetSocketAddress getSwitchAddress() {
+    public IpSocketAddress getSwitchAddress() {
         return getAddress(SWITCH_ADDRESS_PROPERTY, SWITCH_ADDRESS_PORT_PROPERTY);
     }
 
     @Override
-    public void setSwitchAddress(InetSocketAddress address) {
+    public void setSwitchAddress(IpSocketAddress address) {
         setAddress(SWITCH_ADDRESS_PROPERTY, SWITCH_ADDRESS_PORT_PROPERTY, address);
     }
 
     @Override
-    public InetSocketAddress getSpeakerAddress() {
+    public IpSocketAddress getSpeakerAddress() {
         return getAddress(SPEAKER_ADDRESS_PROPERTY, SPEAKER_ADDRESS_PORT_PROPERTY);
     }
 
     @Override
-    public void setSpeakerAddress(InetSocketAddress address) {
+    public void setSpeakerAddress(IpSocketAddress address) {
         setAddress(SPEAKER_ADDRESS_PROPERTY, SPEAKER_ADDRESS_PORT_PROPERTY, address);
     }
 
-    private InetSocketAddress getAddress(String addressProperty, String portProperty) {
+    private IpSocketAddress getAddress(String addressProperty, String portProperty) {
         String address = getProperty(addressProperty);
         if (address == null) {
             return null;
         }
-
-        int port = getAddressPort(portProperty);
-        try {
-            return new InetSocketAddress(InetAddress.getByName(address), port);
-        } catch (UnknownHostException e) {
-            throw new IllegalStateException(String.format(
-                    "Switch connect relation stores invalid address %s:%d (fields %s / %s)",
-                    address, port, addressProperty, portProperty));
-        }
+        return new IpSocketAddress(address, getAddressPort(portProperty));
     }
 
-    private void setAddress(String addressProperty, String portProperty, InetSocketAddress address) {
-        if (address == null) {
+    private void setAddress(String addressProperty, String portProperty, IpSocketAddress ipSocketAddress) {
+        if (ipSocketAddress == null) {
             setProperty(addressProperty, null);
             setProperty(portProperty, null);
             return;
         }
 
-        setProperty(addressProperty, address.getAddress().getHostAddress());
-        setProperty(portProperty, address.getPort());
+        setProperty(addressProperty, ipSocketAddress.getAddress());
+        setProperty(portProperty, ipSocketAddress.getPort());
     }
 
     private int getAddressPort(String property) {

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/frames/SwitchFrame.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/frames/SwitchFrame.java
@@ -15,8 +15,7 @@
 
 package org.openkilda.persistence.ferma.frames;
 
-import static java.lang.String.format;
-
+import org.openkilda.model.IpSocketAddress;
 import org.openkilda.model.Switch.SwitchData;
 import org.openkilda.model.SwitchFeature;
 import org.openkilda.model.SwitchId;
@@ -32,9 +31,6 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -74,27 +70,22 @@ public abstract class SwitchFrame extends KildaBaseVertexFrame implements Switch
     public abstract void setStatus(SwitchStatus status);
 
     @Override
-    public InetSocketAddress getSocketAddress() {
+    public IpSocketAddress getSocketAddress() {
         int port = Optional.ofNullable(getProperty(PORT_PROPERTY)).map(l -> ((Number) l).intValue()).orElse(0);
         return Optional.ofNullable((String) getProperty(ADDRESS_PROPERTY))
-                .map(address -> convert(address, port))
+                .map(address -> new IpSocketAddress(address, port))
                 .orElse(null);
     }
 
-    private InetSocketAddress convert(String address, int port) {
-        try {
-            return new InetSocketAddress(InetAddress.getByName(address), port);
-        } catch (UnknownHostException e) {
-            throw new IllegalStateException(format("Switch address '%s' is invalid", address), e);
-        }
-    }
-
     @Override
-    public void setSocketAddress(InetSocketAddress socketAddress) {
-        setProperty(ADDRESS_PROPERTY, socketAddress != null && socketAddress.getAddress() != null
-                ? socketAddress.getAddress().getHostAddress() : null);
-        setProperty(PORT_PROPERTY, socketAddress != null
-                ? socketAddress.getPort() : null);
+    public void setSocketAddress(IpSocketAddress ipSocketAddress) {
+        if (ipSocketAddress != null) {
+            setProperty(ADDRESS_PROPERTY, ipSocketAddress.getAddress());
+            setProperty(PORT_PROPERTY, ipSocketAddress.getPort());
+        } else {
+            setProperty(ADDRESS_PROPERTY, null);
+            setProperty(PORT_PROPERTY, null);
+        }
     }
 
     @Override

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/TimeModifyPropertyOnFramesTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/TimeModifyPropertyOnFramesTest.java
@@ -18,6 +18,7 @@ package org.openkilda.persistence.ferma.frames;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
+import org.openkilda.model.IpSocketAddress;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchId;
 import org.openkilda.model.SwitchStatus;
@@ -30,7 +31,6 @@ import net.jodah.failsafe.function.CheckedSupplier;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.time.Instant;
 
@@ -75,9 +75,8 @@ public class TimeModifyPropertyOnFramesTest extends InMemoryGraphBasedTest {
         Instant timeModifyBefore = transactionManager.doInTransaction(() -> createTestSwitch(1).getTimeModify());
         waitUntilNowIsAfter(timeModifyBefore);
 
-        transactionManager.doInTransaction(() -> {
-            switchRepository.findById(new SwitchId(1)).get().setSocketAddress(new InetSocketAddress(12345));
-        });
+        transactionManager.doInTransaction(() -> switchRepository.findById(
+                new SwitchId(1)).get().setSocketAddress(new IpSocketAddress("192.168.10.20", 12345)));
 
         Instant timeModifyAfter = switchRepository.findById(new SwitchId(1)).get().getTimeModify();
 

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/inmemory/InMemoryGraphBasedTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/inmemory/InMemoryGraphBasedTest.java
@@ -17,6 +17,7 @@ package org.openkilda.persistence.inmemory;
 
 import org.openkilda.config.provider.ConfigurationProvider;
 import org.openkilda.config.provider.PropertiesBasedConfigurationProvider;
+import org.openkilda.model.IpSocketAddress;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchId;
 import org.openkilda.model.SwitchStatus;
@@ -28,10 +29,6 @@ import org.openkilda.persistence.tx.TransactionManager;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.mockito.Mockito;
-
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 
 public abstract class InMemoryGraphBasedTest {
 
@@ -62,19 +59,15 @@ public abstract class InMemoryGraphBasedTest {
     }
 
     protected Switch createTestSwitch(SwitchId switchId) {
-        try {
-            Switch sw = Switch.builder()
-                    .switchId(switchId)
-                    .description("test_description")
-                    .socketAddress(new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 30070))
-                    .controller("test_ctrl")
-                    .hostname("test_host_" + switchId)
-                    .status(SwitchStatus.ACTIVE)
-                    .build();
-            repositoryFactory.createSwitchRepository().add(sw);
-            return sw;
-        } catch (UnknownHostException e) {
-            throw new IllegalStateException(e);
-        }
+        Switch sw = Switch.builder()
+                .switchId(switchId)
+                .description("test_description")
+                .socketAddress(new IpSocketAddress("10.0.0.1", 30070))
+                .controller("test_ctrl")
+                .hostname("test_host_" + switchId)
+                .status(SwitchStatus.ACTIVE)
+                .build();
+        repositoryFactory.createSwitchRepository().add(sw);
+        return sw;
     }
 }

--- a/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/storm/bolt/bfd/worker/BfdWorker.java
+++ b/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/storm/bolt/bfd/worker/BfdWorker.java
@@ -27,6 +27,7 @@ import org.openkilda.messaging.info.grpc.CreateLogicalPortResponse;
 import org.openkilda.messaging.info.grpc.DeleteLogicalPortResponse;
 import org.openkilda.messaging.model.NoviBfdSession;
 import org.openkilda.messaging.model.grpc.LogicalPortType;
+import org.openkilda.model.IpSocketAddress;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchId;
 import org.openkilda.persistence.PersistenceManager;
@@ -53,7 +54,6 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 
-import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -231,8 +231,8 @@ public class BfdWorker extends WorkerBolt {
             return Optional.empty();
         }
 
-        InetSocketAddress address = sw.get().getSocketAddress();
-        return Optional.of(address.getAddress().getHostAddress());
+        IpSocketAddress address = sw.get().getSocketAddress();
+        return Optional.of(address.getAddress());
     }
 
     private ErrorData makeSwitchAddressNotFoundError(SwitchId switchId) {

--- a/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkBfdSessionServiceTest.java
+++ b/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkBfdSessionServiceTest.java
@@ -28,6 +28,7 @@ import org.openkilda.messaging.floodlight.response.BfdSessionResponse;
 import org.openkilda.messaging.model.NoviBfdSession;
 import org.openkilda.model.BfdProperties;
 import org.openkilda.model.BfdSession;
+import org.openkilda.model.IpSocketAddress;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchId;
 import org.openkilda.persistence.PersistenceManager;
@@ -54,7 +55,6 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.Optional;
@@ -84,15 +84,15 @@ public class NetworkBfdSessionServiceTest {
 
     private final Switch alphaSwitch = Switch.builder()
             .switchId(alphaEndpoint.getDatapath())
-            .socketAddress(getSocketAddress(alphaAddress, 30070))
+            .socketAddress(new IpSocketAddress(alphaAddress, 30070))
             .build();
     private final Switch betaSwitch = Switch.builder()
             .switchId(betaEndpoint.getDatapath())
-            .socketAddress(getSocketAddress(betaAddress, 30071))
+            .socketAddress(new IpSocketAddress(betaAddress, 30071))
             .build();
     private final Switch gammaSwitch = Switch.builder()
             .switchId(gammaEndpoint.getDatapath())
-            .socketAddress(getSocketAddress(gammaAddress, 30072))
+            .socketAddress(new IpSocketAddress(gammaAddress, 30072))
             .build();
 
     private final String setupRequestKey = "bfd-setup-speaker-key";
@@ -668,14 +668,6 @@ public class NetworkBfdSessionServiceTest {
     private void mockBfdSessionLookup(BfdSession session) {
         when(bfdSessionRepository.findBySwitchIdAndPort(session.getSwitchId(), session.getPort()))
                 .thenReturn(Optional.of(session));
-    }
-
-    private InetSocketAddress getSocketAddress(String host, int port) {
-        try {
-            return new InetSocketAddress(InetAddress.getByName(host), port);
-        } catch (UnknownHostException e) {
-            throw new IllegalStateException(e);
-        }
     }
 
     private void resetCarrier() {

--- a/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkIntegrationTest.java
+++ b/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkIntegrationTest.java
@@ -21,6 +21,7 @@ import org.openkilda.messaging.info.event.SwitchInfoData;
 import org.openkilda.messaging.model.SpeakerSwitchDescription;
 import org.openkilda.messaging.model.SpeakerSwitchPortView;
 import org.openkilda.messaging.model.SpeakerSwitchView;
+import org.openkilda.model.IpSocketAddress;
 import org.openkilda.model.SwitchFeature;
 import org.openkilda.model.SwitchId;
 import org.openkilda.persistence.NetworkConfig;
@@ -106,12 +107,15 @@ public class NetworkIntegrationTest {
                 new SpeakerSwitchPortView(2, SpeakerSwitchPortView.State.DOWN),
                 new SpeakerSwitchPortView(2 + bfdLocalPortOffset, SpeakerSwitchPortView.State.DOWN));
         SpeakerSwitchView speakerSwitchView = new SpeakerSwitchView(
-                alphaDatapath, alphaInetAddress, speakerInetAddress, "OF_13", switchDescription, features, ports);
+                alphaDatapath,
+                new IpSocketAddress(alphaInetAddress.getHostString(), alphaInetAddress.getPort()),
+                new IpSocketAddress(speakerInetAddress.getHostString(), speakerInetAddress.getPort()),
+                alphaInetAddress.getHostString(), "OF_13", switchDescription, features, ports);
 
         NetworkSwitchService switchService = integrationCarrier.getSwitchService();
         SwitchInfoData switchAddEvent = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ADDED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 speakerSwitchView);
@@ -119,7 +123,7 @@ public class NetworkIntegrationTest {
 
         SwitchInfoData switchActivateEvent = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ACTIVATED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 speakerSwitchView);

--- a/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkSwitchServiceTest.java
+++ b/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkSwitchServiceTest.java
@@ -42,6 +42,7 @@ import org.openkilda.messaging.model.SpeakerSwitchPortView;
 import org.openkilda.messaging.model.SpeakerSwitchPortView.State;
 import org.openkilda.messaging.model.SpeakerSwitchView;
 import org.openkilda.model.FlowPathDirection;
+import org.openkilda.model.IpSocketAddress;
 import org.openkilda.model.Isl;
 import org.openkilda.model.KildaConfiguration;
 import org.openkilda.model.Switch;
@@ -134,12 +135,10 @@ public class NetworkSwitchServiceTest {
             .datapath("OpenFlow switch AABBCC")
             .build();
 
-    private final InetSocketAddress speakerInetAddress = new InetSocketAddress(
-            Inet4Address.getByName("127.1.0.254"), 6653);
+    private final IpSocketAddress speakerInetAddress = new IpSocketAddress("127.1.0.254", 6653);
 
     private final SwitchId alphaDatapath = new SwitchId(1);
-    private final InetSocketAddress alphaInetAddress = new InetSocketAddress(
-            Inet4Address.getByName("127.1.0.1"), 32768);
+    private final IpSocketAddress alphaInetAddress = new IpSocketAddress("127.1.0.1", 32768);
 
     private final SwitchId betaDatapath = new SwitchId(2);
     private final InetSocketAddress betaInetAddress = new InetSocketAddress(
@@ -202,7 +201,7 @@ public class NetworkSwitchServiceTest {
 
         SwitchInfoData switchAddEvent = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ACTIVATED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 speakerSwitchView);
@@ -228,7 +227,7 @@ public class NetworkSwitchServiceTest {
 
         SwitchInfoData switchAddEvent = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ACTIVATED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 speakerSwitchView);
@@ -341,7 +340,7 @@ public class NetworkSwitchServiceTest {
 
         SwitchInfoData switchAddEvent = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ACTIVATED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 speakerSwitchView);
@@ -367,7 +366,7 @@ public class NetworkSwitchServiceTest {
 
         SwitchInfoData switchAddEvent = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ACTIVATED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 speakerSwitchView);
@@ -389,7 +388,7 @@ public class NetworkSwitchServiceTest {
 
         SwitchInfoData switchAddEvent2 = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ACTIVATED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 speakerSwitchView2);
@@ -436,7 +435,7 @@ public class NetworkSwitchServiceTest {
 
         SwitchInfoData switchAddEvent = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ACTIVATED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 speakerSwitchView);
@@ -523,7 +522,7 @@ public class NetworkSwitchServiceTest {
     public void portAddEventOnOnlineSwitch() {
         SwitchInfoData switchAddEvent = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ACTIVATED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 getSpeakerSwitchView());
@@ -556,7 +555,7 @@ public class NetworkSwitchServiceTest {
 
         SwitchInfoData switchAddEvent = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ACTIVATED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 speakerSwitchView);
@@ -600,7 +599,7 @@ public class NetworkSwitchServiceTest {
 
         SwitchInfoData switchAddEvent = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ACTIVATED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 speakerSwitchView);
@@ -636,7 +635,7 @@ public class NetworkSwitchServiceTest {
 
         SwitchInfoData switchAddEvent = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ACTIVATED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 speakerSwitchView);
@@ -666,7 +665,7 @@ public class NetworkSwitchServiceTest {
 
         SwitchInfoData switchAddEvent = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ACTIVATED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 speakerSwitchView);
@@ -709,7 +708,7 @@ public class NetworkSwitchServiceTest {
 
         SwitchInfoData switchAddEvent = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ACTIVATED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 speakerSwitchView);
@@ -753,7 +752,7 @@ public class NetworkSwitchServiceTest {
 
         SwitchInfoData switchAddEvent = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ACTIVATED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 speakerSwitchView);
@@ -787,7 +786,7 @@ public class NetworkSwitchServiceTest {
 
         SwitchInfoData switchAddEvent = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ACTIVATED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 speakerSwitchView);
@@ -820,7 +819,7 @@ public class NetworkSwitchServiceTest {
 
         SwitchInfoData switchAddEvent = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ACTIVATED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 speakerSwitchView);
@@ -864,7 +863,7 @@ public class NetworkSwitchServiceTest {
 
         SwitchInfoData switchAddEvent = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ACTIVATED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 speakerSwitchView);
@@ -973,7 +972,7 @@ public class NetworkSwitchServiceTest {
 
         SwitchInfoData switchAddEvent = new SwitchInfoData(
                 alphaDatapath, SwitchChangeType.ACTIVATED,
-                alphaInetAddress.toString(), alphaInetAddress.toString(), alphaDescription,
+                alphaInetAddress.toString(), alphaDescription,
                 speakerInetAddress.toString(),
                 false,
                 speakerSwitchView);

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/converter/SwitchMapper.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/converter/SwitchMapper.java
@@ -33,6 +33,7 @@ import org.openkilda.messaging.model.SwitchAvailabilityEntry;
 import org.openkilda.messaging.model.SwitchLocation;
 import org.openkilda.messaging.model.SwitchPatch;
 import org.openkilda.messaging.payload.history.PortHistoryPayload;
+import org.openkilda.model.IpSocketAddress;
 import org.openkilda.model.MacAddress;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchStatus;
@@ -63,7 +64,6 @@ import org.openkilda.northbound.dto.v2.switches.SwitchPatchDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-import java.net.InetSocketAddress;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
@@ -79,7 +79,7 @@ public abstract class SwitchMapper {
     @Mapping(source = "ofDescriptionSoftware", target = "software")
     @Mapping(source = "ofDescriptionSerialNumber", target = "serialNumber")
     @Mapping(source = "status", target = "state")
-    @Mapping(source = "socketAddress.address.hostAddress", target = "address")
+    @Mapping(source = "socketAddress.address", target = "address")
     @Mapping(source = "socketAddress.port", target = "port")
     @Mapping(target = "location", expression = "java(new SwitchLocationDto("
             + "data.getLatitude(), data.getLongitude(), data.getStreet(), data.getCity(), data.getCountry()))")
@@ -187,7 +187,7 @@ public abstract class SwitchMapper {
     @Mapping(source = "ofDescriptionSoftware", target = "software")
     @Mapping(source = "ofDescriptionSerialNumber", target = "serialNumber")
     @Mapping(source = "status", target = "state")
-    @Mapping(source = "socketAddress.address.hostAddress", target = "address")
+    @Mapping(source = "socketAddress.address", target = "address")
     @Mapping(source = "socketAddress.port", target = "port")
     @Mapping(target = "location", expression = "java(new SwitchLocationDtoV2("
             + "data.getLatitude(), data.getLongitude(), data.getStreet(), data.getCity(), data.getCountry()))")
@@ -216,7 +216,13 @@ public abstract class SwitchMapper {
         return DateTimeFormatter.ISO_INSTANT.format(data);
     }
 
-    public String map(InetSocketAddress data) {
-        return String.format("%s:%d", data.getAddress().getHostAddress(), data.getPort());
+    /**
+     * Produce string representation of {@link IpSocketAddress}.
+     */
+    public String map(IpSocketAddress address) {
+        if (address == null) {
+            return null;
+        }
+        return String.format("%s:%d", address.getAddress(), address.getPort());
     }
 }

--- a/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/converter/SwitchMapperTest.java
+++ b/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/converter/SwitchMapperTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.openkilda.messaging.model.SwitchPatch;
 import org.openkilda.model.FlowEncapsulationType;
+import org.openkilda.model.IpSocketAddress;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchId;
 import org.openkilda.model.SwitchStatus;
@@ -31,8 +32,6 @@ import org.openkilda.northbound.dto.v2.switches.SwitchPatchDto;
 import com.google.common.collect.Lists;
 import org.junit.Test;
 import org.mapstruct.factory.Mappers;
-
-import java.net.InetSocketAddress;
 
 public class SwitchMapperTest {
     private SwitchMapper switchMapper = Mappers.getMapper(SwitchMapper.class);
@@ -135,7 +134,7 @@ public class SwitchMapperTest {
     private Switch getSwitch() {
         return Switch.builder()
                 .switchId(new SwitchId(1))
-                .socketAddress(new InetSocketAddress("localhost", 5050))
+                .socketAddress(new IpSocketAddress("127.0.0.1", 5050))
                 .hostname("hostname")
                 .description("description")
                 .status(SwitchStatus.ACTIVE)

--- a/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/bolts/StatsRequesterBolt.java
+++ b/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/bolts/StatsRequesterBolt.java
@@ -21,6 +21,7 @@ import static org.openkilda.wfm.topology.stats.StatsStreamType.STATS_REQUEST;
 import org.openkilda.messaging.command.CommandMessage;
 import org.openkilda.messaging.command.grpc.GetPacketInOutStatsRequest;
 import org.openkilda.messaging.command.stats.StatsRequest;
+import org.openkilda.model.IpSocketAddress;
 import org.openkilda.model.Switch;
 import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.persistence.repositories.KildaFeatureTogglesRepository;
@@ -36,8 +37,6 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -96,8 +95,7 @@ public class StatsRequesterBolt extends AbstractBolt {
 
     private void emitGrpcStatsRequest(Tuple input, Switch sw) {
         Optional<String> address = Optional.ofNullable(sw.getSocketAddress())
-                .map(InetSocketAddress::getAddress)
-                .map(InetAddress::getHostAddress);
+                .map(IpSocketAddress::getAddress);
 
         if (!address.isPresent()) {
             return;

--- a/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/bolts/StatsRequesterBoltTest.java
+++ b/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/bolts/StatsRequesterBoltTest.java
@@ -33,6 +33,7 @@ import org.openkilda.bluegreen.LifecycleEvent;
 import org.openkilda.bluegreen.Signal;
 import org.openkilda.messaging.command.CommandMessage;
 import org.openkilda.messaging.command.grpc.GetPacketInOutStatsRequest;
+import org.openkilda.model.IpSocketAddress;
 import org.openkilda.model.KildaFeatureToggles;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchId;
@@ -56,7 +57,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.net.InetSocketAddress;
 import java.util.Collections;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -153,7 +153,7 @@ public class StatsRequesterBoltTest {
         String address = "192.168.1.1";
         Switch sw = Switch.builder()
                 .switchId(new SwitchId(1))
-                .socketAddress(new InetSocketAddress(address, 20))
+                .socketAddress(new IpSocketAddress(address, 20))
                 .build();
         sw.setOfDescriptionSoftware("NW500.1.1");
 


### PR DESCRIPTION
Serialization layer represet InetSocketAddress as hostname (reversed DNS
lookup) plus ":" plus port number. It creates issues for distributes
services placed in different networks (in our calse OpenFlow speakers
and storm topologies) - one network can't resolve addresses available in
another network.

As result the "wave" possible NPE errors/checks in all related code.
Simpliest way to explicitly solve this issue - do not allow to transfer
InetSocketAddress object via our messaging layer.