### PR TITLE
Fix slow PathsServiceTest caused by logging to the console

### DIFF
--- a/src-java/kilda-pce/build.gradle
+++ b/src-java/kilda-pce/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3'
 
     implementation 'org.slf4j:slf4j-api'
-    testRuntimeOnly 'org.slf4j:slf4j-simple'
+    testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.vintage:junit-vintage-engine'

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/finder/BestWeightAndShortestPathFinder.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/finder/BestWeightAndShortestPathFinder.java
@@ -351,7 +351,7 @@ public class BestWeightAndShortestPathFinder implements PathFinder {
 
         while (!toVisit.isEmpty()) {
             SearchNode current = toVisit.pop();
-            log.debug("Going to visit node {} with weight {}.", current.dstSw, current.getParentWeight().toLong());
+            log.trace("Going to visit node {} with weight {}.", current.dstSw, current.getParentWeight().toLong());
 
             // Determine if this node is the destination node.
             if (current.dstSw.equals(end)) {
@@ -363,7 +363,7 @@ public class BestWeightAndShortestPathFinder implements PathFinder {
                     bestPath = current;
                 }
                 // We found dest, no need to keep processing
-                log.debug("Found destination using {} with path {}", current.dstSw, current.parentPath);
+                log.trace("Found destination using {} with path {}", current.dstSw, current.parentPath);
                 continue;
             }
 
@@ -375,14 +375,14 @@ public class BestWeightAndShortestPathFinder implements PathFinder {
 
             // Stop processing entirely if we've gone too far, or over bestWeight
             if (current.allowedDepth <= 0 || current.parentWeight.compareTo(bestWeight) > 0) {
-                log.debug("Skip node {} processing", current.dstSw);
+                log.trace("Skip node {} processing", current.dstSw);
                 continue;
             }
 
             // Either this is the first time, or this one has less weight .. either way, this node should
             // be the one in the visited list
             visited.put(current.dstSw, current);
-            log.debug("Save new path to node {} and process it's outgoing links", current.dstSw);
+            log.trace("Save new path to node {} and process it's outgoing links", current.dstSw);
 
             // At this stage .. haven't found END, haven't gone too deep, and we are not over weight.
             // So, add the outbound isls.
@@ -423,11 +423,11 @@ public class BestWeightAndShortestPathFinder implements PathFinder {
 
         while (!toVisit.isEmpty()) {
             SearchNode current = toVisit.pop();
-            log.debug("Going to visit node {} with weight {}.", current.dstSw, current.getParentWeight().toLong());
+            log.trace("Going to visit node {} with weight {}.", current.dstSw, current.getParentWeight().toLong());
 
             // Leave if the path contains this node
             if (current.containsSwitch(current.dstSw.getSwitchId())) {
-                log.debug("Skip node {} already in the path", current.dstSw);
+                log.trace("Skip node {} already in the path", current.dstSw);
                 continue;
             }
 
@@ -444,7 +444,7 @@ public class BestWeightAndShortestPathFinder implements PathFinder {
                     desiredPath = current;
                 }
                 // We found dest, no need to keep processing
-                log.debug("Found destination using {} with path {}", current.dstSw, current.parentPath);
+                log.trace("Found destination using {} with path {}", current.dstSw, current.parentPath);
                 continue;
             }
 
@@ -457,14 +457,14 @@ public class BestWeightAndShortestPathFinder implements PathFinder {
             SearchNode prior = visited.get(current.dstSw);
             // Use non-greedy way to save visited nodes to fix issue mentioned in docs/design/pce/max-latency-issue
             if (prior != null && shiftedCurrentWeight < Math.abs(maxWeight - prior.parentWeight.toLong())) {
-                log.debug("Skip node {} processing", current.dstSw);
+                log.trace("Skip node {} processing", current.dstSw);
                 continue;
             }
 
             // Either this is the first time, or this one has less weight .. either way, this node should
             // be the one in the visited list
             visited.put(current.dstSw, current);
-            log.debug("Save new path to node {} and process it's outgoing links", current.dstSw);
+            log.trace("Save new path to node {} and process it's outgoing links", current.dstSw);
 
             // At this stage .. haven't found END, haven't gone too deep, and we are not over weight.
             // So, add the outbound isls.

--- a/src-java/kilda-pce/src/test/resources/log4j2.xml
+++ b/src-java/kilda-pce/src/test/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ISO8601} %-5p %c{1.}:%L - [%X] %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="org.openkilda" level="DEBUG"/>
+        <Root level="WARN">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
The changes:
- Lower the logging lever for debug messages in BestWeightAndShortestPathFinder.
- Add log4j2 configuration which gives ability to lower logging threshold for tests.