### PR TITLE
Fixed path search with max latency over under-maintenance isls

### DIFF
--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseResourceAllocationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseResourceAllocationAction.java
@@ -220,7 +220,8 @@ public abstract class BaseResourceAllocationAction<T extends FlowPathSwappingFsm
                                               boolean forceToIgnoreBandwidth, List<PathId> pathsToReuseBandwidth,
                                               FlowPathPair oldPaths, boolean allowOldPaths,
                                               String sharedBandwidthGroupId,
-                                              Predicate<GetPathsResult> whetherCreatePathSegments)
+                                              Predicate<GetPathsResult> whetherCreatePathSegments,
+                                              boolean isProtected)
             throws RecoverableException, UnroutableFlowException, ResourceAllocationException {
         // Lazy initialisable map with reused bandwidth...
         Supplier<Map<IslEndpoints, Long>> reuseBandwidthPerIsl = Suppliers.memoize(() -> {
@@ -262,7 +263,7 @@ public abstract class BaseResourceAllocationAction<T extends FlowPathSwappingFsm
                     potentialPath = pathComputer.getPath(flow);
                     flow.setIgnoreBandwidth(originalIgnoreBandwidth);
                 } else {
-                    potentialPath = pathComputer.getPath(flow, pathsToReuseBandwidth);
+                    potentialPath = pathComputer.getPath(flow, pathsToReuseBandwidth, isProtected);
                 }
 
                 boolean newPathFound = isNotSamePath(potentialPath, oldPaths);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocatePrimaryResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocatePrimaryResourcesAction.java
@@ -81,7 +81,7 @@ public class AllocatePrimaryResourcesAction extends
         log.debug("Finding a new primary path for flow {}", flowId);
         GetPathsResult allocatedPaths = allocatePathPair(tmpFlowCopy, newForwardPathId, newReversePathId,
                 stateMachine.isIgnoreBandwidth(), pathsToReuse, oldPaths, stateMachine.isRecreateIfSamePath(),
-                stateMachine.getSharedBandwidthGroupId(), path -> true);
+                stateMachine.getSharedBandwidthGroupId(), path -> true, false);
         if (allocatedPaths != null) {
             log.debug("New primary paths have been allocated: {}", allocatedPaths);
             stateMachine.setBackUpPrimaryPathComputationWayUsed(allocatedPaths.isBackUpPathComputationWayUsed());

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocateProtectedResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/AllocateProtectedResourcesAction.java
@@ -92,7 +92,7 @@ public class AllocateProtectedResourcesAction extends
         log.debug("Finding a new protected path for flow {}", flowId);
         GetPathsResult allocatedPaths = allocatePathPair(tmpFlowCopy, newForwardPathId, newReversePathId,
                 stateMachine.isIgnoreBandwidth(), pathsToReuse, oldPaths, stateMachine.isRecreateIfSamePath(),
-                stateMachine.getSharedBandwidthGroupId(), testNonOverlappingPath);
+                stateMachine.getSharedBandwidthGroupId(), testNonOverlappingPath, true);
         if (allocatedPaths != null) {
             stateMachine.setBackUpProtectedPathComputationWayUsed(allocatedPaths.isBackUpPathComputationWayUsed());
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocatePrimaryResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocatePrimaryResourcesAction.java
@@ -80,7 +80,7 @@ public class AllocatePrimaryResourcesAction extends
         log.debug("Finding a new primary path for flow {}", flowId);
         GetPathsResult allocatedPaths = allocatePathPair(tmpFlow, newForwardPathId, newReversePathId,
                 false, pathIdsToReuse, oldPaths, true,
-                stateMachine.getSharedBandwidthGroupId(), path -> true);
+                stateMachine.getSharedBandwidthGroupId(), path -> true, false);
         if (allocatedPaths == null) {
             throw new ResourceAllocationException("Unable to allocate a path");
         }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocateProtectedResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocateProtectedResourcesAction.java
@@ -88,7 +88,7 @@ public class AllocateProtectedResourcesAction extends
         log.debug("Finding a new protected path for flow {}", flowId);
         GetPathsResult allocatedPaths = allocatePathPair(tmpFlow, newForwardPathId, newReversePathId,
                 false, pathIdsToReuse, oldPaths, true,
-                stateMachine.getSharedBandwidthGroupId(), testNonOverlappingPath);
+                stateMachine.getSharedBandwidthGroupId(), testNonOverlappingPath, true);
         if (allocatedPaths == null) {
             throw new ResourceAllocationException("Unable to allocate a path");
         }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteServiceTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -103,7 +104,7 @@ public class FlowRerouteServiceTest extends AbstractFlowTest<FlowSegmentRequest>
         testExpectedFailure(dummyRequestKey, request, commandContext, origin, FlowStatus.DOWN, ErrorType.NOT_FOUND);
 
         verify(pathComputer, times(11))
-                .getPath(makeFlowArgumentMatch(origin.getFlowId()), any());
+                .getPath(makeFlowArgumentMatch(origin.getFlowId()), any(), anyBoolean());
     }
 
     @Test
@@ -116,7 +117,7 @@ public class FlowRerouteServiceTest extends AbstractFlowTest<FlowSegmentRequest>
         testExpectedFailure(dummyRequestKey, request, commandContext, origin, FlowStatus.UP, ErrorType.INTERNAL_ERROR);
 
         verify(pathComputer, times(PATH_ALLOCATION_RETRIES_LIMIT + 1))
-                .getPath(makeFlowArgumentMatch(origin.getFlowId()), any());
+                .getPath(makeFlowArgumentMatch(origin.getFlowId()), any(), anyBoolean());
     }
 
     @Test
@@ -507,7 +508,7 @@ public class FlowRerouteServiceTest extends AbstractFlowTest<FlowSegmentRequest>
         transactionManager.doInTransaction(() ->
                 repositoryFactory.createFlowRepository().updateStatus(origin.getFlowId(), FlowStatus.DOWN));
 
-        when(pathComputer.getPath(makeFlowArgumentMatch(origin.getFlowId()), any()))
+        when(pathComputer.getPath(makeFlowArgumentMatch(origin.getFlowId()), any(), anyBoolean()))
                 .thenReturn(make2SwitchAltPathPair())
                 .thenReturn(make3SwitchesPathPair());
 
@@ -637,7 +638,7 @@ public class FlowRerouteServiceTest extends AbstractFlowTest<FlowSegmentRequest>
         setupFlowRepositorySpy().findById(origin.getFlowId())
                 .ifPresent(foundPath -> foundPath.setTargetPathComputationStrategy(MAX_LATENCY));
         when(pathComputer.getPath(makeFlowArgumentMatch(origin.getFlowId()),
-                any(Collection.class))).thenReturn(make3SwitchesPathPair(true));
+                any(Collection.class), anyBoolean())).thenReturn(make3SwitchesPathPair(true));
 
         FlowRerouteService service = makeService();
         IslEndpoint affectedEndpoint = extractIslEndpoint(origin);
@@ -692,12 +693,12 @@ public class FlowRerouteServiceTest extends AbstractFlowTest<FlowSegmentRequest>
     private void preparePathComputation(String flowId, Throwable error)
             throws RecoverableException, UnroutableFlowException {
         doThrow(error).when(pathComputer)
-                .getPath(makeFlowArgumentMatch(flowId), any());
+                .getPath(makeFlowArgumentMatch(flowId), any(), anyBoolean());
     }
 
     private void preparePathComputation(String flowId, GetPathsResult pathPair)
             throws RecoverableException, UnroutableFlowException {
-        when(pathComputer.getPath(makeFlowArgumentMatch(flowId), any())).thenReturn(pathPair);
+        when(pathComputer.getPath(makeFlowArgumentMatch(flowId), any(), anyBoolean())).thenReturn(pathPair);
     }
 
     @Override

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowUpdateServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowUpdateServiceTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -97,7 +98,7 @@ public class FlowUpdateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
     public void shouldFailUpdateFlowIfNoPathAvailable()
             throws RecoverableException, UnroutableFlowException, DuplicateKeyException {
         Flow origin = makeFlow();
-        when(pathComputer.getPath(makeFlowArgumentMatch(origin.getFlowId()), anyCollection()))
+        when(pathComputer.getPath(makeFlowArgumentMatch(origin.getFlowId()), anyCollection(), anyBoolean()))
                 .thenThrow(new UnroutableFlowException(injectedErrorMessage));
 
         FlowRequest request = makeRequest()
@@ -108,14 +109,15 @@ public class FlowUpdateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
         Flow result = testExpectedFailure(request, origin, ErrorType.NOT_FOUND);
         Assert.assertEquals(origin.getBandwidth(), result.getBandwidth());
 
-        verify(pathComputer, times(11)).getPath(makeFlowArgumentMatch(origin.getFlowId()), any());
+        verify(pathComputer, times(11))
+                .getPath(makeFlowArgumentMatch(origin.getFlowId()), any(), anyBoolean());
     }
 
     @Test
     public void shouldFailUpdateFlowIfRecoverableException()
             throws RecoverableException, UnroutableFlowException, DuplicateKeyException {
         Flow origin = makeFlow();
-        when(pathComputer.getPath(makeFlowArgumentMatch(origin.getFlowId()), anyCollection()))
+        when(pathComputer.getPath(makeFlowArgumentMatch(origin.getFlowId()), anyCollection(), anyBoolean()))
                 .thenThrow(new RecoverableException(injectedErrorMessage));
 
         FlowRequest request = makeRequest()
@@ -125,7 +127,7 @@ public class FlowUpdateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
         testExpectedFailure(request, origin, ErrorType.INTERNAL_ERROR);
 
         verify(pathComputer, times(PATH_ALLOCATION_RETRIES_LIMIT + 1))
-                .getPath(makeFlowArgumentMatch(origin.getFlowId()), any());
+                .getPath(makeFlowArgumentMatch(origin.getFlowId()), any(), anyBoolean());
     }
 
     @Test
