### PR TITLE
PoC for shared bandwidth group solution

### DIFF
--- a/docker/db-migration/migrations/019-add-shared-bandwidth-group-properties.yaml
+++ b/docker/db-migration/migrations/019-add-shared-bandwidth-group-properties.yaml
@@ -1,0 +1,28 @@
+databaseChangeLog:
+  - changeSet:
+      id: tag
+      author: siakovenko
+      changes:
+        - tagDatabase:
+            tag: 019-add-shared-bandwidth-group-properties
+
+  - changeSet:
+      id: add_shared_bandwidth_group_properties
+      author: siakovenko
+      changes:
+        - sql: "CREATE PROPERTY path_segment.shared_bw_group_id IF NOT EXISTS STRING"
+        - sql: "CREATE PROPERTY flow_path.shared_bw_group_id IF NOT EXISTS STRING"
+        - sql: "CREATE INDEX flow_path.shared_bw_group_id NOTUNIQUE_HASH_INDEX"
+      rollback:
+        - sql: "DROP INDEX flow_path.shared_bw_group_id"
+        - sql: "DROP PROPERTY flow_path.shared_bw_group_id IF EXISTS"
+        - sql: "DROP PROPERTY path_segment.shared_bw_group_id IF EXISTS"
+  - changeSet:
+      id: set_shared_bandwidth_group_on_existing_entities
+      author: siakovenko
+      changes:
+        - sql: "UPDATE flow_path SET shared_bw_group_id = flow_id"
+        - sql: "UPDATE path_segment SET shared_bw_group_id = in('owns').shared_bw_group_id"
+      rollback:
+        - sql: "UPDATE path_segment REMOVE shared_bw_group_id"
+        - sql: "UPDATE flow_path REMOVE shared_bw_group_id"

--- a/docker/db-migration/migrations/root.yaml
+++ b/docker/db-migration/migrations/root.yaml
@@ -66,3 +66,6 @@ databaseChangeLog:
   - include:
       relativeToChangelogFile: true
       file: 018-add-support-of-yflow-meters.yaml
