### PR TITLE
Making repeatable builds possible w/o Internet

### DIFF
--- a/docker/db-migration/Dockerfile
+++ b/docker/db-migration/Dockerfile
@@ -50,19 +50,32 @@ RUN GNUPGHOME="$(mktemp -d)"
 
 # Download JDBC libraries and plugins
 
-ADD --chown=liquibase:liquibase https://repo1.maven.org/maven2/com/orientechnologies/orientdb-jdbc/3.0.34/orientdb-jdbc-3.0.34-all.jar /liquibase/lib/orientdb-jdbc-3.0.34-all.jar
-#ADD --chown=liquibase:liquibase https://dl.bintray.com/till-krullmann/tools/org/unbroken-dome/liquibase-orientdb/liquibase-orientdb/0.3.0/liquibase-orientdb-0.3.0.jar /liquibase/lib/liquibase-orientdb-0.3.0.jar
-COPY --chown=liquibase:liquibase lib/liquibase-orientdb-0.3.0.jar /liquibase/lib/liquibase-orientdb-0.3.0.jar
+RUN set -x \
+  && mkdir -p /liquibase/lib/ \
+  && wget -O /liquibase/lib/orientdb-jdbc-3.0.34-all.jar \
+             "https://repo1.maven.org/maven2/com/orientechnologies/orientdb-jdbc/3.0.34/orientdb-jdbc-3.0.34-all.jar"  \
+  # && wget -O /liquibase/lib/liquibase-orientdb-0.3.0.jar \
+  #            "https://dl.bintray.com/till-krullmann/tools/org/unbroken-dome/liquibase-orientdb/liquibase-orientdb/0.3.0/liquibase-orientdb-0.3.0.jar"  \
+  # black magic satisfying dependencies of `liquibase-orientdb-0.3.0.jar`
+  && wget -O /liquibase/lib/commons-lang3-3.6.jar \
+             "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.6/commons-lang3-3.6.jar" \
+  && wget -O /liquibase/lib/commons-beanutils-1.9.2.jar \
+             "https://repo1.maven.org/maven2/commons-beanutils/commons-beanutils/1.9.2/commons-beanutils-1.9.2.jar" \
+  && wget -O /liquibase/lib/guava-23.3-jre.jar \
+             "https://repo1.maven.org/maven2/com/google/guava/guava/23.3-jre/guava-23.3-jre.jar" \
+  && wget -O /liquibase/lib/validation-api-1.1.0.Final.jar \
+             "https://repo1.maven.org/maven2/javax/validation/validation-api/1.1.0.Final/validation-api-1.1.0.Final.jar" \
+  && wget -O /liquibase/lib/hibernate-validator-5.2.4.Final.jar \
+             "https://repo1.maven.org/maven2/org/hibernate/hibernate-validator/5.2.4.Final/hibernate-validator-5.2.4.Final.jar" \
+  && wget -O /liquibase/lib/jackson-databind-2.6.7.jar \
+             "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.6.7/jackson-databind-2.6.7.jar" \
+  && wget -O /liquibase/lib/jboss-logging-3.2.1.Final.jar \
+             "https://repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.2.1.Final/jboss-logging-3.2.1.Final.jar" \
+  && wget -O /liquibase/lib/classmate-1.1.0.jar \
+             "https://repo1.maven.org/maven2/com/fasterxml/classmate/1.1.0/classmate-1.1.0.jar" \
+  && chown -R liquibase:liquibase /liquibase/lib/
 
-# black magic satisfying dependencies of `liquibase-orientdb-0.3.0.jar`
-ADD --chown=liquibase:liquibase https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.6/commons-lang3-3.6.jar /liquibase/lib/commons-lang3-3.6.jar
-ADD --chown=liquibase:liquibase https://repo1.maven.org/maven2/commons-beanutils/commons-beanutils/1.9.2/commons-beanutils-1.9.2.jar /liquibase/lib/commons-beanutils-1.9.2.jar
-ADD --chown=liquibase:liquibase https://repo1.maven.org/maven2/com/google/guava/guava/23.3-jre/guava-23.3-jre.jar /liquibase/lib/guava-23.3-jre.jar
-ADD --chown=liquibase:liquibase https://repo1.maven.org/maven2/javax/validation/validation-api/1.1.0.Final/validation-api-1.1.0.Final.jar /liquibase/lib/validation-api-1.1.0.Final.jar
-ADD --chown=liquibase:liquibase https://repo1.maven.org/maven2/org/hibernate/hibernate-validator/5.2.4.Final/hibernate-validator-5.2.4.Final.jar /liquibase/lib/hibernate-validator-5.2.4.Final.jar
-ADD --chown=liquibase:liquibase https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.6.7/jackson-databind-2.6.7.jar /liquibase/lib/jackson-databind-2.6.7.jar
-ADD --chown=liquibase:liquibase https://repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.2.1.Final/jboss-logging-3.2.1.Final.jar /liquibase/lib/jboss-logging-3.2.1.Final.jar
-ADD --chown=liquibase:liquibase https://repo1.maven.org/maven2/com/fasterxml/classmate/1.1.0/classmate-1.1.0.jar /liquibase/lib/classmate-1.1.0.jar
+COPY --chown=liquibase:liquibase lib/liquibase-orientdb-0.3.0.jar /liquibase/lib/liquibase-orientdb-0.3.0.jar
 
 ENV KILDA_ORIENTDB_USER=kilda
 ENV KILDA_ORIENTDB_PASSWORD=kilda

--- a/src-gui/Makefile
+++ b/src-gui/Makefile
@@ -1,13 +1,13 @@
 APP := openkilda-gui
 
-rebuild: clean clean-java build
+rebuild: clean clean-java clean-cache build
 
-build:  clean-cache build/libs/${APP}.war
+build: build/libs/${APP}.war
 
 build/libs/${APP}.war: .deps/node .deps/resources
 	./gradlew build
 
-.deps/node: .deps
+.deps/node: | .deps
 	docker run --rm -e LOCAL_UID=`id -u $(USER)` -e LOCAL_GID=`id -g $(USER)` -v $(CURDIR)/src:/app/src -v $(CURDIR)/ui:/app/ui node:14.17-alpine  \
 		sh -c 'npm cache clean -f && npm install -g @angular/cli@12.0.0 --unsafe-perm && cd /app/ui && npm install && ng build --prod && chown -R $$LOCAL_UID:$$LOCAL_GID /app/src /app/ui'
 	touch $@


### PR DESCRIPTION
Few fixes to make repeatable builds possible w/o Internet:
* in `db_migration` Dockerfile replaced ADD with wget as docker ADD instruction downloads files each time for getting SHA hash of each file
* in `src-gui` Makefile removed cleaning caches each time