@@ -712,7 +714,7 @@ public class FlowUpdateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
 
     private void preparePathComputation(String flowId, GetPathsResult pathPair)
             throws RecoverableException, UnroutableFlowException {
-        when(pathComputer.getPath(makeFlowArgumentMatch(flowId), any())).thenReturn(pathPair);
+        when(pathComputer.getPath(makeFlowArgumentMatch(flowId), any(), anyBoolean())).thenReturn(pathPair);
     }
 
     private FlowUpdateService makeService() {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowRerouteServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowRerouteServiceTest.java
@@ -17,6 +17,7 @@ package org.openkilda.wfm.topology.flowhs.service.yflow;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -151,7 +152,7 @@ public class YFlowRerouteServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         YFlowRequest createYFlowRequest = createYFlow();
         YFlowRerouteRequest request = new YFlowRerouteRequest(createYFlowRequest.getYFlowId(), "reason");
 
-        when(pathComputer.getPath(buildFlowIdArgumentMatch("test_flow_1"), any()))
+        when(pathComputer.getPath(buildFlowIdArgumentMatch("test_flow_1"), any(), anyBoolean()))
                 .thenThrow(new UnroutableFlowException(injectedErrorMessage));
         preparePathComputationForReroute("test_flow_2", buildSecondSubFlowPathPairWithNewTransit());
         prepareYPointComputation(SWITCH_SHARED, SWITCH_FIRST_EP, SWITCH_SECOND_EP, SWITCH_NEW_TRANSIT);
@@ -174,7 +175,7 @@ public class YFlowRerouteServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         YFlowRerouteRequest request = new YFlowRerouteRequest(createYFlowRequest.getYFlowId(), "reason");
 
         preparePathComputationForReroute("test_flow_1", buildFirstSubFlowPathPairWithNewTransit());
-        when(pathComputer.getPath(buildFlowIdArgumentMatch("test_flow_2"), any()))
+        when(pathComputer.getPath(buildFlowIdArgumentMatch("test_flow_2"), any(), anyBoolean()))
                 .thenThrow(new UnroutableFlowException(injectedErrorMessage));
         prepareYPointComputation(SWITCH_SHARED, SWITCH_FIRST_EP, SWITCH_SECOND_EP, SWITCH_NEW_TRANSIT);
 
@@ -528,12 +529,13 @@ public class YFlowRerouteServiceTest extends AbstractYFlowTest<SpeakerRequest> {
 
     private void preparePathComputationForReroute(String flowId, GetPathsResult pathPair)
             throws RecoverableException, UnroutableFlowException {
-        when(pathComputer.getPath(buildFlowIdArgumentMatch(flowId), any())).thenReturn(pathPair);
+        when(pathComputer.getPath(buildFlowIdArgumentMatch(flowId), any(), anyBoolean())).thenReturn(pathPair);
     }
 
     private void preparePathComputationForReroute(String flowId, GetPathsResult pathPair, GetPathsResult pathPair2)
             throws RecoverableException, UnroutableFlowException {
-        when(pathComputer.getPath(buildFlowIdArgumentMatch(flowId), any())).thenReturn(pathPair).thenReturn(pathPair2);
+        when(pathComputer.getPath(buildFlowIdArgumentMatch(flowId), any(), anyBoolean()))
+                .thenReturn(pathPair).thenReturn(pathPair2);
     }
 
     private void prepareYPointComputation(SwitchId sharedEndpoint, SwitchId first, SwitchId second, SwitchId yPoint) {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowUpdateServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowUpdateServiceTest.java
@@ -17,6 +17,7 @@ package org.openkilda.wfm.topology.flowhs.service.yflow;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -167,7 +168,7 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         request.getSubFlows().get(0).setEndpoint(newFirstEndpoint);
         request.getSubFlows().get(1).setEndpoint(newSecondEndpoint);
 
-        when(pathComputer.getPath(buildFlowIdArgumentMatch("test_flow_1"), any()))
+        when(pathComputer.getPath(buildFlowIdArgumentMatch("test_flow_1"), any(), anyBoolean()))
                 .thenThrow(new UnroutableFlowException(injectedErrorMessage));
         preparePathComputationForUpdate("test_flow_2", buildNewSecondSubFlowPathPair(), buildSecondSubFlowPathPair());
         prepareYPointComputation(SWITCH_SHARED, SWITCH_NEW_FIRST_EP, SWITCH_NEW_SECOND_EP, SWITCH_TRANSIT);
@@ -198,7 +199,7 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         request.getSubFlows().get(1).setEndpoint(newSecondEndpoint);
 
         preparePathComputationForUpdate("test_flow_1", buildNewFirstSubFlowPathPair(), buildFirstSubFlowPathPair());
-        when(pathComputer.getPath(buildFlowIdArgumentMatch("test_flow_2"), any()))
+        when(pathComputer.getPath(buildFlowIdArgumentMatch("test_flow_2"), any(), anyBoolean()))
                 .thenThrow(new UnroutableFlowException(injectedErrorMessage));
         prepareYPointComputation(SWITCH_SHARED, SWITCH_NEW_FIRST_EP, SWITCH_NEW_SECOND_EP, SWITCH_TRANSIT);
 
@@ -571,12 +572,13 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
 
     private void preparePathComputationForUpdate(String flowId, GetPathsResult pathPair)
             throws RecoverableException, UnroutableFlowException {
-        when(pathComputer.getPath(buildFlowIdArgumentMatch(flowId), any())).thenReturn(pathPair);
+        when(pathComputer.getPath(buildFlowIdArgumentMatch(flowId), any(), anyBoolean())).thenReturn(pathPair);
     }
 
     private void preparePathComputationForUpdate(String flowId, GetPathsResult pathPair, GetPathsResult pathPair2)
             throws RecoverableException, UnroutableFlowException {
-        when(pathComputer.getPath(buildFlowIdArgumentMatch(flowId), any())).thenReturn(pathPair).thenReturn(pathPair2);
+        when(pathComputer.getPath(buildFlowIdArgumentMatch(flowId), any(), anyBoolean()))
+                .thenReturn(pathPair).thenReturn(pathPair2);
     }
 
     private void prepareYPointComputation(SwitchId sharedEndpoint, SwitchId first, SwitchId second, SwitchId yPoint) {

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/PathComputer.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/PathComputer.java
@@ -42,7 +42,7 @@ public interface PathComputer {
      * @return {@link GetPathsResult} instance
      */
     default GetPathsResult getPath(Flow flow) throws UnroutableFlowException, RecoverableException {
-        return getPath(flow, Collections.emptyList());
+        return getPath(flow, Collections.emptyList(), false);
     }
 
     /**
@@ -53,7 +53,7 @@ public interface PathComputer {
      *                               be reused in new path computation.
      * @return {@link GetPathsResult} instance
      */
-    GetPathsResult getPath(Flow flow, Collection<PathId> reusePathsResources)
+    GetPathsResult getPath(Flow flow, Collection<PathId> reusePathsResources, boolean isProtected)
             throws UnroutableFlowException, RecoverableException;
 
     /**

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/finder/BestWeightAndShortestPathFinder.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/finder/BestWeightAndShortestPathFinder.java
@@ -27,6 +27,7 @@ import org.openkilda.pce.model.FindOneDirectionPathResult;
 import org.openkilda.pce.model.FindPathResult;
 import org.openkilda.pce.model.Node;
 import org.openkilda.pce.model.PathWeight;
+import org.openkilda.pce.model.PathWeight.Penalty;
 import org.openkilda.pce.model.WeightFunction;
 
 import com.google.common.collect.Lists;
@@ -221,7 +222,7 @@ public class BestWeightAndShortestPathFinder implements PathFinder {
                     totalPath.addAll(pathFromSpurNode.getFoundPath());
                     // Add the potential k-shortest path to the heap.
                     long totalPathWeight = totalPath.stream().map(weightFunction)
-                            .map(PathWeight::toLong)
+                            .map(PathWeight::getTotalWeight)
                             .reduce(0L, Long::sum);
                     // Filtering by maxWeight.
                     if (totalPathWeight < maxWeight) {
@@ -289,7 +290,7 @@ public class BestWeightAndShortestPathFinder implements PathFinder {
         if (path.isEmpty()) {
             return Long.MAX_VALUE;
         }
-        return path.stream().map(weightFunction).mapToLong(PathWeight::toLong).sum();
+        return path.stream().map(weightFunction).mapToLong(PathWeight::getTotalWeight).sum();
     }
 
     private void removeEdge(Edge edge) {
@@ -367,7 +368,8 @@ public class BestWeightAndShortestPathFinder implements PathFinder {
 
         while (!toVisit.isEmpty()) {
             SearchNode current = toVisit.pop();
-            log.trace("Going to visit node {} with weight {}.", current.dstSw, current.getParentWeight().toLong());
+            log.trace("Going to visit node {} with weight {}.",
+                    current.dstSw, current.getParentWeight().getTotalWeight());
 
             // Determine if this node is the destination node.
             if (current.dstSw.equals(end)) {
@@ -429,7 +431,6 @@ public class BestWeightAndShortestPathFinder implements PathFinder {
      * @return A desired path from start to end as SearchNode representation, or null
      */
     private SearchNode getDesiredPath(Node start, Node end, WeightFunction weightFunction, long maxWeight) {
-        long desiredWeight = Long.MAX_VALUE;
         SearchNode desiredPath = null;
 
         Deque<SearchNode> toVisit = new LinkedList<>();
@@ -439,7 +440,8 @@ public class BestWeightAndShortestPathFinder implements PathFinder {
 
         while (!toVisit.isEmpty()) {
             SearchNode current = toVisit.pop();
-            log.trace("Going to visit node {} with weight {}.", current.dstSw, current.getParentWeight().toLong());
+            PathWeight currentPathWeight = current.getParentWeight();
+            log.trace("Going to visit node {} with weight {}.", current.dstSw, currentPathWeight);
 
             // Leave if the path contains this node
             if (current.containsSwitch(current.dstSw.getSwitchId())) {
@@ -448,33 +450,83 @@ public class BestWeightAndShortestPathFinder implements PathFinder {
             }
 
             // Shift the current weight relative to maxWeight
-            long shiftedCurrentWeight = Math.abs(maxWeight - current.parentWeight.toLong());
+            long shiftedCurrentWeight = Math.abs(maxWeight - current.parentWeight.getBaseWeight());
 
             // Determine if this node is the destination node.
             if (current.dstSw.equals(end)) {
                 // We found the destination
-                if (shiftedCurrentWeight < desiredWeight && current.parentWeight.toLong() < maxWeight) {
+                if (current.parentWeight.getBaseWeight() < maxWeight) {
                     // We found a best path. If we don't get here, then the entire graph will be
                     // searched until we run out of nodes or the depth is reached.
-                    desiredWeight = shiftedCurrentWeight;
-                    desiredPath = current;
+                    if (isContainHardDiversityPenalties(current.parentWeight)) {
+                        // Have not to use path with hard diversity penalties
+                        continue;
+                    }
+
+                    if (desiredPath == null) {
+                        desiredPath = current;
+                        continue;
+                    }
+
+                    long currentDiversitySum = getPathWeightDiversityPenaltiesValue(currentPathWeight);
+                    long desiredDiversitySum = getPathWeightDiversityPenaltiesValue(desiredPath.parentWeight);
+
+                    if (currentDiversitySum > desiredDiversitySum) {
+                        // We found path but it diversity-penalties are worse than existed path
+                        continue;
+                    }
+
+                    if (current.parentWeight.getTotalWeight() < maxWeight
+                            && desiredPath.parentWeight.getTotalWeight() >= maxWeight) {
+                        // New path is suitable by totalWeight, but old is not
+                        desiredPath = current;
+                        continue;
+                    }
+
+                    if (desiredPath.parentWeight.getTotalWeight() >= maxWeight
+                            && currentPathWeight.getTotalWeight() >= maxWeight) {
+                        // Both paths are NOT suitable by totalWeight, choose the nearest to maxWeight
+                        if (currentPathWeight.getTotalWeight() < desiredPath.parentWeight.getTotalWeight()) {
+                            desiredPath = current;
+                            continue;
+                        }
+                    }
+
+                    if (desiredPath.parentWeight.getTotalWeight() < maxWeight
+                            && currentPathWeight.getTotalWeight() < maxWeight) {
+                        // Both paths are suitable by totalWeight, but new path is better by diversity
+                        if (currentDiversitySum > 0) {
+                            desiredPath = current;
+                            continue;
+                        }
+                        // Both paths are suitable by totalWeight, choose the nearest to maxWeight
+                        if (currentPathWeight.getTotalWeight() > desiredPath.parentWeight.getTotalWeight()) {
+                            desiredPath = current;
+                            continue;
+                        }
+                    }
                 }
+
                 // We found dest, no need to keep processing
                 log.trace("Found destination using {} with path {}", current.dstSw, current.parentPath);
                 continue;
             }
 
             // Stop processing entirely if we've gone too far, or over maxWeight
-            if (current.allowedDepth <= 0 || current.parentWeight.toLong() >= maxWeight) {
+            if (current.allowedDepth <= 0 || current.parentWeight.getBaseWeight() >= maxWeight) {
                 continue;
             }
 
             // Otherwise, if we've been here before, see if this path is better
             SearchNode prior = visited.get(current.dstSw);
             // Use non-greedy way to save visited nodes to fix issue mentioned in docs/design/pce/max-latency-issue
-            if (prior != null && shiftedCurrentWeight < Math.abs(maxWeight - prior.parentWeight.toLong())) {
-                log.trace("Skip node {} processing", current.dstSw);
-                continue;
+            if (prior != null && shiftedCurrentWeight < Math.abs(maxWeight - prior.parentWeight.getBaseWeight())) {
+
+                // Should check with penalties too
+                if (currentPathWeight.getTotalWeight() > prior.getParentWeight().getTotalWeight()) {
+                    log.trace("Skip node {} processing", current.dstSw);
+                    continue;
+                }
             }
 
             // Either this is the first time, or this one has less weight .. either way, this node should
@@ -606,5 +658,17 @@ public class BestWeightAndShortestPathFinder implements PathFinder {
         boolean containsSwitch(SwitchId switchId) {
             return parentPath.stream().anyMatch(s -> s.getSrcSwitch().getSwitchId().equals(switchId));
         }
+    }
+
+    private long getPathWeightDiversityPenaltiesValue(PathWeight pathWeight) {
+        return pathWeight.getPenaltyValue(PathWeight.Penalty.DIVERSITY_ISL_LATENCY)
+                + pathWeight.getPenaltyValue(PathWeight.Penalty.DIVERSITY_SWITCH_LATENCY)
+                + pathWeight.getPenaltyValue(PathWeight.Penalty.DIVERSITY_POP_ISL_COST);
+    }
+
+    private boolean isContainHardDiversityPenalties(PathWeight pathWeight) {
+        long penaltiesSum = pathWeight.getPenaltyValue(Penalty.PROTECTED_DIVERSITY_ISL_LATENCY)
+                + pathWeight.getPenaltyValue(Penalty.PROTECTED_DIVERSITY_SWITCH_LATENCY);
+        return penaltiesSum > 0;
     }
 }

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/impl/InMemoryPathComputer.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/impl/InMemoryPathComputer.java
@@ -1,4 +1,4 @@
-/* Copyright 2021 Telstra Open Source
+/* Copyright 2022 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -19,6 +19,14 @@ import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static org.openkilda.model.PathComputationStrategy.LATENCY;
 import static org.openkilda.model.PathComputationStrategy.MAX_LATENCY;
+import static org.openkilda.pce.model.PathWeight.Penalty.AFFINITY_ISL_LATENCY;
+import static org.openkilda.pce.model.PathWeight.Penalty.DIVERSITY_ISL_LATENCY;
+import static org.openkilda.pce.model.PathWeight.Penalty.DIVERSITY_POP_ISL_COST;
+import static org.openkilda.pce.model.PathWeight.Penalty.DIVERSITY_SWITCH_LATENCY;
+import static org.openkilda.pce.model.PathWeight.Penalty.PROTECTED_DIVERSITY_ISL_LATENCY;
+import static org.openkilda.pce.model.PathWeight.Penalty.PROTECTED_DIVERSITY_SWITCH_LATENCY;
+import static org.openkilda.pce.model.PathWeight.Penalty.UNDER_MAINTENANCE;
+import static org.openkilda.pce.model.PathWeight.Penalty.UNSTABLE;
 
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowEncapsulationType;
@@ -40,6 +48,7 @@ import org.openkilda.pce.model.Edge;
 import org.openkilda.pce.model.FindOneDirectionPathResult;
 import org.openkilda.pce.model.FindPathResult;
 import org.openkilda.pce.model.PathWeight;
+import org.openkilda.pce.model.PathWeight.Penalty;
 import org.openkilda.pce.model.WeightFunction;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -50,9 +59,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -77,14 +88,15 @@ public class InMemoryPathComputer implements PathComputer {
     }
 
     @Override
-    public GetPathsResult getPath(Flow flow, Collection<PathId> reusePathsResources)
+    public GetPathsResult getPath(Flow flow, Collection<PathId> reusePathsResources, boolean isProtected)
             throws UnroutableFlowException, RecoverableException {
         AvailableNetwork network = availableNetworkFactory.getAvailableNetwork(flow, reusePathsResources);
 
-        return getPath(network, flow, flow.getPathComputationStrategy());
+        return getPath(network, flow, flow.getPathComputationStrategy(), isProtected);
     }
 
-    private GetPathsResult getPath(AvailableNetwork network, Flow flow, PathComputationStrategy strategy)
+    private GetPathsResult getPath(AvailableNetwork network, Flow flow,
+                                   PathComputationStrategy strategy, boolean isProtected)
             throws UnroutableFlowException {
         if (flow.isOneSwitchFlow()) {
             log.info("No path computation for one-switch flow");
@@ -98,7 +110,7 @@ public class InMemoryPathComputer implements PathComputer {
                     .build();
         }
 
-        WeightFunction weightFunction = getWeightFunctionByStrategy(strategy);
+        WeightFunction weightFunction = getWeightFunctionByStrategy(strategy, isProtected);
         FindPathResult findPathResult;
         try {
             findPathResult = findPathInNetwork(flow, network, weightFunction, strategy);
@@ -182,11 +194,11 @@ public class InMemoryPathComputer implements PathComputer {
             case LATENCY:
             case COST_AND_AVAILABLE_BANDWIDTH:
                 paths = pathFinder.findNPathsBetweenSwitches(availableNetwork, srcSwitchId, dstSwitchId, count,
-                        getWeightFunctionByStrategy(pathComputationStrategy));
+                        getWeightFunctionByStrategy(pathComputationStrategy, false));
                 break;
             case MAX_LATENCY:
                 paths = pathFinder.findNPathsBetweenSwitches(availableNetwork, srcSwitchId, dstSwitchId, count,
-                        getWeightFunctionByStrategy(pathComputationStrategy), maxLatencyNs, maxLatencyTier2Ns);
+                        getWeightFunctionByStrategy(pathComputationStrategy, false), maxLatencyNs, maxLatencyTier2Ns);
                 break;
             default:
                 throw new UnsupportedOperationException(String.format(
@@ -208,13 +220,13 @@ public class InMemoryPathComputer implements PathComputer {
                 .collect(Collectors.toList());
     }
 
-    private WeightFunction getWeightFunctionByStrategy(PathComputationStrategy strategy) {
+    private WeightFunction getWeightFunctionByStrategy(PathComputationStrategy strategy, boolean isProtected) {
         switch (strategy) {
             case COST:
                 return this::weightByCost;
             case LATENCY:
             case MAX_LATENCY:
-                return this::weightByLatency;
+                return edge -> weightByLatency(edge, isProtected);
             case COST_AND_AVAILABLE_BANDWIDTH:
                 return this::weightByCostAndAvailableBandwidth;
             default:
@@ -223,48 +235,116 @@ public class InMemoryPathComputer implements PathComputer {
     }
 
     private PathWeight weightByCost(Edge edge) {
-        long total = edge.getCost() == 0 ? config.getDefaultIslCost() : edge.getCost();
+        Map<Penalty, Long> penalties = new EnumMap<>(Penalty.class);
+
         if (edge.isUnderMaintenance()) {
-            total += config.getUnderMaintenanceCostRaise();
+            penalties.put(UNDER_MAINTENANCE, (long) config.getUnderMaintenanceCostRaise());
         }
+
         if (edge.isUnstable()) {
-            total += config.getUnstableCostRaise();
+            penalties.put(UNSTABLE, (long) config.getUnstableCostRaise());
         }
-        total += edge.getDiversityGroupUseCounter() * config.getDiversityIslCost()
-                + edge.getDiversityGroupPerPopUseCounter() * config.getDiversityPopIslCost()
-                + edge.getDestSwitch().getDiversityGroupUseCounter() * config.getDiversitySwitchCost()
-                + edge.getAffinityGroupUseCounter() * config.getAffinityIslCost();
-        return new PathWeight(total);
+
+        if (edge.getDiversityGroupUseCounter() > 0) {
+            int value = edge.getDiversityGroupUseCounter() * config.getDiversityIslCost();
+            penalties.put(DIVERSITY_ISL_LATENCY, (long) value);
+        }
+
+        if (edge.getDiversityGroupPerPopUseCounter() > 0) {
+            int value = edge.getDiversityGroupPerPopUseCounter() * config.getDiversityPopIslCost();
+            penalties.put(DIVERSITY_POP_ISL_COST, (long) value);
+        }
+
+        if (edge.getDestSwitch().getDiversityGroupUseCounter() > 0) {
+            int value = edge.getDestSwitch().getDiversityGroupUseCounter() * config.getDiversitySwitchCost();
+            penalties.put(DIVERSITY_SWITCH_LATENCY, (long) value);
+        }
+
+        if (edge.getAffinityGroupUseCounter() > 0) {
+            long value = edge.getAffinityGroupUseCounter() * config.getAffinityIslCost();
+            penalties.put(AFFINITY_ISL_LATENCY, value);
+        }
+
+        long cost = edge.getCost() == 0 ? config.getDefaultIslCost() : edge.getCost();
+        return new PathWeight(cost, penalties);
     }
 
-    private PathWeight weightByLatency(Edge edge) {
-        long total = edge.getLatency() <= 0 ? config.getDefaultIslLatency() : edge.getLatency();
+    private PathWeight weightByLatency(Edge edge, boolean isForProtectedPath) {
+        Map<Penalty, Long> penalties = new EnumMap<>(Penalty.class);
+
         if (edge.isUnderMaintenance()) {
-            total += config.getUnderMaintenanceLatencyRaise();
+            penalties.put(UNDER_MAINTENANCE, config.getUnderMaintenanceLatencyRaise());
         }
+
         if (edge.isUnstable()) {
-            total += config.getUnstableLatencyRaise();
+            penalties.put(UNSTABLE, config.getUnstableLatencyRaise());
         }
-        total += edge.getDiversityGroupUseCounter() * config.getDiversityIslLatency()
-                + edge.getDiversityGroupPerPopUseCounter() * config.getDiversityPopIslCost()
-                + edge.getDestSwitch().getDiversityGroupUseCounter() * config.getDiversitySwitchLatency()
-                + edge.getAffinityGroupUseCounter() * config.getAffinityIslLatency();
-        return new PathWeight(total);
+
+        if (edge.getDiversityGroupUseCounter() > 0) {
+            long value = edge.getDiversityGroupUseCounter() * config.getDiversityIslLatency();
+            if (isForProtectedPath) {
+                penalties.put(PROTECTED_DIVERSITY_ISL_LATENCY, value);
+            } else {
+                penalties.put(DIVERSITY_ISL_LATENCY, value);
+            }
+        }
+
+        if (edge.getDiversityGroupPerPopUseCounter() > 0) {
+            int value = edge.getDiversityGroupPerPopUseCounter() * config.getDiversityPopIslCost();
+            penalties.put(DIVERSITY_POP_ISL_COST, (long) value);
+        }
+
+        if (edge.getDestSwitch().getDiversityGroupUseCounter() > 0) {
+            long value = edge.getDestSwitch().getDiversityGroupUseCounter() * config.getDiversitySwitchLatency();
+            if (isForProtectedPath) {
+                penalties.put(PROTECTED_DIVERSITY_SWITCH_LATENCY, value);
+            } else {
+                penalties.put(DIVERSITY_SWITCH_LATENCY, value);
+            }
+        }
+
+        if (edge.getAffinityGroupUseCounter() > 0) {
+            long value = edge.getAffinityGroupUseCounter() * config.getAffinityIslLatency();
+            penalties.put(AFFINITY_ISL_LATENCY, value);
+        }
+
+        long edgeLatency = edge.getLatency() <= 0 ? config.getDefaultIslLatency() : edge.getLatency();
+        return new PathWeight(edgeLatency, penalties);
     }
 
     private PathWeight weightByCostAndAvailableBandwidth(Edge edge) {
-        long total = edge.getCost() == 0 ? config.getDefaultIslCost() : edge.getCost();
+        Map<Penalty, Long> penalties = new EnumMap<>(Penalty.class);
+
         if (edge.isUnderMaintenance()) {
-            total += config.getUnderMaintenanceCostRaise();
+            penalties.put(UNDER_MAINTENANCE, (long) config.getUnderMaintenanceCostRaise());
         }
+
         if (edge.isUnstable()) {
-            total += config.getUnstableCostRaise();
+            penalties.put(UNSTABLE, (long) config.getUnstableCostRaise());
         }
-        total += edge.getDiversityGroupUseCounter() * config.getDiversityIslCost()
-                + edge.getDiversityGroupPerPopUseCounter() * config.getDiversityPopIslCost()
-                + edge.getDestSwitch().getDiversityGroupUseCounter() * config.getDiversitySwitchCost()
-                + edge.getAffinityGroupUseCounter() * config.getAffinityIslCost();
-        return new PathWeight(total, edge.getAvailableBandwidth());
+
+        if (edge.getDiversityGroupUseCounter() > 0) {
+            int value = edge.getDiversityGroupUseCounter() * config.getDiversityIslCost();
+            penalties.put(DIVERSITY_ISL_LATENCY, (long) value);
+        }
+
+        if (edge.getDiversityGroupPerPopUseCounter() > 0) {
+            int value = edge.getDiversityGroupPerPopUseCounter() * config.getDiversityPopIslCost();
+            penalties.put(DIVERSITY_POP_ISL_COST, (long) value);
+        }
+
+        if (edge.getDestSwitch().getDiversityGroupUseCounter() > 0) {
+            int value = edge.getDestSwitch().getDiversityGroupUseCounter() * config.getDiversitySwitchCost();
+            penalties.put(DIVERSITY_SWITCH_LATENCY, (long) value);
+        }
+
+        if (edge.getAffinityGroupUseCounter() > 0) {
+            long value = edge.getAffinityGroupUseCounter() * config.getAffinityIslCost();
+            penalties.put(AFFINITY_ISL_LATENCY, value);
+        }
+
+        long cost = edge.getCost() == 0 ? config.getDefaultIslCost() : edge.getCost();
+        return new PathWeight(cost, penalties, edge.getAvailableBandwidth());
     }
 
     private GetPathsResult convertToGetPathsResult(

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/DiversityPathFinderTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/DiversityPathFinderTest.java
@@ -1,0 +1,370 @@
+/* Copyright 2022 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.pce.finder;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.openkilda.model.Flow;
+import org.openkilda.model.FlowEncapsulationType;
+import org.openkilda.model.FlowPath;
+import org.openkilda.model.PathComputationStrategy;
+import org.openkilda.model.PathId;
+import org.openkilda.model.PathSegment;
+import org.openkilda.model.Switch;
+import org.openkilda.model.SwitchId;
+import org.openkilda.pce.AvailableNetworkFactory;
+import org.openkilda.pce.AvailableNetworkFactory.BuildStrategy;
+import org.openkilda.pce.GetPathsResult;
+import org.openkilda.pce.PathComputer;
+import org.openkilda.pce.PathComputerConfig;
+import org.openkilda.pce.exception.RecoverableException;
+import org.openkilda.pce.exception.UnroutableFlowException;
+import org.openkilda.pce.impl.AvailableNetwork;
+import org.openkilda.pce.impl.InMemoryPathComputer;
+import org.openkilda.persistence.repositories.FlowPathRepository;
+import org.openkilda.persistence.repositories.IslRepository;
+import org.openkilda.persistence.repositories.IslRepository.IslImmutableView;
+import org.openkilda.persistence.repositories.RepositoryFactory;
+
+import com.google.common.collect.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@RunWith(Parameterized.class)
+public class DiversityPathFinderTest {
+    public static final SwitchId SWITCH_ID_1 = new SwitchId(1);
+    public static final SwitchId SWITCH_ID_2 = new SwitchId(2);
+    public static final SwitchId SWITCH_ID_3 = new SwitchId(3);
+    public static final SwitchId SWITCH_ID_4 = new SwitchId(4);
+    public static final SwitchId SWITCH_ID_5 = new SwitchId(5);
+    public static final Switch switchA = Switch.builder().switchId(SWITCH_ID_1).build();
+    public static final Switch switchB = Switch.builder().switchId(SWITCH_ID_2).build();
+    public static final Switch switchC = Switch.builder().switchId(SWITCH_ID_3).build();
+    public static final Switch switchD = Switch.builder().switchId(SWITCH_ID_4).build();
+    public static final Switch switchE = Switch.builder().switchId(SWITCH_ID_5).build();
+    public static final PathId FORWARD_PATH_ID = new PathId("path_id_1");
+    public static final PathId REVERSE_PATH_ID = new PathId("path_id_2");
+    public static final String DIVERSE_GROUP_ID = "group_id_1";
+
+    @Mock
+    private PathComputerConfig config;
+    @Mock
+    private RepositoryFactory repositoryFactory;
+    @Mock
+    private IslRepository islRepository;
+    @Mock
+    private FlowPathRepository flowPathRepository;
+
+    private AvailableNetworkFactory availableNetworkFactory;
+
+    @Parameter
+    public PathComputationStrategy pathComputationStrategy;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        when(config.getDiversitySwitchLatency()).thenReturn(10000L);
+        when(config.getDiversityIslLatency()).thenReturn(10000L);
+        when(config.getDiversityIslCost()).thenReturn(10000);
+        when(config.getDiversitySwitchCost()).thenReturn(10000);
+        when(config.getDiversityPopIslCost()).thenReturn(10000);
+
+        when(repositoryFactory.createIslRepository()).thenReturn(islRepository);
+        when(repositoryFactory.createFlowPathRepository()).thenReturn(flowPathRepository);
+
+        availableNetworkFactory = new AvailableNetworkFactory(config, repositoryFactory);
+    }
+
+    @Test
+    public void shouldChooseSamePath() throws RecoverableException, UnroutableFlowException {
+        // Topology:
+        // A----B----C     Already created flow: A-B-C
+        //                 Requested flow: A-B-C
+
+        List<IslImmutableView> isls = new ArrayList<>();
+        isls.addAll(getBidirectionalIsls(switchA, 1, switchB, 2));
+        isls.addAll(getBidirectionalIsls(switchB, 3, switchC, 4));
+
+        List<PathSegment> forwardSegments = new ArrayList<>();
+        forwardSegments.add(PathSegment.builder().pathId(FORWARD_PATH_ID).srcSwitch(switchA).srcPort(10)
+                .destSwitch(switchB).destPort(10).build());
+        forwardSegments.add(PathSegment.builder().pathId(FORWARD_PATH_ID).srcSwitch(switchB).srcPort(10)
+                .destSwitch(switchC).destPort(10).build());
+
+        FlowPath forwardPath = FlowPath.builder()
+                .srcSwitch(switchA)
+                .destSwitch(switchC)
+                .pathId(FORWARD_PATH_ID)
+                .segments(forwardSegments)
+                .build();
+        when(flowPathRepository.findById(FORWARD_PATH_ID)).thenReturn(java.util.Optional.of(forwardPath));
+
+
+        List<PathSegment> reverseSegments = new ArrayList<>();
+        reverseSegments.add(PathSegment.builder().pathId(REVERSE_PATH_ID).srcSwitch(switchC).srcPort(10)
+                .destSwitch(switchB).destPort(10).build());
+        reverseSegments.add(PathSegment.builder().pathId(REVERSE_PATH_ID).srcSwitch(switchB).srcPort(10)
+                .destSwitch(switchA).destPort(10).build());
+
+        FlowPath reversePath = FlowPath.builder()
+                .srcSwitch(switchC)
+                .destSwitch(switchA)
+                .pathId(REVERSE_PATH_ID)
+                .segments(reverseSegments)
+                .build();
+        when(flowPathRepository.findById(REVERSE_PATH_ID)).thenReturn(java.util.Optional.of(reversePath));
+
+        Flow flow = getFlow();
+        flow.setSrcSwitch(switchA);
+        flow.setDestSwitch(switchC);
+        flow.setDiverseGroupId(DIVERSE_GROUP_ID);
+        flow.setForwardPathId(new PathId("forward_path_id"));
+        flow.setReversePathId(new PathId("reverse_path_id"));
+        flow.setMaxLatency(Long.MAX_VALUE);
+        flow.setPathComputationStrategy(pathComputationStrategy);
+
+        when(config.getNetworkStrategy()).thenReturn(BuildStrategy.COST.name());
+        when(islRepository.findActiveByBandwidthAndEncapsulationType(flow.getBandwidth(), flow.getEncapsulationType()))
+                .thenReturn(isls);
+
+        when(flowPathRepository.findPathIdsByFlowDiverseGroupId(DIVERSE_GROUP_ID))
+                .thenReturn(Lists.newArrayList(FORWARD_PATH_ID, REVERSE_PATH_ID));
+
+        // check diversity counter
+        AvailableNetwork availableNetwork = availableNetworkFactory.getAvailableNetwork(flow, Collections.emptyList());
+        assertEquals(2, availableNetwork.getSwitch(switchB.getSwitchId()).getDiversityGroupUseCounter());
+
+        // check found path
+        PathComputer pathComputer = new InMemoryPathComputer(
+                availableNetworkFactory, new BestWeightAndShortestPathFinder(200), config);
+
+        GetPathsResult path = pathComputer.getPath(flow);
+        assertThat(path, is(notNullValue()));
+        assertThat(path.getForward(), is(notNullValue()));
+        assertThat(path.getReverse(), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldUseSameSwitch() throws RecoverableException, UnroutableFlowException {
+        // Topology:
+        //      D
+        //      |
+        // A----B----C     Already created flow: A-B-C
+        //      |          Requested flow: D-B-E
+        //      E
+
+        List<IslImmutableView> isls = new ArrayList<>();
+        isls.addAll(getBidirectionalIsls(switchA, 1, switchB, 2));
+        isls.addAll(getBidirectionalIsls(switchB, 3, switchC, 4));
+        isls.addAll(getBidirectionalIsls(switchD, 5, switchB, 6));
+        isls.addAll(getBidirectionalIsls(switchB, 7, switchE, 8));
+
+        List<PathSegment> forwardSegments = new ArrayList<>();
+        forwardSegments.add(PathSegment.builder().pathId(FORWARD_PATH_ID).srcSwitch(switchA).srcPort(10)
+                .destSwitch(switchB).destPort(10).build());
+        forwardSegments.add(PathSegment.builder().pathId(FORWARD_PATH_ID).srcSwitch(switchB).srcPort(10)
+                .destSwitch(switchC).destPort(10).build());
+
+        FlowPath forwardPath = FlowPath.builder()
+                .srcSwitch(switchA)
+                .destSwitch(switchC)
+                .pathId(FORWARD_PATH_ID)
+                .segments(forwardSegments)
+                .build();
+        when(flowPathRepository.findById(FORWARD_PATH_ID)).thenReturn(java.util.Optional.of(forwardPath));
+
+
+        List<PathSegment> reverseSegments = new ArrayList<>();
+        reverseSegments.add(PathSegment.builder().pathId(REVERSE_PATH_ID).srcSwitch(switchC).srcPort(10)
+                .destSwitch(switchB).destPort(10).build());
+        reverseSegments.add(PathSegment.builder().pathId(REVERSE_PATH_ID).srcSwitch(switchB).srcPort(10)
+                .destSwitch(switchA).destPort(10).build());
+
+        FlowPath reversePath = FlowPath.builder()
+                .srcSwitch(switchC)
+                .destSwitch(switchA)
+                .pathId(REVERSE_PATH_ID)
+                .segments(reverseSegments)
+                .build();
+        when(flowPathRepository.findById(REVERSE_PATH_ID)).thenReturn(java.util.Optional.of(reversePath));
+
+        Flow flow = getFlow();
+        flow.setSrcSwitch(switchD);
+        flow.setDestSwitch(switchE);
+        flow.setDiverseGroupId(DIVERSE_GROUP_ID);
+        flow.setForwardPathId(new PathId("forward_path_id"));
+        flow.setReversePathId(new PathId("reverse_path_id"));
+        flow.setMaxLatency(Long.MAX_VALUE);
+        flow.setPathComputationStrategy(pathComputationStrategy);
+
+        when(config.getNetworkStrategy()).thenReturn(BuildStrategy.COST.name());
+        when(islRepository.findActiveByBandwidthAndEncapsulationType(flow.getBandwidth(), flow.getEncapsulationType()))
+                .thenReturn(isls);
+
+        when(flowPathRepository.findPathIdsByFlowDiverseGroupId(DIVERSE_GROUP_ID))
+                .thenReturn(Lists.newArrayList(FORWARD_PATH_ID, REVERSE_PATH_ID));
+
+        // check diversity counter
+        AvailableNetwork availableNetwork = availableNetworkFactory.getAvailableNetwork(flow, Collections.emptyList());
+        assertEquals(2, availableNetwork.getSwitch(switchB.getSwitchId()).getDiversityGroupUseCounter());
+
+        // check found path
+        PathComputer pathComputer = new InMemoryPathComputer(
+                availableNetworkFactory, new BestWeightAndShortestPathFinder(200), config);
+
+        GetPathsResult path = pathComputer.getPath(flow);
+        assertThat(path, is(notNullValue()));
+        assertThat(path.getForward(), is(notNullValue()));
+        assertThat(path.getReverse(), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldChooseLongerPath() throws RecoverableException, UnroutableFlowException {
+        // Topology:
+        //      D----E
+        //      |    |
+        // A----B----C     Already created flow: A-B-C
+        //                 Requested flow: A-B-D-E-C
+
+        List<IslImmutableView> isls = new ArrayList<>();
+        isls.addAll(getBidirectionalIsls(switchA, 1, switchB, 2));
+        isls.addAll(getBidirectionalIsls(switchB, 3, switchC, 4));
+        isls.addAll(getBidirectionalIsls(switchB, 7, switchD, 8));
+        isls.addAll(getBidirectionalIsls(switchD, 5, switchE, 6));
+        isls.addAll(getBidirectionalIsls(switchE, 9, switchC, 11));
+
+        List<PathSegment> forwardSegments = new ArrayList<>();
+        forwardSegments.add(PathSegment.builder().pathId(FORWARD_PATH_ID).srcSwitch(switchA).srcPort(1)
+                .destSwitch(switchB).destPort(2).build());
+        forwardSegments.add(PathSegment.builder().pathId(FORWARD_PATH_ID).srcSwitch(switchB).srcPort(3)
+                .destSwitch(switchC).destPort(4).build());
+
+        FlowPath forwardPath = FlowPath.builder()
+                .srcSwitch(switchA)
+                .destSwitch(switchC)
+                .pathId(FORWARD_PATH_ID)
+                .segments(forwardSegments)
+                .build();
+        when(flowPathRepository.findById(FORWARD_PATH_ID)).thenReturn(java.util.Optional.of(forwardPath));
+
+
+        List<PathSegment> reverseSegments = new ArrayList<>();
+        reverseSegments.add(PathSegment.builder().pathId(REVERSE_PATH_ID).srcSwitch(switchC).srcPort(4)
+                .destSwitch(switchB).destPort(3).build());
+        reverseSegments.add(PathSegment.builder().pathId(REVERSE_PATH_ID).srcSwitch(switchB).srcPort(3)
+                .destSwitch(switchA).destPort(1).build());
+
+        FlowPath reversePath = FlowPath.builder()
+                .srcSwitch(switchC)
+                .destSwitch(switchA)
+                .pathId(REVERSE_PATH_ID)
+                .segments(reverseSegments)
+                .build();
+        when(flowPathRepository.findById(REVERSE_PATH_ID)).thenReturn(java.util.Optional.of(reversePath));
+
+        Flow flow = getFlow();
+        flow.setSrcSwitch(switchA);
+        flow.setDestSwitch(switchC);
+        flow.setDiverseGroupId(DIVERSE_GROUP_ID);
+        flow.setForwardPathId(new PathId("forward_path_id"));
+        flow.setReversePathId(new PathId("reverse_path_id"));
+        flow.setMaxLatency(Long.MAX_VALUE);
+        flow.setPathComputationStrategy(pathComputationStrategy);
+
+        when(config.getNetworkStrategy()).thenReturn(BuildStrategy.COST.name());
+        when(islRepository.findActiveByBandwidthAndEncapsulationType(flow.getBandwidth(), flow.getEncapsulationType()))
+                .thenReturn(isls);
+
+        when(flowPathRepository.findPathIdsByFlowDiverseGroupId(DIVERSE_GROUP_ID))
+                .thenReturn(Lists.newArrayList(FORWARD_PATH_ID, REVERSE_PATH_ID));
+
+        // check diversity counter
+        AvailableNetwork availableNetwork = availableNetworkFactory.getAvailableNetwork(flow, Collections.emptyList());
+        assertEquals(2, availableNetwork.getSwitch(switchB.getSwitchId()).getDiversityGroupUseCounter());
+
+        // check found path
+        PathComputer pathComputer = new InMemoryPathComputer(
+                availableNetworkFactory, new BestWeightAndShortestPathFinder(200), config);
+
+        GetPathsResult path = pathComputer.getPath(flow);
+        assertThat(path, is(notNullValue()));
+        assertThat(path.getForward(), is(notNullValue()));
+        assertThat(path.getForward().getSegments().size(), is(4));
+        assertThat(path.getReverse(), is(notNullValue()));
+        assertThat(path.getReverse().getSegments().size(), is(4));
+    }
+
+    private static List<IslImmutableView> getBidirectionalIsls(Switch srcSwitch, int srcPort,
+                                                               Switch dstSwitch, int dstPort) {
+        return Lists.newArrayList(
+                getIslView(srcSwitch, srcPort, dstSwitch, dstPort),
+                getIslView(dstSwitch, dstPort, srcSwitch, srcPort));
+    }
+
+    private static IslImmutableView getIslView(Switch srcSwitch, int srcPort, Switch dstSwitch, int dstPort) {
+        IslImmutableView isl = mock(IslImmutableView.class);
+        when(isl.getSrcSwitchId()).thenReturn(srcSwitch.getSwitchId());
+        when(isl.getSrcPort()).thenReturn(srcPort);
+        when(isl.getDestSwitchId()).thenReturn(dstSwitch.getSwitchId());
+        when(isl.getDestPort()).thenReturn(dstPort);
+        when(isl.getCost()).thenReturn(10);
+        when(isl.getLatency()).thenReturn(33L);
+        when(isl.getAvailableBandwidth()).thenReturn(1000L);
+        when(isl.isUnderMaintenance()).thenReturn(false);
+        when(isl.isUnstable()).thenReturn(false);
+        return isl;
+    }
+
+    private static Flow getFlow() {
+        return Flow.builder()
+                .flowId("test-id")
+                .srcSwitch(Switch.builder().switchId(new SwitchId("1")).build())
+                .destSwitch(Switch.builder().switchId(new SwitchId("2")).build())
+                .encapsulationType(FlowEncapsulationType.TRANSIT_VLAN)
+                .bandwidth(100)
+                .ignoreBandwidth(false)
+                .build();
+    }
+
+    /**
+     * PathComputationStrategies.
+     */
+    @Parameters(name = "PathComputationStrategy = {0}")
+    public static Object[][] data() {
+        return new Object[][] {
+                {PathComputationStrategy.MAX_LATENCY},
+                {PathComputationStrategy.LATENCY},
+                {PathComputationStrategy.COST},
+                {PathComputationStrategy.COST_AND_AVAILABLE_BANDWIDTH}
+        };
+    }
+}

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/FindPathWithLatencyLimitsTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/FindPathWithLatencyLimitsTest.java
@@ -1,0 +1,197 @@
+/* Copyright 2022 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.pce.finder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.openkilda.pce.model.PathWeight.Penalty.AFFINITY_ISL_LATENCY;
+import static org.openkilda.pce.model.PathWeight.Penalty.DIVERSITY_ISL_LATENCY;
+import static org.openkilda.pce.model.PathWeight.Penalty.DIVERSITY_POP_ISL_COST;
+import static org.openkilda.pce.model.PathWeight.Penalty.DIVERSITY_SWITCH_LATENCY;
+import static org.openkilda.pce.model.PathWeight.Penalty.UNDER_MAINTENANCE;
+import static org.openkilda.pce.model.PathWeight.Penalty.UNSTABLE;
+
+import org.openkilda.model.SwitchId;
+import org.openkilda.pce.exception.UnroutableFlowException;
+import org.openkilda.pce.impl.AvailableNetwork;
+import org.openkilda.pce.model.Edge;
+import org.openkilda.pce.model.FindPathResult;
+import org.openkilda.pce.model.PathWeight;
+import org.openkilda.pce.model.PathWeight.Penalty;
+import org.openkilda.pce.model.WeightFunction;
+
+import org.junit.Test;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+public class FindPathWithLatencyLimitsTest {
+    private static final int ALLOWED_DEPTH = 35;
+    private static final long PENALTY = 10_000L;
+    private static final SwitchId SWITCH_ID_1 = new SwitchId("00:00:00:00:00:00:00:01");
+    private static final SwitchId SWITCH_ID_2 = new SwitchId("00:00:00:00:00:00:00:02");
+    private static final SwitchId SWITCH_ID_3 = new SwitchId("00:00:00:00:00:00:00:03");
+    private static final SwitchId SWITCH_ID_4 = new SwitchId("00:00:00:00:00:00:00:04");
+    private final WeightFunction weightFunction = this::weightByLatency;
+    private final AvailableNetwork network = new AvailableNetwork();
+    private final BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
+
+    @Test
+    public void shouldFindPathIfAllIslsOnUnderMaintainance() throws UnroutableFlowException {
+        /*
+         *   Topology:
+         *
+         *   SW1--m--SW2--m---SW3
+         *
+         *   All ISLs are in under-maintenance mode
+         */
+        addBidirectionalLink(network, SWITCH_ID_1, SWITCH_ID_2, 1, 2, true, 5);
+        addBidirectionalLink(network, SWITCH_ID_2, SWITCH_ID_3, 5, 6, true, 5);
+
+        FindPathResult path = pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_1, SWITCH_ID_3,
+                weightFunction, 100, 100);
+
+        assertThat(path, is(notNullValue()));
+    }
+
+    @Test(expected = UnroutableFlowException.class)
+    public void shouldNotFindPath() throws UnroutableFlowException {
+        /*
+         *   Topology:
+         *
+         *   SW1--m--SW2--m---SW3
+         *
+         *   All ISLs are in under-maintenance mode
+         */
+        addBidirectionalLink(network, SWITCH_ID_1, SWITCH_ID_2, 1, 2, true, 55);
+        addBidirectionalLink(network, SWITCH_ID_2, SWITCH_ID_3, 5, 6, true, 55);
+
+        FindPathResult path = pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_1, SWITCH_ID_3,
+                weightFunction, 100, 100);
+    }
+
+    @Test
+    public void shouldChoosePathCloseToMaxWeight() throws UnroutableFlowException {
+        /*
+         *   Topology:
+         *
+         *   SW1--m--SW2--m---SW3
+         *            \        |
+         *             ok     ok
+         *              \_SW4_|
+         *
+         */
+        addBidirectionalLink(network, SWITCH_ID_1, SWITCH_ID_2, 1, 2, true, 5);
+        addBidirectionalLink(network, SWITCH_ID_2, SWITCH_ID_3, 5, 6, true, 5);
+        addBidirectionalLink(network, SWITCH_ID_2, SWITCH_ID_4, 7, 8, false, 25);
+        addBidirectionalLink(network, SWITCH_ID_4, SWITCH_ID_3, 9, 10, false, 25);
+
+        FindPathResult path = pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_1, SWITCH_ID_3,
+                weightFunction, 100, 100);
+
+        assertThat(path, is(notNullValue()));
+        List<Edge> forwardPath = path.getFoundPath().getLeft();
+
+        assertAll(
+                () -> assertThat(forwardPath.size(), is(3)),
+                () -> assertThat(forwardPath.get(forwardPath.size() - 1).getSrcSwitch().getSwitchId(), is(SWITCH_ID_4))
+        );
+    }
+
+    @Test
+    public void shouldFindPathAroundMaintainancedIsls() throws UnroutableFlowException {
+        /*
+         *   Topology:
+         *
+         *   SW1--m--SW2--m---SW3
+         *      \             |
+         *       ok          ok
+         *        \___SW4____|
+         *
+         */
+        addBidirectionalLink(network, SWITCH_ID_1, SWITCH_ID_2, 1, 2, true, 5);
+        addBidirectionalLink(network, SWITCH_ID_2, SWITCH_ID_3, 5, 6, true, 5);
+        addBidirectionalLink(network, SWITCH_ID_1, SWITCH_ID_4, 7, 8, false, 25);
+        addBidirectionalLink(network, SWITCH_ID_4, SWITCH_ID_3, 9, 10, false, 25);
+
+        FindPathResult path = pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_1, SWITCH_ID_3,
+                weightFunction, 100, 100);
+
+        assertThat(path, is(notNullValue()));
+        List<Edge> forwardPath = path.getFoundPath().getLeft();
+        assertThat(forwardPath.get(forwardPath.size() - 1).getSrcSwitch().getSwitchId(), is(SWITCH_ID_4));
+    }
+
+    private PathWeight weightByLatency(Edge edge) {
+        long edgeLatency = edge.getLatency() <= 0 ? 10_000L : edge.getLatency();
+        Map<Penalty, Long> penalties = new EnumMap<>(Penalty.class);
+
+        if (edge.isUnderMaintenance()) {
+            penalties.put(UNDER_MAINTENANCE, PENALTY);
+        }
+
+        if (edge.isUnstable()) {
+            penalties.put(UNSTABLE, PENALTY);
+        }
+
+        if (edge.getDiversityGroupUseCounter() > 0) {
+            long value = edge.getDiversityGroupUseCounter() * PENALTY;
+            penalties.put(DIVERSITY_ISL_LATENCY, value);
+        }
+
+        if (edge.getDiversityGroupPerPopUseCounter() > 0) {
+            int value = edge.getDiversityGroupPerPopUseCounter() * (int) PENALTY;
+            penalties.put(DIVERSITY_POP_ISL_COST, (long) value);
+        }
+
+        if (edge.getDestSwitch().getDiversityGroupUseCounter() > 0) {
+            long value = edge.getDestSwitch().getDiversityGroupUseCounter() * PENALTY;
+            penalties.put(DIVERSITY_SWITCH_LATENCY, value);
+        }
+
+        if (edge.getAffinityGroupUseCounter() > 0) {
+            long value = edge.getAffinityGroupUseCounter() * PENALTY;
+            penalties.put(AFFINITY_ISL_LATENCY, value);
+        }
+
+        return new PathWeight(edgeLatency, penalties);
+    }
+
+    private void addBidirectionalLink(AvailableNetwork network, SwitchId firstSwitch, SwitchId secondSwitch,
+                                      int srcPort, int dstPort, boolean isUnderMaintainatce, int weight) {
+        addLink(network, firstSwitch, secondSwitch, srcPort, dstPort, isUnderMaintainatce, weight);
+        addLink(network, secondSwitch, firstSwitch, dstPort, srcPort, isUnderMaintainatce, weight);
+    }
+
+    private void addLink(AvailableNetwork network, SwitchId srcDpid, SwitchId dstDpid, int srcPort, int dstPort,
+                         boolean isUnderMaintainatce, int weight) {
+        Edge edge = Edge.builder()
+                .srcSwitch(network.getOrAddNode(srcDpid, null))
+                .srcPort(srcPort)
+                .destSwitch(network.getOrAddNode(dstDpid, null))
+                .destPort(dstPort)
+                .latency(weight)
+                .cost(weight)
+                .availableBandwidth(500000)
+                .underMaintenance(isUnderMaintainatce)
+                .unstable(false)
+                .build();
+        network.addEdge(edge);
+    }
+}

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/ProtectedPathFinderTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/ProtectedPathFinderTest.java
@@ -1,0 +1,423 @@
+/* Copyright 2022 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.pce.finder;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.openkilda.model.Flow;
+import org.openkilda.model.FlowEncapsulationType;
+import org.openkilda.model.FlowPath;
+import org.openkilda.model.PathComputationStrategy;
+import org.openkilda.model.PathId;
+import org.openkilda.model.PathSegment;
+import org.openkilda.model.Switch;
+import org.openkilda.model.SwitchId;
+import org.openkilda.pce.AvailableNetworkFactory;
+import org.openkilda.pce.AvailableNetworkFactory.BuildStrategy;
+import org.openkilda.pce.GetPathsResult;
+import org.openkilda.pce.PathComputer;
+import org.openkilda.pce.PathComputerConfig;
+import org.openkilda.pce.exception.RecoverableException;
+import org.openkilda.pce.exception.UnroutableFlowException;
+import org.openkilda.pce.impl.AvailableNetwork;
+import org.openkilda.pce.impl.InMemoryPathComputer;
+import org.openkilda.persistence.repositories.FlowPathRepository;
+import org.openkilda.persistence.repositories.IslRepository;
+import org.openkilda.persistence.repositories.IslRepository.IslImmutableView;
+import org.openkilda.persistence.repositories.RepositoryFactory;
+
+import com.google.common.collect.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ProtectedPathFinderTest {
+    private static final SwitchId SWITCH_ID_1 = new SwitchId(1);
+    private static final SwitchId SWITCH_ID_2 = new SwitchId(2);
+    private static final SwitchId SWITCH_ID_3 = new SwitchId(3);
+    private static final SwitchId SWITCH_ID_4 = new SwitchId(4);
+    private static final SwitchId SWITCH_ID_5 = new SwitchId(5);
+    private static final SwitchId SWITCH_ID_6 = new SwitchId(6);
+    private static final SwitchId SWITCH_ID_7 = new SwitchId(7);
+    private static final Switch switchA = Switch.builder().switchId(SWITCH_ID_1).build();
+    private static final Switch switchB = Switch.builder().switchId(SWITCH_ID_2).build();
+    private static final Switch switchC = Switch.builder().switchId(SWITCH_ID_3).build();
+    private static final Switch switchD = Switch.builder().switchId(SWITCH_ID_4).build();
+    private static final Switch switchE = Switch.builder().switchId(SWITCH_ID_5).build();
+    private static final Switch switchG = Switch.builder().switchId(SWITCH_ID_6).build();
+    private static final Switch switchF = Switch.builder().switchId(SWITCH_ID_7).build();
+    private static final PathId FORWARD_PATH_ID = new PathId("forward_path_1");
+    private static final PathId REVERSE_PATH_ID = new PathId("reverse_path_1");
+    private static final String DIVERSE_GROUP_ID = "group_id_1";
+    private static final PathComputationStrategy PATH_COMPUTATION_STRATEGY = PathComputationStrategy.MAX_LATENCY;
+
+    @Mock
+    private PathComputerConfig config;
+    @Mock
+    private RepositoryFactory repositoryFactory;
+    @Mock
+    private IslRepository islRepository;
+    @Mock
+    private FlowPathRepository flowPathRepository;
+
+    private AvailableNetworkFactory availableNetworkFactory;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        when(config.getDiversitySwitchLatency()).thenReturn(10000L);
+        when(config.getDiversityIslLatency()).thenReturn(10000L);
+        when(config.getDiversityIslCost()).thenReturn(10000);
+        when(config.getDiversitySwitchCost()).thenReturn(10000);
+        when(config.getDiversityPopIslCost()).thenReturn(10000);
+
+        when(repositoryFactory.createIslRepository()).thenReturn(islRepository);
+        when(repositoryFactory.createFlowPathRepository()).thenReturn(flowPathRepository);
+
+        availableNetworkFactory = new AvailableNetworkFactory(config, repositoryFactory);
+    }
+
+    @Test
+    public void shouldNotFindProtectedPath() throws RecoverableException, UnroutableFlowException {
+        // Topology:
+        // A----B----C     Already created flow: A-B-C
+        //                 No protected path here for this flow
+
+        List<IslImmutableView> isls = new ArrayList<>();
+        isls.addAll(getBidirectionalIsls(switchA, 1, switchB, 2));
+        isls.addAll(getBidirectionalIsls(switchB, 3, switchC, 4));
+
+        List<PathSegment> forwardSegments = new ArrayList<>();
+        forwardSegments.add(PathSegment.builder().pathId(FORWARD_PATH_ID).srcSwitch(switchA).srcPort(10)
+                .destSwitch(switchB).destPort(10).build());
+        forwardSegments.add(PathSegment.builder().pathId(FORWARD_PATH_ID).srcSwitch(switchB).srcPort(10)
+                .destSwitch(switchC).destPort(10).build());
+
+        FlowPath forwardPath = FlowPath.builder()
+                .srcSwitch(switchA)
+                .destSwitch(switchC)
+                .pathId(FORWARD_PATH_ID)
+                .segments(forwardSegments)
+                .build();
+        when(flowPathRepository.findById(FORWARD_PATH_ID)).thenReturn(java.util.Optional.of(forwardPath));
+
+
+        List<PathSegment> reverseSegments = new ArrayList<>();
+        reverseSegments.add(PathSegment.builder().pathId(REVERSE_PATH_ID).srcSwitch(switchC).srcPort(10)
+                .destSwitch(switchB).destPort(10).build());
+        reverseSegments.add(PathSegment.builder().pathId(REVERSE_PATH_ID).srcSwitch(switchB).srcPort(10)
+                .destSwitch(switchA).destPort(10).build());
+
+        FlowPath reversePath = FlowPath.builder()
+                .srcSwitch(switchC)
+                .destSwitch(switchA)
+                .pathId(REVERSE_PATH_ID)
+                .segments(reverseSegments)
+                .build();
+        when(flowPathRepository.findById(REVERSE_PATH_ID)).thenReturn(java.util.Optional.of(reversePath));
+
+        Flow flow = getFlow(switchA, switchC);
+        flow.setForwardPath(forwardPath);
+        flow.setReversePath(reversePath);
+
+        when(config.getNetworkStrategy()).thenReturn(BuildStrategy.COST.name());
+        when(islRepository.findActiveByBandwidthAndEncapsulationType(flow.getBandwidth(), flow.getEncapsulationType()))
+                .thenReturn(isls);
+
+        when(flowPathRepository.findPathIdsByFlowDiverseGroupId(DIVERSE_GROUP_ID))
+                .thenReturn(Lists.newArrayList(FORWARD_PATH_ID, REVERSE_PATH_ID));
+
+        // check diversity counter
+        AvailableNetwork availableNetwork = availableNetworkFactory.getAvailableNetwork(flow, Collections.emptyList());
+        assertEquals(2, availableNetwork.getSwitch(switchB.getSwitchId()).getDiversityGroupUseCounter());
+
+        // check found path
+        PathComputer pathComputer = new InMemoryPathComputer(
+                availableNetworkFactory, new BestWeightAndShortestPathFinder(200), config);
+
+        assertThrows(UnroutableFlowException.class, () -> pathComputer.getPath(flow, Collections.emptyList(), true));
+    }
+
+    @Test
+    public void shouldNotFindAnyProtectedPath() throws RecoverableException, UnroutableFlowException {
+        // Topology:
+        //      D----E
+        //      |    |
+        // A----B----C     Already created flow: A-B-C
+        //                 No protected path here for this flow
+
+        List<IslImmutableView> isls = new ArrayList<>();
+        isls.addAll(getBidirectionalIsls(switchA, 1, switchB, 2));
+        isls.addAll(getBidirectionalIsls(switchB, 3, switchC, 4));
+        isls.addAll(getBidirectionalIsls(switchB, 7, switchD, 8));
+        isls.addAll(getBidirectionalIsls(switchD, 5, switchE, 6));
+        isls.addAll(getBidirectionalIsls(switchE, 9, switchC, 11));
+
+        List<PathSegment> forwardSegments = new ArrayList<>();
+        forwardSegments.add(PathSegment.builder().pathId(FORWARD_PATH_ID).srcSwitch(switchA).srcPort(1)
+                .destSwitch(switchB).destPort(2).build());
+        forwardSegments.add(PathSegment.builder().pathId(FORWARD_PATH_ID).srcSwitch(switchB).srcPort(3)
+                .destSwitch(switchC).destPort(4).build());
+
+        FlowPath forwardPath = FlowPath.builder()
+                .srcSwitch(switchA)
+                .destSwitch(switchC)
+                .pathId(FORWARD_PATH_ID)
+                .segments(forwardSegments)
+                .build();
+        when(flowPathRepository.findById(FORWARD_PATH_ID)).thenReturn(java.util.Optional.of(forwardPath));
+
+
+        List<PathSegment> reverseSegments = new ArrayList<>();
+        reverseSegments.add(PathSegment.builder().pathId(REVERSE_PATH_ID).srcSwitch(switchC).srcPort(4)
+                .destSwitch(switchB).destPort(3).build());
+        reverseSegments.add(PathSegment.builder().pathId(REVERSE_PATH_ID).srcSwitch(switchB).srcPort(3)
+                .destSwitch(switchA).destPort(1).build());
+
+        FlowPath reversePath = FlowPath.builder()
+                .srcSwitch(switchC)
+                .destSwitch(switchA)
+                .pathId(REVERSE_PATH_ID)
+                .segments(reverseSegments)
+                .build();
+        when(flowPathRepository.findById(REVERSE_PATH_ID)).thenReturn(java.util.Optional.of(reversePath));
+
+        Flow flow = getFlow(switchA, switchC);
+        flow.setForwardPath(forwardPath);
+        flow.setReversePath(reversePath);
+
+        when(config.getNetworkStrategy()).thenReturn(BuildStrategy.COST.name());
+        when(islRepository.findActiveByBandwidthAndEncapsulationType(flow.getBandwidth(), flow.getEncapsulationType()))
+                .thenReturn(isls);
+
+        when(flowPathRepository.findPathIdsByFlowDiverseGroupId(DIVERSE_GROUP_ID))
+                .thenReturn(Lists.newArrayList(FORWARD_PATH_ID, REVERSE_PATH_ID));
+
+        // check diversity counter
+        AvailableNetwork availableNetwork = availableNetworkFactory.getAvailableNetwork(flow, Collections.emptyList());
+        assertEquals(2, availableNetwork.getSwitch(switchB.getSwitchId()).getDiversityGroupUseCounter());
+
+        // check found path
+        PathComputer pathComputer = new InMemoryPathComputer(
+                availableNetworkFactory, new BestWeightAndShortestPathFinder(200), config);
+
+        assertThrows(UnroutableFlowException.class, () -> pathComputer
+                .getPath(flow, Collections.emptyList(), true));
+    }
+
+    @Test
+    public void shouldFindProtectedPath() throws RecoverableException, UnroutableFlowException {
+        // Topology:
+        //     D-----E
+        //   /       |
+        // A----B----C     Already created flow: A-B-C
+        //                 Expected protected path: A-D-E-C
+
+        List<IslImmutableView> isls = new ArrayList<>();
+        isls.addAll(getBidirectionalIsls(switchA, 1, switchB, 2));
+        isls.addAll(getBidirectionalIsls(switchB, 3, switchC, 4));
+        isls.addAll(getBidirectionalIsls(switchA, 7, switchD, 8));
+        isls.addAll(getBidirectionalIsls(switchD, 5, switchE, 6));
+        isls.addAll(getBidirectionalIsls(switchE, 9, switchC, 11));
+
+        List<PathSegment> forwardSegments = new ArrayList<>();
+        forwardSegments.add(PathSegment.builder().pathId(FORWARD_PATH_ID).srcSwitch(switchA).srcPort(1)
+                .destSwitch(switchB).destPort(2).build());
+        forwardSegments.add(PathSegment.builder().pathId(FORWARD_PATH_ID).srcSwitch(switchB).srcPort(3)
+                .destSwitch(switchC).destPort(4).build());
+
+        FlowPath forwardPath = FlowPath.builder()
+                .srcSwitch(switchA)
+                .destSwitch(switchC)
+                .pathId(FORWARD_PATH_ID)
+                .segments(forwardSegments)
+                .build();
+        when(flowPathRepository.findById(FORWARD_PATH_ID)).thenReturn(java.util.Optional.of(forwardPath));
+
+
+        List<PathSegment> reverseSegments = new ArrayList<>();
+        reverseSegments.add(PathSegment.builder().pathId(REVERSE_PATH_ID).srcSwitch(switchC).srcPort(4)
+                .destSwitch(switchB).destPort(3).build());
+        reverseSegments.add(PathSegment.builder().pathId(REVERSE_PATH_ID).srcSwitch(switchB).srcPort(3)
+                .destSwitch(switchA).destPort(1).build());
+
+        FlowPath reversePath = FlowPath.builder()
+                .srcSwitch(switchC)
+                .destSwitch(switchA)
+                .pathId(REVERSE_PATH_ID)
+                .segments(reverseSegments)
+                .build();
+        when(flowPathRepository.findById(REVERSE_PATH_ID)).thenReturn(java.util.Optional.of(reversePath));
+
+        Flow flow = getFlow(switchA, switchC);
+        flow.setForwardPath(forwardPath);
+        flow.setReversePath(reversePath);
+
+        when(config.getNetworkStrategy()).thenReturn(BuildStrategy.COST.name());
+        when(islRepository.findActiveByBandwidthAndEncapsulationType(flow.getBandwidth(), flow.getEncapsulationType()))
+                .thenReturn(isls);
+
+        when(flowPathRepository.findPathIdsByFlowDiverseGroupId(DIVERSE_GROUP_ID))
+                .thenReturn(Lists.newArrayList(FORWARD_PATH_ID, REVERSE_PATH_ID));
+
+        // check diversity counter
+        AvailableNetwork availableNetwork = availableNetworkFactory.getAvailableNetwork(flow, Collections.emptyList());
+        assertEquals(2, availableNetwork.getSwitch(switchB.getSwitchId()).getDiversityGroupUseCounter());
+
+        // check found path
+        PathComputer pathComputer = new InMemoryPathComputer(
+                availableNetworkFactory, new BestWeightAndShortestPathFinder(200), config);
+
+        GetPathsResult path = pathComputer.getPath(flow, Collections.emptyList(), true);
+
+        assertThat(path, is(notNullValue()));
+        assertThat(path.getForward(), is(notNullValue()));
+        assertThat(path.getForward().getSegments().size(), is(3));
+        assertThat(path.getReverse(), is(notNullValue()));
+        assertThat(path.getReverse().getSegments().size(), is(3));
+    }
+
+    private static List<IslImmutableView> getBidirectionalIsls(Switch srcSwitch, int srcPort,
+                                                               Switch dstSwitch, int dstPort) {
+        return Lists.newArrayList(
+                getIslView(srcSwitch, srcPort, dstSwitch, dstPort),
+                getIslView(dstSwitch, dstPort, srcSwitch, srcPort));
+    }
+
+    private static IslImmutableView getIslView(Switch srcSwitch, int srcPort, Switch dstSwitch, int dstPort) {
+        IslImmutableView isl = mock(IslImmutableView.class);
+        when(isl.getSrcSwitchId()).thenReturn(srcSwitch.getSwitchId());
+        when(isl.getSrcPort()).thenReturn(srcPort);
+        when(isl.getDestSwitchId()).thenReturn(dstSwitch.getSwitchId());
+        when(isl.getDestPort()).thenReturn(dstPort);
+        when(isl.getCost()).thenReturn(10);
+        when(isl.getLatency()).thenReturn(33L);
+        when(isl.getAvailableBandwidth()).thenReturn(1000L);
+        when(isl.isUnderMaintenance()).thenReturn(false);
+        when(isl.isUnstable()).thenReturn(false);
+        return isl;
+    }
+
+    @Test
+    public void shouldNotFindProtectedPathWithSharedSwitch() throws RecoverableException, UnroutableFlowException {
+        // Topology:
+        //  Already created flow: A-B-C-E-F
+        //  No protected path here for this flow
+        //       G----F
+        //       |    |
+        //  B----C----E
+        //  |    |
+        //  A----D
+
+        List<IslImmutableView> isls = new ArrayList<>();
+        isls.addAll(getBidirectionalIsls(switchA, 1, switchB, 2));
+        isls.addAll(getBidirectionalIsls(switchA, 3, switchD, 4));
+        isls.addAll(getBidirectionalIsls(switchB, 5, switchC, 6));
+        isls.addAll(getBidirectionalIsls(switchD, 7, switchC, 8));
+        isls.addAll(getBidirectionalIsls(switchC, 1, switchG, 2));
+        isls.addAll(getBidirectionalIsls(switchC, 2, switchE, 3));
+        isls.addAll(getBidirectionalIsls(switchG, 3, switchF, 4));
+        isls.addAll(getBidirectionalIsls(switchE, 5, switchF, 6));
+
+        List<PathSegment> forwardSegments = new ArrayList<>();
+        forwardSegments.add(PathSegment.builder().pathId(FORWARD_PATH_ID).srcSwitch(switchA).srcPort(10)
+                .destSwitch(switchB).destPort(10).build());
+        forwardSegments.add(PathSegment.builder().pathId(FORWARD_PATH_ID).srcSwitch(switchB).srcPort(11)
+                .destSwitch(switchC).destPort(11).build());
+        forwardSegments.add(PathSegment.builder().pathId(FORWARD_PATH_ID).srcSwitch(switchC).srcPort(12)
+                .destSwitch(switchE).destPort(12).build());
+        forwardSegments.add(PathSegment.builder().pathId(FORWARD_PATH_ID).srcSwitch(switchE).srcPort(13)
+                .destSwitch(switchF).destPort(13).build());
+
+        FlowPath forwardPath = FlowPath.builder()
+                .srcSwitch(switchA)
+                .destSwitch(switchF)
+                .pathId(FORWARD_PATH_ID)
+                .segments(forwardSegments)
+                .build();
+        when(flowPathRepository.findById(FORWARD_PATH_ID)).thenReturn(java.util.Optional.of(forwardPath));
+
+
+        List<PathSegment> reverseSegments = new ArrayList<>();
+        reverseSegments.add(PathSegment.builder().pathId(REVERSE_PATH_ID).srcSwitch(switchF).srcPort(13)
+                .destSwitch(switchE).destPort(13).build());
+        reverseSegments.add(PathSegment.builder().pathId(REVERSE_PATH_ID).srcSwitch(switchE).srcPort(12)
+                .destSwitch(switchC).destPort(12).build());
+        reverseSegments.add(PathSegment.builder().pathId(REVERSE_PATH_ID).srcSwitch(switchC).srcPort(11)
+                .destSwitch(switchB).destPort(11).build());
+        reverseSegments.add(PathSegment.builder().pathId(REVERSE_PATH_ID).srcSwitch(switchB).srcPort(10)
+                .destSwitch(switchA).destPort(10).build());
+
+        FlowPath reversePath = FlowPath.builder()
+                .srcSwitch(switchF)
+                .destSwitch(switchA)
+                .pathId(REVERSE_PATH_ID)
+                .segments(reverseSegments)
+                .build();
+        when(flowPathRepository.findById(REVERSE_PATH_ID)).thenReturn(java.util.Optional.of(reversePath));
+
+        Flow flow = getFlow(switchA, switchF);
+        flow.setForwardPath(forwardPath);
+        flow.setReversePath(reversePath);
+
+        when(config.getNetworkStrategy()).thenReturn(BuildStrategy.COST.name());
+        when(islRepository.findActiveByBandwidthAndEncapsulationType(flow.getBandwidth(), flow.getEncapsulationType()))
+                .thenReturn(isls);
+
+        when(flowPathRepository.findPathIdsByFlowDiverseGroupId(DIVERSE_GROUP_ID))
+                .thenReturn(Lists.newArrayList(FORWARD_PATH_ID, REVERSE_PATH_ID));
+
+        // check diversity counter
+        AvailableNetwork availableNetwork = availableNetworkFactory.getAvailableNetwork(flow, Collections.emptyList());
+        assertEquals(2, availableNetwork.getSwitch(switchC.getSwitchId()).getDiversityGroupUseCounter());
+
+        // check found path
+        PathComputer pathComputer = new InMemoryPathComputer(
+                availableNetworkFactory, new BestWeightAndShortestPathFinder(200), config);
+
+        assertThrows(UnroutableFlowException.class, () -> pathComputer.getPath(flow, Collections.emptyList(), true));
+    }
+
+    private static Flow getFlow(Switch from, Switch to) {
+        Flow flow = Flow.builder()
+                .flowId("test-id")
+                .srcSwitch(from)
+                .destSwitch(to)
+                .encapsulationType(FlowEncapsulationType.TRANSIT_VLAN)
+                .bandwidth(100)
+                .ignoreBandwidth(false)
+                .diverseGroupId(DIVERSE_GROUP_ID)
+                .maxLatency(Long.MAX_VALUE)
+                .pathComputationStrategy(PATH_COMPUTATION_STRATEGY)
+                .allocateProtectedPath(true)
+                .build();
+        flow.setForwardPathId(new PathId("forward_path_id"));
+        flow.setReversePathId(new PathId("reverse_path_id"));
+        return flow;
+    }
+}

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/AvailableNetworkTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/AvailableNetworkTest.java
@@ -118,7 +118,7 @@ public class AvailableNetworkTest {
                         buildPathWithSegment(SWITCH_3, SWITCH_5, 2, 2, POP_4, POP_3, 1)));
         long expectedWeight = cost + 1000L;
         for (Edge edge : network.edges) {
-            long currentWeight = weightFunction.apply(edge).toLong();
+            long currentWeight = weightFunction.apply(edge).getTotalWeight();
             if (edge.getSrcSwitch().getPop().equals(POP_4)
                     || edge.getDestSwitch().getPop().equals(POP_4)) {
                 assertEquals(expectedWeight, currentWeight);
@@ -146,7 +146,7 @@ public class AvailableNetworkTest {
                 asList(buildPathWithSegment(SWITCH_1, SWITCH_3, 2, 1, POP_1, null, 0),
                         buildPathWithSegment(SWITCH_3, SWITCH_5, 2, 2, null, POP_3, 1)));
         for (Edge edge : network.edges) {
-            long currentWeight = weightFunction.apply(edge).toLong();
+            long currentWeight = weightFunction.apply(edge).getTotalWeight();
             assertEquals(cost, currentWeight);
         }
     }
@@ -169,7 +169,7 @@ public class AvailableNetworkTest {
                 asList(buildPathWithSegment(SWITCH_1, SWITCH_3, 2, 1, POP_1, null, 0),
                         buildPathWithSegment(SWITCH_3, SWITCH_5, 2, 2, null, POP_3, 1)));
         for (Edge edge : network.edges) {
-            long currentWeight = weightFunction.apply(edge).toLong();
+            long currentWeight = weightFunction.apply(edge).getTotalWeight();
             assertEquals(cost, currentWeight);
         }
     }
@@ -192,7 +192,7 @@ public class AvailableNetworkTest {
                 asList(buildPathSegment(SWITCH_1, SWITCH_3, 2, 1, 0),
                         buildPathSegment(SWITCH_3, SWITCH_5, 2, 2, 1)));
         for (Edge edge : network.edges) {
-            long currentWeight = weightFunction.apply(edge).toLong();
+            long currentWeight = weightFunction.apply(edge).getTotalWeight();
             assertEquals(cost, currentWeight);
         }
     }

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/CostAndBandwidthPathComputationStrategyTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/CostAndBandwidthPathComputationStrategyTest.java
@@ -270,7 +270,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
 
         flowRepository.add(flow);
 
-        GetPathsResult path2 = pathComputer.getPath(flow, flow.getPathIds());
+        GetPathsResult path2 = pathComputer.getPath(flow, flow.getPathIds(), false);
         assertEquals(diversePath, path2);
     }
 

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/CostPathComputationStrategyTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/CostPathComputationStrategyTest.java
@@ -294,7 +294,7 @@ public class CostPathComputationStrategyTest extends InMemoryPathComputerBaseTes
 
         flowRepository.add(flow);
 
-        GetPathsResult path2 = pathComputer.getPath(flow, flow.getPathIds());
+        GetPathsResult path2 = pathComputer.getPath(flow, flow.getPathIds(), false);
         assertEquals(diversePath, path2);
     }
 

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/InMemoryPathComputerBaseTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/InMemoryPathComputerBaseTest.java
@@ -233,7 +233,7 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
         Flow oldFlow = flowRepository.findById(flowId).orElseThrow(() -> new AssertionError("Flow not found"));
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        GetPathsResult result = pathComputer.getPath(flow, oldFlow.getPathIds());
+        GetPathsResult result = pathComputer.getPath(flow, oldFlow.getPathIds(), false);
 
         assertThat(result.getForward().getSegments(), Matchers.hasSize(2));
         assertThat(result.getReverse().getSegments(), Matchers.hasSize(2));
@@ -269,7 +269,7 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
         thrown.expect(UnroutableFlowException.class);
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        pathComputer.getPath(flow, flow.getPathIds());
+        pathComputer.getPath(flow, flow.getPathIds(), false);
     }
 
     @Test
@@ -503,7 +503,8 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
     }
 
     // A - B - D    and A-B-D is used in flow affinity group
-    //   + C +
+    //   \   /
+    //     C
     void createDiamondWithAffinity() {
         Switch nodeA = createSwitch("00:0A");
         Switch nodeB = createSwitch("00:0B");

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/LatencyPathComputationStrategyBaseTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/LatencyPathComputationStrategyBaseTest.java
@@ -299,7 +299,7 @@ public class LatencyPathComputationStrategyBaseTest extends InMemoryPathComputer
 
         flowRepository.add(flow);
 
-        GetPathsResult path2 = pathComputer.getPath(flow, flow.getPathIds());
+        GetPathsResult path2 = pathComputer.getPath(flow, flow.getPathIds(), false);
         assertEquals(diversePath, path2);
     }
 

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/model/PathWeightTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/model/PathWeightTest.java
@@ -1,4 +1,4 @@
-/* Copyright 2020 Telstra Open Source
+/* Copyright 2022 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -18,27 +18,31 @@ package org.openkilda.pce.model;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.openkilda.pce.model.PathWeight.Penalty;
+
 import org.junit.Test;
+
+import java.util.EnumMap;
 
 public class PathWeightTest {
 
     @Test
-    public void add() {
-        PathWeight first = new PathWeight(2, 7);
-        PathWeight second = new PathWeight(1, 2);
+    public void shouldAddWithAlterWeight() {
+        PathWeight first = new PathWeight(2L, 7L);
+        PathWeight second = new PathWeight(1L, 2L);
 
         PathWeight actual = first.add(second);
 
-        assertEquals(0, actual.compareTo(new PathWeight(3, 9)));
+        assertEquals(0, actual.compareTo(new PathWeight(3L, 9L)));
     }
 
     @Test
-    public void compareTo() {
-        final PathWeight first = new PathWeight(2, 7);
-        final PathWeight second = new PathWeight(5, 7);
-        final PathWeight equalToSecond = new PathWeight(5, 7);
-        final PathWeight third = new PathWeight(7);
-        final PathWeight fourth = new PathWeight(7, 2);
+    public void shouldComparePathWeights() {
+        final PathWeight first = new PathWeight(2L, 7L);
+        final PathWeight second = new PathWeight(5L, 7L);
+        final PathWeight equalToSecond = new PathWeight(5L, 7L);
+        final PathWeight third = new PathWeight(7L);
+        final PathWeight fourth = new PathWeight(7L, 2L);
 
         assertTrue(first.compareTo(second) < 0);
         assertTrue(second.compareTo(first) > 0);
@@ -46,5 +50,76 @@ public class PathWeightTest {
         assertTrue(second.compareTo(third) < 0);
         assertTrue(third.compareTo(fourth) < 0);
         assertTrue(fourth.compareTo(third) > 0);
+    }
+
+    @Test
+    public void shouldAddWithPenalties() {
+        EnumMap<Penalty, Long> firstPenalties = new EnumMap<>(Penalty.class);
+        firstPenalties.put(Penalty.UNSTABLE, 1L);
+        firstPenalties.put(Penalty.UNDER_MAINTENANCE, 2L);
+        firstPenalties.put(Penalty.AFFINITY_ISL_LATENCY, 3L);
+        firstPenalties.put(Penalty.DIVERSITY_ISL_LATENCY, 4L);
+        firstPenalties.put(Penalty.DIVERSITY_POP_ISL_COST, 5L);
+        firstPenalties.put(Penalty.DIVERSITY_SWITCH_LATENCY, 6L);
+        PathWeight first = new PathWeight(2L, firstPenalties, 5L);
+
+        EnumMap<Penalty, Long> secondPenalties = new EnumMap<>(Penalty.class);
+        secondPenalties.put(Penalty.UNSTABLE, 1L);
+        secondPenalties.put(Penalty.UNDER_MAINTENANCE, 2L);
+        secondPenalties.put(Penalty.AFFINITY_ISL_LATENCY, 3L);
+        secondPenalties.put(Penalty.DIVERSITY_ISL_LATENCY, 4L);
+        secondPenalties.put(Penalty.DIVERSITY_POP_ISL_COST, 5L);
+        secondPenalties.put(Penalty.DIVERSITY_SWITCH_LATENCY, 6L);
+        PathWeight second = new PathWeight(1L, secondPenalties, 2L);
+
+        PathWeight result = first.add(second);
+
+        assertEquals(3L, result.getBaseWeight());
+        assertEquals(7L, result.getAlternativeBaseWeight());
+        assertEquals(2L, result.getPenaltyValue(Penalty.UNSTABLE));
+        assertEquals(4L, result.getPenaltyValue(Penalty.UNDER_MAINTENANCE));
+        assertEquals(6L, result.getPenaltyValue(Penalty.AFFINITY_ISL_LATENCY));
+        assertEquals(8L, result.getPenaltyValue(Penalty.DIVERSITY_ISL_LATENCY));
+        assertEquals(10L, result.getPenaltyValue(Penalty.DIVERSITY_POP_ISL_COST));
+        assertEquals(12L, result.getPenaltyValue(Penalty.DIVERSITY_SWITCH_LATENCY));
+        assertEquals(45L, result.getTotalWeight());
+    }
+
+    @Test
+    public void shouldComparePathWeightsWithPenalties() {
+        EnumMap<Penalty, Long> firstPenalties = new EnumMap<>(Penalty.class);
+        firstPenalties.put(Penalty.UNSTABLE, 1L);
+        final PathWeight first = new PathWeight(2L, firstPenalties);
+
+        EnumMap<Penalty, Long> secondPenalties = new EnumMap<>(Penalty.class);
+        secondPenalties.put(Penalty.UNDER_MAINTENANCE, 1L);
+        final PathWeight second = new PathWeight(5L, secondPenalties);
+
+        final PathWeight equalToSecond = new PathWeight(5L, secondPenalties);
+
+        EnumMap<Penalty, Long> thirdPenalties = new EnumMap<>(Penalty.class);
+        thirdPenalties.put(Penalty.AFFINITY_ISL_LATENCY, 10L);
+        final PathWeight third = new PathWeight(1L, thirdPenalties);
+
+        EnumMap<Penalty, Long> fourthPenalties = new EnumMap<>(Penalty.class);
+        fourthPenalties.put(Penalty.AFFINITY_ISL_LATENCY, 2L);
+        fourthPenalties.put(Penalty.DIVERSITY_SWITCH_LATENCY, 2L);
+        fourthPenalties.put(Penalty.DIVERSITY_POP_ISL_COST, 2L);
+        fourthPenalties.put(Penalty.DIVERSITY_ISL_LATENCY, 2L);
+        fourthPenalties.put(Penalty.UNSTABLE, 2L);
+        fourthPenalties.put(Penalty.UNDER_MAINTENANCE, 2L);
+        final PathWeight fourth = new PathWeight(1L, fourthPenalties);
+
+        EnumMap<Penalty, Long> fifthPenalties = new EnumMap<>(Penalty.class);
+        fifthPenalties.put(Penalty.UNDER_MAINTENANCE, 30L);
+        final PathWeight fifth = new PathWeight(1L, fifthPenalties);
+
+        assertTrue(first.compareTo(second) < 0);
+        assertTrue(second.compareTo(first) > 0);
+        assertTrue(second.compareTo(equalToSecond) == 0);
+        assertTrue(second.compareTo(third) < 0);
+        assertTrue(third.compareTo(fourth) < 0);
+        assertTrue(fourth.compareTo(third) > 0);
+        assertTrue(fifth.compareTo(fourth) > 0);
     }
 }


### PR DESCRIPTION
Refactored PathWeight-class for storing penalties separately.
Fixed findPathWithWeightCloseToMaxWeight-method for avoid penalties while desired path is not found.

Closes https://github.com/telstra/open-kilda/issues/4927