### PR TITLE
Added "discover new isls in under maintenance mode" feature with toggle;

### DIFF
--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/system/FeatureTogglesDto.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/system/FeatureTogglesDto.java
@@ -68,6 +68,9 @@ public class FeatureTogglesDto implements Serializable {
     @JsonProperty("sync_switch_on_connect")
     private Boolean syncSwitchOnConnect;
 
+    @JsonProperty("discover_new_isls_in_under_maintenance_mode")
+    private Boolean discoverNewIslsInUnderMaintenanceMode;
+
     @JsonCreator
     public FeatureTogglesDto(@JsonProperty("flows_reroute_on_isl_discovery") Boolean flowsRerouteOnIslDiscoveryEnabled,
                              @JsonProperty("create_flow") Boolean createFlowEnabled,
@@ -83,7 +86,9 @@ public class FeatureTogglesDto implements Serializable {
                                          Boolean flowLatencyMonitoringReactions,
                              @JsonProperty("server42_isl_rtt") Boolean server42IslRtt,
                              @JsonProperty("modify_y_flow_enabled") Boolean modifyYFlowEnabled,
-                             @JsonProperty("sync_switch_on_connect") Boolean syncSwitchOnConnect) {
+                             @JsonProperty("sync_switch_on_connect") Boolean syncSwitchOnConnect,
+                             @JsonProperty("discover_new_isls_in_under_maintenance_mode")
+                                 Boolean discoverNewIslsInUnderMaintenanceMode) {
         this.flowsRerouteOnIslDiscoveryEnabled = flowsRerouteOnIslDiscoveryEnabled;
         this.createFlowEnabled = createFlowEnabled;
         this.updateFlowEnabled = updateFlowEnabled;
@@ -97,5 +102,6 @@ public class FeatureTogglesDto implements Serializable {
         this.server42IslRtt = server42IslRtt;
         this.modifyYFlowEnabled = modifyYFlowEnabled;
         this.syncSwitchOnConnect = syncSwitchOnConnect;
+        this.discoverNewIslsInUnderMaintenanceMode = discoverNewIslsInUnderMaintenanceMode;
     }
 }

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/KildaFeatureToggles.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/KildaFeatureToggles.java
@@ -55,6 +55,7 @@ public class KildaFeatureToggles implements CompositeDataEntity<KildaFeatureTogg
             .server42IslRtt(false)
             .modifyYFlowEnabled(false)
             .syncSwitchOnConnect(true)
+            .discoverNewIslsInUnderMaintenanceMode(false)
             .build();
 
     @Getter
@@ -86,7 +87,8 @@ public class KildaFeatureToggles implements CompositeDataEntity<KildaFeatureTogg
                                Boolean floodlightRoutePeriodicSync,
                                Boolean flowsRerouteUsingDefaultEncapType, Boolean collectGrpcStats,
                                Boolean server42FlowRtt, Boolean flowLatencyMonitoringReactions,
-                               Boolean server42IslRtt, Boolean modifyYFlowEnabled, Boolean syncSwitchOnConnect) {
+                               Boolean server42IslRtt, Boolean modifyYFlowEnabled, Boolean syncSwitchOnConnect,
+                               Boolean discoverNewIslsInUnderMaintenanceMode) {
         data = KildaFeatureTogglesDataImpl.builder()
                 .flowsRerouteOnIslDiscoveryEnabled(flowsRerouteOnIslDiscoveryEnabled)
                 .createFlowEnabled(createFlowEnabled).updateFlowEnabled(updateFlowEnabled)
@@ -99,6 +101,7 @@ public class KildaFeatureToggles implements CompositeDataEntity<KildaFeatureTogg
                 .flowLatencyMonitoringReactions(flowLatencyMonitoringReactions)
                 .modifyYFlowEnabled(modifyYFlowEnabled)
                 .syncSwitchOnConnect(syncSwitchOnConnect)
+                .discoverNewIslsInUnderMaintenanceMode(discoverNewIslsInUnderMaintenanceMode)
                 .build();
     }
 
@@ -129,6 +132,7 @@ public class KildaFeatureToggles implements CompositeDataEntity<KildaFeatureTogg
                 .append(getServer42IslRtt(), that.getServer42IslRtt())
                 .append(getModifyYFlowEnabled(), that.getModifyYFlowEnabled())
                 .append(getSyncSwitchOnConnect(), that.getSyncSwitchOnConnect())
+                .append(getDiscoverNewIslsInUnderMaintenanceMode(), that.getDiscoverNewIslsInUnderMaintenanceMode())
                 .isEquals();
     }
 
@@ -139,7 +143,7 @@ public class KildaFeatureToggles implements CompositeDataEntity<KildaFeatureTogg
                 getUseBfdForIslIntegrityCheck(), getFloodlightRoutePeriodicSync(),
                 getFlowsRerouteUsingDefaultEncapType(), getCollectGrpcStats(), getServer42FlowRtt(),
                 getFlowLatencyMonitoringReactions(), getServer42IslRtt(), getModifyYFlowEnabled(),
