### PR TITLE
Compare LAG physical ports ignoring order

### DIFF
--- a/src-java/swmanager-topology/swmanager-storm-topology/src/main/java/org/openkilda/wfm/topology/switchmanager/service/impl/ValidationServiceImpl.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/main/java/org/openkilda/wfm/topology/switchmanager/service/impl/ValidationServiceImpl.java
@@ -75,10 +75,12 @@ import org.openkilda.wfm.topology.switchmanager.model.ValidateMetersResult;
 import org.openkilda.wfm.topology.switchmanager.model.ValidateRulesResult;
 import org.openkilda.wfm.topology.switchmanager.service.ValidationService;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 
 import java.util.ArrayList;
@@ -285,7 +287,8 @@ public class ValidationServiceImpl implements ValidationService {
         return misconfiguredGroups;
     }
 
-    private LogicalPortInfoEntry calculateMisconfiguredLogicalPort(
+    @VisibleForTesting
+    LogicalPortInfoEntry calculateMisconfiguredLogicalPort(
             LogicalPortInfoEntry expectedPort, LogicalPortInfoEntry actualPort) {
         LogicalPortMisconfiguredInfoEntry expected = new LogicalPortMisconfiguredInfoEntry();
         LogicalPortMisconfiguredInfoEntry actual = new LogicalPortMisconfiguredInfoEntry();
@@ -295,7 +298,8 @@ public class ValidationServiceImpl implements ValidationService {
             actual.setType(actualPort.getType());
         }
 
-        if (!Objects.equals(expectedPort.getPhysicalPorts(), actualPort.getPhysicalPorts())) {
+        // compare, ignoring order
+        if (!CollectionUtils.isEqualCollection(expectedPort.getPhysicalPorts(), actualPort.getPhysicalPorts())) {
             expected.setPhysicalPorts(expectedPort.getPhysicalPorts());
             actual.setPhysicalPorts(actualPort.getPhysicalPorts());
         }

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/service/impl/ValidationServiceImplTest.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/service/impl/ValidationServiceImplTest.java
@@ -20,6 +20,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -386,6 +387,29 @@ public class ValidationServiceImplTest {
                         Lists.newArrayList(PHYSICAL_PORT_3, PHYSICAL_PORT_4)))
                 .build();
         assertEquals(misconfiguredEntry, result.getMisconfiguredLogicalPorts().get(0));
+    }
+
+    @Test
+    public void calculateMisconfiguredLogicalPortDifferentPortOrderTest() {
+        ValidationServiceImpl validationService = new ValidationServiceImpl(persistenceManager().build(),
+                topologyConfig, flowResourcesConfig);
+
+        LogicalPortInfoEntry actual = LogicalPortInfoEntry.builder()
+                .type(org.openkilda.messaging.info.switches.LogicalPortType.LAG)
+                .logicalPortNumber(LOGICAL_PORT_NUMBER_1)
+                .physicalPorts(Lists.newArrayList(PHYSICAL_PORT_1, PHYSICAL_PORT_2, PHYSICAL_PORT_3))
+                .build();
+
+        LogicalPortInfoEntry expected = LogicalPortInfoEntry.builder()
+                .type(org.openkilda.messaging.info.switches.LogicalPortType.LAG)
+                .logicalPortNumber(LOGICAL_PORT_NUMBER_1)
+                .physicalPorts(Lists.newArrayList(PHYSICAL_PORT_3, PHYSICAL_PORT_2, PHYSICAL_PORT_1))
+                .build();
+
+        LogicalPortInfoEntry difference = validationService.calculateMisconfiguredLogicalPort(expected, actual);
+        // physical ports are equal. Only order is different. So port difference must be null
+        assertNull(difference.getActual().getPhysicalPorts());
+        assertNull(difference.getExpected().getPhysicalPorts());
     }
 
     private void assertMeter(MeterInfoEntry meterInfoEntry, MeterEntry expected) {


### PR DESCRIPTION
In some cases expected phys port order could be different with actual port order. We must not mark such ports as misconfigured