### PR TITLE
Fixed deleteAllFlows endpoint timeout while flow in progress

### DIFF
--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/impl/FlowServiceImpl.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/impl/FlowServiceImpl.java
@@ -404,7 +404,7 @@ public class FlowServiceImpl implements FlowService {
                                 System.currentTimeMillis(),
                                 ErrorType.REQUEST_INVALID,
                                 "Couldn't delete flow",
-                                errorBuilder.append(String.join(",", failedFlows))
+                                errorBuilder.append(String.join(", ", failedFlows))
                                         .toString()));
                     }
                     return result.complete(results);

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/impl/FlowServiceImpl.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/impl/FlowServiceImpl.java
@@ -375,7 +375,8 @@ public class FlowServiceImpl implements FlowService {
         logger.warn("Delete all flows request");
         // TODO: Need a getFlowIDs .. since that is all we need
         CompletableFuture<List<FlowResponsePayload>> getFlowsStage = this.getAllFlows();
-
+        final String correlationId = RequestCorrelationId.getId();
+        List<String> failedFlows = Collections.synchronizedList(new ArrayList<>());
         getFlowsStage.thenApply(flows -> {
             List<CompletableFuture<?>> deletionRequests = new ArrayList<>();
             for (int i = 0; i < flows.size(); i++) {
@@ -385,12 +386,29 @@ public class FlowServiceImpl implements FlowService {
                     // Skip y-sub-flows.
                     continue;
                 }
-                deletionRequests.add(sendDeleteFlow(flow.getId(), requestId));
+                CompletableFuture<FlowResponsePayload> request = sendDeleteFlow(flow.getId(), requestId)
+                        .handle((value, possibleException) -> {
+                            if (possibleException != null) {
+                                failedFlows.add(flow.getId());
+                            }
+                            return value;
+                        });
+                deletionRequests.add(request);
             }
             return deletionRequests;
         }).thenApply(requests -> collectResponses(requests, FlowResponsePayload.class)
-                .thenApply(result::complete));
-
+                .thenApply(results -> {
+                    if (!failedFlows.isEmpty()) {
+                        StringBuilder errorBuilder = new StringBuilder("The following flows haven't been deleted: ");
+                        result.completeExceptionally(new MessageException(correlationId,
+                                System.currentTimeMillis(),
+                                ErrorType.REQUEST_INVALID,
+                                "Couldn't delete flow",
+                                errorBuilder.append(String.join(",", failedFlows))
+                                        .toString()));
+                    }
+                    return result.complete(results);
+                }));
         return result;
     }
 


### PR DESCRIPTION
Response now includes all unsuccessful flow delete requests.
Closes: #4629