+  - include:
+      relativeToChangelogFile: true
+      file: 019-add-shared-bandwidth-group-properties.yaml

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowPathBuilder.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowPathBuilder.java
@@ -108,13 +108,14 @@ public class FlowPathBuilder {
      * @param path path to be used for the flow path.
      * @param cookie cookie to be used for the flow path.
      * @param forceToIgnoreBandwidth force path to ignore bandwidth.
+     * @param sharedBandwidthGroupId a shared bandwidth group to be set for the path
      */
     public FlowPath buildFlowPath(Flow flow, PathResources pathResources, Path path, FlowSegmentCookie cookie,
-                                  boolean forceToIgnoreBandwidth) {
+                                  boolean forceToIgnoreBandwidth, String sharedBandwidthGroupId) {
         List<PathSegment> segments = buildPathSegments(pathResources.getPathId(), path, flow.getBandwidth(),
-                flow.isIgnoreBandwidth() || forceToIgnoreBandwidth);
+                flow.isIgnoreBandwidth() || forceToIgnoreBandwidth, sharedBandwidthGroupId);
         return buildFlowPath(flow, pathResources, path.getLatency(), path.getSrcSwitchId(), path.getDestSwitchId(),
-                segments, cookie, forceToIgnoreBandwidth);
+                segments, cookie, forceToIgnoreBandwidth, sharedBandwidthGroupId);
     }
 
     /**
@@ -126,11 +127,12 @@ public class FlowPathBuilder {
      * @param segments segments to be used for the flow path.
      * @param cookie cookie to be used for the flow path.
      * @param forceToIgnoreBandwidth force path to ignore bandwidth.
+     * @param sharedBandwidthGroupId a shared bandwidth group to be set for the path
      */
     public FlowPath buildFlowPath(Flow flow, PathResources pathResources, long pathLatency,
                                   SwitchId srcSwitchId, SwitchId destSwitchId,
                                   List<PathSegment> segments, FlowSegmentCookie cookie,
-                                  boolean forceToIgnoreBandwidth) {
+                                  boolean forceToIgnoreBandwidth, String sharedBandwidthGroupId) {
         Map<SwitchId, Switch> switches = new HashMap<>();
         switches.put(flow.getSrcSwitchId(), flow.getSrcSwitch());
         switches.put(flow.getDestSwitchId(), flow.getDestSwitch());
@@ -166,6 +168,7 @@ public class FlowPathBuilder {
                 .segments(segments)
                 .srcWithMultiTable(srcWithMultiTable)
                 .destWithMultiTable(dstWithMultiTable)
+                .sharedBandwidthGroupId(sharedBandwidthGroupId)
                 .build();
     }
 
@@ -176,9 +179,10 @@ public class FlowPathBuilder {
      * @param pathForSegments path to be used for the segments.
      * @param bandwidth bandwidth to be used for the segments.
      * @param ignoreBandwidth ignore bandwidth be used for the segments.
+     * @param sharedBandwidthGroupId a shared bandwidth group to be set for the segments
      */
     public List<PathSegment> buildPathSegments(PathId pathId, Path pathForSegments, long bandwidth,
-                                               boolean ignoreBandwidth) {
+                                               boolean ignoreBandwidth, String sharedBandwidthGroupId) {
         Map<SwitchId, SwitchProperties> switchProperties = getSwitchProperties(pathId);
 
         List<PathSegment> result = new ArrayList<>();
@@ -200,6 +204,7 @@ public class FlowPathBuilder {
                     .latency(segment.getLatency())
                     .bandwidth(bandwidth)
                     .ignoreBandwidth(ignoreBandwidth)
+                    .sharedBandwidthGroupId(sharedBandwidthGroupId)
                     .build());
         }
 

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowPathBuilderTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowPathBuilderTest.java
@@ -238,7 +238,7 @@ public class FlowPathBuilderTest {
                 .build();
         FlowSegmentCookie cookie = new FlowSegmentCookie(FlowPathDirection.FORWARD, 1);
 
-        FlowPath flowPath = builder.buildFlowPath(flow, pathResources, path, cookie, false);
+        FlowPath flowPath = builder.buildFlowPath(flow, pathResources, path, cookie, false, flow.getFlowId());
 
         assertEquals(pathId, flowPath.getPathId());
         assertEquals(meterId, flowPath.getMeterId());
@@ -275,7 +275,7 @@ public class FlowPathBuilderTest {
                 .build();
         FlowSegmentCookie cookie = new FlowSegmentCookie(FlowPathDirection.FORWARD, 1);
 
-        FlowPath flowPath = builder.buildFlowPath(flow, pathResources, path, cookie, false);
+        FlowPath flowPath = builder.buildFlowPath(flow, pathResources, path, cookie, false, flow.getFlowId());
 
         assertEquals(switchId1, flowPath.getSrcSwitchId());
         assertEquals(switchId2, flowPath.getDestSwitchId());
@@ -320,7 +320,7 @@ public class FlowPathBuilderTest {
                 .build();
         FlowSegmentCookie cookie = new FlowSegmentCookie(FlowPathDirection.FORWARD, 1);
 
-        FlowPath flowPath = builder.buildFlowPath(flow, pathResources, path, cookie, false);
+        FlowPath flowPath = builder.buildFlowPath(flow, pathResources, path, cookie, false, flow.getFlowId());
 
         assertEquals(switchId1, flowPath.getSrcSwitchId());
         assertEquals(switchId2, flowPath.getDestSwitchId());

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowPathSwappingFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowPathSwappingFsm.java
@@ -44,6 +44,7 @@ public abstract class FlowPathSwappingFsm<T extends NbTrackableFsm<T, S, E, C, R
         R extends FlowGenericCarrier> extends NbTrackableFsm<T, S, E, C, R> {
 
     protected final String flowId;
+    protected String sharedBandwidthGroupId;
 
     protected FlowResources newPrimaryResources;
     protected FlowResources newProtectedResources;

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseResourceAllocationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseResourceAllocationAction.java
@@ -213,6 +213,7 @@ public abstract class BaseResourceAllocationAction<T extends FlowPathSwappingFsm
     protected GetPathsResult allocatePathPair(Flow flow, PathId newForwardPathId, PathId newReversePathId,
                                               boolean forceToIgnoreBandwidth, List<PathId> pathsToReuseBandwidth,
                                               FlowPathPair oldPaths, boolean allowOldPaths,
+                                              String sharedBandwidthGroupId,
                                               Predicate<GetPathsResult> whetherCreatePathSegments)
             throws RecoverableException, UnroutableFlowException, ResourceAllocationException {
         // Lazy initialisable map with reused bandwidth...
@@ -267,9 +268,11 @@ public abstract class BaseResourceAllocationAction<T extends FlowPathSwappingFsm
                     if (whetherCreatePathSegments.test(potentialPath)) {
                         boolean ignoreBandwidth = forceToIgnoreBandwidth || flow.isIgnoreBandwidth();
                         List<PathSegment> forwardSegments = flowPathBuilder.buildPathSegments(newForwardPathId,
-                                potentialPath.getForward(), flow.getBandwidth(), ignoreBandwidth);
+                                potentialPath.getForward(), flow.getBandwidth(), ignoreBandwidth,
+                                sharedBandwidthGroupId);
                         List<PathSegment> reverseSegments = flowPathBuilder.buildPathSegments(newReversePathId,
-                                potentialPath.getReverse(), flow.getBandwidth(), ignoreBandwidth);
+                                potentialPath.getReverse(), flow.getBandwidth(), ignoreBandwidth,
+                                sharedBandwidthGroupId);
 
                         transactionManager.doInTransaction(() -> {
                             createPathSegments(forwardSegments, reuseBandwidthPerIsl);
@@ -326,7 +329,7 @@ public abstract class BaseResourceAllocationAction<T extends FlowPathSwappingFsm
     }
 
     protected FlowPathPair createFlowPathPair(String flowId, FlowResources flowResources, GetPathsResult pathPair,
-                                              boolean forceToIgnoreBandwidth) {
+                                              boolean forceToIgnoreBandwidth, String sharedBandwidthGroupId) {
         FlowSegmentCookieBuilder cookieBuilder = FlowSegmentCookie.builder()
                 .flowEffectiveId(flowResources.getUnmaskedCookie());
 
@@ -340,7 +343,8 @@ public abstract class BaseResourceAllocationAction<T extends FlowPathSwappingFsm
             FlowPath newForwardPath = flowPathBuilder.buildFlowPath(
                     flow, flowResources.getForward(), forward.getLatency(),
                     forward.getSrcSwitchId(), forward.getDestSwitchId(), forwardSegments,
-                    cookieBuilder.direction(FlowPathDirection.FORWARD).build(), forceToIgnoreBandwidth);
+                    cookieBuilder.direction(FlowPathDirection.FORWARD).build(), forceToIgnoreBandwidth,
+                    sharedBandwidthGroupId);
             newForwardPath.setStatus(FlowPathStatus.IN_PROGRESS);
 
             Path reverse = pathPair.getReverse();
@@ -349,7 +353,8 @@ public abstract class BaseResourceAllocationAction<T extends FlowPathSwappingFsm
             FlowPath newReversePath = flowPathBuilder.buildFlowPath(
                     flow, flowResources.getReverse(), reverse.getLatency(),
                     reverse.getSrcSwitchId(), reverse.getDestSwitchId(), reverseSegments,
-                    cookieBuilder.direction(FlowPathDirection.REVERSE).build(), forceToIgnoreBandwidth);
+                    cookieBuilder.direction(FlowPathDirection.REVERSE).build(), forceToIgnoreBandwidth,
+                    sharedBandwidthGroupId);
             newReversePath.setStatus(FlowPathStatus.IN_PROGRESS);
 
             log.debug("Persisting the paths {}/{}", newForwardPath, newReversePath);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/create/FlowCreateFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/create/FlowCreateFsm.java
@@ -88,6 +88,7 @@ public final class FlowCreateFsm extends FlowProcessingWithEventSupportFsm<FlowC
     private final String flowId;
 
     private RequestedFlow targetFlow;
+    private String sharedBandwidthGroupId;
     private List<FlowResources> flowResources = new ArrayList<>();
     private PathId forwardPathId;
     private PathId reversePathId;

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/create/action/ResourcesAllocationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/create/action/ResourcesAllocationAction.java
@@ -259,14 +259,16 @@ public class ResourcesAllocationAction extends NbTrackableAction<FlowCreateFsm, 
 
             FlowPath forward = flowPathBuilder.buildFlowPath(
                     flow, flowResources.getForward(), paths.getForward(),
-                    cookieBuilder.direction(FlowPathDirection.FORWARD).build(), false);
+                    cookieBuilder.direction(FlowPathDirection.FORWARD).build(), false,
+                    stateMachine.getSharedBandwidthGroupId());
             forward.setStatus(FlowPathStatus.IN_PROGRESS);
             flowPathRepository.add(forward);
             flow.setForwardPath(forward);
 
             FlowPath reverse = flowPathBuilder.buildFlowPath(
                     flow, flowResources.getReverse(), paths.getReverse(),
-                    cookieBuilder.direction(FlowPathDirection.REVERSE).build(), false);
+                    cookieBuilder.direction(FlowPathDirection.REVERSE).build(), false,
+                    stateMachine.getSharedBandwidthGroupId());
             reverse.setStatus(FlowPathStatus.IN_PROGRESS);
             flowPathRepository.add(reverse);
             flow.setReversePath(reverse);
@@ -312,14 +314,16 @@ public class ResourcesAllocationAction extends NbTrackableAction<FlowCreateFsm, 
 
             FlowPath forward = flowPathBuilder.buildFlowPath(
                     flow, flowResources.getForward(), protectedPath.getForward(),
-                    cookieBuilder.direction(FlowPathDirection.FORWARD).build(), false);
+                    cookieBuilder.direction(FlowPathDirection.FORWARD).build(), false,
+                    stateMachine.getSharedBandwidthGroupId());
             forward.setStatus(FlowPathStatus.IN_PROGRESS);
             flowPathRepository.add(forward);
             flow.setProtectedForwardPath(forward);
 
             FlowPath reverse = flowPathBuilder.buildFlowPath(
                     flow, flowResources.getReverse(), protectedPath.getReverse(),
-                    cookieBuilder.direction(FlowPathDirection.REVERSE).build(), false);
+                    cookieBuilder.direction(FlowPathDirection.REVERSE).build(), false,
+                    stateMachine.getSharedBandwidthGroupId());
             reverse.setStatus(FlowPathStatus.IN_PROGRESS);
             flowPathRepository.add(reverse);
             flow.setProtectedReversePath(reverse);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocatePrimaryResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocatePrimaryResourcesAction.java
@@ -80,7 +80,7 @@ public class AllocatePrimaryResourcesAction extends
         log.debug("Finding a new primary path for flow {}", flowId);
         GetPathsResult allocatedPaths = allocatePathPair(tmpFlowCopy, newForwardPathId, newReversePathId,
                 stateMachine.isIgnoreBandwidth(), pathsToReuse, oldPaths, stateMachine.isRecreateIfSamePath(),
-                path -> true);
+                stateMachine.getSharedBandwidthGroupId(), path -> true);
         if (allocatedPaths != null) {
             log.debug("New primary paths have been allocated: {}", allocatedPaths);
             stateMachine.setBackUpPrimaryPathComputationWayUsed(allocatedPaths.isBackUpPathComputationWayUsed());
@@ -92,7 +92,7 @@ public class AllocatePrimaryResourcesAction extends
             stateMachine.setNewPrimaryResources(flowResources);
 
             FlowPathPair createdPaths = createFlowPathPair(flowId, flowResources, allocatedPaths,
-                    stateMachine.isIgnoreBandwidth());
+                    stateMachine.isIgnoreBandwidth(), stateMachine.getSharedBandwidthGroupId());
             log.debug("New primary paths have been created: {}", createdPaths);
 
             setMirrorPointsToNewPath(oldPaths.getForwardPathId(), newForwardPathId);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocateProtectedResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocateProtectedResourcesAction.java
@@ -91,7 +91,7 @@ public class AllocateProtectedResourcesAction extends
         log.debug("Finding a new protected path for flow {}", flowId);
         GetPathsResult allocatedPaths = allocatePathPair(tmpFlowCopy, newForwardPathId, newReversePathId,
                 stateMachine.isIgnoreBandwidth(), pathsToReuse, oldPaths, stateMachine.isRecreateIfSamePath(),
-                testNonOverlappingPath);
+                stateMachine.getSharedBandwidthGroupId(), testNonOverlappingPath);
         if (allocatedPaths != null) {
             stateMachine.setBackUpProtectedPathComputationWayUsed(allocatedPaths.isBackUpPathComputationWayUsed());
 
@@ -110,7 +110,7 @@ public class AllocateProtectedResourcesAction extends
                 stateMachine.setNewProtectedResources(flowResources);
 
                 FlowPathPair createdPaths = createFlowPathPair(flowId, flowResources, allocatedPaths,
-                        stateMachine.isIgnoreBandwidth());
+                        stateMachine.isIgnoreBandwidth(), stateMachine.getSharedBandwidthGroupId());
                 log.debug("New protected paths have been created: {}", createdPaths);
 
                 saveAllocationActionWithDumpsToHistory(stateMachine, tmpFlowCopy, "protected", createdPaths);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocatePrimaryResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocatePrimaryResourcesAction.java
