### PR TITLE
Feature/create lag port

### DIFF
--- a/src-gui/src/main/java/org/openkilda/constants/IConstants.java
+++ b/src-gui/src/main/java/org/openkilda/constants/IConstants.java
@@ -169,6 +169,9 @@ public abstract class IConstants {
         public static final String UPDATE_SWITCH_LOCATION = VERSION_TWO + "/switches/{switch_id}";
         public static final String GET_LINK_BFD_PROPERTIES = VERSION_TWO
                 + "/links/{src-switch}_{src-port}/{dst-switch}_{dst-port}/bfd";
+        public static final String SWITCH_LOGICAL_PORT = VERSION_TWO + "/switches/{switch_id}/lags";
+        public static final String DELETE_SWITCH_LOGICAL_PORT = VERSION_TWO
+                + "/switches/{switch_id}/lags/{logical_port_number}";
     }
 
     public static final class OpenTsDbUrl {
@@ -315,6 +318,10 @@ public abstract class IConstants {
         public static final String ISL_UPDATE_BFD_PROPERTIES = "isl_update_bfd_properties";
 
         public static final String ISL_DELETE_BFD = "isl_delete_bfd";
+
+        public static final String SW_CREATE_LOGICAL_PORT = "sw_create_logical_port";
+
+        public static final String SW_DELETE_LOGICAL_PORT = "sw_delete_logical_port";
     }
 
     public static final class Settings {

--- a/src-gui/src/main/java/org/openkilda/constants/Metrics.java
+++ b/src-gui/src/main/java/org/openkilda/constants/Metrics.java
@@ -15,6 +15,7 @@
 
 package org.openkilda.constants;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -90,6 +91,7 @@ public enum Metrics {
 
     private final String tag;
 
+    @Getter(AccessLevel.NONE)
     private final String metricName;
 
     private static final Map<String, List<Metrics>> TAG_TO_METRICS_MAP = new HashMap<>();
@@ -117,6 +119,10 @@ public enum Metrics {
         this.metricName = metricName;
     }
 
+    public final String getMetricName(String prefix) {
+        return prefix + this.metricName;
+    }
+
     /**
      * Flow value.
      *
@@ -131,9 +137,9 @@ public enum Metrics {
             return metricNames;
         }
         metrics.forEach(metric -> {
-            metricNames.add(prefix + metric.getMetricName());
+            metricNames.add(metric.getMetricName(prefix));
             if (uniDirectional) {
-                metricNames.add(prefix + metric.getMetricName());
+                metricNames.add(metric.getMetricName(prefix));
             }
         });
         return metricNames;
@@ -150,7 +156,7 @@ public enum Metrics {
             return StringUtils.EMPTY;
         }
         Optional<Metrics> metric = TAG_TO_METRICS_MAP.get("Flow_" + metricPart.toLowerCase()).stream().findFirst();
-        return metric.map(metrics -> prefix + metrics.getMetricName()).orElse(StringUtils.EMPTY);
+        return metric.map(metrics -> metrics.getMetricName(prefix)).orElse(StringUtils.EMPTY);
     }
 
     /**
@@ -164,7 +170,7 @@ public enum Metrics {
             return StringUtils.EMPTY;
         }
         Optional<Metrics> metric = TAG_TO_METRICS_MAP.get("Meter_" + metricPart.toLowerCase()).stream().findFirst();
-        return metric.map(metrics -> prefix + metrics.getMetricName()).orElse(StringUtils.EMPTY);
+        return metric.map(metrics -> metrics.getMetricName(prefix)).orElse(StringUtils.EMPTY);
     }
 
     /**
@@ -178,7 +184,7 @@ public enum Metrics {
         tag = "Flow_raw_" + tag;
         for (Metrics metric : values()) {
             if (metric.getTag().equalsIgnoreCase(tag)) {
-                list.add(prefix + metric.getMetricName());
+                list.add(metric.getMetricName(prefix));
             }
         }
         return list;
@@ -202,7 +208,7 @@ public enum Metrics {
         }
         for (Metrics metric : values()) {
             if (metric.getTag().equalsIgnoreCase(tag)) {
-                list.add(prefix + metric.getMetricName());
+                list.add(metric.getMetricName(prefix));
             }
         }
         return list;
@@ -218,7 +224,7 @@ public enum Metrics {
         List<String> list = new ArrayList<>();
         for (Metrics metric : values()) {
             if (metric.getTag().startsWith(tag)) {
-                list.add(prefix + metric.getMetricName());
+                list.add(metric.getMetricName(prefix));
             }
         }
         return list;
@@ -236,7 +242,7 @@ public enum Metrics {
         if (CollectionUtils.isEmpty(metrics)) {
             return metricNames;
         }
-        metrics.forEach(metric -> metricNames.add(prefix + metric.getMetricName()));
+        metrics.forEach(metric -> metricNames.add(metric.getMetricName(prefix)));
         return metricNames;
     }
 
@@ -246,7 +252,7 @@ public enum Metrics {
      * @return the list
      */
     public static List<String> list(String prefix) {
-        return Arrays.stream(values()).map(metric -> prefix + metric.getMetricName()).collect(Collectors.toList());
+        return Arrays.stream(values()).map(metric -> metric.getMetricName(prefix)).collect(Collectors.toList());
     }
 
     /**

--- a/src-gui/src/main/java/org/openkilda/controller/SwitchController.java
+++ b/src-gui/src/main/java/org/openkilda/controller/SwitchController.java
@@ -34,6 +34,7 @@ import org.openkilda.model.LinkUnderMaintenanceDto;
 import org.openkilda.model.SwitchFlowsInfoPerPort;
 import org.openkilda.model.SwitchInfo;
 import org.openkilda.model.SwitchLocation;
+import org.openkilda.model.SwitchLogicalPort;
 import org.openkilda.model.SwitchMeter;
 import org.openkilda.model.SwitchProperty;
 import org.openkilda.service.SwitchService;
@@ -490,5 +491,39 @@ public class SwitchController {
         activityLogger.log(ActivityType.DELETE_ISL_BFD, "Src_SW_" + srcSwitch + "\nSrc_PORT_"
                 + srcPort + "\nDst_SW_" + dstSwitch + "\nDst_PORT_" + dstPort);
         return serviceSwitch.deleteLinkBfd(srcSwitch, srcPort, dstSwitch, dstPort);
+    }
+    
+    /**
+     * Creates switch logical port.
+     *
+     * @param switchId the switch id
+     * @param switchLogicalPort the switch logical port
+     * @return the SwitchLogicalPort
+     */
+    @RequestMapping(value = "/{switch_id}/lags", method = RequestMethod.POST)
+    @ResponseStatus(HttpStatus.OK)
+    @Permissions(values = IConstants.Permission.SW_CREATE_LOGICAL_PORT)
+    public @ResponseBody SwitchLogicalPort createLogicalPort(@PathVariable("switch_id") final String switchId,
+            @RequestBody(required = true) SwitchLogicalPort switchLogicalPort) {
+        activityLogger.log(ActivityType.CREATE_LOGICAL_PORT, "SW_" + switchId + ", "
+                + "PORT_" + switchLogicalPort.getPortNumbers());
+        return serviceSwitch.createLogicalPort(switchId, switchLogicalPort);
+    }
+    
+    /**
+     * Deletes switch logical port.
+     *
+     * @param switchId the switch id
+     * @param logicalPortNumber the switch logical port
+     * @return the SwitchLogicalPort
+     */
+    @RequestMapping(value = "/{switch_id}/lags/{logical_port_number}", method = RequestMethod.DELETE)
+    @ResponseStatus(HttpStatus.OK)
+    @Permissions(values = IConstants.Permission.SW_DELETE_LOGICAL_PORT)
+    public @ResponseBody SwitchLogicalPort deleteLogicalPort(@PathVariable("switch_id") final String switchId,
+            @PathVariable("logical_port_number") final String logicalPortNumber) {
+        activityLogger.log(ActivityType.DELETE_LOGICAL_PORT, "SW_" + switchId + ", "
+                + "L-PORT_" + logicalPortNumber);
+        return serviceSwitch.deleteLogicalPort(switchId, logicalPortNumber);
     }
 }

--- a/src-gui/src/main/java/org/openkilda/integration/service/StatsIntegrationService.java
+++ b/src-gui/src/main/java/org/openkilda/integration/service/StatsIntegrationService.java
@@ -248,7 +248,8 @@ public class StatsIntegrationService {
         if (!statsType.equals(StatsType.ISL)) {
             query.setRate(OpenTsDb.RATE);
         }
-        if (statsType.equals(StatsType.SWITCH_PORT) && Metrics.SWITCH_STATE.getMetricName().equals(metric)) {
+        if (statsType.equals(StatsType.SWITCH_PORT)
+                && Metrics.SWITCH_STATE.getMetricName(appProps.getMetricPrefix()).equals(metric)) {
             query.setRate(false);
         } else {
             if (validateDownSample(paramDownSample)) {

--- a/src-gui/src/main/java/org/openkilda/integration/service/SwitchIntegrationService.java
+++ b/src-gui/src/main/java/org/openkilda/integration/service/SwitchIntegrationService.java
@@ -43,6 +43,7 @@ import org.openkilda.model.LinkUnderMaintenanceDto;
 import org.openkilda.model.SwitchFlowsInfoPerPort;
 import org.openkilda.model.SwitchInfo;
 import org.openkilda.model.SwitchLocation;
+import org.openkilda.model.SwitchLogicalPort;
 import org.openkilda.model.SwitchMeter;
 import org.openkilda.model.SwitchProperty;
 import org.openkilda.service.ApplicationService;
@@ -875,6 +876,81 @@ public class SwitchIntegrationService {
             throw new InvalidResponseException(e.getCode(), e.getResponse());
         } catch (UnsupportedOperationException e) {
             e.printStackTrace();
+        }
+        return null;
+    }
+    
+    /**
+     * Creates switch logical port.
+     *
+     * @param switchId the switch id
+     * @param switchLogicalPort the switch logical port
+     * @return the SwitchLogicalPort
+     */
+    public SwitchLogicalPort createLogicalPort(String switchId, SwitchLogicalPort switchLogicalPort) {
+        try {
+            HttpResponse response = restClientManager.invoke(
+                    applicationProperties.getNbBaseUrl() + IConstants.NorthBoundUrl
+                    .SWITCH_LOGICAL_PORT.replace("{switch_id}", switchId), 
+                    HttpMethod.POST, objectMapper.writeValueAsString(switchLogicalPort), "application/json", 
+                    applicationService.getAuthHeader());
+            if (RestClientManager.isValidResponse(response)) {
+                return restClientManager.getResponse(response, SwitchLogicalPort.class);
+            }
+        } catch (InvalidResponseException e) {
+            LOGGER.error("Error occurred while creating switch logical port:" + switchId, e);
+            throw new InvalidResponseException(e.getCode(), e.getResponse());
+        } catch (JsonProcessingException e) {
+            LOGGER.warn("Error occurred while creating switch logical port:" + switchId, e);
+            throw new IntegrationException(e.getMessage(), e);
+        }
+        return null;
+    }
+    
+    /**
+     * Deletes switch logical port.
+     *
+     * @param switchId the switch id
+     * @param logicalPortNumber the switch logical port number
+     * @return the SwitchLogicalPort
+     */
+    public SwitchLogicalPort deleteLogicalPort(String switchId, String logicalPortNumber) {
+        try {
+            HttpResponse response = restClientManager.invoke(
+                    applicationProperties.getNbBaseUrl() + IConstants.NorthBoundUrl
+                    .DELETE_SWITCH_LOGICAL_PORT.replace("{switch_id}", switchId)
+                    .replace("{logical_port_number}", logicalPortNumber), 
+                    HttpMethod.DELETE, "", "application/json", 
+                    applicationService.getAuthHeader());
+            if (RestClientManager.isValidResponse(response)) {
+                return restClientManager.getResponse(response, SwitchLogicalPort.class);
+            }
+        } catch (InvalidResponseException e) {
+            LOGGER.error("Error occurred while deleting switch logical port:" + switchId, e);
+            throw new InvalidResponseException(e.getCode(), e.getResponse());
+        }
+        return null;
+    }
+    
+    /**
+     * Gets switch logical ports.
+     *
+     * @param switchId the switch id
+     * @return the SwitchLogicalPort
+     */
+    public List<SwitchLogicalPort> getLogicalPort(String switchId) {
+        try {
+            HttpResponse response = restClientManager.invoke(
+                    applicationProperties.getNbBaseUrl() + IConstants.NorthBoundUrl
+                    .SWITCH_LOGICAL_PORT.replace("{switch_id}", switchId), 
+                    HttpMethod.GET, "", "application/json", 
+                    applicationService.getAuthHeader());
+            if (RestClientManager.isValidResponse(response)) {
+                return restClientManager.getResponseList(response, SwitchLogicalPort.class);
+            }
+        } catch (InvalidResponseException e) {
+            LOGGER.error("Error occurred while getting switch logical port:" + switchId, e);
+            throw new InvalidResponseException(e.getCode(), e.getResponse());
         }
         return null;
     }

--- a/src-gui/src/main/java/org/openkilda/log/constants/ActivityType.java
+++ b/src-gui/src/main/java/org/openkilda/log/constants/ActivityType.java
@@ -66,7 +66,9 @@ public enum ActivityType {
     UNLOCK_USER_ACCOUNT(48L),
     UPDATE_SWITCH_LOCATION(43L),
     UPDATE_ISL_BFD_PROPERTIES(44L),
-    DELETE_ISL_BFD(45L);
+    DELETE_ISL_BFD(45L),
+    CREATE_LOGICAL_PORT(49L),
+    DELETE_LOGICAL_PORT(50L);
     private Long id;
     private ActivityTypeEntity activityTypeEntity;
 

--- a/src-gui/src/main/java/org/openkilda/model/PortInfo.java
+++ b/src-gui/src/main/java/org/openkilda/model/PortInfo.java
@@ -26,6 +26,7 @@ import lombok.Data;
 
 import java.io.Serializable;
 import java.math.BigInteger;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -96,6 +97,15 @@ public class PortInfo implements Serializable, Comparable<PortInfo> {
 
     @JsonProperty("is-active")
     private String isActive;
+    
+    @JsonProperty("is_logical_port")
+    private boolean logicalPort;
+    
+    @JsonProperty("logical_group_name")
+    private String logicalGroupName;
+    
+    @JsonProperty("lag_group")
+    private List<String> portNumbers;
     
     @JsonProperty("discrepancy")
     private PortDiscrepancy discrepancy;

--- a/src-gui/src/main/java/org/openkilda/model/SwitchLogicalPort.java
+++ b/src-gui/src/main/java/org/openkilda/model/SwitchLogicalPort.java
@@ -17,8 +17,8 @@ package org.openkilda.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.util.List;
@@ -26,11 +26,10 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SwitchLogicalPort {
-    
-    @JsonProperty("port_numbers")
+
     private List<String> portNumbers;
-    
-    @JsonProperty("logical_port_number")
+    private Boolean lacpReply;
     private String logicalPortNumber;
 }

--- a/src-gui/src/main/java/org/openkilda/model/SwitchLogicalPort.java
+++ b/src-gui/src/main/java/org/openkilda/model/SwitchLogicalPort.java
@@ -1,0 +1,36 @@
+/* Copyright 2020 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+public class SwitchLogicalPort {
+    
+    @JsonProperty("port_numbers")
+    private List<String> portNumbers;
+    
+    @JsonProperty("logical_port_number")
+    private String logicalPortNumber;
+}

--- a/src-gui/src/main/java/org/openkilda/service/StatsService.java
+++ b/src-gui/src/main/java/org/openkilda/service/StatsService.java
@@ -15,6 +15,8 @@
 
 package org.openkilda.service;
 
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+
 import org.openkilda.config.ApplicationProperties;
 import org.openkilda.constants.Direction;
 import org.openkilda.constants.IConstants.Status;
@@ -428,18 +430,18 @@ public class StatsService {
         List<PortInfo> portInfos = getPortInfo(portStatsByPortNo);
         String switchIdentifier = IoUtil.switchCodeToSwitchId(switchid);
         List<SwitchLogicalPort> switchLogicalPorts = switchIntegrationService.getLogicalPort(switchIdentifier);
-        if (!switchLogicalPorts.isEmpty()) {
+        if (isNotEmpty(switchLogicalPorts)) {
             for (SwitchLogicalPort logicalPort : switchLogicalPorts) {
-                for (String portnumber : logicalPort.getPortNumbers()) {
-                    for (int i = 0; i < portInfos.size(); i++) {
-                        if (portInfos.get(i).getPortNumber().equals(logicalPort.getLogicalPortNumber())) {
-                            portInfos.get(i).setLogicalPort(true);
-                            portInfos.get(i).setAssignmenttype("PORT");
-                            portInfos.get(i).setPortNumbers(logicalPort.getPortNumbers());
-                        } else if (portInfos.get(i).getPortNumber().equals(portnumber)) {
-                            portInfos.get(i).setAssignmenttype("LAG_GROUP");
-                            portInfos.get(i).setLogicalGroupName(logicalPort.getLogicalPortNumber());
-                            portInfos.get(i).setLogicalPort(false);
+                for (String portNumber : logicalPort.getPortNumbers()) {
+                    for (PortInfo portInfo : portInfos) {
+                        if (portInfo.getPortNumber().equals(logicalPort.getLogicalPortNumber())) {
+                            portInfo.setLogicalPort(true);
+                            portInfo.setAssignmenttype("PORT");
+                            portInfo.setPortNumbers(logicalPort.getPortNumbers());
+                        } else if (portInfo.getPortNumber().equals(portNumber)) {
+                            portInfo.setAssignmenttype("LAG_GROUP");
+                            portInfo.setLogicalGroupName(logicalPort.getLogicalPortNumber());
+                            portInfo.setLogicalPort(false);
                         }
                     }
                 }
@@ -452,9 +454,9 @@ public class StatsService {
                 for (IslPath islPath : islLink.getPath()) {
                     switchIdInfo = ("SW" + islPath.getSwitchId().replaceAll(":", "")).toUpperCase();
                     if (switchIdInfo.equals(switchid)) {
-                        for (int i = 0; i < portInfos.size(); i++) {
-                            if (portInfos.get(i).getPortNumber().equals(islPath.getPortNo().toString())) {
-                                portInfos.get(i).setAssignmenttype("ISL");
+                        for (PortInfo portInfo : portInfos) {
+                            if (portInfo.getPortNumber().equals(islPath.getPortNo().toString())) {
+                                portInfo.setAssignmenttype("ISL");
                             }
                         }
                     }
@@ -497,7 +499,7 @@ public class StatsService {
 
         LinkedHashMap<Long, Double> timeToValueMap = new LinkedHashMap<>();
         Map<String, String> tags = new HashMap<>();
-        if (dbData.getData() != null && CollectionUtils.isNotEmpty(dbData.getData().getResult())) {
+        if (dbData.getData() != null && isNotEmpty(dbData.getData().getResult())) {
             tags = dbData.getData().getResult().get(0).getTags();
             dbData.getData().getResult().get(0).getValues()
                     .forEach(timeToValue ->

--- a/src-gui/src/main/java/org/openkilda/service/SwitchService.java
+++ b/src-gui/src/main/java/org/openkilda/service/SwitchService.java
@@ -41,6 +41,7 @@ import org.openkilda.model.SwitchDiscrepancy;
 import org.openkilda.model.SwitchFlowsInfoPerPort;
 import org.openkilda.model.SwitchInfo;
 import org.openkilda.model.SwitchLocation;
+import org.openkilda.model.SwitchLogicalPort;
 import org.openkilda.model.SwitchMeter;
 import org.openkilda.model.SwitchProperty;
 import org.openkilda.model.SwitchStatus;
@@ -613,6 +614,14 @@ public class SwitchService {
 
     public String deleteLinkBfd(String srcSwitch, String srcPort, String dstSwitch, String dstPort) {
         return switchIntegrationService.deleteLinkBfd(srcSwitch, srcPort, dstSwitch, dstPort);
+    }
+    
+    public SwitchLogicalPort createLogicalPort(String switchId, SwitchLogicalPort switchLogicalPort) {
+        return switchIntegrationService.createLogicalPort(switchId, switchLogicalPort);
+    }
+    
+    public SwitchLogicalPort deleteLogicalPort(String switchId, String logicalPortNumber) {
+        return switchIntegrationService.deleteLogicalPort(switchId, logicalPortNumber);
     }
 
 }

--- a/src-gui/src/main/resources/db/import-script_33.sql
+++ b/src-gui/src/main/resources/db/import-script_33.sql
@@ -1,0 +1,18 @@
+INSERT INTO VERSION_ENTITY (Version_ID, Version_Number, Version_Deployment_Date)
+VALUES (33, 33, CURRENT_TIMESTAMP);
+
+INSERT INTO KILDA_PERMISSION (PERMISSION_ID, PERMISSION, IS_EDITABLE, IS_ADMIN_PERMISSION, STATUS_ID, CREATED_BY, CREATED_DATE, UPDATED_BY, UPDATED_DATE,DESCRIPTION) VALUES 
+	(363, 'sw_create_logical_port', false, false, 1, 1, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP, 'Permission to create switch logical port'),
+	(364, 'sw_delete_logical_port', false, false, 1, 1, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP, 'Permission to delete switch logical port');
+	
+INSERT INTO ROLE_PERMISSION (ROLE_ID,PERMISSION_ID) VALUES 
+	(2, 363),
+	(2, 364);
+	
+INSERT  INTO ACTIVITY_TYPE (activity_type_id, activity_name) VALUES 
+	(49, 'CREATE_LOGICAL_PORT'),
+	(50, 'DELETE_LOGICAL_PORT');
+	
+
+	
+

--- a/src-gui/ui/src/app/app.module.ts
+++ b/src-gui/ui/src/app/app.module.ts
@@ -111,6 +111,7 @@ import {SamlListTableComponent} from './modules/settings/saml-list-table/saml-li
 import {SwitchupdatemodalComponent} from './common/components/switchupdatemodal/switchupdatemodal.component';
 import {UseractivityListComponent} from './modules/useractivity/useractivity-list/useractivity-list.component';
 import {FlowPingModalComponent} from './common/components/flow-ping-modal/flow-ping-modal.component';
+import { CreateLagPortComponent } from './modules/switches/create-lag-port/create-lag-port.component';
 
 @NgModule({
     declarations: [
@@ -205,6 +206,7 @@ import {FlowPingModalComponent} from './common/components/flow-ping-modal/flow-p
         SwitchupdatemodalComponent,
         UseractivityListComponent,
         FlowPingModalComponent,
+        CreateLagPortComponent,
     ],
     imports: [
         HttpClientModule,
@@ -250,6 +252,7 @@ import {FlowPingModalComponent} from './common/components/flow-ping-modal/flow-p
         IslmaintenancemodalComponent,
         SwitchupdatemodalComponent,
         FlowPingModalComponent,
+        CreateLagPortComponent,
     ]
 })
 export class AppModule { }

--- a/src-gui/ui/src/app/common/constants/constants.ts
+++ b/src-gui/ui/src/app/common/constants/constants.ts
@@ -159,6 +159,9 @@ export const MessageObj = {
     updating_bfd_properties_error: 'Error in updating BFD properties.',
     BFD_properties_deleted: 'BFD properties deleted successfully.',
     error_BFD_properties_delete: 'Error in deleting BFD properties.',
-    delete_isl_bfd_not_authorised: 'You are not authorised to delete the ISL BFD Properties.'
+    delete_isl_bfd_not_authorised: 'You are not authorised to delete the ISL BFD Properties.',
+    create_lag_port: 'Requested Lag Port Created Successfully! Port List Data  will be updated in some time',
+    error_in_create_lag_port: 'Error in create Lag Port!',
+    port_deleted: 'Port deleted successfully'
 
 };

--- a/src-gui/ui/src/app/common/data-models/create-lag-port-model.ts
+++ b/src-gui/ui/src/app/common/data-models/create-lag-port-model.ts
@@ -1,0 +1,5 @@
+interface CreateLagPortModel {
+    port_numbers: number[];
+    lacp_rely: boolean;
+    logical_port_number: number;
+}

--- a/src-gui/ui/src/app/common/services/switch.service.ts
+++ b/src-gui/ui/src/app/common/services/switch.service.ts
@@ -118,11 +118,11 @@ getNetworkPath(source_switch, target_switch, strategy, max_latency) {
     }
     xhr.send(requestBody);
   }
-  createLagLogicalPort(data,switchid){
-    return this.httpClient.post<any>(`${environment.apiEndPoint}/switch/${switchid}/lags`,data);
+  createLagLogicalPort(data: CreateLagPortModel, switchid) {
+    return this.httpClient.post<any>(`${environment.apiEndPoint}/switch/${switchid}/lags`, data);
   }
 
-  deleteLagLogicalPort(switchid,logical_port_number ){
+  deleteLagLogicalPort(switchid, logical_port_number ) {
     return this.httpClient.delete(`${environment.apiEndPoint}/switch/${switchid}/lags/${logical_port_number }`);
   }
 

--- a/src-gui/ui/src/app/common/services/switch.service.ts
+++ b/src-gui/ui/src/app/common/services/switch.service.ts
@@ -118,5 +118,12 @@ getNetworkPath(source_switch, target_switch, strategy, max_latency) {
     }
     xhr.send(requestBody);
   }
+  createLagLogicalPort(data,switchid){
+    return this.httpClient.post<any>(`${environment.apiEndPoint}/switch/${switchid}/lags`,data);
+  }
+
+  deleteLagLogicalPort(switchid,logical_port_number ){
+    return this.httpClient.delete(`${environment.apiEndPoint}/switch/${switchid}/lags/${logical_port_number }`);
+  }
 
 }

--- a/src-gui/ui/src/app/modules/flows/flow-detail/flow-detail.component.ts
+++ b/src-gui/ui/src/app/modules/flows/flow-detail/flow-detail.component.ts
@@ -485,7 +485,7 @@ export class FlowDetailComponent implements OnInit {
       },
       error => {
         const errorMsg = error && error.error && error.error['error-auxiliary-message'] ? error.error['error-auxiliary-message'] : 'No Flow found';
-        // this.toaster.error(errorMsg, "Error");
+        this.toaster.error(errorMsg, 'Error');
        }
     );
   }

--- a/src-gui/ui/src/app/modules/switches/create-lag-port/create-lag-port.component.html
+++ b/src-gui/ui/src/app/modules/switches/create-lag-port/create-lag-port.component.html
@@ -1,0 +1,33 @@
+<div class="modal-header">
+    <h4 class="modal-title"><span class="ml-1">Create Lag Port</span></h4>
+    <button type="button" class="close" aria-label="Close" (click)="activeModal.dismiss('Cross click')">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <div class="modal-body">
+    <div class="row" [formGroup]="createLogPortForm">
+      <div class="form-group col-lg-12" >
+        <label class='col-lg-3 col-form-label'>Port:</label>
+        <div class="col-lg-9">
+          <ng-select 
+          formControlName="port_numbers"
+            [items]="data"
+             bindLabel="port_number"
+             bindValue="port_number"
+             [multiple]="true"
+             placeholder="Select Port Number"
+             [ngClass]="{ 'is-invalid': submitted && f.port_numbers.errors }" >
+          </ng-select>
+          <div *ngIf="submitted && f.port_numbers.errors" class="invalid-feedback">
+            <div *ngIf="f.port_numbers.errors.required">Port Numbers is required</div>
+        </div>
+    </div>
+        </div>
+  </div>
+  
+  </div>
+  
+
+  <div class="modal-footer">
+    <button type="button" class="btn kilda_btn" (click)="createPort()">Create</button>
+  </div>

--- a/src-gui/ui/src/app/modules/switches/create-lag-port/create-lag-port.component.html
+++ b/src-gui/ui/src/app/modules/switches/create-lag-port/create-lag-port.component.html
@@ -1,33 +1,48 @@
 <div class="modal-header">
     <h4 class="modal-title"><span class="ml-1">Create Lag Port</span></h4>
     <button type="button" class="close" aria-label="Close" (click)="activeModal.dismiss('Cross click')">
-      <span aria-hidden="true">&times;</span>
+        <span aria-hidden="true">&times;</span>
     </button>
-  </div>
-  <div class="modal-body">
+</div>
+<div class="modal-body">
     <div class="row" [formGroup]="createLogPortForm">
-      <div class="form-group col-lg-12" >
-        <label class='col-lg-3 col-form-label'>Port:</label>
-        <div class="col-lg-9">
-          <ng-select 
-          formControlName="port_numbers"
-            [items]="data"
-             bindLabel="port_number"
-             bindValue="port_number"
-             [multiple]="true"
-             placeholder="Select Port Number"
-             [ngClass]="{ 'is-invalid': submitted && f.port_numbers.errors }" >
-          </ng-select>
-          <div *ngIf="submitted && f.port_numbers.errors" class="invalid-feedback">
-            <div *ngIf="f.port_numbers.errors.required">Port Numbers is required</div>
+        <div class="form-group col-lg-12">
+            <label class='col-lg-3 col-form-label'>Port:</label>
+            <div class="col-lg-9">
+                <ng-select
+                        formControlName="port_numbers"
+                        [items]="data"
+                        bindLabel="port_number"
+                        bindValue="port_number"
+                        [multiple]="true"
+                        placeholder="Select Port Number"
+                        [ngClass]="{ 'is-invalid': submitted && f.port_numbers.errors }">
+                </ng-select>
+                <div *ngIf="submitted && f.port_numbers.errors" class="invalid-feedback">
+                    <div *ngIf="f.port_numbers.errors.required">Port Numbers is required</div>
+                </div>
+            </div>
+        </div>
+        <div class="form-group col-lg-6">
+            <label class='col-lg-6 col-form-label'>Lacp reply:</label>
+            <div class='col-sm-3'>
+                <div>
+                    <div class="onoffswitch">
+                        <input formControlName="lacp_reply" type="checkbox"
+                               name="lacp_reply" class="onoffswitch-checkbox"
+                               id="onofflacp_reply">
+                        <label class="onoffswitch-label" for="onofflacp_reply">
+                            <span class="onoffswitch-inner "></span>
+                            <span class="onoffswitch-switch"></span>
+                        </label>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
-        </div>
-  </div>
-  
-  </div>
-  
+</div>
 
-  <div class="modal-footer">
+
+<div class="modal-footer">
     <button type="button" class="btn kilda_btn" (click)="createPort()">Create</button>
-  </div>
+</div>

--- a/src-gui/ui/src/app/modules/switches/create-lag-port/create-lag-port.component.spec.ts
+++ b/src-gui/ui/src/app/modules/switches/create-lag-port/create-lag-port.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CreateLagPortComponent } from './create-lag-port.component';
+
+describe('CreateLagPortComponent', () => {
+  let component: CreateLagPortComponent;
+  let fixture: ComponentFixture<CreateLagPortComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CreateLagPortComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CreateLagPortComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src-gui/ui/src/app/modules/switches/create-lag-port/create-lag-port.component.ts
+++ b/src-gui/ui/src/app/modules/switches/create-lag-port/create-lag-port.component.ts
@@ -9,7 +9,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 })
 export class CreateLagPortComponent implements OnInit {
   createLogPortForm:FormGroup;
-  private data:any;
+  data:any;
   createData:any;
   @Output() emitService = new EventEmitter();
   submitted = false;

--- a/src-gui/ui/src/app/modules/switches/create-lag-port/create-lag-port.component.ts
+++ b/src-gui/ui/src/app/modules/switches/create-lag-port/create-lag-port.component.ts
@@ -1,0 +1,41 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'app-create-lag-port',
+  templateUrl: './create-lag-port.component.html',
+  styleUrls: ['./create-lag-port.component.css']
+})
+export class CreateLagPortComponent implements OnInit {
+  createLogPortForm:FormGroup;
+  private data:any;
+  createData:any;
+  @Output() emitService = new EventEmitter();
+  submitted = false;
+  constructor(public activeModal: NgbActiveModal,public formBuilder:FormBuilder) { }
+
+  ngOnInit() {
+    let result= JSON.parse(localStorage.getItem('switchPortDetail'));
+    this.data = result.filter(element => {
+      return ((element.assignmenttype === "PORT"||element.assignmenttype === "Unallocated") && ! element.is_logical_port);
+    });
+    this.createLogPortForm = this.formBuilder.group({
+      port_numbers: ['',Validators.required],
+    }); 
+  }
+  get f() {
+    return this.createLogPortForm.controls;
+  }
+  createPort(){
+    this.submitted = true;
+    if (this.createLogPortForm.invalid) {
+      return;
+  }
+     
+   this.createData=this.createLogPortForm.controls['port_numbers'].value
+   this.emitService.emit(this.createData);
+
+  }
+
+}

--- a/src-gui/ui/src/app/modules/switches/create-lag-port/create-lag-port.component.ts
+++ b/src-gui/ui/src/app/modules/switches/create-lag-port/create-lag-port.component.ts
@@ -1,41 +1,50 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import {Component, EventEmitter, OnInit, Output} from '@angular/core';
+import {FormBuilder, FormGroup, Validators} from '@angular/forms';
+import {NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
-  selector: 'app-create-lag-port',
-  templateUrl: './create-lag-port.component.html',
-  styleUrls: ['./create-lag-port.component.css']
+    selector: 'app-create-lag-port',
+    templateUrl: './create-lag-port.component.html',
+    styleUrls: ['./create-lag-port.component.css']
 })
 export class CreateLagPortComponent implements OnInit {
-  createLogPortForm:FormGroup;
-  data:any;
-  createData:any;
-  @Output() emitService = new EventEmitter();
-  submitted = false;
-  constructor(public activeModal: NgbActiveModal,public formBuilder:FormBuilder) { }
+    createLogPortForm: FormGroup;
+    data: any;
+    createLagPortModel: CreateLagPortModel;
+    @Output() emitService = new EventEmitter();
+    submitted = false;
 
-  ngOnInit() {
-    let result= JSON.parse(localStorage.getItem('switchPortDetail'));
-    this.data = result.filter(element => {
-      return ((element.assignmenttype === "PORT"||element.assignmenttype === "Unallocated") && ! element.is_logical_port);
-    });
-    this.createLogPortForm = this.formBuilder.group({
-      port_numbers: ['',Validators.required],
-    }); 
-  }
-  get f() {
-    return this.createLogPortForm.controls;
-  }
-  createPort(){
-    this.submitted = true;
-    if (this.createLogPortForm.invalid) {
-      return;
-  }
-     
-   this.createData=this.createLogPortForm.controls['port_numbers'].value
-   this.emitService.emit(this.createData);
+    constructor(public activeModal: NgbActiveModal, public formBuilder: FormBuilder) {
+    }
 
-  }
+    ngOnInit() {
+        const result = JSON.parse(localStorage.getItem('switchPortDetail'));
+        this.data = result.filter(element => {
+            return ((element.assignmenttype === 'PORT' || element.assignmenttype === 'Unallocated') && !element.is_logical_port);
+        });
+        this.createLogPortForm = this.formBuilder.group({
+            port_numbers: ['', Validators.required],
+            lacp_reply: [true],
+        });
+    }
 
+    get f() {
+        return this.createLogPortForm.controls;
+    }
+
+    createPort() {
+        this.submitted = true;
+        if (this.createLogPortForm.invalid) {
+            return;
+        }
+        const portNumbers = this.createLogPortForm.controls['port_numbers'].value;
+        const portNumbersArray: number[] = Array.isArray(portNumbers) ? portNumbers : [portNumbers];
+
+        this.createLagPortModel = {
+            logical_port_number: null,
+            port_numbers: portNumbersArray.map(i => Number(i)),
+            lacp_rely: this.createLogPortForm.controls['lacp_reply'].value
+        };
+        this.emitService.emit(this.createLagPortModel);
+    }
 }

--- a/src-gui/ui/src/app/modules/switches/port-details/port-details.component.html
+++ b/src-gui/ui/src/app/modules/switches/port-details/port-details.component.html
@@ -7,6 +7,7 @@
         <button class="btn kilda_btn" *ngIf="!editConfigStatus && commonService.hasPermission('sw_port_config')" (click)="configurePortDetails()">Configure</button>
         <button class="btn kilda_btn" *ngIf="editConfigStatus" (click)="savePortDetails()" style="margin-right: 5px;">Save</button>
         <button class="btn kilda_btn" *ngIf="editConfigStatus" (click)="cancelConfigurePort()">Cancel</button>
+        <button class="btn kilda_btn ml-3" *ngIf="portDataObject?.is_logical_port"  (click)="deleteLogicalPort()">Delete</button>
     </div>
   </div>
   <form [formGroup]="portForm">

--- a/src-gui/ui/src/app/modules/switches/port-details/port-details.component.ts
+++ b/src-gui/ui/src/app/modules/switches/port-details/port-details.component.ts
@@ -1,11 +1,7 @@
 import {Component, OnInit, EventEmitter, Output, AfterViewInit, OnDestroy} from '@angular/core';
 import {SwitchidmaskPipe} from '../../../common/pipes/switchidmask.pipe';
 import {FormBuilder, FormGroup, Validators, NgForm} from '@angular/forms';
-import * as _moment from 'moment';
-import {NgxSpinnerService} from 'ngx-spinner';
 import {ToastrService} from 'ngx-toastr';
-import {DygraphService} from '../../../common/services/dygraph.service';
-import {IslDataService} from '../../../common/services/isl-data.service';
 import {SwitchService} from '../../../common/services/switch.service';
 import {ActivatedRoute, Router, NavigationEnd} from '@angular/router';
 import {filter} from 'rxjs/operators';
@@ -65,7 +61,6 @@ export class PortDetailsComponent implements OnInit, OnDestroy {
                 private toastr: ToastrService,
                 private loaderService: LoaderService,
                 private router: Router,
-                private dygraphService: DygraphService,
                 private route: ActivatedRoute,
                 private switchService: SwitchService,
                 private clipboardService: ClipboardService,
@@ -169,7 +164,7 @@ export class PortDetailsComponent implements OnInit, OnDestroy {
         }
         return status;
 
-    };
+    }
 
     commitConfig() {
         const portStatus = this.portForm.value.portStatus;
@@ -295,7 +290,7 @@ export class PortDetailsComponent implements OnInit, OnDestroy {
                     this.router.navigate(['/switches/details/' + this.retrievedSwitchObject.switch_id]);
                 }, error => {
                     this.loaderService.hide();
-                    var message = (error.error['error-auxiliary-message']) ? error.error['error-auxiliary-message'] : error.error['error-description'];
+                    const message = `${error.error['error-auxiliary-message'] + ','} ${error.error['error-description']}`;
                     this.toastr.error(message, 'Error');
                 });
             }

--- a/src-gui/ui/src/app/modules/switches/port-details/port-details.component.ts
+++ b/src-gui/ui/src/app/modules/switches/port-details/port-details.component.ts
@@ -1,292 +1,309 @@
-import { Component, OnInit, EventEmitter, Output, AfterViewInit, OnDestroy } from '@angular/core';
-import { SwitchidmaskPipe } from '../../../common/pipes/switchidmask.pipe';
-import { FormBuilder, FormGroup, Validators, NgForm } from '@angular/forms';
+import {Component, OnInit, EventEmitter, Output, AfterViewInit, OnDestroy} from '@angular/core';
+import {SwitchidmaskPipe} from '../../../common/pipes/switchidmask.pipe';
+import {FormBuilder, FormGroup, Validators, NgForm} from '@angular/forms';
 import * as _moment from 'moment';
-import { NgxSpinnerService } from 'ngx-spinner';
-import { ToastrService } from 'ngx-toastr';
-import { DygraphService } from '../../../common/services/dygraph.service';
-import { IslDataService } from '../../../common/services/isl-data.service';
-import { SwitchService } from '../../../common/services/switch.service';
-import { ActivatedRoute, Router, NavigationEnd} from '@angular/router';
-import { filter } from 'rxjs/operators';
-import { LoaderService } from '../../../common/services/loader.service';
-import { ClipboardService } from 'ngx-clipboard';
-import { Title } from '@angular/platform-browser';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { ModalconfirmationComponent } from '../../../common/components/modalconfirmation/modalconfirmation.component';
-import { CommonService } from 'src/app/common/services/common.service';
-import { MessageObj } from 'src/app/common/constants/constants';
+import {NgxSpinnerService} from 'ngx-spinner';
+import {ToastrService} from 'ngx-toastr';
+import {DygraphService} from '../../../common/services/dygraph.service';
+import {IslDataService} from '../../../common/services/isl-data.service';
+import {SwitchService} from '../../../common/services/switch.service';
+import {ActivatedRoute, Router, NavigationEnd} from '@angular/router';
+import {filter} from 'rxjs/operators';
+import {LoaderService} from '../../../common/services/loader.service';
+import {ClipboardService} from 'ngx-clipboard';
+import {Title} from '@angular/platform-browser';
+import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
+import {ModalconfirmationComponent} from '../../../common/components/modalconfirmation/modalconfirmation.component';
+import {CommonService} from 'src/app/common/services/common.service';
+import {MessageObj} from 'src/app/common/constants/constants';
 
 declare var moment: any;
 
 @Component({
-  selector: 'app-port-details',
-  templateUrl: './port-details.component.html',
-  styleUrls: ['./port-details.component.css']
+    selector: 'app-port-details',
+    templateUrl: './port-details.component.html',
+    styleUrls: ['./port-details.component.css']
 })
 export class PortDetailsComponent implements OnInit, OnDestroy {
-  portDataObject: any;
-  retrievedSwitchObject: any;
-  port_src_switch: any;
-  openedTab = 'graph';
-  portForm: FormGroup;
-  portFlows: any = [];
-  flowBandwidthSum: any = 0;
-  flowBandwidthFlag = false;
-  switchId  = null;
-  portId  = null;
+    portDataObject: any;
+    retrievedSwitchObject: any;
+    port_src_switch: any;
+    openedTab = 'graph';
+    portForm: FormGroup;
+    portFlows: any = [];
+    flowBandwidthSum: any = 0;
+    flowBandwidthFlag = false;
+    switchId = null;
+    portId = null;
 
-  hasStoreSetting = false;
+    hasStoreSetting = false;
 
 
-  currentRoute: any;
-  editConfigStatus = false;
-  currentPortState: string;
-  requestedPortState: string;
-  dateMessage: string;
-  discoverypackets = false;
-  clipBoardItems = {
-    sourceSwitch: '',
-  };
+    currentRoute: any;
+    editConfigStatus = false;
+    currentPortState: string;
+    requestedPortState: string;
+    dateMessage: string;
+    discoverypackets = false;
+    clipBoardItems = {
+        sourceSwitch: '',
+    };
 
-  descrepancyData = {
-    assignmentType: {
-      controller: '-',
-      inventory: '-'
-    }
-  };
-
-  assignmentTypeDescrepancy = false;
-
-  @Output() hideToValue: EventEmitter<any> = new EventEmitter();
-  constructor(private maskPipe: SwitchidmaskPipe,
-    private formBuiler: FormBuilder,
-    private toastr: ToastrService,
-    private loaderService: LoaderService,
-    private router: Router,
-    private dygraphService: DygraphService,
-    private route: ActivatedRoute,
-
-    private switchService: SwitchService,
-    private clipboardService: ClipboardService,
-    private titleService: Title,
-    private modalService: NgbModal,
-    public commonService: CommonService,
-  ) {
-    this.hasStoreSetting = localStorage.getItem('hasSwtStoreSetting') == '1' ? true : false;
-    if (!this.commonService.hasPermission('menu_switches')) {
-      this.toastr.error(MessageObj.unauthorised);
-       this.router.navigate(['/home']);
-      }
-
-  }
-
-  ngOnInit() {
-      this.titleService.setTitle('OPEN KILDA - Port');
-      this.route.parent.params.subscribe(params => this.switchId = params['id']);
-      this.route.params.subscribe(params => this.portId = params['port']);
-
-      const portDataObjectKey = 'portDataObject_' + this.switchId + '_' + this.portId;
-      this.portDataObject = JSON.parse(localStorage.getItem(portDataObjectKey));
-      this.portForm = this.formBuiler.group({
-          portStatus: [this.portDataObject.status],
-      });
-      const switchDetailsKey = 'switchDetailsKey_' + this.switchId;
-      this.retrievedSwitchObject = JSON.parse(localStorage.getItem(switchDetailsKey));
-      this.port_src_switch = this.maskPipe.transform(this.retrievedSwitchObject.switch_id, 'legacy');
-      this.clipBoardItems.sourceSwitch = this.retrievedSwitchObject.switch_id;
-
-    if (this.portDataObject['discrepancy'] && (this.portDataObject['discrepancy']['assignment-type'])) {
-      if (this.portDataObject['discrepancy']['assignment-type']) {
-        this.assignmentTypeDescrepancy  = true;
-        this.descrepancyData.assignmentType.controller = (typeof(this.portDataObject['discrepancy']['controller-assignment-type']) != 'undefined') ?  this.portDataObject['discrepancy']['controller-assignment-type'] : '-';
-        this.descrepancyData.assignmentType.inventory = (typeof(this.portDataObject['discrepancy']['inventory-assignment-type']) != 'undefined') ?  this.portDataObject['discrepancy']['inventory-assignment-type'] : '-';
-      }
-
-    }
-
-    this.router.events
-      .pipe(filter(event => event instanceof NavigationEnd)) .pipe(filter(event => event instanceof NavigationEnd))
-      .subscribe(event => {
-        const tempRoute: any = event;
-        if (tempRoute.url.includes('/port')) {
-          this.currentRoute = 'port-details';
-        } else {
-          this.currentRoute = 'switch-details';
+    descrepancyData = {
+        assignmentType: {
+            controller: '-',
+            inventory: '-'
         }
-   });
-    this.loadPortFlows();
-     this.getDiscoveryPackets();
-  }
+    };
 
-  getDiscoveryPackets() {
-    this.switchService.getdiscoveryPackets(this.retrievedSwitchObject.switch_id, this.portDataObject.port_number).subscribe((response: any) => {
-       this.discoverypackets = response.discovery_enabled;
-    }, error => {
-      // this.toastr.error('Error in updating discovery packets mode! ','Error');
-    });
-  }
+    assignmentTypeDescrepancy = false;
 
-  maskSwitchId(switchType, e) {
-    if (e.target.checked) {
-      this.retrievedSwitchObject.switch_id = this.maskPipe.transform(this.retrievedSwitchObject.switch_id, 'legacy');
-    } else {
-      this.retrievedSwitchObject.switch_id = this.maskPipe.transform(this.retrievedSwitchObject.switch_id, 'kilda');
-    }
+    @Output() hideToValue: EventEmitter<any> = new EventEmitter();
 
-    this.clipBoardItems.sourceSwitch = this.retrievedSwitchObject.switch_id;
-  }
-
-  savePortDetails() {
-
-    this.currentPortState = this.portDataObject.status;
-    this.requestedPortState = this.portForm.value.portStatus;
-    $('#old_status_val').text(this.portDataObject.status);
-    $('#new_status_val').text(this.portForm.value.portStatus);
-
-    if (this.currentPortState == this.requestedPortState) {
-      this.toastr.info(MessageObj.nothing_changed, 'Information');
-    } else {
-
-      const modalRef = this.modalService.open(ModalconfirmationComponent);
-      modalRef.componentInstance.title = 'Confirmation';
-      modalRef.componentInstance.content = $('#final_configure_confirm_modal')[0].innerHTML;
-
-      modalRef.result.then((response) => {
-        if (response && response == true) {
-            this.loaderService.show(MessageObj.updating_port_details);
-            this.commitConfig();
+    constructor(private maskPipe: SwitchidmaskPipe,
+                private formBuiler: FormBuilder,
+                private toastr: ToastrService,
+                private loaderService: LoaderService,
+                private router: Router,
+                private dygraphService: DygraphService,
+                private route: ActivatedRoute,
+                private switchService: SwitchService,
+                private clipboardService: ClipboardService,
+                private titleService: Title,
+                private modalService: NgbModal,
+                public commonService: CommonService,
+    ) {
+        this.hasStoreSetting = localStorage.getItem('hasSwtStoreSetting') == '1' ? true : false;
+        if (!this.commonService.hasPermission('menu_switches')) {
+            this.toastr.error(MessageObj.unauthorised);
+            this.router.navigate(['/home']);
         }
-      });
+
     }
-  }
 
-  getPortStatus = (status) => {
-    if (status.toLowerCase() == 'good') {
-      return 'UP';
-    } else if (status.toLowerCase() == 'bad') {
-      return 'DOWN';
-    }
-   return status;
+    ngOnInit() {
+        this.titleService.setTitle('OPEN KILDA - Port');
+        this.route.parent.params.subscribe(params => this.switchId = params['id']);
+        this.route.params.subscribe(params => this.portId = params['port']);
 
-  }
-
-  commitConfig() {
-      const portStatus = this.portForm.value.portStatus;
-      this.switchService.configurePort(this.retrievedSwitchObject.switch_id,
-                                       this.portDataObject.port_number,
-                                       portStatus).subscribe(status => {
-        this.loaderService.hide();
-        this.toastr.success(MessageObj.port_configured, 'Success');
-        this.portDataObject.status = portStatus;
         const portDataObjectKey = 'portDataObject_' + this.switchId + '_' + this.portId;
-        localStorage.setItem(portDataObjectKey, JSON.stringify(this.portDataObject));
-        this.editConfigStatus = false;
-
-      }, error => {
-        this.loaderService.hide();
-        this.editConfigStatus = false;
-        if (error.status == '500') {
-          this.toastr.error(error.error['error-auxiliary-message']);
-        } else {
-          this.toastr.error('Something went wrong!');
-        }
-      });
-  }
-
-  enableDisableDiscoveryPackets(e) {
-   const modalRef = this.modalService.open(ModalconfirmationComponent);
-   modalRef.componentInstance.title = 'Confirmation';
-   modalRef.componentInstance.content = 'Are you sure you want to update discovery packets value?';
-   const OldValue = this.discoverypackets;
-   this.discoverypackets = e.target.checked;
-   modalRef.result.then((response) => {
-    if (response && response == true) {
-        this.loaderService.show(MessageObj.updating_discovery_flag);
-         this.switchService.updatediscoveryPackets(this.retrievedSwitchObject.switch_id, this.portDataObject.port_number, this.discoverypackets).subscribe((response) => {
-           this.toastr.success(MessageObj.discovery_packets_updated, 'Success');
-           this.loaderService.hide();
-           this.discoverypackets = e.target.checked;
-         }, error => {
-          this.discoverypackets = OldValue;
-          this.loaderService.hide();
-           this.toastr.error(MessageObj.error_updating_discovery_packets, 'Error');
-         });
-    } else {
-      this.discoverypackets = OldValue;
-    }
-  });
- }
-
-  configurePortDetails() {
-    const modalRef = this.modalService.open(ModalconfirmationComponent);
-    modalRef.componentInstance.title = 'Confirmation';
-    modalRef.componentInstance.content = 'Are you sure you want to configure the port?';
-    modalRef.result.then((response) => {
-      if (response && response == true) {
-        this.editConfigStatus = true;
+        this.portDataObject = JSON.parse(localStorage.getItem(portDataObjectKey));
         this.portForm = this.formBuiler.group({
-          portStatus: [this.portDataObject.status],
+            portStatus: [this.portDataObject.status],
         });
-      }
-    });
-  }
+        const switchDetailsKey = 'switchDetailsKey_' + this.switchId;
+        this.retrievedSwitchObject = JSON.parse(localStorage.getItem(switchDetailsKey));
+        this.port_src_switch = this.maskPipe.transform(this.retrievedSwitchObject.switch_id, 'legacy');
+        this.clipBoardItems.sourceSwitch = this.retrievedSwitchObject.switch_id;
 
-  loadPortFlows() {
-    if (this.portDataObject['port_number'] && (this.retrievedSwitchObject['switch_id'])) {
-        const switchId = this.retrievedSwitchObject.switch_id;
-        const portnumber = this.portDataObject.port_number;
-        this.flowBandwidthFlag = true;
-        this.switchService.getSwitchFlows(switchId, false, portnumber).subscribe(data => {
-          this.portFlows = data;
-          if (this.portFlows && this.portFlows.length) {
-            for (const flow of this.portFlows) {
-                this.flowBandwidthSum = this.flowBandwidthSum + (flow.maximum_bandwidth / 1000);
+        if (this.portDataObject['discrepancy'] && (this.portDataObject['discrepancy']['assignment-type'])) {
+            if (this.portDataObject['discrepancy']['assignment-type']) {
+                this.assignmentTypeDescrepancy = true;
+                this.descrepancyData.assignmentType.controller = (typeof (this.portDataObject['discrepancy']['controller-assignment-type']) != 'undefined') ? this.portDataObject['discrepancy']['controller-assignment-type'] : '-';
+                this.descrepancyData.assignmentType.inventory = (typeof (this.portDataObject['discrepancy']['inventory-assignment-type']) != 'undefined') ? this.portDataObject['discrepancy']['inventory-assignment-type'] : '-';
             }
-          } else {
-            if (this.portFlows == null) {
-              this.portFlows = [];
-            }
-          }
-          if (this.flowBandwidthSum) {
-            this.flowBandwidthSum = this.flowBandwidthSum.toFixed(3);
-          }
 
-          this.flowBandwidthFlag = false;
+        }
+
+        this.router.events
+            .pipe(filter(event => event instanceof NavigationEnd)).pipe(filter(event => event instanceof NavigationEnd))
+            .subscribe(event => {
+                const tempRoute: any = event;
+                if (tempRoute.url.includes('/port')) {
+                    this.currentRoute = 'port-details';
+                } else {
+                    this.currentRoute = 'switch-details';
+                }
+            });
+        this.loadPortFlows();
+        this.getDiscoveryPackets();
+    }
+
+    getDiscoveryPackets() {
+        this.switchService.getdiscoveryPackets(this.retrievedSwitchObject.switch_id, this.portDataObject.port_number).subscribe((response: any) => {
+            this.discoverypackets = response.discovery_enabled;
         }, error => {
-          this.portFlows = [];
-          this.flowBandwidthSum = 0;
-          this.flowBandwidthFlag = false;
+            // this.toastr.error('Error in updating discovery packets mode! ','Error');
         });
     }
 
-  }
+    maskSwitchId(switchType, e) {
+        if (e.target.checked) {
+            this.retrievedSwitchObject.switch_id = this.maskPipe.transform(this.retrievedSwitchObject.switch_id, 'legacy');
+        } else {
+            this.retrievedSwitchObject.switch_id = this.maskPipe.transform(this.retrievedSwitchObject.switch_id, 'kilda');
+        }
 
+        this.clipBoardItems.sourceSwitch = this.retrievedSwitchObject.switch_id;
+    }
 
-  cancelConfigurePort() {
-     this.editConfigStatus = false;
-  }
+    savePortDetails() {
 
-  copyToClip(event, copyItem) {
-    this.clipboardService.copyFromContent(this.clipBoardItems[copyItem]);
-  }
+        this.currentPortState = this.portDataObject.status;
+        this.requestedPortState = this.portForm.value.portStatus;
+        $('#old_status_val').text(this.portDataObject.status);
+        $('#new_status_val').text(this.portForm.value.portStatus);
 
-  toggleTab(tab) {
-    this.openedTab = tab;
-  }
+        if (this.currentPortState == this.requestedPortState) {
+            this.toastr.info(MessageObj.nothing_changed, 'Information');
+        } else {
 
-  assignDate(timestamp) {
-    if (timestamp) {
-      return  moment(timestamp * 1000).format('LLL');
-    } else {
-      return '-';
+            const modalRef = this.modalService.open(ModalconfirmationComponent);
+            modalRef.componentInstance.title = 'Confirmation';
+            modalRef.componentInstance.content = $('#final_configure_confirm_modal')[0].innerHTML;
+
+            modalRef.result.then((response) => {
+                if (response && response == true) {
+                    this.loaderService.show(MessageObj.updating_port_details);
+                    this.commitConfig();
+                }
+            });
+        }
+    }
+
+    getPortStatus = (status) => {
+        if (status.toLowerCase() == 'good') {
+            return 'UP';
+        } else if (status.toLowerCase() == 'bad') {
+            return 'DOWN';
+        }
+        return status;
+
+    };
+
+    commitConfig() {
+        const portStatus = this.portForm.value.portStatus;
+        this.switchService.configurePort(this.retrievedSwitchObject.switch_id,
+            this.portDataObject.port_number,
+            portStatus).subscribe(status => {
+            this.loaderService.hide();
+            this.toastr.success(MessageObj.port_configured, 'Success');
+            this.portDataObject.status = portStatus;
+            const portDataObjectKey = 'portDataObject_' + this.switchId + '_' + this.portId;
+            localStorage.setItem(portDataObjectKey, JSON.stringify(this.portDataObject));
+            this.editConfigStatus = false;
+
+        }, error => {
+            this.loaderService.hide();
+            this.editConfigStatus = false;
+            if (error.status == '500') {
+                this.toastr.error(error.error['error-auxiliary-message']);
+            } else {
+                this.toastr.error('Something went wrong!');
+            }
+        });
+    }
+
+    enableDisableDiscoveryPackets(e) {
+        const modalRef = this.modalService.open(ModalconfirmationComponent);
+        modalRef.componentInstance.title = 'Confirmation';
+        modalRef.componentInstance.content = 'Are you sure you want to update discovery packets value?';
+        const OldValue = this.discoverypackets;
+        this.discoverypackets = e.target.checked;
+        modalRef.result.then((response) => {
+            if (response && response == true) {
+                this.loaderService.show(MessageObj.updating_discovery_flag);
+                this.switchService.updatediscoveryPackets(this.retrievedSwitchObject.switch_id, this.portDataObject.port_number, this.discoverypackets).subscribe((response) => {
+                    this.toastr.success(MessageObj.discovery_packets_updated, 'Success');
+                    this.loaderService.hide();
+                    this.discoverypackets = e.target.checked;
+                }, error => {
+                    this.discoverypackets = OldValue;
+                    this.loaderService.hide();
+                    this.toastr.error(MessageObj.error_updating_discovery_packets, 'Error');
+                });
+            } else {
+                this.discoverypackets = OldValue;
+            }
+        });
+    }
+
+    configurePortDetails() {
+        const modalRef = this.modalService.open(ModalconfirmationComponent);
+        modalRef.componentInstance.title = 'Confirmation';
+        modalRef.componentInstance.content = 'Are you sure you want to configure the port?';
+        modalRef.result.then((response) => {
+            if (response && response == true) {
+                this.editConfigStatus = true;
+                this.portForm = this.formBuiler.group({
+                    portStatus: [this.portDataObject.status],
+                });
+            }
+        });
+    }
+
+    loadPortFlows() {
+        if (this.portDataObject['port_number'] && (this.retrievedSwitchObject['switch_id'])) {
+            const switchId = this.retrievedSwitchObject.switch_id;
+            const portnumber = this.portDataObject.port_number;
+            this.flowBandwidthFlag = true;
+            this.switchService.getSwitchFlows(switchId, false, portnumber).subscribe(data => {
+                this.portFlows = data;
+                if (this.portFlows && this.portFlows.length) {
+                    for (const flow of this.portFlows) {
+                        this.flowBandwidthSum = this.flowBandwidthSum + (flow.maximum_bandwidth / 1000);
+                    }
+                } else {
+                    if (this.portFlows == null) {
+                        this.portFlows = [];
+                    }
+                }
+                if (this.flowBandwidthSum) {
+                    this.flowBandwidthSum = this.flowBandwidthSum.toFixed(3);
+                }
+
+                this.flowBandwidthFlag = false;
+            }, error => {
+                this.portFlows = [];
+                this.flowBandwidthSum = 0;
+                this.flowBandwidthFlag = false;
+            });
+        }
+
     }
 
 
-  }
+    cancelConfigurePort() {
+        this.editConfigStatus = false;
+    }
 
-  ngOnDestroy() {
-    localStorage.setItem('portLoaderEnabled', '1');
-  }
+    copyToClip(event, copyItem) {
+        this.clipboardService.copyFromContent(this.clipBoardItems[copyItem]);
+    }
+
+    toggleTab(tab) {
+        this.openedTab = tab;
+    }
+
+    assignDate(timestamp) {
+        if (timestamp) {
+            return moment(timestamp * 1000).format('LLL');
+        } else {
+            return '-';
+        }
+    }
+
+    deleteLogicalPort() {
+        const modalRef = this.modalService.open(ModalconfirmationComponent);
+        modalRef.componentInstance.title = 'Delete Port';
+        modalRef.componentInstance.content = 'Are you sure you want to perform delete action ?';
+        modalRef.result.then((response) => {
+            if (response && response == true) {
+                this.switchService.deleteLagLogicalPort(this.retrievedSwitchObject.switch_id, this.portDataObject.port_number).subscribe(res => {
+                    modalRef.close();
+                    this.toastr.success(MessageObj.port_deleted, 'Success!');
+                    this.router.navigate(['/switches/details/' + this.retrievedSwitchObject.switch_id]);
+                }, error => {
+                    this.loaderService.hide();
+                    var message = (error.error['error-auxiliary-message']) ? error.error['error-auxiliary-message'] : error.error['error-description'];
+                    this.toastr.error(message, 'Error');
+                });
+            }
+        });
+    }
+
+    ngOnDestroy() {
+        localStorage.setItem('portLoaderEnabled', '1');
+    }
 }
 

--- a/src-gui/ui/src/app/modules/switches/port-list/port-list.component.html
+++ b/src-gui/ui/src/app/modules/switches/port-list/port-list.component.html
@@ -20,6 +20,9 @@
        </div>
       <div class="clear clearfix"></div>
     </div>
+    <div>
+      <button  class="btn btn-dark btn-sm pull-right mr-3"  [disabled]="switchPortDataSet==null"    (click)="createLagPort()">Create Lag Port</button> 
+    </div>
     <div id="portsTable_wrapper" class="dataTables_wrapper no-footer">
       <table datatable [dtOptions]="dtOptions" [dtTrigger]="dtTrigger" id="portsTable" class="display no-footer dataTable custom-margin-datatable" cellspacing="0"
         role="grid" aria-describedby="portsTable_info">

--- a/src-gui/ui/src/app/modules/switches/port-list/port-list.component.ts
+++ b/src-gui/ui/src/app/modules/switches/port-list/port-list.component.ts
@@ -1,210 +1,217 @@
-import { Component, OnInit, AfterViewInit, OnDestroy, ViewChild, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { SwitchService } from '../../../common/services/switch.service';
-import { SwitchidmaskPipe } from '../../../common/pipes/switchidmask.pipe';
-import { ToastrService } from 'ngx-toastr';
-import { ActivatedRoute, Router } from '@angular/router';
-import { DataTableDirective } from 'angular-datatables';
-import { Subject , Subscription} from 'rxjs';
-import { NgxSpinnerService } from 'ngx-spinner';
-import { LoaderService } from '../../../common/services/loader.service';
-import { Title } from '@angular/platform-browser';
-import { CommonService } from 'src/app/common/services/common.service';
+import {Component, OnInit, AfterViewInit, OnDestroy, ViewChild, Input, OnChanges, SimpleChanges} from '@angular/core';
+import {SwitchService} from '../../../common/services/switch.service';
+import {SwitchidmaskPipe} from '../../../common/pipes/switchidmask.pipe';
+import {ToastrService} from 'ngx-toastr';
+import {ActivatedRoute, Router} from '@angular/router';
+import {DataTableDirective} from 'angular-datatables';
+import {Subject, Subscription} from 'rxjs';
+import {NgxSpinnerService} from 'ngx-spinner';
+import {LoaderService} from '../../../common/services/loader.service';
+import {Title} from '@angular/platform-browser';
+import {CommonService} from 'src/app/common/services/common.service';
+import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
+import {CreateLagPortComponent} from '../create-lag-port/create-lag-port.component';
+import {MessageObj} from 'src/app/common/constants/constants';
 
 @Component({
-  selector: 'app-port-list',
-  templateUrl: './port-list.component.html',
-  styleUrls: ['./port-list.component.css']
+    selector: 'app-port-list',
+    templateUrl: './port-list.component.html',
+    styleUrls: ['./port-list.component.css']
 })
 export class PortListComponent implements OnInit, AfterViewInit, OnDestroy, OnChanges {
-  @ViewChild(DataTableDirective, { static: true })
-  dtElement: DataTableDirective;
-  @Input() switch = null;
-  @Input() loadinterval = false;
-  isLoaderActive = false;
-  dtOptions: any = {};
-  dtTrigger: Subject<any> = new Subject();
+    @ViewChild(DataTableDirective, {static: true})
+    dtElement: DataTableDirective;
+    @Input() switch = null;
+    @Input() loadinterval = false;
+    isLoaderActive = false;
+    dtOptions: any = {};
+    dtTrigger: Subject<any> = new Subject();
 
-  currentActivatedRoute: string;
-  switch_id: string;
-  switchPortDataSet: any;
-  anyData: any;
-  portListTimerId: any;
-  portFlowData: any = {};
-  portListSubscriber = null;
-  portFlowSubscription: Subscription[] = [];
-  loadPorts = false;
-  switchFilterFlag: string = localStorage.getItem('switchFilterFlag') || 'controller';
-  hasStoreSetting ;
-  constructor(private switchService: SwitchService,
-    private toastr: ToastrService,
-    private maskPipe: SwitchidmaskPipe,
-    private router: Router,
-    private loaderService: LoaderService,
-    private titleService: Title,
-    private route: ActivatedRoute,
-    private commonService: CommonService,
-  ) {
-    this.hasStoreSetting = localStorage.getItem('hasSwtStoreSetting') == '1' ? true : false;
-  }
+    currentActivatedRoute: string;
+    switch_id: string;
+    switchPortDataSet: any;
+    anyData: any;
+    portListTimerId: any;
+    portFlowData: any = {};
+    portListSubscriber = null;
+    portFlowSubscription: Subscription[] = [];
+    loadPorts = false;
+    switchFilterFlag: string = localStorage.getItem('switchFilterFlag') || 'controller';
+    hasStoreSetting;
 
-  ngOnInit() {
-      const ref = this;
-    this.switch_id = this.switch;
-    this.dtOptions = {
-      paging: false,
-      retrieve: true,
-      autoWidth: false,
-      colResize: false,
-      dom: 'tpli',
-      initComplete: function( settings, json ) {
-        if (localStorage.getItem('portLoaderEnabled')) {
-            setTimeout(() => {ref.loaderService.hide(); }, 2000);
-            localStorage.removeItem('portLoaderEnabled');
-        }
-      },
-      'aLengthMenu': [[10, 20, 35, 50, -1], [10, 20, 35, 50, 'All']],
-      'aoColumns': [
-        { sWidth: '5%' },
-        { sWidth: '10%' },
-        { sWidth: '10%' },
-        { sWidth: '10%' },
-        { sWidth: '10%' },
-        { sWidth: '13%' },
-        { sWidth: '13%' },
-        { sWidth: '13%' },
-        { sWidth: '13%' },
-        { sWidth: '5%' },
-        { sWidth: '5%' },
-        { sWidth: '5%' },
-        { sWidth: '8%' } ],
-      language: {
-        searchPlaceholder: 'Search'
-        },
-    columnDefs: [
-        { targets: [1], visible: this.hasStoreSetting},
-        ]
-    };
-    this.initPortListData();
-  	this.initSwitchPortList();
-  }
+    constructor(private switchService: SwitchService,
+                private toastr: ToastrService,
+                private maskPipe: SwitchidmaskPipe,
+                private router: Router,
+                private loaderService: LoaderService,
+                private titleService: Title,
+                private modalService: NgbModal,
+                private route: ActivatedRoute,
+                private commonService: CommonService,
+    ) {
+        this.hasStoreSetting = localStorage.getItem('hasSwtStoreSetting') == '1' ? true : false;
+    }
 
-  fulltextSearch(e: any) {
-      const value = e.target.value;
+    ngOnInit() {
+        const ref = this;
+        this.switch_id = this.switch;
+        this.dtOptions = {
+            paging: false,
+            retrieve: true,
+            autoWidth: false,
+            colResize: false,
+            dom: 'tpli',
+            initComplete: function (settings, json) {
+                if (localStorage.getItem('portLoaderEnabled')) {
+                    setTimeout(() => {
+                        ref.loaderService.hide();
+                    }, 2000);
+                    localStorage.removeItem('portLoaderEnabled');
+                }
+            },
+            'aLengthMenu': [[10, 20, 35, 50, -1], [10, 20, 35, 50, 'All']],
+            'aoColumns': [
+                {sWidth: '5%'},
+                {sWidth: '10%'},
+                {sWidth: '10%'},
+                {sWidth: '10%'},
+                {sWidth: '10%'},
+                {sWidth: '13%'},
+                {sWidth: '13%'},
+                {sWidth: '13%'},
+                {sWidth: '13%'},
+                {sWidth: '5%'},
+                {sWidth: '5%'},
+                {sWidth: '5%'},
+                {sWidth: '8%'}],
+            language: {
+                searchPlaceholder: 'Search'
+            },
+            columnDefs: [
+                {targets: [1], visible: this.hasStoreSetting},
+            ]
+        };
+        this.initPortListData();
+        this.initSwitchPortList();
+    }
+
+    fulltextSearch(e: any) {
+        const value = e.target.value;
         this.dtElement.dtInstance.then((dtInstance: DataTables.Api) => {
             if (this.hasStoreSetting) {
-                dtInstance.columns( [1] ).visible( true );
+                dtInstance.columns([1]).visible(true);
             } else {
-                dtInstance.columns( [1] ).visible( false );
+                dtInstance.columns([1]).visible(false);
             }
 
             dtInstance.search(value)
-                  .draw();
+                .draw();
         });
-  }
+    }
 
-  showPortDetail(item) {
-    const portDataObject = item;
-    const portDataObjectKey = 'portDataObject_' + this.switch_id + '_' + item.port_number;
-    localStorage.setItem(portDataObjectKey, JSON.stringify(portDataObject));
-    this.currentActivatedRoute = 'port-details';
-    this.router.navigate(['/switches/details/' + this.switch_id + '/port/' + item.port_number]);
-  }
+    showPortDetail(item) {
+        const portDataObject = item;
+        const portDataObjectKey = 'portDataObject_' + this.switch_id + '_' + item.port_number;
+        localStorage.setItem(portDataObjectKey, JSON.stringify(portDataObject));
+        this.currentActivatedRoute = 'port-details';
+        this.router.navigate(['/switches/details/' + this.switch_id + '/port/' + item.port_number]);
+    }
 
-   initSwitchPortList() {
-      this.portListTimerId = setInterval(() => {
-        if (this.loadinterval) {
-            this.initPortListData();
+    initSwitchPortList() {
+        this.portListTimerId = setInterval(() => {
+            if (this.loadinterval) {
+                this.initPortListData();
+            }
+        }, 30000);
+    }
+
+    initPortListData() {
+        if (this.loadPorts) {
+            return;
         }
-      }, 30000);
-  }
-
-  initPortListData() {
-      if (this.loadPorts) {
-        return ;
-      }
-      if (localStorage.getItem('portLoaderEnabled')) {
-          this.loaderService.show('Loading Ports');
-      }
-      this.loadPorts = true;
-      this.portListSubscriber = this.switchService.getSwitchPortsStats(this.maskPipe.transform(this.switch_id, 'legacy')).subscribe((data: Array<object>) => {
-        this.rerender();
-        this.ngAfterViewInit();
-        this.loadPorts = false;
-        localStorage.setItem('switchPortDetail', JSON.stringify(data));
-        this.switchPortDataSet = data;
-        for (let i = 0; i < this.switchPortDataSet.length; i++) {
-          if (this.switchPortDataSet[i].port_number === '' || this.switchPortDataSet[i].port_number === undefined) {
-              this.switchPortDataSet[i].port_number = '-';
-          }
-          if (this.switchPortDataSet[i].interfacetype === '' || this.switchPortDataSet[i].interfacetype === undefined) {
-              this.switchPortDataSet[i].interfacetype = '-';
-          }
-          if (typeof(this.switchPortDataSet[i].stats) !== 'undefined') {
-            if (this.switchPortDataSet[i].stats['tx-bytes'] === '' || this.switchPortDataSet[i].stats['tx-bytes'] === undefined) {
-                this.switchPortDataSet[i].stats['tx-bytes'] = '-';
-            } else {
-                this.switchPortDataSet[i].stats['tx-bytes'] =  this.commonService.convertBytesToMbps(this.switchPortDataSet[i].stats['tx-bytes']);
-            }
-
-            if (this.switchPortDataSet[i].stats['rx-bytes'] === '' || this.switchPortDataSet[i].stats['rx-bytes'] === undefined) {
-                this.switchPortDataSet[i].stats['rx-bytes'] = '-';
-            } else {
-                this.switchPortDataSet[i].stats['rx-bytes'] =  this.commonService.convertBytesToMbps(this.switchPortDataSet[i].stats['rx-bytes']);
-            }
-
-            if (this.switchPortDataSet[i].stats['tx-packets'] === '' || this.switchPortDataSet[i].stats['tx-packets'] === undefined) {
-                this.switchPortDataSet[i].stats['tx-packets'] = '-';
-            }
-
-            if (this.switchPortDataSet[i].stats['rx-packets'] === '' || this.switchPortDataSet[i].stats['rx-packets'] === undefined) {
-                this.switchPortDataSet[i].stats['rx-packets'] = '-';
-            }
-
-            if (this.switchPortDataSet[i].stats['tx-dropped'] === '' || this.switchPortDataSet[i].stats['tx-dropped'] === undefined) {
-                this.switchPortDataSet[i].stats['tx-dropped'] = '-';
-            }
-
-            if (this.switchPortDataSet[i].stats['rx-dropped'] === '' || this.switchPortDataSet[i].stats['rx-dropped'] === undefined) {
-                this.switchPortDataSet[i].stats['rx-dropped'] = '-';
-            }
-
-
-            if (this.switchPortDataSet[i].stats['tx-errors'] === '' || this.switchPortDataSet[i].stats['tx-errors'] === undefined) {
-                this.switchPortDataSet[i].stats['tx-errors'] = '-';
-            }
-
-            if (this.switchPortDataSet[i].stats['rx-errors'] === '' || this.switchPortDataSet[i].stats['rx-errors'] === undefined) {
-                this.switchPortDataSet[i].stats['rx-errors'] = '-';
-            }
-
-            if (this.switchPortDataSet[i].stats['collisions'] === '' || this.switchPortDataSet[i].stats['collisions'] === undefined) {
-                this.switchPortDataSet[i].stats['collisions'] = '-';
-            }
-
-              if (this.switchPortDataSet[i].stats['rx-frame-error'] === '' || this.switchPortDataSet[i].stats['rx-frame-error'] === undefined) {
-                this.switchPortDataSet[i].stats['rx-frame-error'] = '-';
-            }
-
-            if (this.switchPortDataSet[i].stats['rx-over-error'] === '' || this.switchPortDataSet[i].stats['rx-over-error'] === undefined) {
-                this.switchPortDataSet[i].stats['rx-over-error'] = '-';
-            }
-
-            if (this.switchPortDataSet[i].stats['rx-crc-error'] === '' || this.switchPortDataSet[i].stats['rx-crc-error'] === undefined) {
-                this.switchPortDataSet[i].stats['rx-crc-error'] = '-';
-            }
-          } else {
-            this.switchPortDataSet[i]['stats'] = {};
-          }
-      }
-        const ports: Array<number> = this.switchPortDataSet.filter(obj => !isNaN(parseInt(obj.port_number, 10)))
-              .map(obj => parseInt(obj.port_number, 10));
-        if (ports.length !== 0) {
-            this.initPortFlowData(this.switch_id, ports);
+        if (localStorage.getItem('portLoaderEnabled')) {
+            this.loaderService.show('Loading Ports');
         }
-     }, error => {
-        // this.toastr.error("No Switch Port data",'Error');
-     });
-  }
+        this.loadPorts = true;
+        this.portListSubscriber = this.switchService.getSwitchPortsStats(this.maskPipe.transform(this.switch_id, 'legacy')).subscribe((data: Array<object>) => {
+            this.rerender();
+            this.ngAfterViewInit();
+            this.loadPorts = false;
+            localStorage.setItem('switchPortDetail', JSON.stringify(data));
+            this.switchPortDataSet = data;
+            for (let i = 0; i < this.switchPortDataSet.length; i++) {
+                if (this.switchPortDataSet[i].port_number === '' || this.switchPortDataSet[i].port_number === undefined) {
+                    this.switchPortDataSet[i].port_number = '-';
+                }
+                if (this.switchPortDataSet[i].interfacetype === '' || this.switchPortDataSet[i].interfacetype === undefined) {
+                    this.switchPortDataSet[i].interfacetype = '-';
+                }
+                if (typeof (this.switchPortDataSet[i].stats) !== 'undefined') {
+                    if (this.switchPortDataSet[i].stats['tx-bytes'] === '' || this.switchPortDataSet[i].stats['tx-bytes'] === undefined) {
+                        this.switchPortDataSet[i].stats['tx-bytes'] = '-';
+                    } else {
+                        this.switchPortDataSet[i].stats['tx-bytes'] = this.commonService.convertBytesToMbps(this.switchPortDataSet[i].stats['tx-bytes']);
+                    }
+
+                    if (this.switchPortDataSet[i].stats['rx-bytes'] === '' || this.switchPortDataSet[i].stats['rx-bytes'] === undefined) {
+                        this.switchPortDataSet[i].stats['rx-bytes'] = '-';
+                    } else {
+                        this.switchPortDataSet[i].stats['rx-bytes'] = this.commonService.convertBytesToMbps(this.switchPortDataSet[i].stats['rx-bytes']);
+                    }
+
+                    if (this.switchPortDataSet[i].stats['tx-packets'] === '' || this.switchPortDataSet[i].stats['tx-packets'] === undefined) {
+                        this.switchPortDataSet[i].stats['tx-packets'] = '-';
+                    }
+
+                    if (this.switchPortDataSet[i].stats['rx-packets'] === '' || this.switchPortDataSet[i].stats['rx-packets'] === undefined) {
+                        this.switchPortDataSet[i].stats['rx-packets'] = '-';
+                    }
+
+                    if (this.switchPortDataSet[i].stats['tx-dropped'] === '' || this.switchPortDataSet[i].stats['tx-dropped'] === undefined) {
+                        this.switchPortDataSet[i].stats['tx-dropped'] = '-';
+                    }
+
+                    if (this.switchPortDataSet[i].stats['rx-dropped'] === '' || this.switchPortDataSet[i].stats['rx-dropped'] === undefined) {
+                        this.switchPortDataSet[i].stats['rx-dropped'] = '-';
+                    }
+
+
+                    if (this.switchPortDataSet[i].stats['tx-errors'] === '' || this.switchPortDataSet[i].stats['tx-errors'] === undefined) {
+                        this.switchPortDataSet[i].stats['tx-errors'] = '-';
+                    }
+
+                    if (this.switchPortDataSet[i].stats['rx-errors'] === '' || this.switchPortDataSet[i].stats['rx-errors'] === undefined) {
+                        this.switchPortDataSet[i].stats['rx-errors'] = '-';
+                    }
+
+                    if (this.switchPortDataSet[i].stats['collisions'] === '' || this.switchPortDataSet[i].stats['collisions'] === undefined) {
+                        this.switchPortDataSet[i].stats['collisions'] = '-';
+                    }
+
+                    if (this.switchPortDataSet[i].stats['rx-frame-error'] === '' || this.switchPortDataSet[i].stats['rx-frame-error'] === undefined) {
+                        this.switchPortDataSet[i].stats['rx-frame-error'] = '-';
+                    }
+
+                    if (this.switchPortDataSet[i].stats['rx-over-error'] === '' || this.switchPortDataSet[i].stats['rx-over-error'] === undefined) {
+                        this.switchPortDataSet[i].stats['rx-over-error'] = '-';
+                    }
+
+                    if (this.switchPortDataSet[i].stats['rx-crc-error'] === '' || this.switchPortDataSet[i].stats['rx-crc-error'] === undefined) {
+                        this.switchPortDataSet[i].stats['rx-crc-error'] = '-';
+                    }
+                } else {
+                    this.switchPortDataSet[i]['stats'] = {};
+                }
+            }
+            const ports: Array<number> = this.switchPortDataSet.filter(obj => !isNaN(parseInt(obj.port_number, 10)))
+                .map(obj => parseInt(obj.port_number, 10));
+            if (ports.length !== 0) {
+                this.initPortFlowData(this.switch_id, ports);
+            }
+        }, error => {
+            // this.toastr.error("No Switch Port data",'Error');
+        });
+    }
 
     initPortFlowData(switchId: string, ports: Array<number>) {
         ports.forEach(port => {
@@ -229,76 +236,104 @@ export class PortListComponent implements OnInit, AfterViewInit, OnDestroy, OnCh
                         });
                     }
 
-            }, error => {
+                }, error => {
                     ports.forEach(port => {
                         this.portFlowData[port] = {};
                         this.portFlowData[port].sumflowbandwidth = 0;
                         this.portFlowData[port].noofflows = 0;
                     });
 
-            });
+                });
             this.portFlowSubscription.push(subscriptionPortFlows);
         }
     }
 
-   ngAfterViewInit(): void {
-       try {
-        this.dtTrigger.next();
-       } catch (err) {
+    ngAfterViewInit(): void {
+        try {
+            this.dtTrigger.next();
+        } catch (err) {
 
-       }
-  }
-
-  ngOnDestroy(): void {
-    // Unsubscribe the event
-    this.dtTrigger.unsubscribe();
-    clearInterval(this.portListTimerId);
-    if (this.portListSubscriber) {
-      this.portListSubscriber.unsubscribe();
-      this.portListSubscriber = null;
-    }
-    if (this.portFlowSubscription && this.portFlowSubscription.length) {
-      this.portFlowSubscription.forEach((subscription) => subscription.unsubscribe());
-      this.portFlowSubscription = [];
-    }
-    this.loadPorts = false;
-  }
-
-  rerender(): void {
-      try {
-    this.dtElement.dtInstance.then((dtInstance: DataTables.Api) => {
-      // Destroy the table first
-      try {
-
-        dtInstance.destroy();
-        this.dtTrigger.next();
-      } catch (err) {}
-    });
-    } catch (err) {}
-
-    this.initiateInterval();
-  }
-
-  initiateInterval() {
-    const interval = setInterval(() => {
-        this.dtElement.dtInstance.then((dtInstance: DataTables.Api) => {
-            if (this.hasStoreSetting) {
-                dtInstance.columns( [1] ).visible( true );
-            } else {
-                dtInstance.columns( [1] ).visible( false );
-            }
-            clearInterval(interval);
-        });
-    }, 1000);
-
-  }
-
-  ngOnChanges(change: SimpleChanges) {
-    if (change.loader) {
-        if (change.loadinterval.currentValue) {
-          this.loadinterval  = change.loadinterval.currentValue;
         }
-      }
-  }
+    }
+
+    ngOnDestroy(): void {
+        // Unsubscribe the event
+        this.dtTrigger.unsubscribe();
+        clearInterval(this.portListTimerId);
+        if (this.portListSubscriber) {
+            this.portListSubscriber.unsubscribe();
+            this.portListSubscriber = null;
+        }
+        if (this.portFlowSubscription && this.portFlowSubscription.length) {
+            this.portFlowSubscription.forEach((subscription) => subscription.unsubscribe());
+            this.portFlowSubscription = [];
+        }
+        this.loadPorts = false;
+    }
+
+    rerender(): void {
+        try {
+            this.dtElement.dtInstance.then((dtInstance: DataTables.Api) => {
+                // Destroy the table first
+                try {
+
+                    dtInstance.destroy();
+                    this.dtTrigger.next();
+                } catch (err) {
+                }
+            });
+        } catch (err) {
+        }
+
+        this.initiateInterval();
+    }
+
+    initiateInterval() {
+        const interval = setInterval(() => {
+            this.dtElement.dtInstance.then((dtInstance: DataTables.Api) => {
+                if (this.hasStoreSetting) {
+                    dtInstance.columns([1]).visible(true);
+                } else {
+                    dtInstance.columns([1]).visible(false);
+                }
+                clearInterval(interval);
+            });
+        }, 1000);
+
+    }
+
+    ngOnChanges(change: SimpleChanges) {
+        if (change.loader) {
+            if (change.loadinterval.currentValue) {
+                this.loadinterval = change.loadinterval.currentValue;
+            }
+        }
+    }
+
+    createLagPort() {
+        const modalRef = this.modalService.open(CreateLagPortComponent, {size: 'lg', windowClass: 'modal-port slideInUp'});
+        modalRef.componentInstance.emitService.subscribe((res) => {
+            let result = res.map(i => Number(i));
+            this.loaderService.show(MessageObj.apply_changes);
+            this.switchService.createLagLogicalPort({port_numbers: result}, this.switch_id).subscribe(res => {
+                if (res) {
+                    this.toastr.success(MessageObj.create_lag_port, 'Success');
+                    this.loaderService.hide();
+                    modalRef.componentInstance.activeModal.close(true);
+                    this.portListData();
+                }
+
+            }, error => {
+                this.loaderService.hide();
+                modalRef.componentInstance.activeModal.close(true);
+                var message = (error.error['error-auxiliary-message']) ? error.error['error-auxiliary-message'] : error.error['error-description'];
+                this.toastr.error(message, 'Error');
+            });
+        });
+      
+
+    }
+
+
 }
 

--- a/src-gui/ui/src/app/modules/switches/port-list/port-list.component.ts
+++ b/src-gui/ui/src/app/modules/switches/port-list/port-list.component.ts
@@ -1,11 +1,10 @@
-import {Component, OnInit, AfterViewInit, OnDestroy, ViewChild, Input, OnChanges, SimpleChanges} from '@angular/core';
+import {AfterViewInit, Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewChild} from '@angular/core';
 import {SwitchService} from '../../../common/services/switch.service';
 import {SwitchidmaskPipe} from '../../../common/pipes/switchidmask.pipe';
 import {ToastrService} from 'ngx-toastr';
 import {ActivatedRoute, Router} from '@angular/router';
 import {DataTableDirective} from 'angular-datatables';
 import {Subject, Subscription} from 'rxjs';
-import {NgxSpinnerService} from 'ngx-spinner';
 import {LoaderService} from '../../../common/services/loader.service';
 import {Title} from '@angular/platform-browser';
 import {CommonService} from 'src/app/common/services/common.service';
@@ -312,28 +311,23 @@ export class PortListComponent implements OnInit, AfterViewInit, OnDestroy, OnCh
 
     createLagPort() {
         const modalRef = this.modalService.open(CreateLagPortComponent, {size: 'lg', windowClass: 'modal-port slideInUp'});
-        modalRef.componentInstance.emitService.subscribe((res) => {
-            let result = res.map(i => Number(i));
+        modalRef.componentInstance.emitService.subscribe((createLagPort: CreateLagPortModel) => {
             this.loaderService.show(MessageObj.apply_changes);
-            this.switchService.createLagLogicalPort({port_numbers: result}, this.switch_id).subscribe(res => {
+            this.switchService.createLagLogicalPort(createLagPort, this.switch_id).subscribe(res => {
                 if (res) {
                     this.toastr.success(MessageObj.create_lag_port, 'Success');
                     this.loaderService.hide();
                     modalRef.componentInstance.activeModal.close(true);
-                    this.portListData();
+                    this.initPortListData();
                 }
 
             }, error => {
                 this.loaderService.hide();
                 modalRef.componentInstance.activeModal.close(true);
-                var message = (error.error['error-auxiliary-message']) ? error.error['error-auxiliary-message'] : error.error['error-description'];
+                const message = `${error.error['error-auxiliary-message'] + ','} ${error.error['error-description']}`;
                 this.toastr.error(message, 'Error');
             });
         });
-      
-
     }
-
-
 }
 

--- a/src-gui/ui/src/app/modules/switches/switch-datatable/switch-datatable.component.ts
+++ b/src-gui/ui/src/app/modules/switches/switch-datatable/switch-datatable.component.ts
@@ -339,6 +339,6 @@ export class SwitchDatatableComponent implements OnInit, OnChanges, OnDestroy, A
     this.clipboardService.copyFromContent(copyData);
   }
 
-
+ 
 
 }

--- a/src-gui/ui/src/styles.css
+++ b/src-gui/ui/src/styles.css
@@ -1552,6 +1552,10 @@ label {
   width: 85% !important;
   max-width: 85%;
 }
+.modal-port .modal-dialog.modal-lg{
+  width: 40% !important;
+  max-width: 85%;
+}
 
 .tab-wrapper ul li a {
   text-decoration: none;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/LagPortRequest.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/LagPortRequest.java
@@ -42,6 +42,6 @@ public class LagPortRequest {
     }
 
     public void setLacpReply(Boolean lacpReply) {
-        this.lacpReply = lacpReply == null ? true : lacpReply;
+        this.lacpReply = lacpReply == null || lacpReply;
     }
 }

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/controller/v1/SwitchController.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/controller/v1/SwitchController.java
@@ -110,7 +110,7 @@ public class SwitchController extends BaseController {
      * Get switch rules.
      *
      * @param switchId the switch
-     * @param cookie filter the response based on this cookie
+     * @param cookie   filter the response based on this cookie
      * @return list of the cookies of the rules that have been deleted
      */
     @ApiOperation(value = "Get switch rules from the switch", response = SwitchFlowEntries.class)
@@ -128,12 +128,12 @@ public class SwitchController extends BaseController {
     /**
      * Delete switch rules.
      *
-     * @param switchId switch id to delete rules from
+     * @param switchId     switch id to delete rules from
      * @param deleteAction defines what to do about the default rules
-     * @param cookie the cookie to use if deleting a rule (could be any rule)
-     * @param inPort the in port to use if deleting a rule
-     * @param inVlan the in vlan to use if deleting a rule
-     * @param outPort the out port to use if deleting a rule
+     * @param cookie       the cookie to use if deleting a rule (could be any rule)
+     * @param inPort       the in port to use if deleting a rule
+     * @param inVlan       the in vlan to use if deleting a rule
+     * @param outPort      the out port to use if deleting a rule
      * @return list of the cookies of the rules that have been deleted
      */
     @ApiOperation(value = "Delete switch rules. Requires special authorization",
@@ -213,7 +213,7 @@ public class SwitchController extends BaseController {
     /**
      * Install switch rules.
      *
-     * @param switchId switch id to delete rules from
+     * @param switchId      switch id to delete rules from
      * @param installAction defines what to do about the default rules
      * @return list of the cookies of the rules that have been installed
      */
@@ -308,6 +308,7 @@ public class SwitchController extends BaseController {
 
     /**
      * Gets meters from the switch.
+     *
      * @param switchId switch dpid.
      * @return list of meters exists on the switch
      */
@@ -320,8 +321,9 @@ public class SwitchController extends BaseController {
 
     /**
      * Remove the meter from specific switch.
+     *
      * @param switchId switch dpid.
-     * @param meterId id of the meter to be deleted.
+     * @param meterId  id of the meter to be deleted.
      * @return result of the operation wrapped into {@link DeleteMeterResult}. True means no errors is occurred.
      */
     @ApiOperation(value = "Delete meter from the switch", response = DeleteMeterResult.class)
@@ -335,8 +337,8 @@ public class SwitchController extends BaseController {
     /**
      * Configure port.
      *
-     * @param switchId the switch id
-     * @param portNo the port no
+     * @param switchId   the switch id
+     * @param portNo     the port no
      * @param portConfig the port configuration payload
      * @return the response entity
      */
@@ -368,7 +370,7 @@ public class SwitchController extends BaseController {
      * Get a description of the switch port.
      *
      * @param switchId the switch id.
-     * @param port the port of the switch.
+     * @param port     the port of the switch.
      * @return port description.
      */
     @ApiOperation(value = "Get port description from the switch", response = PortDescription.class)
@@ -383,7 +385,7 @@ public class SwitchController extends BaseController {
     /**
      * Update "Under maintenance" flag for the switch.
      *
-     * @param switchId the switch id.
+     * @param switchId            the switch id.
      * @param underMaintenanceDto under maintenance flag.
      * @return updated switch.
      */
@@ -391,7 +393,8 @@ public class SwitchController extends BaseController {
     @PostMapping(path = "/{switch-id}/under-maintenance",
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    public CompletableFuture<SwitchDto> updateLinkUnderMaintenance(@PathVariable("switch-id") SwitchId switchId,
+    public CompletableFuture<SwitchDto> updateLinkUnderMaintenance(
+            @PathVariable("switch-id") SwitchId switchId,
             @RequestBody UnderMaintenanceDto underMaintenanceDto) {
         return switchService.updateSwitchUnderMaintenance(switchId, underMaintenanceDto);
     }
@@ -400,8 +403,8 @@ public class SwitchController extends BaseController {
      * Delete switch.
      *
      * @param switchId id of switch to delete
-     * @param force True value means that all switch checks (switch is deactivated, there is no flow with this switch,
-     *              switch has no ISLs) will be ignored.
+     * @param force    True value means that all switch checks (switch is deactivated,
+     *                 there is no flow with this switch, switch has no ISLs) will be ignored.
      * @return result of the operation wrapped into {@link DeleteSwitchResult}. True means no errors is occurred.
      */
     @ApiOperation(value = "Delete switch. Requires special authorization.", response = DeleteSwitchResult.class)
@@ -420,7 +423,7 @@ public class SwitchController extends BaseController {
      * Get all flows for a particular switch.
      *
      * @param switchId the switch
-     * @param port the port
+     * @param port     the port
      * @return all flows for a particular switch.
      */
     @ApiOperation(value = "Get a list of flows that goes through a particular switch, based on arguments.",
@@ -429,7 +432,7 @@ public class SwitchController extends BaseController {
     @ResponseStatus(HttpStatus.OK)
     public CompletableFuture<List<FlowPayload>> getFlowsForSwitch(@PathVariable(value = "switch-id") SwitchId switchId,
                                                                   @RequestParam(value = "port", required = false)
-                                                                          Integer port) {
+                                                                  Integer port) {
         return switchService.getFlowsForSwitch(switchId, port);
     }
 


### PR DESCRIPTION
resolves #4666 

+added modal window with creation of lag port on switch detail screen.
+show created lag port in port list and provide option to delete the lag port 
{ 

In order to create logical port on the switch in the VM env we need to add "lag" feature for the desired switch(we could do so via oriendDb),  
then we need to change its ip address to the following one:

go to the VM terminal and execute the following command:
`docker ps | grep stub`
select CONTAINER ID for kilda/grpc-stub:latest image. 
execute `docker inspect CONTAINER ID` and copy NetwrokSettings.Networks.IPAddress field value from the output.
change the IP address for our selected switch. 



 Then , in the UI go to the switch detail page, press Create Lag Port button (1 on the screenshot), select desired ports and press create.
<img width="1369" alt="image" src="https://github.com/telstra/open-kilda/assets/9297385/6d6ee2ad-7cb0-49b0-8adc-147b9d14eb91">
two points to consider:
1)Virtual port will be shown in the list of ports section on the switch detail page only if we have some stats for this logical/virtual port.  We need somehow to send some traffic via virtual/logical port to see it on the port list.
2) all the physical ports that belongs to the logical port should have LAG_GROUP  Assignment type.

}
