### PR TITLE
Unignore test according to #3847

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortAntiflapSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortAntiflapSpec.groovy
@@ -23,7 +23,6 @@ import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
-import spock.lang.Ignore
 import spock.lang.Isolated
 import spock.lang.Issue
 import spock.lang.Narrative
@@ -181,7 +180,6 @@ timeout"() {
      * directly to kafka, because currently it is the only way to simulate an incredibly rapid port flapping that
      * may sometimes occur on hardware switches(overheat?)
      */
-    @Ignore("https://github.com/telstra/open-kilda/issues/3847")
     @Tags(SMOKE)
     def "System properly registers events order when port flaps incredibly fast (end with Down)"() {
 


### PR DESCRIPTION
The bug described in the issue #3847 is not reproduced. Therefore, the `Ignore` annotation has been removed from the associated test.

Closes: #3847