### PR TITLE
Fix PCE for protected YFlows.

### DIFF
--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/reroute/YFlowRerouteFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/reroute/YFlowRerouteFsm.java
@@ -188,11 +188,11 @@ public final class YFlowRerouteFsm extends YFlowProcessingFsm<YFlowRerouteFsm, S
             builder.internalTransition()
                     .within(State.REROUTING_SUB_FLOWS)
                     .on(Event.SUB_FLOW_ALLOCATED)
-                    .perform(new OnSubFlowAllocatedAction(flowRerouteService, persistenceManager));
+                    .perform(new OnSubFlowAllocatedAction(persistenceManager));
             builder.internalTransition()
                     .within(State.REROUTING_SUB_FLOWS)
                     .on(Event.SUB_FLOW_REROUTED)
-                    .perform(new OnSubFlowReroutedAction());
+                    .perform(new OnSubFlowReroutedAction(flowRerouteService));
             builder.internalTransition()
                     .within(State.REROUTING_SUB_FLOWS)
                     .on(Event.SUB_FLOW_FAILED)

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/reroute/actions/RerouteSubFlowsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/reroute/actions/RerouteSubFlowsAction.java
@@ -1,4 +1,4 @@
-/* Copyright 2021 Telstra Open Source
+/* Copyright 2022 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ public class RerouteSubFlowsAction extends HistoryRecordingAction<YFlowRerouteFs
         boolean isMainAffinityFlowRequestSent = false;
         String yFlowId = stateMachine.getYFlowId();
         for (String subFlowId : targetSubFlowIds) {
+            stateMachine.addSubFlow(subFlowId);
             FlowRerouteRequest rerouteRequest = new FlowRerouteRequest(subFlowId, stateMachine.isForceReroute(), false,
                     stateMachine.isIgnoreBandwidth(), stateMachine.getAffectedIsls(),
                     stateMachine.getRerouteReason(), false);
@@ -67,7 +68,6 @@ public class RerouteSubFlowsAction extends HistoryRecordingAction<YFlowRerouteFs
 
     private void sendRerouteRequest(YFlowRerouteFsm stateMachine, FlowRerouteRequest rerouteRequest, String yFlowId) {
         String subFlowId = rerouteRequest.getFlowId();
-        stateMachine.addSubFlow(subFlowId);
         stateMachine.addReroutingSubFlow(subFlowId);
         stateMachine.notifyEventListeners(listener ->
                 listener.onSubFlowProcessingStart(yFlowId, subFlowId));

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/update/YFlowUpdateFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/update/YFlowUpdateFsm.java
@@ -1,4 +1,4 @@
-/* Copyright 2021 Telstra Open Source
+/* Copyright 2022 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -197,11 +197,11 @@ public final class YFlowUpdateFsm extends YFlowProcessingFsm<YFlowUpdateFsm, Sta
             builder.internalTransition()
                     .within(State.UPDATING_SUB_FLOWS)
                     .on(Event.SUB_FLOW_ALLOCATED)
-                    .perform(new OnSubFlowAllocatedAction(flowUpdateService, persistenceManager));
+                    .perform(new OnSubFlowAllocatedAction(persistenceManager));
             builder.internalTransition()
                     .within(State.UPDATING_SUB_FLOWS)
                     .on(Event.SUB_FLOW_UPDATED)
-                    .perform(new OnSubFlowUpdatedAction());
+                    .perform(new OnSubFlowUpdatedAction(flowUpdateService));
             builder.internalTransition()
                     .within(State.UPDATING_SUB_FLOWS)
                     .on(Event.SUB_FLOW_FAILED)
@@ -390,11 +390,11 @@ public final class YFlowUpdateFsm extends YFlowProcessingFsm<YFlowUpdateFsm, Sta
             builder.internalTransition()
                     .within(State.REVERTING_SUB_FLOWS)
                     .on(Event.SUB_FLOW_ALLOCATED)
-                    .perform(new OnRevertSubFlowAllocatedAction(flowUpdateService, persistenceManager));
+                    .perform(new OnRevertSubFlowAllocatedAction(persistenceManager));
             builder.internalTransition()
                     .within(State.REVERTING_SUB_FLOWS)
                     .on(Event.SUB_FLOW_UPDATED)
-                    .perform(new OnSubFlowRevertedAction());
+                    .perform(new OnSubFlowRevertedAction(flowUpdateService));
             builder.internalTransition()
                     .within(State.REVERTING_SUB_FLOWS)
                     .on(Event.SUB_FLOW_FAILED)

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/update/actions/OnSubFlowUpdatedAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/update/actions/OnSubFlowUpdatedAction.java
@@ -1,4 +1,4 @@
-/* Copyright 2021 Telstra Open Source
+/* Copyright 2022 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -17,17 +17,25 @@ package org.openkilda.wfm.topology.flowhs.fsm.yflow.update.actions;
 
 import static java.lang.String.format;
 
+import org.openkilda.wfm.CommandContext;
 import org.openkilda.wfm.topology.flowhs.fsm.common.actions.HistoryRecordingAction;
 import org.openkilda.wfm.topology.flowhs.fsm.yflow.update.YFlowUpdateContext;
 import org.openkilda.wfm.topology.flowhs.fsm.yflow.update.YFlowUpdateFsm;
 import org.openkilda.wfm.topology.flowhs.fsm.yflow.update.YFlowUpdateFsm.Event;
 import org.openkilda.wfm.topology.flowhs.fsm.yflow.update.YFlowUpdateFsm.State;
+import org.openkilda.wfm.topology.flowhs.service.FlowUpdateService;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class OnSubFlowUpdatedAction extends
         HistoryRecordingAction<YFlowUpdateFsm, State, Event, YFlowUpdateContext> {
+    private final FlowUpdateService flowUpdateService;
+
+    public OnSubFlowUpdatedAction(FlowUpdateService flowUpdateService) {
+        this.flowUpdateService = flowUpdateService;
+    }
+
     @Override
     protected void perform(State from, State to, Event event, YFlowUpdateContext context, YFlowUpdateFsm stateMachine) {
         String subFlowId = context.getSubFlowId();
@@ -41,6 +49,20 @@ public class OnSubFlowUpdatedAction extends
         stateMachine.removeUpdatingSubFlow(subFlowId);
         stateMachine.notifyEventListeners(listener ->
                 listener.onSubFlowProcessingFinished(stateMachine.getYFlowId(), subFlowId));
+
+        String yFlowId = stateMachine.getYFlowId();
+        if (subFlowId.equals(stateMachine.getMainAffinityFlowId())) {
+            stateMachine.getRequestedFlows().forEach(requestedFlow -> {
+                String requestedFlowId = requestedFlow.getFlowId();
+                if (!requestedFlowId.equals(subFlowId)) {
+                    stateMachine.addUpdatingSubFlow(requestedFlowId);
+                    stateMachine.notifyEventListeners(listener ->
+                            listener.onSubFlowProcessingStart(yFlowId, requestedFlowId));
+                    CommandContext flowContext = stateMachine.getCommandContext().fork(requestedFlowId);
+                    flowUpdateService.startFlowUpdating(flowContext, requestedFlow, yFlowId);
+                }
+            });
+        }
 
         if (stateMachine.getUpdatingSubFlows().isEmpty()) {
             if (stateMachine.getFailedSubFlows().isEmpty()) {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/update/actions/UpdateSubFlowsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/update/actions/UpdateSubFlowsAction.java
@@ -1,4 +1,4 @@
-/* Copyright 2021 Telstra Open Source
+/* Copyright 2022 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -46,17 +46,17 @@ public class UpdateSubFlowsAction extends HistoryRecordingAction<YFlowUpdateFsm,
         stateMachine.clearUpdatingSubFlows();
 
         String yFlowId = stateMachine.getYFlowId();
-        requestedFlows.stream()
-                .filter(requestedFlow -> requestedFlow.getFlowId().equals(stateMachine.getMainAffinityFlowId()))
-                .forEach(requestedFlow -> {
-                    String subFlowId = requestedFlow.getFlowId();
-                    stateMachine.addSubFlow(subFlowId);
-                    stateMachine.addUpdatingSubFlow(subFlowId);
-                    stateMachine.notifyEventListeners(listener ->
-                            listener.onSubFlowProcessingStart(yFlowId, subFlowId));
-                    CommandContext flowContext = stateMachine.getCommandContext().fork(subFlowId);
-                    requestedFlow.setDiverseFlowId(stateMachine.getDiverseFlowId());
-                    flowUpdateService.startFlowUpdating(flowContext, requestedFlow, yFlowId);
-                });
+        requestedFlows.forEach(requestedFlow -> {
+            String subFlowId = requestedFlow.getFlowId();
+            stateMachine.addSubFlow(subFlowId);
+            if (requestedFlow.getFlowId().equals(stateMachine.getMainAffinityFlowId())) {
+                stateMachine.addUpdatingSubFlow(subFlowId);
+                stateMachine.notifyEventListeners(listener ->
+                        listener.onSubFlowProcessingStart(yFlowId, subFlowId));
+                CommandContext flowContext = stateMachine.getCommandContext().fork(subFlowId);
+                requestedFlow.setDiverseFlowId(stateMachine.getDiverseFlowId());
+                flowUpdateService.startFlowUpdating(flowContext, requestedFlow, yFlowId);
+            }
+        });
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowRerouteServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowRerouteServiceTest.java
@@ -180,7 +180,7 @@ public class YFlowRerouteServiceTest extends AbstractYFlowTest<SpeakerRequest> {
 
         // when
         processRerouteRequestAndSpeakerCommands(request,
-                FlowStatus.IN_PROGRESS, FlowStatus.IN_PROGRESS, FlowStatus.DOWN);
+                FlowStatus.IN_PROGRESS, FlowStatus.IN_PROGRESS, FlowStatus.UP);
 
         verifyNorthboundErrorResponse(yFlowRerouteHubCarrier, ErrorType.NOT_FOUND);
         verifyYFlowStatus(request.getYFlowId(), FlowStatus.DEGRADED, FlowStatus.UP, FlowStatus.DOWN);
@@ -293,7 +293,7 @@ public class YFlowRerouteServiceTest extends AbstractYFlowTest<SpeakerRequest> {
 
         // when
         service.handleRequest(request.getYFlowId(), new CommandContext(), request);
-        verifyYFlowAndSubFlowStatus(request.getYFlowId(), FlowStatus.IN_PROGRESS);
+        verifyYFlowStatus(request.getYFlowId(), FlowStatus.IN_PROGRESS, FlowStatus.IN_PROGRESS, FlowStatus.UP);
         // and
         handleSpeakerCommandsAndFailInstall(service, request.getYFlowId(), "test_successful_yflow");
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowUpdateServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowUpdateServiceTest.java
@@ -267,7 +267,7 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
 
         // when
         service.handleRequest(request.getYFlowId(), new CommandContext(), request);
-        verifyYFlowAndSubFlowStatus(request.getYFlowId(), FlowStatus.IN_PROGRESS);
+        verifyYFlowStatus(request.getYFlowId(), FlowStatus.IN_PROGRESS, FlowStatus.IN_PROGRESS, FlowStatus.UP);
         // and
         handleSpeakerCommandsAndFailInstall(service, request.getYFlowId(), "test_successful_yflow");
 

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/AvailableNetworkFactory.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/AvailableNetworkFactory.java
@@ -1,4 +1,4 @@
-/* Copyright 2021 Telstra Open Source
+/* Copyright 2022 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -92,8 +92,12 @@ public class AvailableNetworkFactory {
                         .collect(Collectors.toList());
             }
 
+            Collection<PathId> affinityPathIds =
+                    flowPathRepository.findPathIdsByFlowAffinityGroupId(flow.getAffinityGroupId());
             flowPaths.forEach(pathId ->
                     flowPathRepository.findById(pathId)
+                            .filter(flowPath -> !affinityPathIds.contains(flowPath.getPathId())
+                                    || flowPath.getFlowId().equals(flow.getFlowId()))
                             .ifPresent(flowPath -> {
                                 network.processDiversitySegments(flowPath.getSegments(), flow);
                                 network.processDiversitySegmentsWithPop(flowPath.getSegments());


### PR DESCRIPTION
- fixed increasing diverse counters for affinity flows;
- secondary affinity flows start updating/rerouting only after the main affinity flow is fully updated/rerouted.