### PR TITLE
#4955: Extend "path not found" error messages tests

### DIFF
--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/exception/ExpectedHttpClientErrorException.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/exception/ExpectedHttpClientErrorException.groovy
@@ -1,0 +1,39 @@
+package org.openkilda.functionaltests.exception
+
+import org.openkilda.messaging.error.MessageError
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.HttpClientErrorException
+
+import java.util.regex.Pattern
+
+class ExpectedHttpClientErrorException {
+    HttpStatus statusCode
+    Pattern messagePattern
+
+    ExpectedHttpClientErrorException(HttpStatus statusCode, Pattern messagePattern) {
+        this.statusCode = statusCode
+        this.messagePattern = messagePattern
+    }
+
+    boolean equals(other) {
+        if (other == null) {
+            return false
+        }
+        if (other.class == HttpClientErrorException.class) {
+            return other.statusCode == statusCode &&
+                    other.responseBodyAsString.to(MessageError).errorDescription =~ messagePattern
+        }
+        if (other.class == this.class) {
+            return other.statusCode == statusCode &&
+                    other.messagePattern == messagePattern
+        }
+        return false
+    }
+
+    int hashCode() {
+        int hash = 7
+        hash = 31 * hash + (statusCode == null ? 0 : statusCode.hashCode())
+        hash = 31 * hash + (messagePattern == null ? 0 : messagePattern.hashCode())
+        return hash
+    }
+}

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
@@ -1,5 +1,8 @@
 package org.openkilda.functionaltests.spec.flows
 
+import org.openkilda.functionaltests.exception.ExpectedHttpClientErrorException
+import org.openkilda.model.PathComputationStrategy
+
 import static groovyx.gpars.GParsPool.withPool
 import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
