### PR TITLE
fix/refactor unstable func tests

### DIFF
--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/PortAntiflapHelper.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/PortAntiflapHelper.groovy
@@ -50,7 +50,8 @@ class PortAntiflapHelper {
      * Wait till the current port is in a stable state (deactivated antiflap) by analyzing its history.
      */
     void waitPortIsStable(SwitchId swId, int portNo, Long since = 0) {
-        Wrappers.wait(antiflapCooldown + WAIT_OFFSET) {
+        // '* 2' it takes more time on a hardware env for link via 'a-switch'
+        Wrappers.wait(antiflapCooldown + WAIT_OFFSET * 2) {
             def history = northboundV2.getPortHistory(swId, portNo, since, Long.MAX_VALUE)
 
             if (!history.empty) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
@@ -291,14 +291,14 @@ class AutoRerouteSpec extends HealthCheckSpecification {
         allFlowPaths.findAll { it != flowPath }.each { pathHelper.makePathMorePreferable(it, flowPath) }
 
         when: "Bring the flow port down on the source switch"
-        antiflap.portDown(flow.source.datapath, flow.source.portNumber)
+        northbound.portDown(flow.source.datapath, flow.source.portNumber)
 
         then: "The flow is not rerouted"
         TimeUnit.SECONDS.sleep(rerouteDelay)
         PathHelper.convert(northbound.getFlowPath(flow.id)) == flowPath
 
         when: "Bring the flow port down on the destination switch"
-        antiflap.portDown(flow.destination.datapath, flow.destination.portNumber)
+        northbound.portDown(flow.destination.datapath, flow.destination.portNumber)
 
         then: "The flow is not rerouted"
         TimeUnit.SECONDS.sleep(rerouteDelay)
@@ -307,7 +307,7 @@ class AutoRerouteSpec extends HealthCheckSpecification {
         cleanup: "Bring flow ports up and delete the flow"
         if (flow) {
             flowHelper.deleteFlow(flow.id)
-            ["source", "destination"].each { antiflap.portUp(flow."$it".datapath, flow."$it".portNumber) }
+            ["source", "destination"].each { northbound.portUp(flow."$it".datapath, flow."$it".portNumber) }
         }
     }
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteV2Spec.groovy
@@ -552,14 +552,14 @@ class AutoRerouteV2Spec extends HealthCheckSpecification {
         allFlowPaths.findAll { it != flowPath }.each { pathHelper.makePathMorePreferable(it, flowPath) }
 
         when: "Bring the flow port down on the source switch"
-        antiflap.portDown(flow.source.switchId, flow.source.portNumber)
+        northbound.portDown(flow.source.switchId, flow.source.portNumber)
 
         then: "The flow is not rerouted"
         TimeUnit.SECONDS.sleep(rerouteDelay)
         PathHelper.convert(northbound.getFlowPath(flow.flowId)) == flowPath
 
         when: "Bring the flow port down on the destination switch"
-        antiflap.portDown(flow.destination.switchId, flow.destination.portNumber)
+        northbound.portDown(flow.destination.switchId, flow.destination.portNumber)
 
         then: "The flow is not rerouted"
         TimeUnit.SECONDS.sleep(rerouteDelay)
@@ -568,7 +568,7 @@ class AutoRerouteV2Spec extends HealthCheckSpecification {
         cleanup: "Bring flow ports up and delete the flow"
         if (flow) {
             flowHelperV2.deleteFlow(flow.flowId)
-            ["source", "destination"].each { antiflap.portUp(flow."$it".switchId, flow."$it".portNumber) }
+            ["source", "destination"].each { northbound.portUp(flow."$it".switchId, flow."$it".portNumber) }
         }
     }
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MirrorEndpointsSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MirrorEndpointsSpec.groovy
@@ -991,6 +991,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
     @Tags([LOW_PRIORITY])
     def "Cannot enable connected devices on switch if mirror is present"() {
         given: "A flow with a mirror endpoint"
+        assumeTrue(useMultitable, "Multi table is not enabled in kilda configuration")
         def swPair = topologyHelper.switchPairs[0]
         def flow = flowHelperV2.randomFlow(swPair)
         flowHelperV2.addFlow(flow)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/StormLcmSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/resilience/StormLcmSpec.groovy
@@ -75,6 +75,7 @@ class StormLcmSpec extends HealthCheckSpecification {
         def newRelation = database.dumpAllRelations()
         def newSwitches = database.dumpAllSwitches()
         expect newSwitches, sameBeanAs(switchesDump).ignoring("data.timeModify")
+                .ignoring("data.socketAddress.port")
         expect newRelation, sameBeanAs(relationsDump).ignoring("properties.time_modify")
                 .ignoring("properties.latency")
                 .ignoring("properties.time_create")

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/server42/Server42FlowRttSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/server42/Server42FlowRttSpec.groovy
@@ -127,11 +127,11 @@ class Server42FlowRttSpec extends HealthCheckSpecification {
 
     @Tidy
     def "Flow rtt stats are available in forward and reverse directions for new flows"() {
-        given: "Two active switches with src switch having server42"
+        given: "Two active switches with switch having server42"
         def server42switches = topology.getActiveServer42Switches()
         def server42switchesDpIds = server42switches*.dpId
         def switchPair = topologyHelper.switchPairs.collectMany { [it, it.reversed] }.find {
-            it.src.dpId in server42switchesDpIds && !server42switchesDpIds.contains(it.dst.dpId)
+            [it.src, it.dst].every { it.dpId in server42switchesDpIds }
         }
         assumeTrue(switchPair != null, "Was not able to find a switch with a server42 connected")
         and: "server42FlowRtt feature toggle is set to true"
@@ -205,11 +205,11 @@ class Server42FlowRttSpec extends HealthCheckSpecification {
 
     @Tidy
     def "Flow rtt stats are available only if both global and switch toggles are 'on' on both endpoints"() {
-        given: "Two active switches with src switch having server42"
+        given: "Two active switches with having server42"
         def server42switches = topology.getActiveServer42Switches()
         def server42switchesDpIds = server42switches*.dpId
         def switchPair = topologyHelper.switchPairs.collectMany { [it, it.reversed] }.find {
-            it.src.dpId in server42switchesDpIds && !server42switchesDpIds.contains(it.dst.dpId)
+            [it.src, it.dst].every { it.dpId in server42switchesDpIds }
         }
         assumeTrue(switchPair != null, "Was not able to find a switch with a server42 connected")
         def statsWaitSeconds = 4
@@ -891,12 +891,12 @@ class Server42FlowRttSpec extends HealthCheckSpecification {
     def changeFlowRttSwitch(Switch sw, boolean requiredState) {
         def originalProps = northbound.getSwitchProperties(sw.dpId)
         if (originalProps.server42FlowRtt != requiredState) {
+            def s42Config = sw.prop
             northbound.updateSwitchProperties(sw.dpId, originalProps.jacksonCopy().tap {
                 server42FlowRtt = requiredState
-                def props = sw.prop ?: SwitchHelper.dummyServer42Props
-                server42MacAddress = requiredState ? props.server42MacAddress : null
-                server42Port = requiredState ? props.server42Port : null
-                server42Vlan = requiredState ? props.server42Vlan : null
+                server42MacAddress = s42Config ? s42Config.server42MacAddress : null
+                server42Port = s42Config ? s42Config.server42Port : null
+                server42Vlan = s42Config ? s42Config.server42Vlan : null
             })
         }
         Wrappers.wait(RULES_INSTALLATION_TIME) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesSpec.groovy
@@ -102,7 +102,7 @@ class DefaultRulesSpec extends HealthCheckSpecification {
 
         cleanup: "Install missing default rules"
         northbound.installSwitchRules(sw.dpId, InstallRulesAction.INSTALL_DEFAULTS)
-        Wrappers.wait(RULES_INSTALLATION_TIME) {
+        Wrappers.wait(RULES_INSTALLATION_TIME + discoveryInterval) {
             assert northbound.getSwitchRules(sw.dpId).flowEntries*.cookie.sort() == defaultRules*.cookie.sort()
             assert northbound.getActiveLinks().size() == topology.islsForActiveSwitches.size() * 2
         }
@@ -175,7 +175,7 @@ switch(#sw.dpId, install-action=#data.installRulesAction)"(Map data, Switch sw) 
 
         cleanup: "Install missing default rules and restore switch properties"
         northbound.installSwitchRules(sw.dpId, InstallRulesAction.INSTALL_DEFAULTS)
-        Wrappers.wait(RULES_INSTALLATION_TIME) {
+        Wrappers.wait(RULES_INSTALLATION_TIME + discoveryInterval) {
             assert northbound.getSwitchRules(sw.dpId).flowEntries.size() == defaultRules.size()
             assert northbound.getActiveLinks().size() == topology.islsForActiveSwitches.size() * 2
         }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchPortConfigSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchPortConfigSpec.groovy
@@ -91,19 +91,19 @@ class SwitchPortConfigSpec extends HealthCheckSpecification {
 
         when: "Bring port down on the switch"
         def port = topology.getAllowedPortsForSwitch(sw).find { "LINK_DOWN" in northbound.getPort(sw.dpId, it).state }
-        antiflap.portDown(sw.dpId, port)
+        northbound.portDown(sw.dpId, port)
 
         then: "Port is really DOWN"
         Wrappers.wait(WAIT_OFFSET) { assert "PORT_DOWN" in northbound.getPort(sw.dpId, port).config }
 
         when: "Bring port up on the switch"
-        def portUp = antiflap.portUp(sw.dpId, port)
+        def portUp = northbound.portUp(sw.dpId, port)
 
         then: "Port is really UP"
         Wrappers.wait(WAIT_OFFSET) { assert !("PORT_DOWN" in northbound.getPort(sw.dpId, port).config) }
 
         cleanup:
-        !portUp && antiflap.portUp(sw.dpId, port)
+        !portUp && northbound.portUp(sw.dpId, port)
         database.resetCosts()
 
         where:


### PR DESCRIPTION
- increase waitTime in waitPortIsStable(for a port with non-direct link)
- add discoveryInterval in DefaultRulesSpec
- replace "antiflap" with "nb" in tests with free-isl port
- refactor Server42FlowRttSpec 
- refactor "Cannot enable connected devices on switch if mirror is present"  (run in multiTable mode only)
