### PR TITLE
improve defaultRuleSpec(temporary add sleep)

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesSpec.groovy
@@ -107,6 +107,7 @@ class DefaultRulesSpec extends HealthCheckSpecification {
                     .containsExactlyInAnyOrder(*defaultRules*.cookie.sort())
             assert northbound.getActiveLinks().size() == topology.islsForActiveSwitches.size() * 2
         }
+        sleep(1000) // looks as a bug, wait for ruleManager
 
         where:
         [data, sw] << [
@@ -180,6 +181,7 @@ class DefaultRulesSpec extends HealthCheckSpecification {
             assert northbound.getSwitchRules(sw.dpId).flowEntries.size() == defaultRules.size()
             assert northbound.getActiveLinks().size() == topology.islsForActiveSwitches.size() * 2
         }
+        sleep(1000) // looks as a bug, wait for ruleManager
 
         where:
         [data, sw] << [
@@ -240,6 +242,7 @@ class DefaultRulesSpec extends HealthCheckSpecification {
                 assert northbound.getSwitchRules(sw.dpId).flowEntries*.cookie.sort() == sw.defaultCookies.sort()
             }
         }
+        sleep(1000) // looks as a bug, wait for ruleManager
 
 
         where:


### PR DESCRIPTION
default rule is installing(install_default/syncSw) twice by the same floodlight

kibana request: i.e. `"installing" AND "<switchId>" AND "0x8030000000000004"`
it can cause instability during running func tests on jenkins
add `sleep` to avoid instability, 
this pr is going to reverted once ruleManager is implemented/merged.