@@ -78,7 +78,8 @@ public class AllocatePrimaryResourcesAction extends
 
         log.debug("Finding a new primary path for flow {}", flowId);
         GetPathsResult allocatedPaths = allocatePathPair(tmpFlow, newForwardPathId, newReversePathId,
-                false, pathIdsToReuse, oldPaths, true, path -> true);
+                false, pathIdsToReuse, oldPaths, true,
+                stateMachine.getSharedBandwidthGroupId(), path -> true);
         if (allocatedPaths == null) {
             throw new ResourceAllocationException("Unable to allocate a path");
         }
@@ -91,7 +92,8 @@ public class AllocatePrimaryResourcesAction extends
         FlowResources flowResources = allocateFlowResources(tmpFlow, newForwardPathId, newReversePathId);
         stateMachine.setNewPrimaryResources(flowResources);
 
-        FlowPathPair createdPaths = createFlowPathPair(flowId, flowResources, allocatedPaths, false);
+        FlowPathPair createdPaths = createFlowPathPair(flowId, flowResources, allocatedPaths, false,
+                stateMachine.getSharedBandwidthGroupId());
         log.debug("New primary path has been created: {}", createdPaths);
 
         setMirrorPointsToNewPath(oldPaths.getForwardPathId(), newForwardPathId);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocateProtectedResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocateProtectedResourcesAction.java
