### PR TITLE
Fix switch connections transaction retry policy

### DIFF
--- a/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/controller/sw/SwitchFsm.java
+++ b/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/controller/sw/SwitchFsm.java
@@ -521,6 +521,7 @@ public final class SwitchFsm extends AbstractBaseFsm<SwitchFsm, SwitchFsmState, 
     private void persistSwitchConnections(SwitchAvailabilityData availabilityData) {
         RetryPolicy<?> retryPolicy = new RetryPolicy<>()
                 .handle(RecoverablePersistenceException.class, ConstraintViolationException.class)
+                .withMaxRetries(-1)  // removing default(==2) retries limit
                 .withMaxDuration(Duration.ofSeconds(options.getDbRepeatMaxDurationSeconds()))
                 .withDelay(Duration.ofMillis(20))
                 .withJitter(Duration.ofMillis(8))


### PR DESCRIPTION
Removing default retries count limit, because this retry policy aims to
the maximum number of attempts. The only required limit here is the
duration limit.