### PR TITLE
Adapt existing Flow API to support YFlow sub-flows

### DIFF
--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/FlowDto.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/FlowDto.java
@@ -25,6 +25,8 @@ import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
@@ -206,6 +208,10 @@ public class FlowDto implements Serializable {
     @JsonProperty("latency_last_modified_time")
     private Instant latencyLastModifiedTime;
 
+    @JsonProperty("y_flow_id")
+    @JsonInclude(Include.NON_NULL)
+    private String yFlowId;
+
     public FlowDto() {
     }
 
@@ -247,6 +253,7 @@ public class FlowDto implements Serializable {
      * @param forwardLatency            forward path latency nanoseconds
      * @param reverseLatency            reverse path latency nanoseconds
      * @param latencyLastModifiedTime   latency fields last modified time
+     * @param yFlowId                   the y-flow ID in the case of sub-flow
      */
     @JsonCreator
     @Builder(toBuilder = true)
@@ -288,7 +295,8 @@ public class FlowDto implements Serializable {
                    @JsonProperty("mirror_point_statuses") List<MirrorPointStatusDto> mirrorPointStatuses,
                    @JsonProperty("forward_latency") Long forwardLatency,
                    @JsonProperty("reverse_latency") Long reverseLatency,
-                   @JsonProperty("latency_last_modified_time") Instant latencyLastModifiedTime) {
+                   @JsonProperty("latency_last_modified_time") Instant latencyLastModifiedTime,
+                   @JsonProperty("y_flow_id") @JsonInclude(Include.NON_NULL) String yFlowId) {
         this.flowId = flowId;
         this.bandwidth = bandwidth;
         this.ignoreBandwidth = ignoreBandwidth;
@@ -327,6 +335,7 @@ public class FlowDto implements Serializable {
         this.forwardLatency = forwardLatency;
         this.reverseLatency = reverseLatency;
         this.latencyLastModifiedTime = latencyLastModifiedTime;
+        this.yFlowId = yFlowId;
     }
 
     /**
@@ -368,7 +377,7 @@ public class FlowDto implements Serializable {
                 sourceVlan,
                 destinationVlan, 0, 0,
                 null, 0, null, null, null, null, null, null, pinned, null, detectConnectedDevices, null, null, null,
-                null, null, null, null, null, null);
+                null, null, null, null, null, null, null);
     }
 
     public FlowDto(FlowPayload input) {
@@ -403,7 +412,7 @@ public class FlowDto implements Serializable {
                         input.getDestination().getDetectConnectedDevices().isArp()),
                 input.getPathComputationStrategy() != null ? PathComputationStrategy.valueOf(
                         input.getPathComputationStrategy().toUpperCase()) : null, null, null,
-                null, null, null, null, null, null);
+                null, null, null, null, null, null, null);
     }
 
     @JsonIgnore

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/mappers/FlowMapper.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/mappers/FlowMapper.java
@@ -79,6 +79,7 @@ public abstract class FlowMapper {
     @Mapping(target = "forwardLatency", ignore = true)
     @Mapping(target = "reverseLatency", ignore = true)
     @Mapping(target = "latencyLastModifiedTime", ignore = true)
+    @Mapping(target = "yFlowId", source = "YFlowId")
     public abstract FlowDto map(Flow flow);
 
     /**

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/payload/flow/FlowResponsePayload.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/payload/flow/FlowResponsePayload.java
@@ -61,6 +61,10 @@ public class FlowResponsePayload extends FlowPayload {
     @JsonProperty("latency-last-modified-time")
     private String latencyLastModifiedTime;
 
+    @JsonProperty("y_flow_id")
+    @JsonInclude(Include.NON_NULL)
+    private String yFlowId;
+
     /**
      * Instance constructor.
      *
@@ -88,6 +92,7 @@ public class FlowResponsePayload extends FlowPayload {
      * @param forwardLatency            forward path latency nanoseconds
      * @param reverseLatency            reverse path latency nanoseconds
      * @param latencyLastModifiedTime   latency last modified time
+     * @param yFlowId                   the y-flow ID in the case of sub-flow
      */
     @Builder(builderMethodName = "flowResponsePayloadBuilder")
     @JsonCreator
@@ -114,7 +119,8 @@ public class FlowResponsePayload extends FlowPayload {
                                @JsonProperty("loop-switch-id") SwitchId loopSwitchId,
                                @JsonProperty("forward-latency") long forwardLatency,
                                @JsonProperty("reverse-latency") long reverseLatency,
-                               @JsonProperty("latency-last-modified-time") String latencyLastModifiedTime) {
+                               @JsonProperty("latency-last-modified-time") String latencyLastModifiedTime,
+                               @JsonProperty("y_flow_id") String yFlowId) {
         super(id, source, destination, maximumBandwidth, ignoreBandwidth, periodicPings, allocateProtectedPath,
                 description, created, lastUpdated, status, maxLatency, priority, pinned, encapsulationType,
                 pathComputationStrategy);
@@ -126,5 +132,6 @@ public class FlowResponsePayload extends FlowPayload {
         this.forwardLatency = forwardLatency;
         this.reverseLatency = reverseLatency;
         this.latencyLastModifiedTime = latencyLastModifiedTime;
+        this.yFlowId = yFlowId;
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/mapper/RequestedFlowMapper.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/mapper/RequestedFlowMapper.java
@@ -113,6 +113,7 @@ public abstract class RequestedFlowMapper {
     @Mapping(target = "statusInfo", ignore = true)
     @Mapping(target = "targetPathComputationStrategy", ignore = true)
     @Mapping(target = "loopSwitchId", source = "loopSwitchId")
+    @Mapping(target = "yFlowId", ignore = true)
     public abstract Flow toFlow(RequestedFlow requestedFlow);
 
     @Mapping(source = "encapsulationType", target = "flowEncapsulationType")

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowDeleteService.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowDeleteService.java
@@ -53,6 +53,10 @@ public class FlowDeleteService extends FlowProcessingWithEventSupportService<Flo
      * @param flowId the flow to delete.
      */
     public void handleRequest(String key, CommandContext commandContext, String flowId) throws DuplicateKeyException {
+        if (yFlowRepository.isSubFlow(flowId)) {
+            sendForbiddenSubFlowOperationToNorthbound(flowId, commandContext);
+            return;
+        }
         startFlowDeletion(key, commandContext, flowId, true);
     }
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowDeleteServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowDeleteServiceTest.java
@@ -271,6 +271,17 @@ public class FlowDeleteServiceTest extends AbstractFlowTest {
         verifyFlowIsMissing(target);
     }
 
+    @Test
+    public void shouldFailDeleteYSubFlow() throws DuplicateKeyException {
+        Flow flow = makeFlow();
+        createTestYFlowForSubFlow(flow);
+
+        makeService().handleRequest(dummyRequestKey, commandContext, flow.getFlowId());
+
+        verifyNoSpeakerInteraction(carrier);
+        verifyNorthboundErrorResponse(carrier, ErrorType.REQUEST_INVALID);
+    }
+
     private void verifyFlowIsMissing(Flow flow) {
         RepositoryFactory repositoryFactory = persistenceManager.getRepositoryFactory();
         FlowRepository flowRepository = repositoryFactory.createFlowRepository();

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteServiceTest.java
@@ -647,6 +647,22 @@ public class FlowRerouteServiceTest extends AbstractFlowTest {
         assertNull(result.getTargetPathComputationStrategy());
     }
 
+    @Test
+    public void shouldFailRerouteYSubFlow() throws UnroutableFlowException, RecoverableException {
+        Flow origin = makeFlow();
+        createTestYFlowForSubFlow(origin);
+        preparePathComputation(origin.getFlowId(), make3SwitchesPathPair());
+
+        FlowRerouteService service = makeService();
+        IslEndpoint affectedEndpoint = extractIslEndpoint(origin);
+        FlowRerouteRequest request = new FlowRerouteRequest(origin.getFlowId(), false, true,
+                false, Collections.singleton(affectedEndpoint), null, false);
+        service.handleRequest(currentRequestKey, request, commandContext);
+
+        verifyNoSpeakerInteraction(carrier);
+        verifyNorthboundErrorResponse(carrier, ErrorType.REQUEST_INVALID);
+    }
+
     protected void produceAsyncResponse(FlowRerouteService service, FlowSegmentRequest speakerRequest) {
         service.handleAsyncResponse(currentRequestKey, buildSpeakerResponse(speakerRequest));
     }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowUpdateServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowUpdateServiceTest.java
@@ -633,6 +633,45 @@ public class FlowUpdateServiceTest extends AbstractFlowTest {
         assertNull(result.getLoopSwitchId());
     }
 
+    @Test
+    public void shouldFailUpdateYSubFlow() throws UnroutableFlowException, RecoverableException {
+        Flow origin = makeFlow();
+        createTestYFlowForSubFlow(origin);
+        preparePathComputation(origin.getFlowId(), make3SwitchesPathPair());
+
+        FlowRequest request = makeRequest()
+                .flowId(origin.getFlowId())
+                .build();
+
+        testExpectedFailure(request, origin, ErrorType.REQUEST_INVALID);
+    }
+
+    @Test
+    public void shouldFailCreateLoopOnYSubFlow() {
+        Flow origin = makeFlow();
+        createTestYFlowForSubFlow(origin);
+
+        CreateFlowLoopRequest request = new CreateFlowLoopRequest(origin.getFlowId(), origin.getSrcSwitchId());
+        FlowUpdateService service = makeService();
+        service.handleCreateFlowLoopRequest(dummyRequestKey, commandContext, request);
+
+        verifyNoSpeakerInteraction(carrier);
+        verifyNorthboundErrorResponse(carrier, ErrorType.REQUEST_INVALID);
+    }
+
+    @Test
+    public void shouldFailDeleteLoopOnYSubFlow() {
+        Flow origin = makeFlow();
+        createTestYFlowForSubFlow(origin);
+
+        DeleteFlowLoopRequest request = new DeleteFlowLoopRequest(origin.getFlowId());
+        FlowUpdateService service = makeService();
+        service.handleDeleteFlowLoopRequest(dummyRequestKey, commandContext, request);
+
+        verifyNoSpeakerInteraction(carrier);
+        verifyNorthboundErrorResponse(carrier, ErrorType.REQUEST_INVALID);
+    }
+
     private void testExpectedSuccess(FlowRequest request, Flow origin) {
         FlowUpdateService service = makeService();
         service.handleUpdateRequest(dummyRequestKey, commandContext, request);

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/Flow.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/Flow.java
@@ -93,7 +93,8 @@ public class Flow implements CompositeDataEntity<Flow.FlowData> {
                 FlowEncapsulationType encapsulationType, FlowStatus status, String statusInfo,
                 Long maxLatency, Long maxLatencyTier2, Integer priority, boolean pinned,
                 DetectConnectedDevices detectConnectedDevices, PathComputationStrategy pathComputationStrategy,
-                PathComputationStrategy targetPathComputationStrategy, SwitchId loopSwitchId, String affinityGroupId) {
+                PathComputationStrategy targetPathComputationStrategy, SwitchId loopSwitchId, String affinityGroupId,
+                String yFlowId) {
         FlowDataImpl.FlowDataImplBuilder builder = FlowDataImpl.builder()
                 .flowId(flowId).srcSwitch(srcSwitch).destSwitch(destSwitch)
                 .srcPort(srcPort).srcVlan(srcVlan).srcInnerVlan(srcInnerVlan)
@@ -104,7 +105,8 @@ public class Flow implements CompositeDataEntity<Flow.FlowData> {
                 .status(status).statusInfo(statusInfo).maxLatency(maxLatency).maxLatencyTier2(maxLatencyTier2)
                 .priority(priority).pinned(pinned).pathComputationStrategy(pathComputationStrategy)
                 .targetPathComputationStrategy(targetPathComputationStrategy)
-                .loopSwitchId(loopSwitchId).affinityGroupId(affinityGroupId);
+                .loopSwitchId(loopSwitchId).affinityGroupId(affinityGroupId)
+                .yFlowId(yFlowId);
         if (detectConnectedDevices != null) {
             builder.detectConnectedDevices(detectConnectedDevices);
         }
@@ -431,6 +433,7 @@ public class Flow implements CompositeDataEntity<Flow.FlowData> {
                 .append(getDetectConnectedDevices(), that.getDetectConnectedDevices())
                 .append(getPathComputationStrategy(), that.getPathComputationStrategy())
                 .append(new HashSet<>(getPaths()), new HashSet<>(that.getPaths()))
+                .append(getYFlowId(), that.getYFlowId())
                 .isEquals();
     }
 
@@ -442,7 +445,8 @@ public class Flow implements CompositeDataEntity<Flow.FlowData> {
                 isAllocateProtectedPath(), getProtectedForwardPathId(), getProtectedReversePathId(),
                 getDiverseGroupId(), getBandwidth(), isIgnoreBandwidth(), getDescription(), isPeriodicPings(),
                 getEncapsulationType(), getStatus(), getStatusInfo(), getMaxLatency(), getPriority(), getTimeCreate(),
-                getTimeModify(), isPinned(), getDetectConnectedDevices(), getPathComputationStrategy(), getPaths());
+                getTimeModify(), isPinned(), getDetectConnectedDevices(), getPathComputationStrategy(), getPaths(),
+                getYFlowId());
     }
 
     /**
@@ -598,6 +602,8 @@ public class Flow implements CompositeDataEntity<Flow.FlowData> {
         SwitchId getLoopSwitchId();
 
         void setLoopSwitchId(SwitchId loopSwitchId);
+
+        String getYFlowId();
     }
 
     /**
@@ -644,6 +650,8 @@ public class Flow implements CompositeDataEntity<Flow.FlowData> {
         PathComputationStrategy pathComputationStrategy;
         PathComputationStrategy targetPathComputationStrategy;
         SwitchId loopSwitchId;
+        @Setter(AccessLevel.NONE)
+        String yFlowId;
         @ToString.Exclude
         @EqualsAndHashCode.Exclude
         final Set<FlowPath> paths = new HashSet<>();

--- a/src-java/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/YFlowRepository.java
+++ b/src-java/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/YFlowRepository.java
@@ -30,5 +30,7 @@ public interface YFlowRepository extends Repository<YFlow> {
 
     Optional<YFlow> findById(String yFlowId);
 
+    boolean isSubFlow(String flowId);
+
     Optional<YFlow> remove(String yFlowId);
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/frames/FlowFrame.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/frames/FlowFrame.java
@@ -517,6 +517,21 @@ public abstract class FlowFrame extends KildaBaseVertexFrame implements FlowData
         }
     }
 
+    @Override
+    public String getYFlowId() {
+        List<? extends YSubFlowFrame> subFlowFrames = traverse(v -> v.inE(YSubFlowFrame.FRAME_LABEL))
+                .toListExplicit(YSubFlowFrame.class);
+        if (subFlowFrames.isEmpty()) {
+            return null;
+        }
+        if (subFlowFrames.size() > 1) {
+            throw new IllegalStateException(format("The flow %s has more than one y_subflow references: %s",
+                    getId(), subFlowFrames));
+        }
+        return subFlowFrames.get(0).getYFlowId();
+    }
+
+
     public static Optional<FlowFrame> load(FramedGraph graph, String flowId) {
         List<? extends FlowFrame> flowFrames = graph.traverse(g -> g.V()
                         .hasLabel(FRAME_LABEL)

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaYFlowRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaYFlowRepository.java
@@ -70,6 +70,18 @@ public class FermaYFlowRepository extends FermaGenericRepository<YFlow, YFlowDat
     }
 
     @Override
+    public boolean isSubFlow(String flowId) {
+        try (GraphTraversal<?, ?> traversal = framedGraph().traverse(g -> g.E()
+                        .hasLabel(YSubFlowFrame.FRAME_LABEL)
+                        .has(YSubFlowFrame.SUBFLOW_ID_PROPERTY, flowId))
+                .getRawTraversal()) {
+            return traversal.hasNext();
+        } catch (Exception e) {
+            throw new PersistenceException("Failed to traverse", e);
+        }
+    }
+
+    @Override
     public Optional<YFlow> remove(String flowId) {
         TransactionManager transactionManager = getTransactionManager();
         if (transactionManager.isTxOpen()) {
@@ -85,7 +97,6 @@ public class FermaYFlowRepository extends FermaGenericRepository<YFlow, YFlowDat
                             return flow;
                         }));
     }
-
 
     @Override
     protected YFlowFrame doAdd(YFlowData data) {

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/main/java/org/openkilda/wfm/share/mappers/RequestedFlowMapper.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/main/java/org/openkilda/wfm/share/mappers/RequestedFlowMapper.java
@@ -91,6 +91,7 @@ public abstract class RequestedFlowMapper {
     @Mapping(target = "statusInfo", ignore = true)
     @Mapping(target = "targetPathComputationStrategy", ignore = true)
     @Mapping(target = "status", ignore = true)
+    @Mapping(target = "yFlowId", ignore = true)
     public abstract Flow toFlow(FlowRequest request);
 
     public SwitchId map(String value) {

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowResponseV2.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowResponseV2.java
@@ -17,6 +17,9 @@ package org.openkilda.northbound.dto.v2.flows;
 
 import org.openkilda.model.SwitchId;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
@@ -68,4 +71,8 @@ public class FlowResponseV2 {
     private String lastUpdated;
 
     private List<MirrorPointStatus> mirrorPointStatuses;
+
+    @JsonProperty("y_flow_id")
+    @JsonInclude(Include.NON_NULL)
+    private String yFlowId;
 }

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/converter/FlowMapper.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/converter/FlowMapper.java
@@ -324,6 +324,7 @@ public abstract class FlowMapper {
     @Mapping(target = "loopSwitchId", source = "f.loopSwitchId")
     @Mapping(target = "forwardPathLatencyNs", source = "f.forwardLatency")
     @Mapping(target = "reversePathLatencyNs", source = "f.reverseLatency")
+    @Mapping(target = "yFlowId", source = "f.YFlowId")
     protected abstract FlowResponseV2 generatedMap(FlowDto f, FlowEndpointV2 source, FlowEndpointV2 destination);
 
     @Mapping(target = "id", source = "flowId")

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/impl/FlowServiceImpl.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/impl/FlowServiceImpl.java
@@ -65,7 +65,6 @@ import org.openkilda.messaging.payload.flow.FlowCreatePayload;
 import org.openkilda.messaging.payload.flow.FlowIdStatusPayload;
 import org.openkilda.messaging.payload.flow.FlowPathPayload;
 import org.openkilda.messaging.payload.flow.FlowPathPayload.FlowProtectedPath;
-import org.openkilda.messaging.payload.flow.FlowPayload;
 import org.openkilda.messaging.payload.flow.FlowReroutePayload;
 import org.openkilda.messaging.payload.flow.FlowResponsePayload;
 import org.openkilda.messaging.payload.flow.FlowUpdatePayload;
@@ -381,7 +380,11 @@ public class FlowServiceImpl implements FlowService {
             List<CompletableFuture<?>> deletionRequests = new ArrayList<>();
             for (int i = 0; i < flows.size(); i++) {
                 String requestId = idFactory.produceChained(String.valueOf(i));
-                FlowPayload flow = flows.get(i);
+                FlowResponsePayload flow = flows.get(i);
+                if (flow.getYFlowId() != null) {
+                    // Skip y-sub-flows.
+                    continue;
+                }
                 deletionRequests.add(sendDeleteFlow(flow.getId(), requestId));
             }
             return deletionRequests;


### PR DESCRIPTION
The changes:
- Extend Flow responses in Flow APIs with y-flow field.		
- Forbid amend (update, delete, etc.) ops for YFlow sub-flows.

**MERGE NOTE:** merge after #4534 and change the base correspondingly.