@@ -86,7 +86,8 @@ public class AllocateProtectedResourcesAction extends
 
         log.debug("Finding a new protected path for flow {}", flowId);
         GetPathsResult allocatedPaths = allocatePathPair(tmpFlow, newForwardPathId, newReversePathId,
-                false, pathIdsToReuse, oldPaths, true, testNonOverlappingPath);
+                false, pathIdsToReuse, oldPaths, true,
+                stateMachine.getSharedBandwidthGroupId(), testNonOverlappingPath);
         if (allocatedPaths == null) {
             throw new ResourceAllocationException("Unable to allocate a path");
         }
@@ -103,7 +104,8 @@ public class AllocateProtectedResourcesAction extends
             FlowResources flowResources = allocateFlowResources(tmpFlow, newForwardPathId, newReversePathId);
             stateMachine.setNewProtectedResources(flowResources);
 
-            FlowPathPair createdPaths = createFlowPathPair(flowId, flowResources, allocatedPaths, false);
+            FlowPathPair createdPaths = createFlowPathPair(flowId, flowResources, allocatedPaths, false,
+                    stateMachine.getSharedBandwidthGroupId());
             log.debug("New protected path has been created: {}", createdPaths);
 
             saveAllocationActionWithDumpsToHistory(stateMachine, tmpFlow, "protected", createdPaths);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/create/action/CreateSubFlowsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/create/action/CreateSubFlowsAction.java
