### PR TITLE
#4984: Sub-flow descriptions are rewritten by y-flow description test

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowUpdateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowUpdateSpec.groovy
@@ -130,8 +130,7 @@ class YFlowUpdateSpec extends HealthCheckSpecification {
         //update involved switches after update
         involvedSwitches.addAll(pathHelper.getInvolvedYSwitches(yFlow.YFlowId))
         involvedSwitches.unique { it.dpId }
-        def ignores = ["subFlows.timeUpdate", "subFlows.status", "timeUpdate", "status",
-                       "subFlows.description" /* https://github.com/telstra/open-kilda/issues/4984 */]
+        def ignores = ["subFlows.timeUpdate", "subFlows.status", "timeUpdate", "status"]
 
         then: "Requested updates are reflected in the response and in 'get' API"
         expect updateResponse, sameBeanAs(yFlow, ignores)


### PR DESCRIPTION
* Enabled back check in YFlowUpdateSpec after bugfix.