### PR TITLE
move bw fail reason to the end of the log message

### DIFF
--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/impl/InMemoryPathComputer.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/impl/InMemoryPathComputer.java
@@ -119,9 +119,13 @@ public class InMemoryPathComputer implements PathComputer {
         try {
             findPathResult = findPathInNetwork(flow, network, weightFunction, strategy);
         } catch (UnroutableFlowException e) {
-            String message = format("%s=%s: %s", FailReasonType.MAX_BANDWIDTH,
-                    flow.isIgnoreBandwidth() ? " ignored" : flow.getBandwidth(), e.getMessage());
-            throw new UnroutableFlowException(message, e, flow.getFlowId(), flow.isIgnoreBandwidth());
+            String bandwidthMessage = "";
+            if (flow.getBandwidth() > 0) {
+                bandwidthMessage = format(", %s=%s", FailReasonType.MAX_BANDWIDTH,
+                        flow.isIgnoreBandwidth() ? " ignored" : flow.getBandwidth());
+            }
+            throw new UnroutableFlowException(e.getMessage().concat(bandwidthMessage), e, flow.getFlowId(),
+                    flow.isIgnoreBandwidth());
         }
 
         return convertToGetPathsResult(flow.getSrcSwitchId(), flow.getDestSwitchId(), findPathResult,

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
@@ -134,8 +134,8 @@ class AutoRerouteSpec extends HealthCheckSpecification {
             history = northbound.getFlowHistory(flow.flowId)
             verifyAll {
                 history.count { it.action == REROUTE_ACTION } == 4 //original + 3 retries
-                history.last().payload.last().details.startsWith("Not enough bandwidth or no path found. " +
-                        "Failed to find path with requested bandwidth=$flow.maximumBandwidth:")
+                history.last().payload.last().details.endsWith(
+                        "Failed to find path with requested bandwidth=$flow.maximumBandwidth")
                 history.last().payload.last().action == REROUTE_FAIL
             }
         }
@@ -160,8 +160,8 @@ class AutoRerouteSpec extends HealthCheckSpecification {
             history = northbound.getFlowHistory(flow.flowId, manualRerouteTime, null)
             verifyAll {
                 history.count { it.action == REROUTE_ACTION } == 4 //manual original + 3 reties
-                history.last().payload.last().details.startsWith("Not enough bandwidth or no path found. " +
-                        "Failed to find path with requested bandwidth=$flow.maximumBandwidth:")
+                history.last().payload.last().details.endsWith(
+                        "Failed to find path with requested bandwidth=$flow.maximumBandwidth")
                 history.last().payload.last().action == REROUTE_FAIL
             }
         }
@@ -976,8 +976,8 @@ have links with enough bandwidth"
             history = northbound.getFlowHistory(flow.flowId)
             verifyAll {
                 history[-2].payload.last().action == REROUTE_FAIL
-                history[-2].payload.last().details.startsWith("Not enough bandwidth or no path found. " +
-                        "Failed to find path with requested bandwidth=$flow.maximumBandwidth:")
+                history[-2].payload.last().details.endsWith(
+                        "Failed to find path with requested bandwidth=$flow.maximumBandwidth")
                 history[-1].payload.last().action == REROUTE_COMPLETE
             }
         }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
@@ -889,9 +889,9 @@ class AutoRerouteIsolatedSpec extends HealthCheckSpecification {
                 sleep(500)
             }
             assert northboundV2.getFlow(firstFlow.flowId).statusInfo =~ /ISL (.*) become INACTIVE(.*)/
-            assert northboundV2.getFlow(secondFlow.flowId).statusInfo == "No path found.\
- Failed to find path with requested bandwidth= ignored: Switch $secondFlow.source.switchId doesn't \
-have links with enough bandwidth"
+            assert northboundV2.getFlow(secondFlow.flowId).statusInfo == "No path found. \
+Switch $secondFlow.source.switchId doesn't have links with enough bandwidth, \
+Failed to find path with requested bandwidth= ignored"
         }
 
         when: "Connect the switch back to the controller"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
@@ -450,7 +450,8 @@ class ProtectedPathSpec extends HealthCheckSpecification {
                 status == FlowState.DEGRADED.toString()
                 flowStatusDetails.mainFlowPathStatus == "Up"
                 flowStatusDetails.protectedFlowPathStatus == "Down"
-                statusInfo.startsWith("Not enough bandwidth or no path found. Failed to find path with requested bandwidth=$flow.maximumBandwidth")
+                statusInfo == "Not enough bandwidth or no path found. Switch ${switchPair.getSrc().getDpId()} \
+doesn't have links with enough bandwidth, Failed to find path with requested bandwidth=$flow.maximumBandwidth"
             }
         }
 


### PR DESCRIPTION
This commit moves the fail to the end of the log message. Also it only prints this message if the bandwidth > 0.