@@ -51,7 +51,7 @@ public class CreateSubFlowsAction extends HistoryRecordingAction<YFlowCreateFsm,
             stateMachine.addCreatingSubFlow(subFlowId);
             stateMachine.notifyEventListeners(listener -> listener.onSubFlowProcessingStart(yFlowId, subFlowId));
             CommandContext flowContext = stateMachine.getCommandContext().fork(subFlowId);
-            flowCreateService.startFlowCreation(flowContext, requestedFlow, false);
+            flowCreateService.startFlowCreation(flowContext, requestedFlow, false, yFlowId);
         });
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteService.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteService.java
@@ -75,6 +75,7 @@ public class FlowRerouteService extends FsmBasedFlowProcessingService<FlowRerout
         }
 
         FlowRerouteFsm fsm = fsmFactory.newInstance(commandContext, flowId);
+        fsm.setSharedBandwidthGroupId(flowId);
         registerFsm(key, fsm);
 
         FlowRerouteContext context = FlowRerouteContext.builder()

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowUpdateService.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowUpdateService.java
@@ -185,6 +185,7 @@ public class FlowUpdateService extends FsmBasedFlowProcessingService<FlowUpdateF
         }
 
         FlowUpdateFsm fsm = fsmFactory.newInstance(commandContext, flowId);
+        fsm.setSharedBandwidthGroupId(request.getFlowId());
         registerFsm(key, fsm);
 
         RequestedFlow requestedFlow = RequestedFlowMapper.INSTANCE.toRequestedFlow(request);

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/FlowPath.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/FlowPath.java
@@ -61,7 +61,7 @@ import java.util.stream.Collectors;
 public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
     @Getter
     @Setter
-    @Delegate
+    @Delegate(excludes = FlowPathInternalData.class)
     @JsonIgnore
     private FlowPathData data;
 
@@ -87,12 +87,14 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
                     FlowSegmentCookie cookie, MeterId meterId, GroupId ingressMirrorGroupId,
                     long latency, long bandwidth,
                     boolean ignoreBandwidth, FlowPathStatus status, List<PathSegment> segments,
-                    Set<FlowApplication> applications, boolean srcWithMultiTable, boolean destWithMultiTable) {
+                    Set<FlowApplication> applications, boolean srcWithMultiTable, boolean destWithMultiTable,
+                    String sharedBandwidthGroupId) {
         data = FlowPathDataImpl.builder().pathId(pathId).srcSwitch(srcSwitch).destSwitch(destSwitch)
                 .cookie(cookie).meterId(meterId).ingressMirrorGroupId(ingressMirrorGroupId)
                 .latency(latency).bandwidth(bandwidth)
                 .ignoreBandwidth(ignoreBandwidth).status(status)
                 .applications(applications).srcWithMultiTable(srcWithMultiTable).destWithMultiTable(destWithMultiTable)
+                .sharedBandwidthGroupId(sharedBandwidthGroupId)
                 .build();
         // The reference is used to link path segments back to the path. See {@link #setSegments(List)}.
         ((FlowPathDataImpl) data).flowPath = this;
@@ -146,6 +148,45 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
         return flow != null && flow.isProtectedPath(getPathId());
     }
 
+    /**
+     * Sets the bandwidth.
+     * This also updates the corresponding path segments.
+     */
+    public void setBandwidth(long bandwidth) {
+        data.setBandwidth(bandwidth);
+
+        List<PathSegment> segments = getSegments();
+        if (segments != null) {
+            segments.forEach(segment -> segment.getData().setBandwidth(bandwidth));
+        }
+    }
+
+    /**
+     * Sets the ignoreBandwidth flag.
+     * This also updates the corresponding path segments.
+     */
+    public void setIgnoreBandwidth(boolean ignoreBandwidth) {
+        data.setIgnoreBandwidth(ignoreBandwidth);
+
+        List<PathSegment> segments = getSegments();
+        if (segments != null) {
+            segments.forEach(segment -> segment.getData().setIgnoreBandwidth(ignoreBandwidth));
+        }
+    }
+
+    /**
+     * Sets the sharedBandwidthGroupId.
+     * This also updates the corresponding path segments.
+     */
+    public void setSharedBandwidthGroupId(String sharedBandwidthGroupId) {
+        data.setSharedBandwidthGroupId(sharedBandwidthGroupId);
+
+        List<PathSegment> segments = getSegments();
+        if (segments != null) {
+            segments.forEach(segment -> segment.getData().setSharedBandwidthGroupId(sharedBandwidthGroupId));
+        }
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -173,6 +214,7 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
                 .append(getApplications(), that.getApplications())
                 .append(isSrcWithMultiTable(), that.isSrcWithMultiTable())
                 .append(isDestWithMultiTable(), that.isDestWithMultiTable())
+                .append(getSharedBandwidthGroupId(), that.getSharedBandwidthGroupId())
                 .isEquals();
     }
 
