### PR TITLE
Add max depth to the error while path computation

### DIFF
--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/finder/BestWeightAndShortestPathFinder.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/finder/BestWeightAndShortestPathFinder.java
@@ -425,7 +425,8 @@ public class BestWeightAndShortestPathFinder implements PathFinder {
                 }
                 if (current.allowedDepth <= 0) {
                     reasons.put(FailReasonType.ALLOWED_DEPTH_EXCEEDED,
-                            new FailReason(FailReasonType.ALLOWED_DEPTH_EXCEEDED));
+                            new FailReason(FailReasonType.ALLOWED_DEPTH_EXCEEDED,
+                                    format("Max allowed depth is %d", allowedDepth)));
                 }
                 destinationFound = true; //to no add the reason
                 continue;
@@ -573,7 +574,8 @@ public class BestWeightAndShortestPathFinder implements PathFinder {
             if (current.allowedDepth <= 0 || current.parentWeight.getBaseWeight() >= maxWeight) {
                 if (current.allowedDepth <= 0) {
                     reasons.put(FailReasonType.ALLOWED_DEPTH_EXCEEDED,
-                            new FailReason(FailReasonType.ALLOWED_DEPTH_EXCEEDED));
+                            new FailReason(FailReasonType.ALLOWED_DEPTH_EXCEEDED,
+                                    format("Max allowed depth is %d", allowedDepth)));
                 } else if (!reasons.containsKey(FailReasonType.MAX_WEIGHT_EXCEEDED)) {
                     reasons.put(FailReasonType.MAX_WEIGHT_EXCEEDED,
                             new FailReason(FailReasonType.MAX_WEIGHT_EXCEEDED));

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/BestWeightAndShortestPathFinderTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/BestWeightAndShortestPathFinderTest.java
@@ -17,6 +17,7 @@ package org.openkilda.pce.finder;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -229,24 +230,24 @@ public class BestWeightAndShortestPathFinderTest {
 
     @Test
     public void shouldFailWhenPathIsLongerThanAllowedDepth() {
+        int allowedDepth = 1;
         AvailableNetwork network = buildTestNetwork();
-
-        BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(1);
+        BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(allowedDepth);
 
         Exception exception = assertThrows(UnroutableFlowException.class, () -> {
             pathFinder.findPathWithMinWeight(network, SWITCH_ID_D, SWITCH_ID_F, WEIGHT_FUNCTION);
         });
 
         MatcherAssert.assertThat(exception.getMessage(),
-                containsString(FailReasonType.ALLOWED_DEPTH_EXCEEDED.toString()));
+                endsWith(FailReasonType.ALLOWED_DEPTH_EXCEEDED + ": Max allowed depth is " + allowedDepth));
     }
 
     @Test
     public void shouldFailWhenPathIsLongerThanAllowedDepthMaxWeightStrategy() throws UnroutableFlowException {
+        int allowedDepth = 1;
         AvailableNetwork network = buildTestNetwork();
 
-        BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(1);
-
+        BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(allowedDepth);
 
         Exception exception = assertThrows(UnroutableFlowException.class, () -> {
             pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_D, SWITCH_ID_F, WEIGHT_FUNCTION,
@@ -254,7 +255,7 @@ public class BestWeightAndShortestPathFinderTest {
         });
 
         MatcherAssert.assertThat(exception.getMessage(),
-                containsString(FailReasonType.ALLOWED_DEPTH_EXCEEDED.toString()));
+                endsWith(FailReasonType.ALLOWED_DEPTH_EXCEEDED + ": Max allowed depth is " + allowedDepth));
     }
 
     @Test


### PR DESCRIPTION
During the path computation, if the path has more hops than the max depth property, it raises an error. This commit extends this error to include the maximun depth allowed.

Closes #5085