### PR TITLE
Set FlowHs worker count to 1

### DIFF
--- a/confd/vars/main.yaml
+++ b/confd/vars/main.yaml
@@ -166,7 +166,7 @@ kilda_storm_parallelism_level_new: 2
 kilda_storm_parallelism_level: 1
 kilda_storm_flow_hs_parallelism: 2
 kilda_storm_flow_hs_reroute_hub_count_multiplier: 2
-kilda_storm_flowhs_workers: 2
+kilda_storm_flowhs_workers: 1
 kilda_storm_parallelism_workers_count: 1
 
 kilda_storm_flow_monitoring_parallelism: 2


### PR DESCRIPTION
At this moment FlowHs is not ready to have more than 1 workers because
some objects in massages are not serializable