@@ -180,7 +222,8 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
     public int hashCode() {
         return Objects.hash(getPathId(), getSrcSwitchId(), getDestSwitchId(), getFlowId(), getCookie(), getMeterId(),
                 getLatency(), getBandwidth(), isIgnoreBandwidth(), getTimeCreate(), getTimeModify(), getStatus(),
-                getSegments(), getApplications(), isSrcWithMultiTable(), isDestWithMultiTable());
+                getSegments(), getApplications(), isSrcWithMultiTable(), isDestWithMultiTable(),
+                getSharedBandwidthGroupId());
     }
 
     /**
@@ -262,6 +305,21 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
         Set<FlowMirrorPoints> getFlowMirrorPointsSet();
 
         void addFlowMirrorPoints(FlowMirrorPoints flowMirrorPoints);
+
+        String getSharedBandwidthGroupId();
+
+        void setSharedBandwidthGroupId(String sharedBandwidthGroupId);
+    }
+
+    /**
+     * Defines methods which don't need to be delegated.
+     */
+    interface FlowPathInternalData {
+        void setBandwidth(long bandwidth);
+
+        void setIgnoreBandwidth(boolean ignoreBandwidth);
+
+        void setSharedBandwidthGroupId(String sharedBandwidthGroupId);
     }
 
     /**
@@ -300,14 +358,6 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
         @EqualsAndHashCode.Exclude
         final Set<FlowMirrorPoints> flowMirrorPointsSet = new HashSet<>();
 
-        public void setPathId(PathId pathId) {
-            this.pathId = pathId;
-
-            if (segments != null) {
-                segments.forEach(segment -> segment.getData().setPathId(pathId));
-            }
-        }
-
         // The reference is used to link path segments back to the path. See {@link #setSegments(List)}.
         @Setter(AccessLevel.NONE)
         @Getter(AccessLevel.NONE)
@@ -317,6 +367,15 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
 
         boolean srcWithMultiTable;
         boolean destWithMultiTable;
+        String sharedBandwidthGroupId;
+
+        public void setPathId(PathId pathId) {
+            this.pathId = pathId;
+
+            if (segments != null) {
+                segments.forEach(segment -> segment.getData().setPathId(pathId));
+            }
+        }
 
         @Override
         public String getFlowId() {
@@ -331,22 +390,6 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
         @Override
         public SwitchId getDestSwitchId() {
             return destSwitch.getSwitchId();
-        }
-
-        public void setBandwidth(long bandwidth) {
-            this.bandwidth = bandwidth;
-
-            if (segments != null) {
-                segments.forEach(segment -> segment.getData().setBandwidth(bandwidth));
-            }
-        }
-
-        public void setIgnoreBandwidth(boolean ignoreBandwidth) {
-            this.ignoreBandwidth = ignoreBandwidth;
-
-            if (segments != null) {
-                segments.forEach(segment -> segment.getData().setIgnoreBandwidth(ignoreBandwidth));
-            }
         }
 
         @Override
@@ -366,11 +409,11 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
                 data.setSeqId(idx);
                 data.setIgnoreBandwidth(ignoreBandwidth);
                 data.setBandwidth(bandwidth);
+                data.setSharedBandwidthGroupId(sharedBandwidthGroupId);
             }
 
             this.segments = new ArrayList<>(segments);
         }
-
 
         @Override
         public void addFlowMirrorPoints(FlowMirrorPoints flowMirrorPoints) {

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/PathSegment.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/PathSegment.java
@@ -68,11 +68,11 @@ public class PathSegment implements CompositeDataEntity<PathSegment.PathSegmentD
     public PathSegment(@NonNull PathId pathId, @NonNull Switch srcSwitch, @NonNull Switch destSwitch,
                        int srcPort, int destPort,
                        boolean srcWithMultiTable, boolean destWithMultiTable, int seqId, Long latency, long bandwidth,
-                       boolean ignoreBandwidth, boolean failed) {
+                       boolean ignoreBandwidth, boolean failed, String sharedBandwidthGroupId) {
         data = PathSegmentDataImpl.builder().pathId(pathId).srcSwitch(srcSwitch).destSwitch(destSwitch)
                 .srcPort(srcPort).destPort(destPort).srcWithMultiTable(srcWithMultiTable)
                 .destWithMultiTable(destWithMultiTable).seqId(seqId).latency(latency).bandwidth(bandwidth)
-                .ignoreBandwidth(ignoreBandwidth).failed(failed).build();
+                .ignoreBandwidth(ignoreBandwidth).failed(failed).sharedBandwidthGroupId(sharedBandwidthGroupId).build();
     }
 
     public PathSegment(@NonNull PathSegmentData data) {
@@ -115,13 +115,15 @@ public class PathSegment implements CompositeDataEntity<PathSegment.PathSegmentD
                 .append(getDestSwitchId(), that.getDestSwitchId())
                 .append(getLatency(), that.getLatency())
                 .append(getBandwidth(), that.getBandwidth())
+                .append(getSharedBandwidthGroupId(), that.getSharedBandwidthGroupId())
                 .isEquals();
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(getPathId(), getSrcSwitchId(), getDestSwitchId(), getSrcPort(), getDestPort(),
-                isSrcWithMultiTable(), isDestWithMultiTable(), getSeqId(), getLatency(), getBandwidth(), isFailed());
+                isSrcWithMultiTable(), isDestWithMultiTable(), getSeqId(), getLatency(), getBandwidth(), isFailed(),
+                getSharedBandwidthGroupId());
     }
 
     /**
@@ -179,6 +181,10 @@ public class PathSegment implements CompositeDataEntity<PathSegment.PathSegmentD
         boolean isFailed();
 
         void setFailed(boolean failed);
+
+        String getSharedBandwidthGroupId();
+
+        void setSharedBandwidthGroupId(String sharedBandwidthGroupId);
     }
 
     /**
@@ -192,6 +198,8 @@ public class PathSegment implements CompositeDataEntity<PathSegment.PathSegmentD
         void setBandwidth(long bandwidth);
 
         void setIgnoreBandwidth(boolean ignoreBandwidth);
+
+        void setSharedBandwidthGroupId(String sharedBandwidthGroupId);
     }
 
     /**
@@ -215,6 +223,7 @@ public class PathSegment implements CompositeDataEntity<PathSegment.PathSegmentD
         long bandwidth;
         boolean ignoreBandwidth;
         boolean failed;
+        String sharedBandwidthGroupId;
 
         @Override
         public SwitchId getSrcSwitchId() {

--- a/src-java/kilda-persistence-orientdb/src/main/java/org/openkilda/persistence/orientdb/repositories/OrientDbFlowPathRepository.java
+++ b/src-java/kilda-persistence-orientdb/src/main/java/org/openkilda/persistence/orientdb/repositories/OrientDbFlowPathRepository.java
@@ -20,18 +20,14 @@ import static java.lang.String.format;
 import org.openkilda.model.PathId;
 import org.openkilda.persistence.ferma.frames.FlowFrame;
 import org.openkilda.persistence.ferma.frames.FlowPathFrame;
-import org.openkilda.persistence.ferma.frames.PathSegmentFrame;
 import org.openkilda.persistence.ferma.frames.converters.PathIdConverter;
 import org.openkilda.persistence.ferma.repositories.FermaFlowPathRepository;
 import org.openkilda.persistence.orientdb.OrientDbPersistenceImplementation;
 import org.openkilda.persistence.repositories.FlowPathRepository;
 
-import com.syncleus.ferma.FramedGraph;
-import org.apache.tinkerpop.gremlin.orientdb.executor.OGremlinResult;
 import org.apache.tinkerpop.gremlin.orientdb.executor.OGremlinResultSet;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.stream.Collectors;
 
 /**
@@ -67,6 +63,7 @@ public class OrientDbFlowPathRepository extends FermaFlowPathRepository {
         }
     }
 
+    /*TODO: this need to be reimplemented to work with PathSegmentFrame.SHARED_BANDWIDTH_GROUP_ID_PROPERTY
     @Override
     protected long getUsedBandwidthBetweenEndpoints(FramedGraph framedGraph,
                                                     String srcSwitchId, int srcPort, String dstSwitchId, int dstPort) {
@@ -87,4 +84,5 @@ public class OrientDbFlowPathRepository extends FermaFlowPathRepository {
             return 0;
         }
     }
+    */
 }

