### PR TITLE
Fix flow sync deactivate action

### DIFF
--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/common/FlowHsService.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/common/FlowHsService.java
@@ -26,10 +26,9 @@ public abstract class FlowHsService {
      * Handles deactivate command.
      */
     public boolean deactivate() {
-        boolean isChanged = active;
+        boolean wasActive = active;
         active = false;
-
-        return isChanged;
+        return wasActive;
     }
 
     /**

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/path/FlowPathService.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/path/FlowPathService.java
@@ -114,10 +114,6 @@ public class FlowPathService extends FlowHsService {
 
         registry.remove(requestKey);
         carrier.processFlowPathOperationResults(result);
-
-        if (registry.isEmpty()) {
-            carrier.sendInactive();
-        }
     }
 
     private void ensureNoOperationCollisions(String requestKey, String operationName) throws DuplicateKeyException {


### PR DESCRIPTION
Removing deactivate call triggered at the end of action into
`FlowPathService`. Flow path service is under full controll of
`FlowSyncService` and must not interferr with activate/deactivate
actions on its own.