### PR TITLE
Added query parameter to /api/v1/network/paths for limiting amount of computed paths

### DIFF
--- a/confd/templates/base-storm-topology/topology.properties.tmpl
+++ b/confd/templates/base-storm-topology/topology.properties.tmpl
@@ -113,6 +113,7 @@ local.execution.time = 3000
 #######
 # Path computation engine
 pce.network.strategy = {{ getv "/kilda_pce_network_strategy" }}
+pce.max.path.count = {{ getv "/kilda_pce_max_path_count" }}
 #######
 # cost strategy params
 # value added to path weight for each isl used in the same diversity group

--- a/confd/vars/main.yaml
+++ b/confd/vars/main.yaml
@@ -123,6 +123,7 @@ kilda_bfd_interval_ms: 350
 kilda_bfd_multiplier: 3
 
 kilda_pce_network_strategy: "SYMMETRIC_COST"
+kilda_pce_max_path_count: 500
 
 kilda_floodlight_alive_timeout: 10
 kilda_floodlight_alive_interval: 2

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/PathComputerConfig.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/PathComputerConfig.java
@@ -24,6 +24,10 @@ import java.io.Serializable;
 @Configuration
 @Key("pce")
 public interface PathComputerConfig extends Serializable {
+    @Key("max.path.count")
+    @Default("500")
+    int getMaxPathCount();
+
     @Key("max.allowed.depth")
     @Default("35")
     int getMaxAllowedDepth();

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetPathsRequest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetPathsRequest.java
@@ -49,17 +49,22 @@ public class GetPathsRequest extends BaseRequest {
     @JsonProperty("max_latency_tier2")
     Duration maxLatencyTier2;
 
+    @JsonProperty("max_path_count")
+    Integer maxPathCount;
+
     public GetPathsRequest(@JsonProperty("src_switch_id") SwitchId srcSwitchId,
                            @JsonProperty("dst_switch_id") SwitchId dstSwitchId,
                            @JsonProperty("encapsulation_type") FlowEncapsulationType encapsulationType,
                            @JsonProperty("path_computation_strategy") PathComputationStrategy pathComputationStrategy,
                            @JsonProperty("max_latency") Duration maxLatency,
-                           @JsonProperty("max_latency_tier2") Duration maxLatencyTier2) {
+                           @JsonProperty("max_latency_tier2") Duration maxLatencyTier2,
+                           @JsonProperty("max_path_count") Integer maxPathCount) {
         this.srcSwitchId = srcSwitchId;
         this.dstSwitchId = dstSwitchId;
         this.encapsulationType = encapsulationType;
         this.pathComputationStrategy = pathComputationStrategy;
         this.maxLatency = maxLatency;
         this.maxLatencyTier2 = maxLatencyTier2;
+        this.maxPathCount = maxPathCount;
     }
 }

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/PathsBolt.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/PathsBolt.java
@@ -66,7 +66,7 @@ public class PathsBolt extends PersistenceOperationsBolt {
         try {
             return pathService.getPaths(request.getSrcSwitchId(), request.getDstSwitchId(),
                     request.getEncapsulationType(), request.getPathComputationStrategy(), request.getMaxLatency(),
-                    request.getMaxLatencyTier2());
+                    request.getMaxLatencyTier2(), request.getMaxPathCount());
         } catch (IllegalArgumentException e) {
             throw new MessageException(ErrorType.DATA_INVALID, e.getMessage(), "Bad request.");
         } catch (RecoverableException e) {

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/topology/nbworker/services/PathsServiceTest.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/topology/nbworker/services/PathsServiceTest.java
@@ -17,12 +17,13 @@ package org.openkilda.wfm.topology.nbworker.services;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.openkilda.model.FlowEncapsulationType.TRANSIT_VLAN;
 import static org.openkilda.model.FlowEncapsulationType.VXLAN;
 import static org.openkilda.model.PathComputationStrategy.COST;
 import static org.openkilda.model.PathComputationStrategy.LATENCY;
 import static org.openkilda.model.PathComputationStrategy.MAX_LATENCY;
-import static org.openkilda.wfm.topology.nbworker.services.PathsService.MAX_PATH_COUNT;
 
 import org.openkilda.config.provider.PropertiesBasedConfigurationProvider;
 import org.openkilda.messaging.info.network.PathsInfoData;
@@ -56,6 +57,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class PathsServiceTest extends InMemoryGraphBasedTest {
+    private static final int MAX_PATH_COUNT = 500;
     private static final int SWITCH_COUNT = MAX_PATH_COUNT + 50;
     private static final int VXLAN_SWITCH_COUNT = MAX_PATH_COUNT / 2;
 
@@ -134,7 +136,8 @@ public class PathsServiceTest extends InMemoryGraphBasedTest {
     @Test
     public void findNPathsByTransitVlanAndCost()
             throws SwitchNotFoundException, RecoverableException, UnroutableFlowException {
-        List<PathsInfoData> paths = pathsService.getPaths(SWITCH_ID_1, SWITCH_ID_2, TRANSIT_VLAN, COST, null, null);
+        List<PathsInfoData> paths = pathsService.getPaths(
+                SWITCH_ID_1, SWITCH_ID_2, TRANSIT_VLAN, COST, null, null, MAX_PATH_COUNT);
 
         assertEquals(MAX_PATH_COUNT, paths.size());
         assertPathLength(paths);
@@ -153,8 +156,8 @@ public class PathsServiceTest extends InMemoryGraphBasedTest {
     @Test
     public void findNPathsByTransitVlanIgnoreMaxLatency()
             throws SwitchNotFoundException, RecoverableException, UnroutableFlowException {
-        List<PathsInfoData> paths = pathsService.getPaths(
-                SWITCH_ID_1, SWITCH_ID_2, TRANSIT_VLAN, LATENCY, Duration.ofNanos(1L), Duration.ofNanos(2L));
+        List<PathsInfoData> paths = pathsService.getPaths(SWITCH_ID_1, SWITCH_ID_2, TRANSIT_VLAN, LATENCY,
+                Duration.ofNanos(1L), Duration.ofNanos(2L), MAX_PATH_COUNT);
         assertTransitVlanAndLatencyPaths(paths);
     }
 
@@ -163,23 +166,23 @@ public class PathsServiceTest extends InMemoryGraphBasedTest {
             throws SwitchNotFoundException, RecoverableException, UnroutableFlowException {
         Duration maxLatency = Duration.ofNanos(MIN_LATENCY * 2 + 1);
         List<PathsInfoData> paths = pathsService.getPaths(
-                SWITCH_ID_1, SWITCH_ID_2, VXLAN, MAX_LATENCY, maxLatency, Duration.ZERO);
+                SWITCH_ID_1, SWITCH_ID_2, VXLAN, MAX_LATENCY, maxLatency, Duration.ZERO, MAX_PATH_COUNT);
         assertMaxLatencyPaths(paths, maxLatency, 1, VXLAN);
     }
 
     @Test
     public void findNPathsByTransitVlanAndTooSmallMaxLatency()
             throws SwitchNotFoundException, RecoverableException, UnroutableFlowException {
-        List<PathsInfoData> paths = pathsService.getPaths(
-                SWITCH_ID_1, SWITCH_ID_2, TRANSIT_VLAN, MAX_LATENCY, Duration.ofNanos(1L), Duration.ZERO);
+        List<PathsInfoData> paths = pathsService.getPaths(SWITCH_ID_1, SWITCH_ID_2, TRANSIT_VLAN,
+                MAX_LATENCY, Duration.ofNanos(1L), Duration.ZERO, MAX_PATH_COUNT);
         assertTrue(paths.isEmpty());
     }
 
     @Test
     public void findNPathsByTransitVlanAndTooSmallMaxLatencyAndTier2Latency()
             throws SwitchNotFoundException, RecoverableException, UnroutableFlowException {
-        List<PathsInfoData> paths = pathsService.getPaths(
-                SWITCH_ID_1, SWITCH_ID_2, TRANSIT_VLAN, MAX_LATENCY, Duration.ofNanos(1L), Duration.ofNanos(2L));
+        List<PathsInfoData> paths = pathsService.getPaths(SWITCH_ID_1, SWITCH_ID_2, TRANSIT_VLAN,
+                MAX_LATENCY, Duration.ofNanos(1L), Duration.ofNanos(2L), MAX_PATH_COUNT);
         assertTrue(paths.isEmpty());
     }
 
@@ -187,8 +190,8 @@ public class PathsServiceTest extends InMemoryGraphBasedTest {
     public void findNPathsByTransitVlanAndTooSmallMaxLatencyEnoughTier2Latency()
             throws SwitchNotFoundException, RecoverableException, UnroutableFlowException {
         Duration maxLatencyTier2 = Duration.ofNanos(MIN_LATENCY * 2 + 1);
-        List<PathsInfoData> paths = pathsService.getPaths(
-                SWITCH_ID_1, SWITCH_ID_2, TRANSIT_VLAN, MAX_LATENCY, Duration.ofNanos(1L), maxLatencyTier2);
+        List<PathsInfoData> paths = pathsService.getPaths(SWITCH_ID_1, SWITCH_ID_2, TRANSIT_VLAN, MAX_LATENCY,
+                Duration.ofNanos(1L), maxLatencyTier2, MAX_PATH_COUNT);
         assertMaxLatencyPaths(paths, maxLatencyTier2, 1, TRANSIT_VLAN);
     }
 
@@ -197,7 +200,7 @@ public class PathsServiceTest extends InMemoryGraphBasedTest {
             throws SwitchNotFoundException, RecoverableException, UnroutableFlowException {
         // as max latency param is 0 LATENCY starategy will be used instead. It means all 500 paths will be returned
         List<PathsInfoData> paths = pathsService.getPaths(
-                SWITCH_ID_1, SWITCH_ID_2, TRANSIT_VLAN, MAX_LATENCY, Duration.ZERO, null);
+                SWITCH_ID_1, SWITCH_ID_2, TRANSIT_VLAN, MAX_LATENCY, Duration.ZERO, null, MAX_PATH_COUNT);
         assertTransitVlanAndLatencyPaths(paths);
     }
 
@@ -206,34 +209,45 @@ public class PathsServiceTest extends InMemoryGraphBasedTest {
             throws SwitchNotFoundException, RecoverableException, UnroutableFlowException {
         // as max latency param is null LATENCY starategy will be used instead. It means all 500 paths will be returned
         List<PathsInfoData> paths = pathsService.getPaths(SWITCH_ID_1, SWITCH_ID_2, TRANSIT_VLAN, MAX_LATENCY, null,
-                null);
+                null, MAX_PATH_COUNT);
         assertTransitVlanAndLatencyPaths(paths);
     }
 
     @Test
     public void findNPathsByTransitVlanAndLatency()
             throws SwitchNotFoundException, RecoverableException, UnroutableFlowException {
-        List<PathsInfoData> paths = pathsService.getPaths(SWITCH_ID_1, SWITCH_ID_2, TRANSIT_VLAN, LATENCY, null, null);
+        List<PathsInfoData> paths = pathsService.getPaths(SWITCH_ID_1, SWITCH_ID_2, TRANSIT_VLAN, LATENCY,
+                null, null, MAX_PATH_COUNT);
         assertTransitVlanAndLatencyPaths(paths);
     }
 
     @Test
     public void findNPathsByVxlanAndCost()
             throws SwitchNotFoundException, RecoverableException, UnroutableFlowException {
-        List<PathsInfoData> paths = pathsService.getPaths(SWITCH_ID_1, SWITCH_ID_2, VXLAN, COST, null, null);
+        List<PathsInfoData> paths = pathsService.getPaths(SWITCH_ID_1, SWITCH_ID_2, VXLAN, COST, null,
+                null, MAX_PATH_COUNT);
         assertVxlanAndCostPathes(paths);
+    }
+
+    @Test
+    public void findNPathsByMaxPathCount()
+            throws UnroutableFlowException, SwitchNotFoundException, RecoverableException {
+        int maxPathCount = 3;
+        List<PathsInfoData> paths = pathsService.getPaths(SWITCH_ID_1, SWITCH_ID_2, VXLAN, COST, null,
+                null, maxPathCount);
+        assertThat(paths.size(), equalTo(maxPathCount));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void findNPathsByVxlanSrcWithoutVxlanSupport()
             throws SwitchNotFoundException, RecoverableException, UnroutableFlowException {
-        pathsService.getPaths(SWITCH_ID_3, SWITCH_ID_2, VXLAN, COST, null, null);
+        pathsService.getPaths(SWITCH_ID_3, SWITCH_ID_2, VXLAN, COST, null, null, MAX_PATH_COUNT);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void findNPathsByVxlanDstWithoutVxlanSupport()
             throws SwitchNotFoundException, RecoverableException, UnroutableFlowException {
-        pathsService.getPaths(SWITCH_ID_2, SWITCH_ID_3, VXLAN, COST, null, null);
+        pathsService.getPaths(SWITCH_ID_2, SWITCH_ID_3, VXLAN, COST, null, null, MAX_PATH_COUNT);
     }
 
     @Test
@@ -244,7 +258,8 @@ public class PathsServiceTest extends InMemoryGraphBasedTest {
             config.setPathComputationStrategy(LATENCY);
         });
         // find N paths without strategy
-        List<PathsInfoData> paths = pathsService.getPaths(SWITCH_ID_1, SWITCH_ID_2, TRANSIT_VLAN, null, null, null);
+        List<PathsInfoData> paths = pathsService.getPaths(SWITCH_ID_1, SWITCH_ID_2, TRANSIT_VLAN,
+                null, null, null, MAX_PATH_COUNT);
         assertTransitVlanAndLatencyPaths(paths);
     }
 
@@ -256,7 +271,8 @@ public class PathsServiceTest extends InMemoryGraphBasedTest {
             config.setFlowEncapsulationType(VXLAN);
         });
         // find N paths without encapsulation type
-        List<PathsInfoData> paths = pathsService.getPaths(SWITCH_ID_1, SWITCH_ID_2, null, COST, null, null);
+        List<PathsInfoData> paths = pathsService.getPaths(SWITCH_ID_1, SWITCH_ID_2, null, COST,
+                null, null, MAX_PATH_COUNT);
         assertVxlanAndCostPathes(paths);
     }
 

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/controller/v1/NetworkController.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/controller/v1/NetworkController.java
@@ -73,8 +73,8 @@ public class NetworkController extends BaseController {
                     + "max_latency, max_latency_tier2 with be used instead. Used only with MAX_LATENCY strategy. "
                     + "Other strategies will ignore this parameter.")
             @RequestParam(value = "max_latency_tier2", required = false) Long maxLatencyTier2Ms,
-            @ApiParam(value = "Maximum count of paths which will be calculated. " +
-                    "If maximum path count is not specified, default value from Kilda Configuration will be used")
+            @ApiParam(value = "Maximum count of paths which will be calculated. "
+                    + "If maximum path count is not specified, default value from Kilda Configuration will be used")
             @RequestParam(value = "max_path_count", required = false) Integer maxPathCount) {
 
         Duration maxLatency = maxLatencyMs != null ? Duration.ofMillis(maxLatencyMs) : null;

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/controller/v1/NetworkController.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/controller/v1/NetworkController.java
@@ -72,14 +72,16 @@ public class NetworkController extends BaseController {
             @ApiParam(value = "Second tier for flow path latency in milliseconds. If there is no path with required "
                     + "max_latency, max_latency_tier2 with be used instead. Used only with MAX_LATENCY strategy. "
                     + "Other strategies will ignore this parameter.")
-            @RequestParam(value = "max_latency_tier2", required = false)
-                    Long maxLatencyTier2Ms) {
+            @RequestParam(value = "max_latency_tier2", required = false) Long maxLatencyTier2Ms,
+            @ApiParam(value = "Maximum count of paths which will be calculated. " +
+                    "If maximum path count is not specified, default value from Kilda Configuration will be used")
+            @RequestParam(value = "max_path_count", required = false) Integer maxPathCount) {
 
         Duration maxLatency = maxLatencyMs != null ? Duration.ofMillis(maxLatencyMs) : null;
         Duration maxLatencyTier2 = maxLatencyTier2Ms != null ? Duration.ofMillis(maxLatencyTier2Ms) : null;
 
         return networkService.getPaths(srcSwitchId, dstSwitchId, encapsulationType, pathComputationStrategy, maxLatency,
-                maxLatencyTier2);
+                maxLatencyTier2, maxPathCount);
     }
 
     /**

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/NetworkService.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/NetworkService.java
@@ -33,5 +33,6 @@ public interface NetworkService {
      */
     CompletableFuture<PathsDto> getPaths(
             SwitchId srcSwitch, SwitchId dstSwitch, FlowEncapsulationType encapsulationType,
-            PathComputationStrategy pathComputationStrategy, Duration maxLatencyMs, Duration maxLatencyTier2);
+            PathComputationStrategy pathComputationStrategy, Duration maxLatencyMs, Duration maxLatencyTier2,
+            Integer maxPathCount);
 }

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/impl/NetworkServiceImpl.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/impl/NetworkServiceImpl.java
@@ -61,6 +61,11 @@ public class NetworkServiceImpl implements NetworkService {
             Integer maxPathCount) {
         String correlationId = RequestCorrelationId.getId();
 
+        if (maxPathCount != null && maxPathCount <= 0) {
+            throw new MessageException(correlationId, System.currentTimeMillis(), ErrorType.PARAMETERS_INVALID,
+                    "Bad max_path_count parameter", "The number MAX_PATH_COUNT should be positive");
+        }
+
         if (PathComputationStrategy.MAX_LATENCY.equals(pathComputationStrategy) && maxLatency == null) {
             throw new MessageException(correlationId, System.currentTimeMillis(), ErrorType.PARAMETERS_INVALID,
                     "Missed max_latency parameter.", "MAX_LATENCY path computation strategy requires non null "

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/impl/NetworkServiceImpl.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/impl/NetworkServiceImpl.java
@@ -57,7 +57,8 @@ public class NetworkServiceImpl implements NetworkService {
     @Override
     public CompletableFuture<PathsDto> getPaths(
             SwitchId srcSwitch, SwitchId dstSwitch, FlowEncapsulationType encapsulationType,
-            PathComputationStrategy pathComputationStrategy, Duration maxLatency, Duration maxLatencyTier2) {
+            PathComputationStrategy pathComputationStrategy, Duration maxLatency, Duration maxLatencyTier2,
+            Integer maxPathCount) {
         String correlationId = RequestCorrelationId.getId();
 
         if (PathComputationStrategy.MAX_LATENCY.equals(pathComputationStrategy) && maxLatency == null) {
@@ -68,7 +69,7 @@ public class NetworkServiceImpl implements NetworkService {
         }
 
         GetPathsRequest request = new GetPathsRequest(srcSwitch, dstSwitch, encapsulationType, pathComputationStrategy,
-                maxLatency, maxLatencyTier2);
+                maxLatency, maxLatencyTier2, maxPathCount);
         CommandMessage message = new CommandMessage(request, System.currentTimeMillis(), correlationId);
 
         return messagingChannel.sendAndGetChunked(nbworkerTopic, message)


### PR DESCRIPTION
To avoid "Operation has timed out" on /api/v1/network/paths, added a query parameter max_path_count to reduce the time for calculations.

If max_path_count is not specified, then will be used default value which can be configured via topology.properties.