--- a/src-java/kilda-persistence-orientdb/src/main/java/org/openkilda/persistence/orientdb/repositories/OrientDbPathSegmentRepository.java
+++ b/src-java/kilda-persistence-orientdb/src/main/java/org/openkilda/persistence/orientdb/repositories/OrientDbPathSegmentRepository.java
@@ -15,27 +15,12 @@
 
 package org.openkilda.persistence.orientdb.repositories;
 
-import static java.lang.String.format;
-
-import org.openkilda.model.PathSegment;
-import org.openkilda.persistence.ferma.frames.IslFrame;
-import org.openkilda.persistence.ferma.frames.PathSegmentFrame;
-import org.openkilda.persistence.ferma.frames.converters.PathIdConverter;
-import org.openkilda.persistence.ferma.frames.converters.SwitchIdConverter;
 import org.openkilda.persistence.ferma.repositories.FermaPathSegmentRepository;
 import org.openkilda.persistence.orientdb.OrientDbPersistenceImplementation;
 import org.openkilda.persistence.repositories.IslRepository;
 import org.openkilda.persistence.repositories.PathSegmentRepository;
 
-import com.google.common.collect.ImmutableMap;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.tinkerpop.gremlin.orientdb.OrientGraph;
-import org.apache.tinkerpop.gremlin.orientdb.executor.OGremlinResult;
-import org.apache.tinkerpop.gremlin.orientdb.executor.OGremlinResultSet;
-
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Optional;
 
 /**
  * OrientDB implementation of {@link PathSegmentRepository}.
@@ -51,6 +36,7 @@ public class OrientDbPathSegmentRepository extends FermaPathSegmentRepository {
         this.graphSupplier = graphSupplier;
     }
 
+    /*TODO: this need to be reimplemented to work with PathSegmentFrame.SHARED_BANDWIDTH_GROUP_ID_PROPERTY
     @Override
     public Optional<Long> addSegmentAndUpdateIslAvailableBandwidth(PathSegment segment) {
         Map params = ImmutableMap.builder()
@@ -126,5 +112,5 @@ public class OrientDbPathSegmentRepository extends FermaPathSegmentRepository {
                 return Optional.empty();
             }
         }
-    }
+    }*/
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/frames/FlowPathFrame.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/frames/FlowPathFrame.java
@@ -69,6 +69,7 @@ public abstract class FlowPathFrame extends KildaBaseVertexFrame implements Flow
     public static final String BANDWIDTH_PROPERTY = "bandwidth";
     public static final String SRC_MULTI_TABLE_PROPERTY = "src_with_multi_table";
     public static final String DST_MULTI_TABLE_PROPERTY = "dst_with_multi_table";
