### PR TITLE
Fix TypeError in get_issues_from_pr in changelog-generator.py

### DIFF
--- a/tools/changelog-generator/changelog-generator.py
+++ b/tools/changelog-generator/changelog-generator.py
@@ -7,7 +7,8 @@ import click
 
 
 def get_issues_from_pr(p):
-    return [m.groups()[0] for m in re.finditer(r"#(\d+)", p.body)]
+    text = "{}\n{}".format(p.title, "" if p.body is None else p.body)
+    return [m.groups()[0] for m in re.finditer(r"#(\d+)", text)]
 
 
 def generate_topic_list(labels):


### PR DESCRIPTION
I got errors like
```
Traceback (most recent call last):
  File "tools/changelog-generator/changelog-generator.py", line 131, in <module>
    main(auto_envvar_prefix='CHANGELOG_GENERATOR')
  File "/home/nm/ve/github3/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/nm/ve/github3/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/nm/ve/github3/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/nm/ve/github3/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "tools/changelog-generator/changelog-generator.py", line 102, in main
    'issues': sorted(get_issues_from_pr(v)),
  File "tools/changelog-generator/changelog-generator.py", line 13, in get_issues_from_pr
    return [m.groups()[0] for m in re.finditer(r"#(\d+)", p.body)]
  File "/home/nm/ve/github3/lib/python3.6/re.py", line 229, in finditer
    return _compile(pattern, flags).finditer(string)
TypeError: expected string or bytes-like object
```
Github API sends pr.body as None.
