### PR TITLE
Added separate option for action bolt parallelism in flow monitoring topology

### DIFF
--- a/confd/templates/flowmonitoring-topology/flowmonitoring-topology.tmpl
+++ b/confd/templates/flowmonitoring-topology/flowmonitoring-topology.tmpl
@@ -17,3 +17,5 @@ bolts:
     parallelism: 1
   - id: "FLOW_STATE_CACHE_BOLT"
     parallelism: 1
+  - id: "ACTION_BOLT"
+    parallelism: {{ getv "/kilda_storm_flow_monitoring_action_bolt_parallelism" }}

--- a/confd/vars/main.yaml
+++ b/confd/vars/main.yaml
@@ -177,6 +177,7 @@ kilda_storm_stats_parallelism: 1 # must be 1 until bug https://github.com/telstr
 kilda_storm_spout_parallelism: 2
 
 kilda_storm_flow_monitoring_parallelism: 2
+kilda_storm_flow_monitoring_action_bolt_parallelism: 2
 
 kilda_storm_disruptor_wait_timeout: 1000
 kilda_storm_disruptor_batch_timeout: 10


### PR DESCRIPTION
Action Bolt is high loaded bolt so we need to change its parallelism separately 