### PR TITLE
#4984: fix sub flow descriptions

### DIFF
--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/mapper/YFlowRequestMapper.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/mapper/YFlowRequestMapper.java
@@ -92,7 +92,7 @@ public abstract class YFlowRequestMapper {
                         .destVlan(subFlow.getEndpoint().getOuterVlanId())
                         .destInnerVlan(subFlow.getEndpoint().getInnerVlanId())
                         .detectConnectedDevices(new DetectConnectedDevices()) //TODO: map it?
-                        .description(request.getDescription())
+                        .description(subFlow.getDescription())
                         .flowEncapsulationType(request.getEncapsulationType())
                         .bandwidth(request.getMaximumBandwidth())
                         .ignoreBandwidth(request.isIgnoreBandwidth())

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/mapper/YFlowRequestMapperTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/mapper/YFlowRequestMapperTest.java
@@ -1,0 +1,150 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.mapper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
+import org.openkilda.messaging.command.yflow.SubFlowDto;
+import org.openkilda.messaging.command.yflow.SubFlowSharedEndpointEncapsulation;
+import org.openkilda.messaging.command.yflow.YFlowRequest;
+import org.openkilda.model.FlowEncapsulationType;
+import org.openkilda.model.FlowEndpoint;
+import org.openkilda.model.FlowStatus;
+import org.openkilda.model.PathComputationStrategy;
+import org.openkilda.model.SwitchId;
+import org.openkilda.wfm.topology.flowhs.model.RequestedFlow;
+
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class YFlowRequestMapperTest {
+    public static final PathComputationStrategy REQUEST_COMPUTATION_STRATEGY =
+            PathComputationStrategy.COST_AND_AVAILABLE_BANDWIDTH;
+    private static final SwitchId SUB_FLOW_SWITCH_ID_1 = new SwitchId("00:01");
+    private static final String SUB_FLOW_1_ID = "subflow1 id";
+    private static final String SUB_FLOW_DESCRIPTION = "subflow description";
+    private static final Instant SUB_FLOW_TIME_UPDATE = Instant.ofEpochMilli(100_000);
+    private static final int SUB_FLOW_SHARED_END_POINT_VLAN_ID = 12;
+    private static final int SUB_FLOW_SHARED_END_POINT_INNER_VLAN_ID = 13;
+    private static final SubFlowSharedEndpointEncapsulation SUB_FLOW_SHARED_ENDPOINT_ENCAPSULATION =
+            new SubFlowSharedEndpointEncapsulation(SUB_FLOW_SHARED_END_POINT_VLAN_ID,
+                    SUB_FLOW_SHARED_END_POINT_INNER_VLAN_ID);
+    private static final int SUB_FLOW_PORT_NUMBER = 1;
+    private static final int SUB_FLOW_INNER_VLAN = 1000;
+    private static final int SUB_FLOW_OUTER_VLAN = 1001;
+    private static final FlowEndpoint SUB_FLOW_END_POINT =
+            new FlowEndpoint(SUB_FLOW_SWITCH_ID_1, SUB_FLOW_PORT_NUMBER, SUB_FLOW_OUTER_VLAN, SUB_FLOW_INNER_VLAN);
+    private static final FlowStatus SUB_FLOW_STATUS = FlowStatus.UP;
+    public static final YFlowRequest.Type REQUEST_TYPE = YFlowRequest.Type.CREATE;
+    public static final FlowEncapsulationType REQUEST_ENCAPSULATION_TYPE = FlowEncapsulationType.TRANSIT_VLAN;
+    public static final long REQUEST_MAXIMUM_BANDWIDTH = 100500L;
+    public static final boolean REQUEST_IGNORE_BANDWIDTH = true;
+    public static final boolean REQUEST_STRICT_BANDWIDTH = true;
+    public static final boolean REQUEST_PINNED = true;
+    public static final int REQUEST_PRIORITY = 2;
+    public static final long REQUEST_MAX_LATENCY = 42L;
+    public static final long REQUEST_MAX_LATENCY_TIER_2 = 84L;
+    public static final boolean REQUEST_PERIODIC_PINGS = true;
+    public static final boolean REQUEST_ALLOCATE_PROTECTED_PATH = true;
+    private static final SwitchId REQUEST_SWITCH_ID = new SwitchId("00:02");
+    private static final int REQUEST_PORT_NUMBER = 50;
+    public static final FlowEndpoint REQUEST_SHARED_END_POINT =
+            new FlowEndpoint(REQUEST_SWITCH_ID, REQUEST_PORT_NUMBER);
+    public static final String REQUEST_Y_FLOW_ID = "request y-flow id";
+    public static final String REQUEST_DESCRIPTION = "request description";
+    public static final String REQUEST_DIVERSE_FLOW_ID = "request diverse flow id";
+
+    @Test
+    public void toRequestedFlow() {
+        List<SubFlowDto> subFlowDtos = Collections.singletonList(createSubFlowDto());
+        YFlowRequest request = createYflowRequest(subFlowDtos);
+
+        RequestedFlow actualRequestedFlow = new ArrayList<>(
+                new YFlowRequestMapperImpl().toRequestedFlows(request)).get(0);
+
+        // taken from the request
+        assertEquals(REQUEST_SWITCH_ID, actualRequestedFlow.getSrcSwitch());
+        assertEquals(REQUEST_PORT_NUMBER, actualRequestedFlow.getSrcPort());
+        assertEquals(REQUEST_ENCAPSULATION_TYPE, actualRequestedFlow.getFlowEncapsulationType());
+        assertEquals(REQUEST_MAXIMUM_BANDWIDTH, actualRequestedFlow.getBandwidth());
+        assertEquals(REQUEST_IGNORE_BANDWIDTH, actualRequestedFlow.isIgnoreBandwidth());
+        assertEquals(REQUEST_STRICT_BANDWIDTH, actualRequestedFlow.isStrictBandwidth());
+        assertEquals(REQUEST_PINNED, actualRequestedFlow.isPinned());
+        assertEquals(Long.valueOf(REQUEST_PRIORITY), Long.valueOf(actualRequestedFlow.getPriority()));
+        assertEquals(Long.valueOf(REQUEST_MAX_LATENCY), actualRequestedFlow.getMaxLatency());
+        assertEquals(Long.valueOf(REQUEST_MAX_LATENCY_TIER_2), actualRequestedFlow.getMaxLatencyTier2());
+        assertEquals(REQUEST_PERIODIC_PINGS, actualRequestedFlow.isPeriodicPings());
+        assertEquals(REQUEST_COMPUTATION_STRATEGY, actualRequestedFlow.getPathComputationStrategy());
+        assertEquals(REQUEST_ALLOCATE_PROTECTED_PATH, actualRequestedFlow.isAllocateProtectedPath());
+        assertNotEquals("A diverse flow id from the request is ignored",
+                REQUEST_DIVERSE_FLOW_ID, actualRequestedFlow.getDiverseFlowId());
+        assertNull(actualRequestedFlow.getDiverseFlowId());
+
+        // taken from subflows
+        assertEquals(SUB_FLOW_1_ID, actualRequestedFlow.getFlowId());
+        assertEquals(SUB_FLOW_SHARED_END_POINT_VLAN_ID, actualRequestedFlow.getSrcVlan());
+        assertEquals(SUB_FLOW_SHARED_END_POINT_INNER_VLAN_ID, actualRequestedFlow.getSrcInnerVlan());
+        assertEquals(SUB_FLOW_SWITCH_ID_1, actualRequestedFlow.getDestSwitch());
+        assertEquals(SUB_FLOW_PORT_NUMBER, actualRequestedFlow.getDestPort());
+        assertEquals(SUB_FLOW_OUTER_VLAN, actualRequestedFlow.getDestVlan());
+        assertEquals(SUB_FLOW_INNER_VLAN, actualRequestedFlow.getDestInnerVlan());
+        assertEquals(SUB_FLOW_DESCRIPTION, actualRequestedFlow.getDescription());
+        assertNotEquals(REQUEST_DESCRIPTION, actualRequestedFlow.getDescription());
+        assertEquals(SUB_FLOW_SHARED_END_POINT_VLAN_ID, actualRequestedFlow.getSrcVlan());
+        assertEquals(SUB_FLOW_SHARED_END_POINT_INNER_VLAN_ID, actualRequestedFlow.getSrcInnerVlan());
+    }
+
+    private YFlowRequest createYflowRequest(List<SubFlowDto> subFlowDtos) {
+        return YFlowRequest.builder()
+                .allocateProtectedPath(REQUEST_ALLOCATE_PROTECTED_PATH)
+                .diverseFlowId(REQUEST_DIVERSE_FLOW_ID)
+                .description(REQUEST_DESCRIPTION)
+                .encapsulationType(REQUEST_ENCAPSULATION_TYPE)
+                .ignoreBandwidth(REQUEST_IGNORE_BANDWIDTH)
+                .maximumBandwidth(REQUEST_MAXIMUM_BANDWIDTH)
+                .maxLatency(REQUEST_MAX_LATENCY)
+                .maxLatencyTier2(REQUEST_MAX_LATENCY_TIER_2)
+                .pathComputationStrategy(REQUEST_COMPUTATION_STRATEGY)
+                .periodicPings(REQUEST_PERIODIC_PINGS)
+                .pinned(REQUEST_PINNED)
+                .priority(REQUEST_PRIORITY)
+                .sharedEndpoint(REQUEST_SHARED_END_POINT)
+                .strictBandwidth(REQUEST_STRICT_BANDWIDTH)
+                .subFlows(subFlowDtos)
+                .type(REQUEST_TYPE)
+                .yFlowId(REQUEST_Y_FLOW_ID)
+                .build();
+    }
+
+    private SubFlowDto createSubFlowDto() {
+
+
+        return SubFlowDto.builder()
+                .endpoint(SUB_FLOW_END_POINT)
+                .description(SUB_FLOW_DESCRIPTION)
+                .flowId(SUB_FLOW_1_ID)
+                .timeUpdate(SUB_FLOW_TIME_UPDATE)
+                .sharedEndpoint(SUB_FLOW_SHARED_ENDPOINT_ENCAPSULATION)
+                .status(SUB_FLOW_STATUS)
+                .build();
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowUpdateServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowUpdateServiceTest.java
@@ -74,6 +74,9 @@ import java.util.stream.Stream;
 @RunWith(MockitoJUnitRunner.class)
 public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
     private static final int METER_ALLOCATION_RETRIES_LIMIT = 3;
+    private static final String SUB_FLOW_ID_1 = "test_sub_flow_id_1";
+    private static final String SUB_FLOW_ID_2 = "test_sub_flow_id_2";
+    private static final String Y_FLOW_ID = "test_successful_y_flow";
 
     @Mock
     private FlowGenericCarrier flowCreateHubCarrier;
@@ -106,8 +109,8 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         request.setMaximumBandwidth(2000L);
         request.getSubFlows().get(0).setEndpoint(newFirstEndpoint);
         request.getSubFlows().get(1).setEndpoint(newSecondEndpoint);
-        preparePathComputationForUpdate("test_flow_1", buildNewFirstSubFlowPathPair());
-        preparePathComputationForUpdate("test_flow_2", buildNewSecondSubFlowPathPair());
+        preparePathComputationForUpdate(SUB_FLOW_ID_1, buildNewFirstSubFlowPathPair());
+        preparePathComputationForUpdate(SUB_FLOW_ID_2, buildNewSecondSubFlowPathPair());
         prepareYPointComputation(SWITCH_SHARED, SWITCH_NEW_FIRST_EP, SWITCH_NEW_SECOND_EP, SWITCH_TRANSIT);
 
         // when
@@ -135,9 +138,9 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         request.getSubFlows().get(0).setEndpoint(newFirstEndpoint);
         request.getSubFlows().get(1).setEndpoint(newSecondEndpoint);
 
-        preparePathComputationForUpdate("test_flow_1",
+        preparePathComputationForUpdate(SUB_FLOW_ID_1,
                 buildNewFirstSubFlowPathPair(), buildNewFirstSubFlowProtectedPathPair());
-        preparePathComputationForUpdate("test_flow_2",
+        preparePathComputationForUpdate(SUB_FLOW_ID_2,
                 buildNewSecondSubFlowPathPair(), buildNewSecondSubFlowProtectedPathPair());
         prepareYPointComputation(SWITCH_SHARED, SWITCH_NEW_FIRST_EP, SWITCH_NEW_SECOND_EP,
                 SWITCH_TRANSIT, SWITCH_TRANSIT);
@@ -169,9 +172,9 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         request.getSubFlows().get(0).setEndpoint(newFirstEndpoint);
         request.getSubFlows().get(1).setEndpoint(newSecondEndpoint);
 
-        when(pathComputer.getPath(buildFlowIdArgumentMatch("test_flow_1"), any(), anyBoolean()))
+        when(pathComputer.getPath(buildFlowIdArgumentMatch(SUB_FLOW_ID_1), any(), anyBoolean()))
                 .thenThrow(new UnroutableFlowException(injectedErrorMessage));
-        preparePathComputationForUpdate("test_flow_2", buildNewSecondSubFlowPathPair(), buildSecondSubFlowPathPair());
+        preparePathComputationForUpdate(SUB_FLOW_ID_2, buildNewSecondSubFlowPathPair(), buildSecondSubFlowPathPair());
         prepareYPointComputation(SWITCH_SHARED, SWITCH_NEW_FIRST_EP, SWITCH_NEW_SECOND_EP, SWITCH_TRANSIT);
 
         // when
@@ -199,8 +202,8 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         request.getSubFlows().get(0).setEndpoint(newFirstEndpoint);
         request.getSubFlows().get(1).setEndpoint(newSecondEndpoint);
 
-        preparePathComputationForUpdate("test_flow_1", buildNewFirstSubFlowPathPair(), buildFirstSubFlowPathPair());
-        when(pathComputer.getPath(buildFlowIdArgumentMatch("test_flow_2"), any(), anyBoolean()))
+        preparePathComputationForUpdate(SUB_FLOW_ID_1, buildNewFirstSubFlowPathPair(), buildFirstSubFlowPathPair());
+        when(pathComputer.getPath(buildFlowIdArgumentMatch(SUB_FLOW_ID_2), any(), anyBoolean()))
                 .thenThrow(new UnroutableFlowException(injectedErrorMessage));
         prepareYPointComputation(SWITCH_SHARED, SWITCH_NEW_FIRST_EP, SWITCH_NEW_SECOND_EP, SWITCH_TRANSIT);
 
@@ -229,18 +232,18 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         request.getSubFlows().get(0).setEndpoint(newFirstEndpoint);
         request.getSubFlows().get(1).setEndpoint(newSecondEndpoint);
 
-        preparePathComputationForUpdate("test_flow_1", buildNewFirstSubFlowPathPair(), buildFirstSubFlowPathPair());
-        preparePathComputationForUpdate("test_flow_2", buildNewSecondSubFlowPathPair(), buildSecondSubFlowPathPair());
+        preparePathComputationForUpdate(SUB_FLOW_ID_1, buildNewFirstSubFlowPathPair(), buildFirstSubFlowPathPair());
+        preparePathComputationForUpdate(SUB_FLOW_ID_2, buildNewSecondSubFlowPathPair(), buildSecondSubFlowPathPair());
         prepareYPointComputation(SWITCH_SHARED, SWITCH_NEW_FIRST_EP, SWITCH_NEW_SECOND_EP, SWITCH_TRANSIT);
         doThrow(new ResourceAllocationException(injectedErrorMessage))
-                .when(flowResourcesManager).allocateMeter(eq("test_successful_yflow"), eq(SWITCH_TRANSIT));
+                .when(flowResourcesManager).allocateMeter(eq(Y_FLOW_ID), eq(SWITCH_TRANSIT));
 
         // when
         processUpdateRequestAndSpeakerCommands(request);
 
         verifyYFlowStatus(request.getYFlowId(), FlowStatus.UP);
         verify(flowResourcesManager, times(METER_ALLOCATION_RETRIES_LIMIT + 2)) // +1 from YFlowCreateFsm
-                .allocateMeter(eq("test_successful_yflow"), eq(SWITCH_TRANSIT));
+                .allocateMeter(eq(Y_FLOW_ID), eq(SWITCH_TRANSIT));
 
         YFlow flow = getYFlow(request.getYFlowId());
         assertEquals(1000L, flow.getMaximumBandwidth());
@@ -261,8 +264,8 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         request.getSubFlows().get(0).setEndpoint(newFirstEndpoint);
         request.getSubFlows().get(1).setEndpoint(newSecondEndpoint);
 
-        preparePathComputationForUpdate("test_flow_1", buildNewFirstSubFlowPathPair(), buildFirstSubFlowPathPair());
-        preparePathComputationForUpdate("test_flow_2", buildNewSecondSubFlowPathPair(), buildSecondSubFlowPathPair());
+        preparePathComputationForUpdate(SUB_FLOW_ID_1, buildNewFirstSubFlowPathPair(), buildFirstSubFlowPathPair());
+        preparePathComputationForUpdate(SUB_FLOW_ID_2, buildNewSecondSubFlowPathPair(), buildSecondSubFlowPathPair());
         prepareYPointComputation(SWITCH_SHARED, SWITCH_NEW_FIRST_EP, SWITCH_NEW_SECOND_EP, SWITCH_TRANSIT);
 
         YFlowUpdateService service = makeYFlowUpdateService(0);
@@ -271,7 +274,7 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         service.handleRequest(request.getYFlowId(), new CommandContext(), request);
         verifyYFlowStatus(request.getYFlowId(), FlowStatus.IN_PROGRESS, FlowStatus.IN_PROGRESS, FlowStatus.UP);
         // and
-        handleSpeakerCommandsAndFailInstall(service, request.getYFlowId(), "test_successful_yflow");
+        handleSpeakerCommandsAndFailInstall(service, request.getYFlowId(), Y_FLOW_ID);
 
         // then
         verifyYFlowStatus(request.getYFlowId(), FlowStatus.UP);
@@ -287,15 +290,15 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
 
     @Test
     public void shouldFailOnTimeoutDuringMeterInstallation()
-            throws UnroutableFlowException, RecoverableException, DuplicateKeyException, UnknownKeyException {
+            throws UnroutableFlowException, RecoverableException, DuplicateKeyException {
         // given
         YFlowRequest request = createYFlow();
         request.setMaximumBandwidth(2000L);
         request.getSubFlows().get(0).setEndpoint(newFirstEndpoint);
         request.getSubFlows().get(1).setEndpoint(newSecondEndpoint);
 
-        preparePathComputationForUpdate("test_flow_1", buildNewFirstSubFlowPathPair(), buildFirstSubFlowPathPair());
-        preparePathComputationForUpdate("test_flow_2", buildNewSecondSubFlowPathPair(), buildSecondSubFlowPathPair());
+        preparePathComputationForUpdate(SUB_FLOW_ID_1, buildNewFirstSubFlowPathPair(), buildFirstSubFlowPathPair());
+        preparePathComputationForUpdate(SUB_FLOW_ID_2, buildNewSecondSubFlowPathPair(), buildSecondSubFlowPathPair());
         prepareYPointComputation(SWITCH_SHARED, SWITCH_NEW_FIRST_EP, SWITCH_NEW_SECOND_EP, SWITCH_TRANSIT);
 
         YFlowUpdateService service = makeYFlowUpdateService(0);
@@ -325,24 +328,24 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         createYFlow();
         List<SubFlowPartialUpdateDto> subFlowPartialUpdateDtos = new ArrayList<>();
         subFlowPartialUpdateDtos.add(SubFlowPartialUpdateDto.builder()
-                .flowId("test_flow_1")
+                .flowId(SUB_FLOW_ID_1)
                 .endpoint(FlowPartialUpdateEndpoint.builder()
                         .switchId(SWITCH_NEW_FIRST_EP).portNumber(2).vlanId(103).build())
                 .build());
         subFlowPartialUpdateDtos.add(SubFlowPartialUpdateDto.builder()
-                .flowId("test_flow_2")
+                .flowId(SUB_FLOW_ID_2)
                 .endpoint(FlowPartialUpdateEndpoint.builder()
                         .switchId(SWITCH_NEW_SECOND_EP).portNumber(3).vlanId(104).build())
                 .build());
 
-        YFlowPartialUpdateRequest request = YFlowPartialUpdateRequest.builder()
-                .yFlowId("test_successful_yflow")
+        final YFlowPartialUpdateRequest request = YFlowPartialUpdateRequest.builder()
+                .yFlowId(Y_FLOW_ID)
                 .maximumBandwidth(2000L)
                 .subFlows(subFlowPartialUpdateDtos)
                 .build();
 
-        preparePathComputationForUpdate("test_flow_1", buildNewFirstSubFlowPathPair());
-        preparePathComputationForUpdate("test_flow_2", buildNewSecondSubFlowPathPair());
+        preparePathComputationForUpdate(SUB_FLOW_ID_1, buildNewFirstSubFlowPathPair());
+        preparePathComputationForUpdate(SUB_FLOW_ID_2, buildNewSecondSubFlowPathPair());
         prepareYPointComputation(SWITCH_SHARED, SWITCH_NEW_FIRST_EP, SWITCH_NEW_SECOND_EP, SWITCH_TRANSIT);
 
         // when
@@ -361,10 +364,10 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
     }
 
     private YFlowRequest createYFlow() throws UnroutableFlowException, RecoverableException, DuplicateKeyException {
-        YFlowRequest request = buildYFlowRequest("test_successful_yflow", "test_flow_1", "test_flow_2")
+        final YFlowRequest request = buildYFlowRequest(Y_FLOW_ID, SUB_FLOW_ID_1, SUB_FLOW_ID_2)
                 .build();
-        preparePathComputationForCreate("test_flow_1", buildFirstSubFlowPathPair());
-        preparePathComputationForCreate("test_flow_2", buildSecondSubFlowPathPair());
+        preparePathComputationForCreate(SUB_FLOW_ID_1, buildFirstSubFlowPathPair());
+        preparePathComputationForCreate(SUB_FLOW_ID_2, buildSecondSubFlowPathPair());
         prepareYPointComputation(SWITCH_SHARED, SWITCH_FIRST_EP, SWITCH_SECOND_EP, SWITCH_TRANSIT);
 
         processCreateRequestAndSpeakerCommands(request);
@@ -377,12 +380,12 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
 
     private YFlowRequest createYFlowWithProtectedPath()
             throws UnroutableFlowException, RecoverableException, DuplicateKeyException {
-        YFlowRequest request = buildYFlowRequest("test_successful_yflow", "test_flow_1", "test_flow_2")
+        final YFlowRequest request = buildYFlowRequest(Y_FLOW_ID, SUB_FLOW_ID_1, SUB_FLOW_ID_2)
                 .allocateProtectedPath(true)
                 .build();
-        preparePathComputationForCreate("test_flow_1",
+        preparePathComputationForCreate(SUB_FLOW_ID_1,
                 buildFirstSubFlowPathPair(), buildFirstSubFlowProtectedPathPair());
-        preparePathComputationForCreate("test_flow_2",
+        preparePathComputationForCreate(SUB_FLOW_ID_2,
                 buildSecondSubFlowPathPair(), buildSecondSubFlowProtectedPathPair());
         prepareYPointComputation(SWITCH_SHARED, SWITCH_FIRST_EP, SWITCH_SECOND_EP, SWITCH_TRANSIT, SWITCH_TRANSIT);
         prepareYPointComputation(SWITCH_SHARED, SWITCH_FIRST_EP, SWITCH_SECOND_EP, SWITCH_ALT_TRANSIT,

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowUpdateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowUpdateSpec.groovy
@@ -130,8 +130,7 @@ class YFlowUpdateSpec extends HealthCheckSpecification {
         //update involved switches after update
         involvedSwitches.addAll(pathHelper.getInvolvedYSwitches(yFlow.YFlowId))
         involvedSwitches.unique { it.dpId }
-        def ignores = ["subFlows.timeUpdate", "subFlows.status", "timeUpdate", "status",
-                       "subFlows.description" /* https://github.com/telstra/open-kilda/issues/4984 */]
+        def ignores = ["subFlows.timeUpdate", "subFlows.status", "timeUpdate", "status"]
 
         then: "Requested updates are reflected in the response and in 'get' API"
         expect updateResponse, sameBeanAs(yFlow, ignores)


### PR DESCRIPTION
Sub flow description appeared as a regular editable field. But, in fact, it was populated from the parent flow, ignoring the user's input. 
This fix makes the sub flow description field editable.