### PR TITLE
improve check(switchNotFound) in MultiFloodlightsSpec

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/MultiFloodlightsSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/MultiFloodlightsSpec.groovy
@@ -79,20 +79,20 @@ class MultiFloodlightsSpec extends HealthCheckSpecification {
         def knockout2 = lockKeeper.knockoutSwitch(sw, [flHelper.filterRegionsByMode(sw.regions, RW)[0]])
         cleanupActions << { lockKeeper.reviveSwitch(sw, knockout2) }
 
-        and: "Try getting switch rules"
+        then: "Switch is marked as inactive"
+        wait(WAIT_OFFSET) {
+            northbound.getSwitch(sw.dpId).state == DEACTIVATED
+        }
+
+        when: "Try getting switch rules"
         northbound.getSwitchRules(sw.dpId)
 
-        then: "Switch is not found"
+        then: "Human readable error is returned"
         def e = thrown(HttpClientErrorException)
         e.statusCode == HttpStatus.NOT_FOUND
         verifyAll(e.responseBodyAsString.to(MessageError)) {
             errorMessage == "Switch $sw.dpId was not found"
             errorDescription == "The switch was not found when requesting a rules dump."
-        }
-
-        and: "Switch is marked as inactive"
-        wait(WAIT_OFFSET) {
-            northbound.getSwitch(sw.dpId).state == DEACTIVATED
         }
 
         when: "Broken region restores connection to kafka"


### PR DESCRIPTION
try to avoid:
```
2021-11-11 21:59:53.680    MultiFloodlightsSpec ✘ Switch remains online only if at least one of multiple RW floodlights is available
2021-11-11 21:59:53.680  
2021-11-11 21:59:53.680      Expected exception of type 'org.springframework.web.client.HttpClientErrorException', but no exception was thrown
2021-11-11 21:59:53.680          at org.spockframework.lang.SpecInternals.checkExceptionThrown(SpecInternals.java:81)
2021-11-11 21:59:53.680          at org.spockframework.lang.SpecInternals.thrownImpl(SpecInternals.java:68)
2021-11-11 21:59:53.680          at org.openkilda.functionaltests.spec.switches.MultiFloodlightsSpec.Switch remains online only if at least one of multiple RW floodlights is available(MultiFloodlightsSpec.groovy:86)
```