### PR TITLE
Added parallelism options into flow hs for not loaded bolts

### DIFF
--- a/confd/templates/flowhs-topology/flowhs-topology.tmpl
+++ b/confd/templates/flowhs-topology/flowhs-topology.tmpl
@@ -38,3 +38,33 @@ bolts:
     # That is why we need to increase parallelism of speaker worker at least to flow reroute parallelism
   - id: "SPEAKER_WORKER"
     parallelism: {{ mul (atoi (getv "/kilda_storm_flow_hs_parallelism")) (atoi (getv "/kilda_storm_flow_hs_reroute_hub_count_multiplier")) }}
+  - id: "FLOW_CREATE_HUB"
+    parallelism: {{ getv "/kilda_storm_flow_hs_flow_create_hub_parallelism" }}
+  - id: "FLOW_DELETE_HUB"
+    parallelism: {{ getv "/kilda_storm_flow_hs_flow_delete_hub_parallelism" }}
+  - id: "FLOW_SWAP_ENDPOINTS_HUB"
+    parallelism: {{ getv "/kilda_storm_flow_hs_flow_swap_endpoint_hub_parallelism" }}
+  - id: "FLOW_CREATE_MIRROR_POINT_HUB"
+    parallelism: {{ getv "/kilda_storm_flow_hs_flow_create_mirror_hub_parallelism" }}
+  - id: "FLOW_DELETE_MIRROR_POINT_HUB"
+    parallelism: {{ getv "/kilda_storm_flow_hs_flow_delete_mirror_hub_parallelism" }}
+  - id: "YFLOW_CREATE_HUB"
+    parallelism: {{ getv "/kilda_storm_flow_hs_y_flow_create_hub_parallelism" }}
+  - id: "YFLOW_DELETE_HUB"
+    parallelism: {{ getv "/kilda_storm_flow_hs_y_flow_delete_hub_parallelism" }}
+  - id: "YFLOW_READ_BOLT"
+    parallelism: {{ getv "/kilda_storm_flow_hs_y_flow_read_hub_parallelism" }}
+  - id: "HISTORY_BOLT"
+    parallelism: {{ getv "/kilda_storm_flow_hs_history_bolt_parallelism" }}
+  - id: "METRICS_BOLT"
+    parallelism: {{ getv "/kilda_storm_flow_hs_metrics_bolt_parallelism" }}
+  - id: "NB_RESPONSE_SENDER"
+    parallelism: {{ getv "/kilda_storm_flow_hs_nb_response_sender_parallelism" }}
+  - id: "REROUTE_RESPONSE_SENDER"
+    parallelism: {{ getv "/kilda_storm_flow_hs_reroute_response_sender_parallelism" }}
+  - id: "SERVER42_CONTROL_TOPOLOGY_SENDER"
+    parallelism: {{ getv "/kilda_storm_flow_hs_server42_control_sender_parallelism" }}
+  - id: "SPEAKER_DUMP_REQUEST_SENDER"
+    parallelism: {{ getv "/kilda_storm_flow_hs_dump_request_sender_parallelism" }}
+  - id: "STATS_TOPOLOGY_SENDER"
+    parallelism: {{ getv "/kilda_storm_flow_hs_stats_sender_parallelism" }}

--- a/confd/vars/main.yaml
+++ b/confd/vars/main.yaml
@@ -171,12 +171,31 @@ kilda_storm_swmanager_heavy_operation_parallelism: 2
 kilda_storm_isl_latency_parallelism: 4
 kilda_storm_parallelism_level_new: 2
 kilda_storm_parallelism_level: 1
-kilda_storm_flow_hs_parallelism: 2
-kilda_storm_flow_hs_reroute_hub_count_multiplier: 2
-kilda_storm_flowhs_workers: 1
 kilda_storm_parallelism_workers_count: 1
 kilda_storm_history_parallelism: 2
 kilda_storm_stats_parallelism: 2
+
+# Flow HS
+kilda_storm_flow_hs_parallelism: 2
+kilda_storm_flow_hs_reroute_hub_count_multiplier: 2
+kilda_storm_flowhs_workers: 1
+kilda_storm_flow_hs_flow_create_hub_parallelism: 2
+kilda_storm_flow_hs_flow_delete_hub_parallelism: 2
+kilda_storm_flow_hs_flow_swap_endpoint_hub_parallelism: 2
+kilda_storm_flow_hs_flow_create_mirror_hub_parallelism: 2
+kilda_storm_flow_hs_flow_delete_mirror_hub_parallelism: 2
+kilda_storm_flow_hs_y_flow_create_hub_parallelism: 2
+kilda_storm_flow_hs_y_flow_delete_hub_parallelism: 2
+kilda_storm_flow_hs_y_flow_read_hub_parallelism: 2
+
+# Flow HS kafka bolts
+kilda_storm_flow_hs_history_bolt_parallelism: 2
+kilda_storm_flow_hs_metrics_bolt_parallelism: 2
+kilda_storm_flow_hs_nb_response_sender_parallelism: 2
+kilda_storm_flow_hs_reroute_response_sender_parallelism: 2
+kilda_storm_flow_hs_server42_control_sender_parallelism: 2
+kilda_storm_flow_hs_dump_request_sender_parallelism: 2
+kilda_storm_flow_hs_stats_sender_parallelism: 2
 
 kilda_storm_spout_parallelism: 2
 


### PR DESCRIPTION
Some of flow hs bolts are not loaded very much. That is why they parallelism can be decreased to save resources