### PR TITLE
At most once guarantee strategy for flowhs input spout

### DIFF
--- a/confd/templates/docker-compose/docker-compose.tmpl
+++ b/confd/templates/docker-compose/docker-compose.tmpl
@@ -126,7 +126,7 @@ services:
 
   mysql_db:
     hostname: mysql.pendev
-    image: mysql:5.6
+    image: mysql:5.7.34
     command: --default-authentication-plugin=mysql_native_password
     volumes:
       - ./docker/mysql/setup_data:/docker-entrypoint-initdb.d

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/topology/AbstractTopology.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/topology/AbstractTopology.java
@@ -281,8 +281,12 @@ public abstract class AbstractTopology<T extends AbstractTopologyConfig> impleme
     }
 
     protected SpoutDeclarer declareKafkaSpout(TopologyBuilder builder, List<String> topics, String spoutId) {
-        KafkaSpoutConfig<String, Message> config = getKafkaSpoutConfigBuilder(topics, spoutId)
-                .build();
+        KafkaSpoutConfig<String, Message> config = getKafkaSpoutConfigBuilder(topics, spoutId).build();
+        return declareKafkaSpout(builder, config, spoutId);
+    }
+
+    protected <V> SpoutDeclarer declareKafkaSpout(
+            TopologyBuilder builder, KafkaSpoutConfig<String, V> config, String spoutId) {
         logger.info("Setup kafka spout: id={}, group={}, subscriptions={}",
                 spoutId, config.getConsumerGroupId(), config.getSubscription().getTopicsString());
         return declareSpout(builder, new KafkaSpout<>(config), spoutId);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/FlowHsTopology.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/FlowHsTopology.java
@@ -36,6 +36,7 @@ import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.UPDATE_HUB
 import static org.openkilda.wfm.topology.flowhs.bolts.RouterBolt.FLOW_ID_FIELD;
 
 import org.openkilda.messaging.AbstractMessage;
+import org.openkilda.messaging.Message;
 import org.openkilda.pce.PathComputerConfig;
 import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.wfm.LaunchEnvironment;
@@ -70,6 +71,8 @@ import org.openkilda.wfm.topology.flowhs.bolts.SpeakerWorkerBolt;
 
 import org.apache.storm.generated.StormTopology;
 import org.apache.storm.kafka.bolt.KafkaBolt;
+import org.apache.storm.kafka.spout.KafkaSpoutConfig;
+import org.apache.storm.kafka.spout.KafkaSpoutConfig.ProcessingGuarantee;
 import org.apache.storm.topology.TopologyBuilder;
 import org.apache.storm.tuple.Fields;
 
@@ -156,7 +159,13 @@ public class FlowHsTopology extends AbstractTopology<FlowHsTopologyConfig> {
     }
 
     private void inputSpout(TopologyBuilder topologyBuilder) {
-        declareKafkaSpout(topologyBuilder, getConfig().getKafkaFlowHsTopic(), ComponentId.FLOW_SPOUT.name());
+        String spoutId = ComponentId.FLOW_SPOUT.name();
+        KafkaSpoutConfig<String, Message> spoutConfig = getKafkaSpoutConfigBuilder(
+                getConfig().getKafkaFlowHsTopic(), spoutId)
+                .setProcessingGuarantee(ProcessingGuarantee.AT_MOST_ONCE)
+                .setTupleTrackingEnforced(true)
+                .build();
+        declareKafkaSpout(topologyBuilder, spoutConfig, spoutId);
     }
 
     private void inputRouter(TopologyBuilder topologyBuilder) {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowCreateService.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowCreateService.java
@@ -21,7 +21,6 @@ import org.openkilda.pce.PathComputer;
 import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.persistence.repositories.KildaConfigurationRepository;
 import org.openkilda.persistence.repositories.RepositoryFactory;
-import org.openkilda.persistence.repositories.history.FlowEventRepository;
 import org.openkilda.wfm.CommandContext;
 import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
 import org.openkilda.wfm.topology.flowhs.fsm.create.FlowCreateContext;
@@ -43,7 +42,6 @@ public class FlowCreateService {
 
     private final FlowCreateFsm.Factory fsmFactory;
     private final FlowCreateHubCarrier carrier;
-    private final FlowEventRepository flowEventRepository;
     private final KildaConfigurationRepository kildaConfigurationRepository;
     private boolean active;
 
@@ -52,8 +50,8 @@ public class FlowCreateService {
                              int genericRetriesLimit, int pathAllocationRetriesLimit,
                              int pathAllocationRetryDelay, int speakerCommandRetriesLimit) {
         this.carrier = carrier;
+
         RepositoryFactory repositoryFactory = persistenceManager.getRepositoryFactory();
-        flowEventRepository = repositoryFactory.createFlowEventRepository();
         kildaConfigurationRepository = repositoryFactory.createKildaConfigurationRepository();
 
         Config fsmConfig = Config.builder()
@@ -76,12 +74,6 @@ public class FlowCreateService {
 
         if (fsms.containsKey(key)) {
             log.error("Attempt to create a FSM with key {}, while there's another active FSM with the same key.", key);
-            return;
-        }
-
-        String eventKey = commandContext.getCorrelationId();
-        if (flowEventRepository.existsByTaskId(eventKey)) {
-            log.error("Attempt to reuse key {}, but there's a history record(s) for it.", eventKey);
             return;
         }
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowDeleteService.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowDeleteService.java
@@ -18,7 +18,6 @@ package org.openkilda.wfm.topology.flowhs.service;
 import org.openkilda.floodlight.api.response.SpeakerFlowSegmentResponse;
 import org.openkilda.floodlight.flow.response.FlowErrorResponse;
 import org.openkilda.persistence.PersistenceManager;
-import org.openkilda.persistence.repositories.history.FlowEventRepository;
 import org.openkilda.wfm.CommandContext;
 import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
 import org.openkilda.wfm.share.utils.FsmExecutor;
@@ -43,7 +42,6 @@ public class FlowDeleteService {
             = new FsmExecutor<>(Event.NEXT);
 
     private final FlowDeleteHubCarrier carrier;
-    private final FlowEventRepository flowEventRepository;
 
     private boolean active;
 
@@ -51,7 +49,6 @@ public class FlowDeleteService {
                              FlowResourcesManager flowResourcesManager,
                              int speakerCommandRetriesLimit) {
         this.carrier = carrier;
-        flowEventRepository = persistenceManager.getRepositoryFactory().createFlowEventRepository();
         fsmFactory = new FlowDeleteFsm.Factory(carrier, persistenceManager, flowResourcesManager,
                 speakerCommandRetriesLimit);
     }
@@ -67,12 +64,6 @@ public class FlowDeleteService {
 
         if (fsms.containsKey(key)) {
             log.error("Attempt to create a FSM with key {}, while there's another active FSM with the same key.", key);
-            return;
-        }
-
-        String eventKey = commandContext.getCorrelationId();
-        if (flowEventRepository.existsByTaskId(eventKey)) {
-            log.error("Attempt to reuse key %s, but there's a history record(s) for it.", eventKey);
             return;
         }
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowUpdateService.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowUpdateService.java
@@ -30,7 +30,6 @@ import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.persistence.repositories.FlowRepository;
 import org.openkilda.persistence.repositories.KildaConfigurationRepository;
 import org.openkilda.persistence.repositories.RepositoryFactory;
-import org.openkilda.persistence.repositories.history.FlowEventRepository;
 import org.openkilda.wfm.CommandContext;
 import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
 import org.openkilda.wfm.share.utils.FsmExecutor;
@@ -59,7 +58,6 @@ public class FlowUpdateService {
 
     private final FlowUpdateHubCarrier carrier;
     private final FlowRepository flowRepository;
-    private final FlowEventRepository flowEventRepository;
     private final KildaConfigurationRepository kildaConfigurationRepository;
 
     private boolean active;
@@ -71,7 +69,6 @@ public class FlowUpdateService {
         this.carrier = carrier;
         RepositoryFactory repositoryFactory = persistenceManager.getRepositoryFactory();
         flowRepository = repositoryFactory.createFlowRepository();
-        flowEventRepository = repositoryFactory.createFlowEventRepository();
         kildaConfigurationRepository = repositoryFactory.createKildaConfigurationRepository();
         fsmFactory = new FlowUpdateFsm.Factory(carrier, persistenceManager, pathComputer, flowResourcesManager,
                 pathAllocationRetriesLimit, pathAllocationRetryDelay, resourceAllocationRetriesLimit,
@@ -176,12 +173,6 @@ public class FlowUpdateService {
 
         if (fsms.containsKey(key)) {
             log.error("Attempt to create a FSM with key {}, while there's another active FSM with the same key.", key);
-            return;
-        }
-
-        String eventKey = commandContext.getCorrelationId();
-        if (flowEventRepository.existsByTaskId(eventKey)) {
-            log.error("Attempt to reuse key {}, but there's a history record(s) for it.", eventKey);
             return;
         }
 


### PR DESCRIPTION
Flow-HS code already use at-most-once tuple processing strategy, but
inplements it via "heavy" DB call. Usage of correct (provided by storm
kafka spout code) implementation allows to get rid from these DB calls.