### PR TITLE
Bumped version of github api and jwt for changelog generator

### DIFF
--- a/tools/changelog-generator/requirements.txt
+++ b/tools/changelog-generator/requirements.txt
@@ -7,8 +7,8 @@ GitPython==2.1.11
 idna==2.8
 Jinja2==2.11.3
 MarkupSafe==1.1.1
-PyGithub==1.43.7
-PyJWT==1.7.1
+PyGithub==1.55
+PyJWT==2.0.0
 requests==2.22.0
 smmap2==2.0.5
 urllib3==1.25.9


### PR DESCRIPTION
prior to this patch generator fails to work on python 3.9