@@ -61,6 +64,8 @@ More specific cases like partialUpdate/protected/diverse etc. are covered in sep
 """)
 class FlowCrudSpec extends HealthCheckSpecification {
 
+    final static Integer IMPOSSIBLY_LOW_LATENCY = 1
+    final static Long IMPOSSIBLY_HIGH_BANDWIDTH = Long.MAX_VALUE
     @Autowired @Shared
     Provider<TraffExamService> traffExamProvider
 
@@ -478,6 +483,8 @@ class FlowCrudSpec extends HealthCheckSpecification {
     def "Error is returned if there is no available path to #data.isolatedSwitchType switch"() {
         given: "A switch that has no connection to other switches"
         def isolatedSwitch = topologyHelper.notNeighboringSwitchPair.src
+        def expectedException = new ExpectedHttpClientErrorException(HttpStatus.NOT_FOUND,
+                ~/Switch ${isolatedSwitch.dpId.toString()} doesn't have links with enough bandwidth/)
         def flow = data.getFlow(isolatedSwitch)
         topology.getBusyPortsForSwitch(isolatedSwitch).each { port ->
             antiflap.portDown(isolatedSwitch.dpId, port)
@@ -495,12 +502,7 @@ class FlowCrudSpec extends HealthCheckSpecification {
 
         then: "Error is returned, stating that there is no path found for such flow"
         def error = thrown(HttpClientErrorException)
-        error.statusCode == HttpStatus.NOT_FOUND
-        def errorDetails = error.responseBodyAsString.to(MessageError)
-        errorDetails.errorMessage == "Could not create flow"
-        errorDetails.errorDescription == "Not enough bandwidth or no path found. Failed to find path with " +
-                "requested bandwidth=$flow.maximumBandwidth: Switch ${isolatedSwitch.dpId.toString()} doesn't have " +
-                "links with enough bandwidth"
+        expectedException.equals(error)
 
         cleanup: "Restore connection to the isolated switch and reset costs"
         !error && flowHelperV2.deleteFlow(flow.flowId)
@@ -583,41 +585,58 @@ class FlowCrudSpec extends HealthCheckSpecification {
     }
 
     @Tidy
-    def "Unable to create a flow with invalid encapsulation type"() {
-        given: "A flow with invalid encapsulation type"
+    def "Unable to create a flow with #problem"() {
+        given: "A flow with #problem"
         def (Switch srcSwitch, Switch dstSwitch) = topology.activeSwitches
         def flow = flowHelperV2.randomFlow(srcSwitch, dstSwitch)
-        flow.setEncapsulationType("fake")
-
+        flow = update(flow)
         when: "Try to create a flow"
         flowHelperV2.addFlow(flow)
 
         then: "Flow is not created"
-        def exc = thrown(HttpClientErrorException)
-        exc.rawStatusCode == 400
-        exc.responseBodyAsString.to(MessageError).errorDescription == "Can not parse arguments of the create flow request"
-
+        def actualException = thrown(HttpClientErrorException)
+        expectedException.equals(actualException)
         cleanup:
-        !exc && flowHelperV2.deleteFlow(flow.flowId)
+        !actualException && flowHelperV2.deleteFlow(flow.flowId)
+
+        where:
+        problem |   update    | expectedException
+        "invalid encapsulation type"|
+        {FlowRequestV2 flowToSpoil ->
+            flowToSpoil.setEncapsulationType("fake")
+        return flowToSpoil} |
+        new ExpectedHttpClientErrorException(HttpStatus.BAD_REQUEST, ~/Can not parse arguments of the create flow request/)
+        "unavailable latency" |
+                {FlowRequestV2 flowToSpoil ->
+            flowToSpoil.setMaxLatency(IMPOSSIBLY_LOW_LATENCY)
+            flowToSpoil.setPathComputationStrategy(PathComputationStrategy.MAX_LATENCY.toString())
+        return flowToSpoil}|
+                new ExpectedHttpClientErrorException(HttpStatus.NOT_FOUND,
+                        ~/Latency limit: Requested path must have latency ${
+                            IMPOSSIBLY_LOW_LATENCY}ms or lower, but best path has latency \d+ms/)
+
     }
 
     @Tidy
-	def "Unable to update a flow with invalid encapsulation type"() {
-		given: "A flow with invalid encapsulation type"
+	def "Unable to update to a flow with unavailable bandwidth"() {
+		given: "A flow"
 		def (Switch srcSwitch, Switch dstSwitch) = topology.activeSwitches
 		def flow = flowHelperV2.randomFlow(srcSwitch, dstSwitch)
 		flowHelperV2.addFlow(flow)
+        def expectedException = new ExpectedHttpClientErrorException(HttpStatus.NOT_FOUND,
+                ~/Failed to find path with requested bandwidth=${this.IMPOSSIBLY_HIGH_BANDWIDTH}: Switch ${
+                    srcSwitch.dpId.toString()} doesn't have links with enough bandwidth/)
 
-		when: "Try to update the flow (faked encapsulation type)"
+
+		when: "Try to update the flow "
 		def flowInfo = northboundV2.getFlow(flow.flowId)
+        flowInfo = flowInfo.tap {it.maximumBandwidth = this.IMPOSSIBLY_HIGH_BANDWIDTH}
 		northboundV2.updateFlow(flowInfo.flowId,
-                flowHelperV2.toRequest(flowInfo.tap { it.encapsulationType = "fake" }))
+                flowHelperV2.toRequest(flowInfo))
 
 		then: "Flow is not updated"
-		def exc = thrown(HttpClientErrorException)
-		exc.rawStatusCode == 400
-		exc.responseBodyAsString.to(MessageError).errorDescription \
-				== "Can not parse arguments of the update flow request"
+		def actualException = thrown(HttpClientErrorException)
+		expectedException.equals(actualException)
 
         cleanup: "Remove the flow"
         flowHelperV2.deleteFlow(flow.flowId)


### PR DESCRIPTION
* Extended existing tests to verify new messages
* Added class ExpectedHttpClientErrorException that simplifies http errors-related assertions