### PR TITLE
Add js License files into GUI .gitignore file

### DIFF
--- a/src-gui/.gitignore
+++ b/src-gui/.gitignore
@@ -28,6 +28,7 @@ src/main/webapp/lib/font/*
 src/main/webapp/ui/assets/*
 src/main/webapp/ui/*.js
 src/main/webapp/ui/*.js.map
+src/main/webapp/ui/*.js.LICENSE.txt
 ui/node_modules
 ui/package-lock.json
 src/main/webapp/ui/index.html


### PR DESCRIPTION
Project build generates following files:

```
src-gui/src/main/webapp/ui/main-es2015.7067e5d3b7b9f9def49d.js.LICENSE.txt
src-gui/src/main/webapp/ui/polyfills-es2015.94d3ba46aae3a65c2d88.js.LICENSE.txt
src-gui/src/main/webapp/ui/polyfills-es5-es2015.2b49def4071ac93e81dd.js.LICENSE.txt
src-gui/src/main/webapp/ui/scripts.9badfa832b5fa0740686.js.LICENSE.txt
```

We shoud ignore them