### PR TITLE
#5042: Move bw fail reason to the end of the log message tests

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/AutoRerouteSpec.groovy
@@ -889,9 +889,9 @@ class AutoRerouteIsolatedSpec extends HealthCheckSpecification {
                 sleep(500)
             }
             assert northboundV2.getFlow(firstFlow.flowId).statusInfo =~ /ISL (.*) become INACTIVE(.*)/
-            assert northboundV2.getFlow(secondFlow.flowId).statusInfo == "No path found.\
- Failed to find path with requested bandwidth= ignored: Switch $secondFlow.source.switchId doesn't \
-have links with enough bandwidth"
+            assert northboundV2.getFlow(secondFlow.flowId).statusInfo == "No path found. \
+Switch $secondFlow.source.switchId doesn't have links with enough bandwidth, \
+Failed to find path with requested bandwidth= ignored"
         }
 
         when: "Connect the switch back to the controller"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
@@ -450,7 +450,8 @@ class ProtectedPathSpec extends HealthCheckSpecification {
                 status == FlowState.DEGRADED.toString()
                 flowStatusDetails.mainFlowPathStatus == "Up"
                 flowStatusDetails.protectedFlowPathStatus == "Down"
-                statusInfo.startsWith("Not enough bandwidth or no path found. Failed to find path with requested bandwidth=$flow.maximumBandwidth")
+                statusInfo == "Not enough bandwidth or no path found. Switch ${switchPair.getSrc().getDpId()} \
+doesn't have links with enough bandwidth, Failed to find path with requested bandwidth=$flow.maximumBandwidth"
             }
         }
 


### PR DESCRIPTION
* Updated test "Unable to update to a flow with unavailable bandwidth"