### PR TITLE
Fixed incorrect flow sharding in FlowMonitoring topology

### DIFF
--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/service/ActionService.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/service/ActionService.java
@@ -135,13 +135,19 @@ public class ActionService implements FlowSlaMonitoringCarrier {
             log.debug("Processing flow SLA checks for shard {}", shardNumber);
         }
         for (FsmKey key : fsms.keySet()) {
-            if (key.flowId.hashCode() % shardCount == shardNumber) {
+            if (needToCheckSla(key.flowId.hashCode(), shardNumber)) {
                 if (log.isTraceEnabled()) {
                     log.trace("Processing SLA check for flow FSM {}: Shard number: {}", key, shardNumber);
                 }
                 fsmExecutor.fire(fsms.get(key), Event.TICK, context);
             }
         }
+    }
+
+    @VisibleForTesting
+    boolean needToCheckSla(int hashCode, int shardNumber) {
+        // hashCode can be negative, so we can't use expression `hashCode() % shardCount == shardNumber`
+        return (hashCode + shardNumber) % shardCount == 0;
     }
 
     private FsmKey getFsmKey(String flowId, FlowDirection direction) {

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/test/java/org/openkilda/wfm/topology/flowmonitoring/service/ActionServiceTest.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/test/java/org/openkilda/wfm/topology/flowmonitoring/service/ActionServiceTest.java
@@ -351,4 +351,24 @@ public class ActionServiceTest extends InMemoryGraphBasedTest {
 
         verifyNoMoreInteractions(carrier);
     }
+
+    @Test
+    public void needToCheckSlaTest() {
+        int shardCount = 4;
+        ActionService testService = new ActionService(
+                carrier, persistenceManager, clock, TIMEOUT, THRESHOLD, shardCount);
+        int[] shardChecks = new int[shardCount];
+        for (int hash = -20; hash < 20; hash++) {
+            for (int shard = 0; shard < shardCount; shard++) {
+                if (testService.needToCheckSla(hash, shard)) {
+                    shardChecks[shard]++;
+                }
+            }
+        }
+
+        assertEquals(10, shardChecks[0]);
+        assertEquals(10, shardChecks[1]);
+        assertEquals(10, shardChecks[2]);
+        assertEquals(10, shardChecks[3]);
+    }
 }


### PR DESCRIPTION
Following expression was used for sharding:
`hashCode() % shardCount == shardNumber`

But it's incorrect because hash can be negative. In this case
`hashCode() % shardCount` will be negative too and never be equal to
positive `shardNumber`