### PR TITLE
HA flows Part 5: Added CRUD operations stub

### DIFF
--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowCreateHubBolt.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowCreateHubBolt.java
@@ -1,0 +1,138 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.bolts;
+
+import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.HUB_TO_NB_RESPONSE_SENDER;
+import static org.openkilda.wfm.topology.utils.KafkaRecordTranslator.FIELD_ID_PAYLOAD;
+
+import org.openkilda.messaging.command.haflow.HaFlowRequest;
+import org.openkilda.messaging.command.haflow.HaFlowResponse;
+import org.openkilda.messaging.command.haflow.HaSubFlowDto;
+import org.openkilda.messaging.error.ErrorData;
+import org.openkilda.messaging.error.ErrorMessage;
+import org.openkilda.messaging.error.ErrorType;
+import org.openkilda.messaging.info.InfoMessage;
+import org.openkilda.model.FlowStatus;
+import org.openkilda.model.HaFlow;
+import org.openkilda.model.HaSubFlow;
+import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.persistence.repositories.HaFlowRepository;
+import org.openkilda.persistence.repositories.HaSubFlowRepository;
+import org.openkilda.wfm.AbstractBolt;
+import org.openkilda.wfm.error.PipelineException;
+import org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream;
+import org.openkilda.wfm.topology.flowhs.exception.FlowProcessingException;
+import org.openkilda.wfm.topology.flowhs.mapper.HaFlowMapper;
+import org.openkilda.wfm.topology.utils.MessageKafkaTranslator;
+
+import com.fasterxml.uuid.Generators;
+import com.fasterxml.uuid.NoArgGenerator;
+import com.fasterxml.uuid.impl.UUIDUtil;
+import com.google.common.io.BaseEncoding;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.Values;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This implementation of the class is temporary.
+ * It only works with DB. Switch rules wouldn't be modified.
+ * Class is just a stub to give an API for users. It will be modified later.
+ */
+public class HaFlowCreateHubBolt extends AbstractBolt {
+    private static final String HA_FLOW_PREFIX = "haf-";
+    private static final char SUB_FLOW_INITIAL_POSTFIX = 'a';
+    public static final String COMMON_ERROR_MESSAGE = "Couldn't create HA-flow";
+    private transient HaFlowRepository haFlowRepository;
+    private transient HaSubFlowRepository haSubFlowRepository;
+    private transient NoArgGenerator flowIdGenerator;
+
+    public HaFlowCreateHubBolt(PersistenceManager persistenceManager) {
+        super(persistenceManager);
+    }
+
+    @Override
+    protected void init() {
+        haFlowRepository = persistenceManager.getRepositoryFactory().createHaFlowRepository();
+        haSubFlowRepository = persistenceManager.getRepositoryFactory().createHaSubFlowRepository();
+        flowIdGenerator = Generators.timeBasedGenerator();
+    }
+
+    @Override
+    protected void handleInput(Tuple input) throws PipelineException {
+        String key = pullValue(input, MessageKafkaTranslator.FIELD_ID_KEY, String.class);
+        HaFlowRequest payload = pullValue(input, FIELD_ID_PAYLOAD, HaFlowRequest.class);
+        try {
+            handleHaFlowCreate(key, payload);
+        } catch (FlowProcessingException e) {
+            emitErrorMessage(e.getErrorType(), COMMON_ERROR_MESSAGE, e.getMessage());
+        } catch (Exception e) {
+            emitErrorMessage(ErrorType.INTERNAL_ERROR, COMMON_ERROR_MESSAGE, e.getMessage());
+        }
+    }
+
+    private void handleHaFlowCreate(String key, HaFlowRequest payload) {
+        if (payload.getHaFlowId() == null) {
+            payload.setHaFlowId(generateFlowId());
+        }
+        HaFlow haFlow = HaFlowMapper.INSTANCE.toHaFlow(payload);
+
+        Set<HaSubFlow> subflows = new HashSet<>();
+        char postfix = SUB_FLOW_INITIAL_POSTFIX;
+        for (HaSubFlowDto subFlow : payload.getSubFlows()) {
+            String subFlowId = String.format("%s-%c", payload.getHaFlowId(), postfix++);
+            subflows.add(HaFlowMapper.INSTANCE.toSubFlow(subFlowId, subFlow));
+        }
+        persistenceManager.getTransactionManager().doInTransaction(() -> {
+            if (haFlowRepository.exists(payload.getHaFlowId())) {
+                throw new FlowProcessingException(ErrorType.ALREADY_EXISTS,
+                        String.format("Couldn't create ha-flow %s. This ha-flow already exist.",
+                                payload.getHaFlowId()));
+            }
+            for (HaSubFlow subflow : subflows) {
+                subflow.setStatus(FlowStatus.UP);
+                haSubFlowRepository.add(subflow);
+            }
+            haFlowRepository.add(haFlow);
+            haFlow.setSubFlows(new HashSet<>(subflows));
+        });
+        HaFlowResponse response = new HaFlowResponse(HaFlowMapper.INSTANCE.toHaFlowDto(haFlow));
+        InfoMessage message = new InfoMessage(
+                response, System.currentTimeMillis(), getCommandContext().getCorrelationId());
+        emitWithContext(Stream.HUB_TO_NB_RESPONSE_SENDER.name(), getCurrentTuple(), new Values(key, message));
+    }
+
+    private void emitErrorMessage(ErrorType type, String message, String description) {
+        String requestId = getCommandContext().getCorrelationId();
+        ErrorData errorData = new ErrorData(type, message, description);
+        emitWithContext(Stream.HUB_TO_NB_RESPONSE_SENDER.name(), getCurrentTuple(), new Values(requestId,
+                new ErrorMessage(errorData, System.currentTimeMillis(), requestId)));
+    }
+
+    protected String generateFlowId() {
+        byte[] uuidAsBytes = UUIDUtil.asByteArray(flowIdGenerator.generate());
+        String uuidAsBase32 = BaseEncoding.base32().omitPadding().lowerCase().encode(uuidAsBytes);
+        return HA_FLOW_PREFIX + uuidAsBase32;
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        super.declareOutputFields(declarer);
+        declarer.declareStream(HUB_TO_NB_RESPONSE_SENDER.name(), MessageKafkaTranslator.STREAM_FIELDS);
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowDeleteHubBolt.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowDeleteHubBolt.java
@@ -1,0 +1,103 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.bolts;
+
+import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.HUB_TO_NB_RESPONSE_SENDER;
+import static org.openkilda.wfm.topology.utils.KafkaRecordTranslator.FIELD_ID_PAYLOAD;
+
+import org.openkilda.messaging.Message;
+import org.openkilda.messaging.command.haflow.HaFlowDeleteRequest;
+import org.openkilda.messaging.command.haflow.HaFlowResponse;
+import org.openkilda.messaging.error.ErrorData;
+import org.openkilda.messaging.error.ErrorMessage;
+import org.openkilda.messaging.error.ErrorType;
+import org.openkilda.messaging.info.InfoData;
+import org.openkilda.messaging.info.InfoMessage;
+import org.openkilda.model.HaFlow;
+import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.persistence.repositories.HaFlowRepository;
+import org.openkilda.wfm.AbstractBolt;
+import org.openkilda.wfm.CommandContext;
+import org.openkilda.wfm.error.PipelineException;
+import org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream;
+import org.openkilda.wfm.topology.flowhs.exception.FlowProcessingException;
+import org.openkilda.wfm.topology.flowhs.mapper.HaFlowMapper;
+import org.openkilda.wfm.topology.utils.MessageKafkaTranslator;
+
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.Values;
+
+import java.util.Optional;
+
+/**
+ * This implementation of the class is temporary.
+ * It only works with DB. Switch rules wouldn't be modified.
+ * Class is just a stub to give an API for users. It will be modified later.
+ */
+public class HaFlowDeleteHubBolt extends AbstractBolt {
+    public static final String COMMON_ERROR_MESSAGE = "Couldn't delete HA-flow";
+    private transient HaFlowRepository haFlowRepository;
+
+    public HaFlowDeleteHubBolt(PersistenceManager persistenceManager) {
+        super(persistenceManager);
+    }
+
+    @Override
+    protected void init() {
+        haFlowRepository = persistenceManager.getRepositoryFactory().createHaFlowRepository();
+    }
+
+    @Override
+    protected void handleInput(Tuple input) throws PipelineException {
+        String key = pullValue(input, MessageKafkaTranslator.FIELD_ID_KEY, String.class);
+        HaFlowDeleteRequest payload = pullValue(input, FIELD_ID_PAYLOAD, HaFlowDeleteRequest.class);
+
+        try {
+            handleHaFlowDelete(key, payload);
+        } catch (FlowProcessingException e) {
+            emitErrorMessage(e.getErrorType(), COMMON_ERROR_MESSAGE, e.getMessage());
+        } catch (Exception e) {
+            emitErrorMessage(ErrorType.INTERNAL_ERROR, COMMON_ERROR_MESSAGE, e.getMessage());
+        }
+    }
+
+    private void handleHaFlowDelete(String key, HaFlowDeleteRequest payload) {
+        CommandContext context = getCommandContext();
+        Optional<HaFlow> haFlow = haFlowRepository.remove(payload.getHaFlowId());
+        if (haFlow.isPresent()) {
+            InfoData response = new HaFlowResponse(HaFlowMapper.INSTANCE.toHaFlowDto(haFlow.get()));
+            Message message = new InfoMessage(response, System.currentTimeMillis(), context.getCorrelationId());
+            emitWithContext(Stream.HUB_TO_NB_RESPONSE_SENDER.name(), getCurrentTuple(), new Values(key, message));
+        } else {
+            throw new FlowProcessingException(ErrorType.DATA_INVALID,
+                    String.format("Couldn't delete non existent HA-flow %s", payload.getHaFlowId()));
+        }
+    }
+
+    private void emitErrorMessage(ErrorType type, String message, String description) {
+        String requestId = getCommandContext().getCorrelationId();
+        ErrorData errorData = new ErrorData(type, message, description);
+        emitWithContext(Stream.HUB_TO_NB_RESPONSE_SENDER.name(), getCurrentTuple(), new Values(requestId,
+                new ErrorMessage(errorData, System.currentTimeMillis(), requestId)));
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        super.declareOutputFields(declarer);
+        declarer.declareStream(HUB_TO_NB_RESPONSE_SENDER.name(), MessageKafkaTranslator.STREAM_FIELDS);
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowReadBolt.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowReadBolt.java
@@ -1,0 +1,125 @@
+/* Copyright 2021 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.bolts;
+
+import static org.openkilda.wfm.topology.flowhs.bolts.YFlowReadBolt.OUTPUT_STREAM_FIELDS;
+import static org.openkilda.wfm.topology.utils.KafkaRecordTranslator.FIELD_ID_PAYLOAD;
+
+import org.openkilda.messaging.Message;
+import org.openkilda.messaging.command.CommandData;
+import org.openkilda.messaging.command.haflow.HaFlowReadRequest;
+import org.openkilda.messaging.command.haflow.HaFlowResponse;
+import org.openkilda.messaging.command.haflow.HaFlowsDumpRequest;
+import org.openkilda.messaging.error.ErrorData;
+import org.openkilda.messaging.error.ErrorMessage;
+import org.openkilda.messaging.error.ErrorType;
+import org.openkilda.messaging.error.MessageException;
+import org.openkilda.messaging.info.ChunkedInfoMessage;
+import org.openkilda.messaging.info.InfoData;
+import org.openkilda.messaging.info.InfoMessage;
+import org.openkilda.model.HaFlow;
+import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.persistence.repositories.HaFlowRepository;
+import org.openkilda.wfm.AbstractBolt;
+import org.openkilda.wfm.topology.flowhs.mapper.HaFlowMapper;
+
+import lombok.NonNull;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.Values;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * This implementation of the class is temporary.
+ * It only works with DB. Switch rules wouldn't be modified.
+ * Class is just a stub to give an API for users. It will be modified later.
+ */
+public class HaFlowReadBolt extends AbstractBolt {
+    private transient HaFlowRepository haFlowRepository;
+
+    public HaFlowReadBolt(@NonNull PersistenceManager persistenceManager) {
+        super(persistenceManager);
+    }
+
+    @Override
+    public void init() {
+        haFlowRepository = persistenceManager.getRepositoryFactory().createHaFlowRepository();
+    }
+
+    protected void handleInput(Tuple input) throws Exception {
+        String requestId = getCommandContext().getCorrelationId();
+        CommandData request = pullValue(input, FIELD_ID_PAYLOAD, CommandData.class);
+
+        try {
+            if (request instanceof HaFlowsDumpRequest) {
+                List<HaFlowResponse> result = processHaFlowDumpRequest();
+                emitMessages(input, requestId, result);
+            } else if (request instanceof HaFlowReadRequest) {
+                HaFlowResponse result = processHaFlowReadRequest((HaFlowReadRequest) request);
+                emitMessage(input, requestId, result);
+            } else {
+                unhandledInput(input);
+            }
+        } catch (MessageException e) {
+            emitErrorMessage(e.getErrorType(), e.getMessage(), e.getErrorDescription());
+        } catch (Exception e) {
+            emitErrorMessage(ErrorType.INTERNAL_ERROR, e.getMessage(), "Couldn't read HA-flow");
+        }
+    }
+
+    private List<HaFlowResponse> processHaFlowDumpRequest() {
+        return haFlowRepository.findAll().stream()
+                .map(HaFlowMapper.INSTANCE::toHaFlowDto)
+                .map(HaFlowResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    private HaFlowResponse processHaFlowReadRequest(HaFlowReadRequest request) {
+        Optional<HaFlow> haFlow = haFlowRepository.findById(request.getHaFlowId());
+        if (!haFlow.isPresent()) {
+            throw new MessageException(ErrorType.NOT_FOUND, "Couldn't get HA-flow",
+                    String.format("HA-flow %s not found.", request.getHaFlowId()));
+        }
+        return new HaFlowResponse(HaFlowMapper.INSTANCE.toHaFlowDto(haFlow.get()));
+    }
+
+    private void emitMessages(Tuple input, String requestId, List<? extends InfoData> messageData) {
+        for (ChunkedInfoMessage message : ChunkedInfoMessage.createChunkedList(messageData, requestId)) {
+            emit(input, new Values(requestId, message));
+        }
+    }
+
+    private void emitMessage(Tuple input, String requestId, InfoData messageData) {
+        Message message = new InfoMessage(messageData, System.currentTimeMillis(), requestId);
+        emit(input, new Values(requestId, message));
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        super.declareOutputFields(declarer);
+        declarer.declare(OUTPUT_STREAM_FIELDS);
+    }
+
+    private void emitErrorMessage(ErrorType type, String message, String description) {
+        String requestId = getCommandContext().getCorrelationId();
+        ErrorData errorData = new ErrorData(type, message, description);
+        emit(getCurrentTuple(), new Values(requestId,
+                new ErrorMessage(errorData, System.currentTimeMillis(), requestId)));
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowUpdateHubBolt.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowUpdateHubBolt.java
@@ -1,0 +1,232 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.bolts;
+
+import static java.lang.String.format;
+import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.HUB_TO_NB_RESPONSE_SENDER;
+import static org.openkilda.wfm.topology.utils.KafkaRecordTranslator.FIELD_ID_PAYLOAD;
+
+import org.openkilda.messaging.command.CommandData;
+import org.openkilda.messaging.command.haflow.HaFlowPartialUpdateRequest;
+import org.openkilda.messaging.command.haflow.HaFlowRequest;
+import org.openkilda.messaging.command.haflow.HaFlowResponse;
+import org.openkilda.messaging.command.haflow.HaSubFlowDto;
+import org.openkilda.messaging.command.haflow.HaSubFlowPartialUpdateDto;
+import org.openkilda.messaging.command.yflow.FlowPartialUpdateEndpoint;
+import org.openkilda.messaging.error.ErrorData;
+import org.openkilda.messaging.error.ErrorMessage;
+import org.openkilda.messaging.error.ErrorType;
+import org.openkilda.messaging.info.InfoData;
+import org.openkilda.messaging.info.InfoMessage;
+import org.openkilda.model.FlowStatus;
+import org.openkilda.model.HaFlow;
+import org.openkilda.model.HaFlow.HaSharedEndpoint;
+import org.openkilda.model.HaSubFlow;
+import org.openkilda.model.SwitchId;
+import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.persistence.repositories.HaFlowRepository;
+import org.openkilda.wfm.AbstractBolt;
+import org.openkilda.wfm.error.PipelineException;
+import org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream;
+import org.openkilda.wfm.topology.flowhs.exception.FlowProcessingException;
+import org.openkilda.wfm.topology.flowhs.mapper.HaFlowMapper;
+import org.openkilda.wfm.topology.utils.MessageKafkaTranslator;
+
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.Values;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * This implementation of the class is temporary.
+ * It only works with DB. Switch rules wouldn't be modified.
+ * Class is just a stub to give an API for users. It will be modified later.
+ */
+public class HaFlowUpdateHubBolt extends AbstractBolt {
+    public static final String COMMON_ERROR_MESSAGE = "Couldn't update HA-flow";
+    private transient HaFlowRepository haFlowRepository;
+
+    public HaFlowUpdateHubBolt(PersistenceManager persistenceManager) {
+        super(persistenceManager);
+    }
+
+    @Override
+    protected void init() {
+        haFlowRepository = persistenceManager.getRepositoryFactory().createHaFlowRepository();
+    }
+
+    @Override
+    protected void handleInput(Tuple input) throws PipelineException {
+        String key = pullValue(input, MessageKafkaTranslator.FIELD_ID_KEY, String.class);
+        CommandData payload = pullValue(input, FIELD_ID_PAYLOAD, CommandData.class);
+
+        try {
+            if (payload instanceof HaFlowRequest) {
+                handleHaFlowUpdate(key, (HaFlowRequest) payload);
+            } else if (payload instanceof HaFlowPartialUpdateRequest) {
+                handleHaFlowPartialUpdate(key, (HaFlowPartialUpdateRequest) payload);
+            } else {
+                unhandledInput(input);
+            }
+        } catch (FlowProcessingException e) {
+            emitErrorMessage(e.getErrorType(), COMMON_ERROR_MESSAGE,  e.getMessage());
+        } catch (Exception e) {
+            emitErrorMessage(ErrorType.INTERNAL_ERROR, COMMON_ERROR_MESSAGE, e.getMessage());
+        }
+    }
+
+    private void handleHaFlowUpdate(String key, HaFlowRequest payload) {
+        HaFlow returnHaFlow = persistenceManager.getTransactionManager().doInTransaction(() -> {
+            Optional<HaFlow> foundHaFlow = haFlowRepository.findById(payload.getHaFlowId());
+            if (!foundHaFlow.isPresent()) {
+                throw new FlowProcessingException(ErrorType.NOT_FOUND,
+                        format("HA-flow %s not found.", payload.getHaFlowId()));
+            }
+            HaFlow haFlow = foundHaFlow.get();
+            Map<String, HaSubFlow> subFlowMap = haFlow.getSubFlows().stream()
+                    .collect(Collectors.toMap(HaSubFlow::getHaSubFlowId, Function.identity()));
+
+            for (HaSubFlowDto subFlowPayload : payload.getSubFlows()) {
+                HaSubFlow subFlow = subFlowMap.get(subFlowPayload.getFlowId());
+                if (subFlow == null) {
+                    throw new FlowProcessingException(ErrorType.DATA_INVALID,
+                            format("HA-flow %s has no sub flow %s",
+                                    payload.getHaFlowId(), subFlowPayload.getFlowId()));
+                }
+                updateSubFlow(subFlow, subFlowPayload);
+            }
+            updateHaFlow(haFlow, payload);
+            return haFlow;
+        });
+        sendHaFlowToNorthBound(key, new HaFlowResponse(HaFlowMapper.INSTANCE.toHaFlowDto(returnHaFlow)));
+    }
+
+    private void handleHaFlowPartialUpdate(String key, HaFlowPartialUpdateRequest payload) {
+        HaFlow returnHaFlow = persistenceManager.getTransactionManager().doInTransaction(() -> {
+            Optional<HaFlow> foundHaFlow = haFlowRepository.findById(payload.getHaFlowId());
+            if (!foundHaFlow.isPresent()) {
+                throw new FlowProcessingException(ErrorType.NOT_FOUND,
+                        format("HA-flow %s not found.", payload.getHaFlowId()));
+            }
+            HaFlow haFlow = foundHaFlow.get();
+            if (payload.getSubFlows() != null) {
+                updateSubFlows(payload, haFlow);
+            }
+            updateHaFlow(haFlow, payload);
+            return haFlow;
+        });
+        sendHaFlowToNorthBound(key, new HaFlowResponse(HaFlowMapper.INSTANCE.toHaFlowDto(returnHaFlow)));
+    }
+
+    private void updateSubFlows(HaFlowPartialUpdateRequest payload, HaFlow haFlow) {
+        Map<String, HaSubFlow> subFlowMap = haFlow.getSubFlows().stream()
+                .collect(Collectors.toMap(HaSubFlow::getHaSubFlowId, Function.identity()));
+
+        for (HaSubFlowPartialUpdateDto subFlowPayload : payload.getSubFlows()) {
+            HaSubFlow subFlow = subFlowMap.get(subFlowPayload.getFlowId());
+            if (subFlow == null) {
+                throw new FlowProcessingException(ErrorType.DATA_INVALID,
+                        format("HA-flow %s has no sub flow %s",
+                                payload.getHaFlowId(), subFlowPayload.getFlowId()));
+            }
+            updateSubFlow(subFlow, subFlowPayload);
+        }
+    }
+
+    private void updateHaFlow(HaFlow target, HaFlowRequest source) {
+        target.setSharedEndpoint(HaFlowMapper.INSTANCE.toEndpoint(source.getSharedEndpoint()));
+        target.setMaximumBandwidth(source.getMaximumBandwidth());
+        target.setPathComputationStrategy(source.getPathComputationStrategy());
+        target.setEncapsulationType(source.getEncapsulationType());
+        target.setMaxLatency(source.getMaxLatency());
+        target.setMaxLatencyTier2(source.getMaxLatencyTier2());
+        target.setIgnoreBandwidth(source.isIgnoreBandwidth());
+        target.setPeriodicPings(source.isPeriodicPings());
+        target.setPinned(source.isPinned());
+        target.setPriority(source.getPriority());
+        target.setStrictBandwidth(source.isStrictBandwidth());
+        target.setDescription(source.getDescription());
+        target.setAllocateProtectedPath(source.isAllocateProtectedPath());
+    }
+
+    private void updateHaFlow(HaFlow target, HaFlowPartialUpdateRequest source) {
+        updateSharedEndpoint(target, source.getSharedEndpoint());
+        Optional.ofNullable(source.getMaximumBandwidth()).ifPresent(target::setMaximumBandwidth);
+        Optional.ofNullable(source.getPathComputationStrategy()).ifPresent(target::setPathComputationStrategy);
+        Optional.ofNullable(source.getEncapsulationType()).ifPresent(target::setEncapsulationType);
+        Optional.ofNullable(source.getMaxLatency()).ifPresent(target::setMaxLatency);
+        Optional.ofNullable(source.getMaxLatencyTier2()).ifPresent(target::setMaxLatencyTier2);
+        Optional.ofNullable(source.getIgnoreBandwidth()).ifPresent(target::setIgnoreBandwidth);
+        Optional.ofNullable(source.getPeriodicPings()).ifPresent(target::setPeriodicPings);
+        Optional.ofNullable(source.getPinned()).ifPresent(target::setPinned);
+        Optional.ofNullable(source.getPriority()).ifPresent(target::setPriority);
+        Optional.ofNullable(source.getStrictBandwidth()).ifPresent(target::setStrictBandwidth);
+        Optional.ofNullable(source.getDescription()).ifPresent(target::setDescription);
+        Optional.ofNullable(source.getAllocateProtectedPath()).ifPresent(target::setAllocateProtectedPath);
+    }
+
+    private void updateSharedEndpoint(HaFlow targetHaFlow, FlowPartialUpdateEndpoint source) {
+        HaSharedEndpoint targetEndpoint = targetHaFlow.getSharedEndpoint();
+        if (source == null) {
+            return;
+        }
+        SwitchId switchId = Optional.ofNullable(source.getSwitchId()).orElse(targetEndpoint.getSwitchId());
+        int port = Optional.ofNullable(source.getPortNumber()).orElse(targetEndpoint.getPortNumber());
+        int vlanId = Optional.ofNullable(source.getVlanId()).orElse(targetEndpoint.getOuterVlanId());
+        int innerVlanId = Optional.ofNullable(source.getInnerVlanId()).orElse(targetEndpoint.getInnerVlanId());
+        targetHaFlow.setSharedEndpoint(new HaSharedEndpoint(switchId, port, vlanId, innerVlanId));
+    }
+
+    private void updateSubFlow(HaSubFlow target, HaSubFlowDto source) {
+        target.setDescription(source.getDescription());
+        target.setEndpointSwitchId(source.getEndpoint().getSwitchId());
+        target.setEndpointPort(source.getEndpoint().getPortNumber());
+        target.setEndpointVlan(source.getEndpoint().getOuterVlanId());
+        target.setEndpointInnerVlan(source.getEndpoint().getInnerVlanId());
+        target.setStatus(FlowStatus.UP);
+    }
+
+    private void updateSubFlow(HaSubFlow target, HaSubFlowPartialUpdateDto source) {
+        Optional.ofNullable(source.getDescription()).ifPresent(target::setDescription);
+        Optional.ofNullable(source.getEndpoint().getSwitchId()).ifPresent(target::setEndpointSwitchId);
+        Optional.ofNullable(source.getEndpoint().getPortNumber()).ifPresent(target::setEndpointPort);
+        Optional.ofNullable(source.getEndpoint().getVlanId()).ifPresent(target::setEndpointVlan);
+        Optional.ofNullable(source.getEndpoint().getInnerVlanId()).ifPresent(target::setEndpointInnerVlan);
+    }
+
+    private void sendHaFlowToNorthBound(String key, InfoData response) {
+        InfoMessage message = new InfoMessage(response, System.currentTimeMillis(),
+                getCommandContext().getCorrelationId());
+        emitWithContext(Stream.HUB_TO_NB_RESPONSE_SENDER.name(), getCurrentTuple(), new Values(key, message));
+    }
+
+    private void emitErrorMessage(ErrorType type, String message, String description) {
+        String requestId = getCommandContext().getCorrelationId();
+        ErrorData errorData = new ErrorData(type, message, description);
+        emitWithContext(Stream.HUB_TO_NB_RESPONSE_SENDER.name(), getCurrentTuple(), new Values(requestId,
+                new ErrorMessage(errorData, System.currentTimeMillis(), requestId)));
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        super.declareOutputFields(declarer);
+        declarer.declareStream(HUB_TO_NB_RESPONSE_SENDER.name(), MessageKafkaTranslator.STREAM_FIELDS);
+    }
+}

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/impl/YFlowServiceImpl.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/impl/YFlowServiceImpl.java
@@ -150,7 +150,7 @@ public class YFlowServiceImpl implements YFlowService {
             flowRequest = flowMapper.toYFlowUpdateRequest(yFlowId, updatePayload);
         } catch (IllegalArgumentException e) {
             throw new MessageException(correlationId, System.currentTimeMillis(), ErrorType.DATA_INVALID,
-                    e.getMessage(), "Can not parse arguments of the create y-flow request");
+                    e.getMessage(), "Can not parse arguments of the update y-flow request");
         }
 
         CommandMessage command = new CommandMessage(flowRequest, System.currentTimeMillis(), correlationId);


### PR DESCRIPTION
This stub creates/updates/deletes HA flows in DB.
It doesn't change switch rules. The only reason for this patch is to give kilda users API to start work with HA flows.

Related to #5061