### PR TITLE
Add raw port events logging

### DIFF
--- a/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/NetworkTopologyDashboardLogger.java
+++ b/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/NetworkTopologyDashboardLogger.java
@@ -71,6 +71,14 @@ public class NetworkTopologyDashboardLogger extends AbstractDashboardLogger {
         onPortUpDown(endpoint, "DOWN");
     }
 
+    public void onRawPortUp(Endpoint endpoint) {
+        onRawPortUpDown(endpoint, "UP");
+    }
+
+    public void onRawPortDown(Endpoint endpoint) {
+        onRawPortUpDown(endpoint, "DOWN");
+    }
+
     public void onPortFlappingStart(Endpoint endpoint) {
         onPortFlappingStartStop(endpoint, "start");
     }
@@ -142,6 +150,15 @@ public class NetworkTopologyDashboardLogger extends AbstractDashboardLogger {
         populateEvent(context, event);
         String message = String.format("Port status event: switch_id=%s, port_id=%d, state=%s",
                                        endpoint.getDatapath().toString(), endpoint.getPortNumber(), event);
+        invokeLogger(Level.INFO, message, context);
+    }
+
+    private void onRawPortUpDown(Endpoint endpoint, String event) {
+        Map<String, String> context = makeContextTemplate("raw-port");
+        populateCommonPortContext(context, endpoint);
+        String message = String.format(
+                "Port status event (before anti-flap filter): switch_id=%s, port_id=%d, state=%s",
+                endpoint.getDatapath().toString(), endpoint.getPortNumber(), event);
         invokeLogger(Level.INFO, message, context);
     }
 

--- a/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/service/NetworkAntiFlapService.java
+++ b/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/service/NetworkAntiFlapService.java
@@ -32,6 +32,8 @@ import java.util.Map;
 
 @Slf4j
 public class NetworkAntiFlapService {
+    private final NetworkTopologyDashboardLogger dashboardLogger;
+
     private final AntiFlapFsm.AntiFlapFsmFactory controllerFactory;
     private final Map<Endpoint, AntiFlapFsm> controller = new HashMap<>();
     private final FsmExecutor<AntiFlapFsm, State, Event, Context> controllerExecutor;
@@ -40,6 +42,8 @@ public class NetworkAntiFlapService {
     private final AntiFlapFsm.Config config;
 
     public NetworkAntiFlapService(IAntiFlapCarrier carrier, AntiFlapFsm.Config config) {
+        dashboardLogger = new NetworkTopologyDashboardLogger(log);
+
         this.carrier = carrier;
         this.config = config;
 
@@ -58,9 +62,11 @@ public class NetworkAntiFlapService {
         switch (status) {
             case UP:
                 event = AntiFlapFsm.Event.PORT_UP;
+                dashboardLogger.onRawPortUp(endpoint);
                 break;
             case DOWN:
                 event = AntiFlapFsm.Event.PORT_DOWN;
+                dashboardLogger.onRawPortDown(endpoint);
                 break;
             default:
                 throw new IllegalArgumentException(


### PR DESCRIPTION
Add raw(before anti-flap filter) port events logging. Required because
switches now connected to multiple speakers as result each port event is
logged by each speacker this switch connected to. As result port events
statistics are multiplied on some number (differ for each switch).