### PR TITLE
Ignore legacy broken test - "User is able to replug ISL with enabled BFD, receive new ISL, enable bfd on it and replug back"

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslReplugSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslReplugSpec.groovy
@@ -266,7 +266,7 @@ class IslReplugSpec extends HealthCheckSpecification {
         database.resetCosts(topology.isls)
     }
 
-    @Ignore("runtime issue")
+    @Ignore("https://github.com/telstra/open-kilda/issues/5099")
     def "User is able to replug ISL with enabled BFD, receive new ISL, enable bfd on it and replug back"() {
         given: "An ISL with BFD and ability to replug"
         def isl = topology.islsForActiveSwitches.find { it.aswitch?.inPort && it.aswitch?.outPort &&
@@ -318,7 +318,7 @@ class IslReplugSpec extends HealthCheckSpecification {
         when: "Replug a new link back where it was before"
 
         def newOldIsl = islUtils.replug(newIsl, true, isl, true, true)
-//        def originIslIsUp = true
+        def originIslIsUp = true
         verifyAll(newOldIsl) {
             it.srcSwitch == isl.srcSwitch
             it.dstSwitch == isl.dstSwitch
@@ -349,7 +349,6 @@ class IslReplugSpec extends HealthCheckSpecification {
         }
 
         cleanup: "Removed Moved ISL, turn off bfd" //this cleanup is not comprehensive
-//        if (!originIslIsUp) {islUtils.replug(newIsl, true, isl, true, true)}
         newIsl && northbound.deleteLink(islUtils.toLinkParameters(newIsl))
         northboundV2.deleteLinkBfd(newOldIsl)
     }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslReplugSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslReplugSpec.groovy
@@ -266,6 +266,7 @@ class IslReplugSpec extends HealthCheckSpecification {
         database.resetCosts(topology.isls)
     }
 
+    @Ignore("runtime issue")
     def "User is able to replug ISL with enabled BFD, receive new ISL, enable bfd on it and replug back"() {
         given: "An ISL with BFD and ability to replug"
         def isl = topology.islsForActiveSwitches.find { it.aswitch?.inPort && it.aswitch?.outPort &&
@@ -315,7 +316,9 @@ class IslReplugSpec extends HealthCheckSpecification {
         }
 
         when: "Replug a new link back where it was before"
+
         def newOldIsl = islUtils.replug(newIsl, true, isl, true, true)
+//        def originIslIsUp = true
         verifyAll(newOldIsl) {
             it.srcSwitch == isl.srcSwitch
             it.dstSwitch == isl.dstSwitch
@@ -346,6 +349,7 @@ class IslReplugSpec extends HealthCheckSpecification {
         }
 
         cleanup: "Removed Moved ISL, turn off bfd" //this cleanup is not comprehensive
+//        if (!originIslIsUp) {islUtils.replug(newIsl, true, isl, true, true)}
         newIsl && northbound.deleteLink(islUtils.toLinkParameters(newIsl))
         northboundV2.deleteLinkBfd(newOldIsl)
     }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslReplugSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslReplugSpec.groovy
@@ -316,9 +316,7 @@ class IslReplugSpec extends HealthCheckSpecification {
         }
 
         when: "Replug a new link back where it was before"
-
         def newOldIsl = islUtils.replug(newIsl, true, isl, true, true)
-        def originIslIsUp = true
         verifyAll(newOldIsl) {
             it.srcSwitch == isl.srcSwitch
             it.dstSwitch == isl.dstSwitch


### PR DESCRIPTION
test was never run before as not match preconditions
and should be fixed before health run