### PR TITLE
fix max latency reason not shown

### DIFF
--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/finder/BestWeightAndShortestPathFinder.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/finder/BestWeightAndShortestPathFinder.java
@@ -335,7 +335,6 @@ public class BestWeightAndShortestPathFinder implements PathFinder {
         if (pathResult.getFoundPath().isEmpty()) {
             pathResult = getPath(start, end, weightFunction, backUpMaxWeight);
             backUpPathComputationWayUsed = true;
-            reasons.putAll(pathResult.getPathNotFoundReasons());
         }
 
         return FindOneDirectionPathResult.builder()
@@ -457,20 +456,18 @@ public class BestWeightAndShortestPathFinder implements PathFinder {
 
     private FindOneDirectionPathResult getPath(Node start, Node end, WeightFunction weightFunction, long maxWeight) {
         SearchNodeAndReasons desiredPath = getDesiredPath(start, end, weightFunction, maxWeight);
-        Map<FailReasonType, FailReason> reasons = desiredPath.reasons;
 
         List<Edge> foundPath = (desiredPath.searchNode != null)
                 ? desiredPath.searchNode.getParentPath() : new LinkedList<>();
 
         SearchNodeAndReasons desiredReversePath = getDesiredPath(end, start, weightFunction, maxWeight);
-        reasons.putAll(desiredReversePath.reasons);
 
         if (desiredReversePath.searchNode != null && (desiredPath.searchNode == null
                 || desiredReversePath.searchNode.parentWeight.compareTo(desiredPath.searchNode.parentWeight) > 0)) {
             foundPath = getReversePath(start, end, desiredReversePath.searchNode.getParentPath());
         }
 
-        return new FindOneDirectionPathResult(foundPath, reasons);
+        return new FindOneDirectionPathResult(foundPath, desiredPath.reasons);
     }
 
     /**
@@ -577,6 +574,9 @@ public class BestWeightAndShortestPathFinder implements PathFinder {
                 if (current.allowedDepth <= 0) {
                     reasons.put(FailReasonType.ALLOWED_DEPTH_EXCEEDED,
                             new FailReason(FailReasonType.ALLOWED_DEPTH_EXCEEDED));
+                } else if (!reasons.containsKey(FailReasonType.MAX_WEIGHT_EXCEEDED)) {
+                    reasons.put(FailReasonType.MAX_WEIGHT_EXCEEDED,
+                            new FailReason(FailReasonType.MAX_WEIGHT_EXCEEDED));
                 }
                 destinationFound = true;
                 continue;

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/impl/InMemoryPathComputer.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/impl/InMemoryPathComputer.java
@@ -163,19 +163,25 @@ public class InMemoryPathComputer implements PathComputer {
                             Optional.ofNullable(flow.getMaxLatencyTier2()).orElse(0L));
                 } catch (UnroutableFlowException e) {
                     if (e.getFailReason() == null
-                            || !e.getFailReason().containsKey(FailReasonType.MAX_WEIGHT_EXCEEDED)
-                            || e.getFailReason().get(FailReasonType.MAX_WEIGHT_EXCEEDED).getWeight() == null) {
+                            || !e.getFailReason().containsKey(FailReasonType.MAX_WEIGHT_EXCEEDED)) {
                         throw e;
                     }
-                    String[] split = e.getMessage().split(FinderUtils.REASONS_KEYWORD);
-                    long actualLatency = e.getFailReason().get(FailReasonType.MAX_WEIGHT_EXCEEDED).getWeight();
+                    Long actualLatency = e.getFailReason().get(FailReasonType.MAX_WEIGHT_EXCEEDED).getWeight();
                     Map<FailReasonType, FailReason> reasons = e.getFailReason();
                     reasons.remove(FailReasonType.MAX_WEIGHT_EXCEEDED);
+                    String failLatencyReason;
+                    if (actualLatency == null) {
+                        failLatencyReason = format("Requested path must have latency %sms or lower",
+                                TimeUnit.NANOSECONDS.toMillis(flow.getMaxLatency()));
+                    } else {
+                        failLatencyReason = format("Requested path must have latency %sms or lower, "
+                                        + "but best path has latency %sms",
+                                TimeUnit.NANOSECONDS.toMillis(flow.getMaxLatency()),
+                                TimeUnit.NANOSECONDS.toMillis(actualLatency));
+                    }
                     reasons.put(FailReasonType.LATENCY_LIMIT, new FailReason(FailReasonType.LATENCY_LIMIT,
-                            format("Requested path must have latency %sms or lower, but best path has latency %sms",
-                                    TimeUnit.NANOSECONDS.toMillis(flow.getMaxLatency()),
-                                    TimeUnit.NANOSECONDS.toMillis(actualLatency))));
-
+                            failLatencyReason));
+                    String[] split = e.getMessage().split(FinderUtils.REASONS_KEYWORD);
                     throw new UnroutableFlowException(split[0] + FinderUtils.reasonsToString(reasons));
 
                 }


### PR DESCRIPTION
In the case the path is not fully calculated, we can't know the latency of the full path because there is a point during the path computation where the latency is already higher than the max_latency property.

For this case the reason was not properly added so it wasn't inlcuded in the response.

This commit fix it.