-                getSyncSwitchOnConnect());
+                getSyncSwitchOnConnect(), getDiscoverNewIslsInUnderMaintenanceMode());
     }
 
     /**
@@ -197,6 +201,10 @@ public class KildaFeatureToggles implements CompositeDataEntity<KildaFeatureTogg
         Boolean getSyncSwitchOnConnect();
 
         void setSyncSwitchOnConnect(Boolean syncSwitchOnConnect);
+
+        Boolean getDiscoverNewIslsInUnderMaintenanceMode();
+
+        void setDiscoverNewIslsInUnderMaintenanceMode(Boolean discoverNewIslsInUnderMaintenanceMode);
     }
 
     /**
@@ -221,6 +229,7 @@ public class KildaFeatureToggles implements CompositeDataEntity<KildaFeatureTogg
         Boolean server42IslRtt;
         Boolean modifyYFlowEnabled;
         Boolean syncSwitchOnConnect;
+        Boolean discoverNewIslsInUnderMaintenanceMode;
     }
 
     /**
@@ -287,6 +296,9 @@ public class KildaFeatureToggles implements CompositeDataEntity<KildaFeatureTogg
             }
             if (target.getSyncSwitchOnConnect() == null) {
                 target.setSyncSwitchOnConnect(source.getSyncSwitchOnConnect());
+            }
+            if (target.getDiscoverNewIslsInUnderMaintenanceMode() == null) {
+                target.setDiscoverNewIslsInUnderMaintenanceMode(source.getDiscoverNewIslsInUnderMaintenanceMode());
             }
         }
     }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/frames/KildaFeatureTogglesFrame.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/frames/KildaFeatureTogglesFrame.java
@@ -125,4 +125,12 @@ public abstract class KildaFeatureTogglesFrame extends KildaBaseVertexFrame impl
     @Override
     @Property("sync_switch_on_connect")
     public abstract void setSyncSwitchOnConnect(Boolean syncSwitchOnConnect);
+
+    @Override
+    @Property("discover_new_isls_in_under_maintenance_mode")
+    public abstract Boolean getDiscoverNewIslsInUnderMaintenanceMode();
+
+    @Override
+    @Property("discover_new_isls_in_under_maintenance_mode")
+    public abstract void setDiscoverNewIslsInUnderMaintenanceMode(Boolean discoverNewIslsInUnderMaintenanceMode);
 }

--- a/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/controller/isl/IslFsm.java
+++ b/src-java/network-topology/network-storm-topology/src/main/java/org/openkilda/wfm/topology/network/controller/isl/IslFsm.java
@@ -549,9 +549,7 @@ public final class IslFsm extends AbstractBaseFsm<IslFsm, IslFsmState, IslFsmEve
                 .srcPort(sourceEndpoint.getPortNumber())
                 .destSwitch(dest.getSw())
                 .destPort(destEndpoint.getPortNumber())
-                .underMaintenance(source.getSw().isUnderMaintenance()
-                        || dest.getSw().isUnderMaintenance()
-                        || shouldDiscoverNewIslInUnderMaintenance(source, dest));
+                .underMaintenance(isUnderMaintenance(source, dest));
         initializeFromLinkProps(sourceEndpoint, destEndpoint, islBuilder);
         Isl link = islBuilder.build();
 
@@ -560,17 +558,10 @@ public final class IslFsm extends AbstractBaseFsm<IslFsm, IslFsmState, IslFsmEve
         return link;
     }
 
-    private Boolean shouldDiscoverNewIslInUnderMaintenance(Anchor source, Anchor dest) {
-        boolean isFeatureToggleEnabled = featureTogglesRepository.getOrDefault()
-                .getDiscoverNewIslsInUnderMaintenanceMode();
-        if (!isFeatureToggleEnabled) {
-            return false;
-        }
-        Optional<Isl> storedIsl = islRepository.findByPartialEndpoints(
-                source.getSw().getSwitchId(), source.getEndpoint().getPortNumber(),
-                dest.getSw().getSwitchId(), dest.getEndpoint().getPortNumber()
-        ).stream().findAny();
-        return !storedIsl.isPresent();
+    private boolean isUnderMaintenance(Anchor source, Anchor dest) {
+        return featureTogglesRepository.getOrDefault().getDiscoverNewIslsInUnderMaintenanceMode()
+                || source.getSw().isUnderMaintenance()
+                || dest.getSw().isUnderMaintenance();
     }
 
     private Anchor loadSwitchCreateIfMissing(Endpoint endpoint) {


### PR DESCRIPTION
For prevent choosing bad auto-discovered ISLs, I've added a feature which discover new ISLs in  under maintenance mode.

Toggle name: discover_new_isls_in_under_maintenance_mode
Default value: false

Closes #4930