### PR TITLE
Changed Kafka and Zookeeper ports in unit tests

### DIFF
--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/config/KafkaConfig.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/config/KafkaConfig.java
@@ -22,8 +22,8 @@ import com.sabre.oss.conf4j.annotation.Key;
 @Key("kafka")
 public interface KafkaConfig {
     // To be able to run tests in parallel we must use different ports for kafka hosts in each test
-    int STATS_TOPOLOGY_TEST_KAFKA_PORT = 2182;
-    int ISL_LATENCY_TOPOLOGY_TEST_KAFKA_PORT = 2183;
+    int STATS_TOPOLOGY_TEST_KAFKA_PORT = 2188;
+    int ISL_LATENCY_TOPOLOGY_TEST_KAFKA_PORT = 2189;
 
     @Key("hosts")
     String getHosts();

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/config/ZookeeperConfig.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/config/ZookeeperConfig.java
@@ -23,8 +23,8 @@ import com.sabre.oss.conf4j.annotation.Key;
 @Key("zookeeper")
 public interface ZookeeperConfig {
     // To be able to run tests in parallel we must use different ports for zookeeper hosts in each test
-    int STATS_TOPOLOGY_TEST_ZOOKEEPER_PORT = 9093;
-    int ISL_LATENCY_TOPOLOGY_TEST_ZOOKEEPER_PORT = 9094;
+    int STATS_TOPOLOGY_TEST_ZOOKEEPER_PORT = 9098;
+    int ISL_LATENCY_TOPOLOGY_TEST_ZOOKEEPER_PORT = 9099;
 
     @Key("hosts")
     String getHosts();


### PR DESCRIPTION
PR #4529 added port 9093 into Kilda configuration,
but this port was used by unit tests. Because of this
user can't run StatsTopologyTest if Kilda loval env is running.

Ports of kafka and zookeper in unit tests were changed to do not intersect
with Kilda env ports.