+    public static final String SHARED_BANDWIDTH_GROUP_ID_PROPERTY = "shared_bw_group_id";
 
     private Switch srcSwitch;
     private Switch destSwitch;
@@ -181,6 +182,13 @@ public abstract class FlowPathFrame extends KildaBaseVertexFrame implements Flow
     @Property(DST_MULTI_TABLE_PROPERTY)
     public abstract void setDestWithMultiTable(boolean destWithMultiTable);
 
+    @Override
+    @Property(SHARED_BANDWIDTH_GROUP_ID_PROPERTY)
+    public abstract String getSharedBandwidthGroupId();
+
+    @Override
+    @Property(SHARED_BANDWIDTH_GROUP_ID_PROPERTY)
+    public abstract void setSharedBandwidthGroupId(String sharedBandwidthGroupId);
 
     @Override
     public Set<FlowApplication> getApplications() {

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/frames/PathSegmentFrame.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/frames/PathSegmentFrame.java
@@ -43,6 +43,7 @@ public abstract class PathSegmentFrame extends KildaBaseVertexFrame implements P
     public static final String SEQ_ID_PROPERTY = "seq_id";
     public static final String LATENCY_PROPERTY = "latency";
     public static final String FAILED_PROPERTY = "failed";
+    public static final String SHARED_BANDWIDTH_GROUP_ID_PROPERTY = "shared_bw_group_id";
 
     private Switch srcSwitch;
     private Switch destSwitch;
@@ -170,6 +171,14 @@ public abstract class PathSegmentFrame extends KildaBaseVertexFrame implements P
     @Override
     @Property(DST_W_MULTI_TABLE_PROPERTY)
     public abstract void setDestWithMultiTable(boolean destWithMultiTable);
+
+    @Override
+    @Property(SHARED_BANDWIDTH_GROUP_ID_PROPERTY)
+    public abstract String getSharedBandwidthGroupId();
+
+    @Override
+    @Property(SHARED_BANDWIDTH_GROUP_ID_PROPERTY)
+    public abstract void setSharedBandwidthGroupId(String sharedBandwidthGroupId);
 
     public static PathSegmentFrame create(FramedGraph framedGraph, PathSegmentData data) {
         PathSegmentFrame frame = KildaBaseVertexFrame.addNewFramedVertex(framedGraph, FRAME_LABEL,

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaFlowPathRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaFlowPathRepository.java
@@ -41,6 +41,8 @@ import org.openkilda.persistence.tx.TransactionManager;
 import com.syncleus.ferma.FramedGraph;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.structure.Column;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -366,7 +368,13 @@ public class FermaFlowPathRepository extends FermaGenericRepository<FlowPath, Fl
                 .has(PathSegmentFrame.SRC_PORT_PROPERTY, srcPort)
                 .has(PathSegmentFrame.DST_PORT_PROPERTY, dstPort)
                 .has(PathSegmentFrame.IGNORE_BANDWIDTH_PROPERTY, false)
-                .values(PathSegmentFrame.BANDWIDTH_PROPERTY)
+                .choose(__.has(PathSegmentFrame.SHARED_BANDWIDTH_GROUP_ID_PROPERTY),
+                        __.group()
+                                .by(PathSegmentFrame.SHARED_BANDWIDTH_GROUP_ID_PROPERTY)
+                                .by(__.values(PathSegmentFrame.BANDWIDTH_PROPERTY).max())
+                                .select(Column.values)
+                                .unfold(),
+                        __.values(PathSegmentFrame.BANDWIDTH_PROPERTY))
                 .sum())
                 .getRawTraversal()) {
             return traversal.tryNext()


### PR DESCRIPTION
The changes:
- Add "shared_bandwidth_group_id" property to FlowPath and PathSegment entities.
- Change IslRepository and FlowPathRepository to take "shared_bandwidth_group_id" into account on available_bandwidth calculation.
- Update FlowHS services to set "shared_bandwidth_group_id" equal to "flow_id".