### PR TITLE
Improve performance of SwitchConnectedDevices storing

### DIFF
--- a/docker/db-migration/migrations/025-optimise-switch-connected-device-class.yaml
+++ b/docker/db-migration/migrations/025-optimise-switch-connected-device-class.yaml
@@ -1,0 +1,33 @@
+databaseChangeLog:
+  - changeSet:
+      id: tag
+      author: fkantur
+      changes:
+        - tagDatabase:
+            tag: 025-optimise-switch-connected-device-class
+  - changeSet:
+      id: remove_indexes
+      author: fkantur
+      changes:
+        - sql: "DROP INDEX switch_connected_device.port_number IF EXISTS"
+        - sql: "DROP INDEX switch_connected_device.vlan IF EXISTS"
+        - sql: "DROP INDEX switch_connected_device.mac_address IF EXISTS"
+        - sql: "DROP INDEX switch_connected_device.type IF EXISTS"
+        - sql: "DROP INDEX switch_connected_device.chassis_id IF EXISTS"
+        - sql: "DROP INDEX switch_connected_device.port_id IF EXISTS"
+        - sql: "DROP INDEX switch_connected_device.ip_address IF EXISTS"
+      rollback:
+        - sql: "CREATE INDEX switch_connected_device.port_number NOTUNIQUE_HASH_INDEX"
+        - sql: "CREATE INDEX switch_connected_device.vlan NOTUNIQUE_HASH_INDEX"
+        - sql: "CREATE INDEX switch_connected_device.mac_address NOTUNIQUE_HASH_INDEX"
+        - sql: "CREATE INDEX switch_connected_device.type NOTUNIQUE_HASH_INDEX"
+        - sql: "CREATE INDEX switch_connected_device.chassis_id NOTUNIQUE_HASH_INDEX"
+        - sql: "CREATE INDEX switch_connected_device.port_id NOTUNIQUE_HASH_INDEX"
+        - sql: "CREATE INDEX switch_connected_device.ip_address NOTUNIQUE_HASH_INDEX"
+  - changeSet:
+      id: update_oversize
+      author: fkantur
+      changes:
+        - sql: "ALTER CLASS switch_connected_device OVERSIZE 2"
+      rollback:
+        - sql: "ALTER CLASS switch_connected_device OVERSIZE 0"

--- a/docker/db-migration/migrations/root.yaml
+++ b/docker/db-migration/migrations/root.yaml
@@ -84,3 +84,6 @@ databaseChangeLog:
   - include:
       relativeToChangelogFile: true
       file: 024-add-ha-flow-classes.yaml
+  - include:
+      relativeToChangelogFile: true
+      file: 025-optimise-switch-connected-device-class.yaml

--- a/src-java/connecteddevices-topology/connecteddevices-storm-topology/src/main/java/org/openkilda/wfm/topology/connecteddevices/service/PacketService.java
+++ b/src-java/connecteddevices-topology/connecteddevices-storm-topology/src/main/java/org/openkilda/wfm/topology/connecteddevices/service/PacketService.java
@@ -18,8 +18,8 @@ package org.openkilda.wfm.topology.connecteddevices.service;
 import static java.lang.String.format;
 import static org.openkilda.model.ConnectedDeviceType.ARP;
 import static org.openkilda.model.ConnectedDeviceType.LLDP;
-import static org.openkilda.model.SwitchConnectedDevice.createUniqueArpIndex;
-import static org.openkilda.model.SwitchConnectedDevice.createUniqueLldpIndex;
+import static org.openkilda.model.SwitchConnectedDevice.buildUniqueArpIndex;
+import static org.openkilda.model.SwitchConnectedDevice.buildUniqueLldpIndex;
 import static org.openkilda.model.cookie.Cookie.ARP_INGRESS_COOKIE;
 import static org.openkilda.model.cookie.Cookie.ARP_INPUT_PRE_DROP_COOKIE;
 import static org.openkilda.model.cookie.Cookie.ARP_POST_INGRESS_COOKIE;
@@ -87,7 +87,7 @@ public class PacketService {
             return;
         }
 
-        String uniqueIndex = createLldpUniqueIndex(data, flowRelatedData.getOriginalVlan());
+        String uniqueIndex = buildLldpUniqueIndex(data, flowRelatedData.getOriginalVlan());
         SwitchConnectedDevice device = Optional.ofNullable(switchConnectedDeviceCache.get(uniqueIndex))
                 .orElseGet(() -> switchConnectedDeviceRepository.findLldpByUniqueIndex(uniqueIndex).orElse(null));
 
@@ -117,7 +117,7 @@ public class PacketService {
             return;
         }
 
-        String uniqueIndex = createArpUniqueIndex(data, flowRelatedData.getOriginalVlan());
+        String uniqueIndex = buildArpUniqueIndex(data, flowRelatedData.getOriginalVlan());
         SwitchConnectedDevice device = Optional.ofNullable(switchConnectedDeviceCache.get(uniqueIndex))
                 .orElseGet(() -> switchConnectedDeviceRepository.findArpByUniqueIndex(uniqueIndex).orElse(null));
 
@@ -298,14 +298,14 @@ public class PacketService {
     }
 
     @VisibleForTesting
-    String createLldpUniqueIndex(LldpInfoData data, int vlan) {
-        return createUniqueLldpIndex(data.getSwitchId(), data.getPortNumber(), vlan, data.getMacAddress(),
+    String buildLldpUniqueIndex(LldpInfoData data, int vlan) {
+        return buildUniqueLldpIndex(data.getSwitchId(), data.getPortNumber(), vlan, data.getMacAddress(),
                 data.getChassisId(), data.getPortId());
     }
 
     @VisibleForTesting
-    String createArpUniqueIndex(ArpInfoData data, int vlan) {
-        return createUniqueArpIndex(data.getSwitchId(), data.getPortNumber(), vlan, data.getMacAddress(),
+    String buildArpUniqueIndex(ArpInfoData data, int vlan) {
+        return buildUniqueArpIndex(data.getSwitchId(), data.getPortNumber(), vlan, data.getMacAddress(),
                 data.getIpAddress());
     }
 
@@ -418,7 +418,7 @@ public class PacketService {
                 .source(flowRelatedData.getSource())
                 .build();
         switchConnectedDeviceRepository.add(connectedDevice);
-        switchConnectedDeviceCache.put(createLldpUniqueIndex(data, vlan), connectedDevice);
+        switchConnectedDeviceCache.put(buildLldpUniqueIndex(data, vlan), connectedDevice);
     }
 
     private void createArpDevice(ArpInfoData data, FlowRelatedData flowRelatedData) {
@@ -445,7 +445,7 @@ public class PacketService {
                 .source(flowRelatedData.getSource())
                 .build();
         switchConnectedDeviceRepository.add(connectedDevice);
-        switchConnectedDeviceCache.put(createArpUniqueIndex(data, vlan), connectedDevice);
+        switchConnectedDeviceCache.put(buildArpUniqueIndex(data, vlan), connectedDevice);
     }
 
     private String getPacketName(ConnectedDevicePacketBase data) {

--- a/src-java/connecteddevices-topology/connecteddevices-storm-topology/src/test/java/org/openkilda/wfm/topology/connecteddevices/service/PacketServiceTest.java
+++ b/src-java/connecteddevices-topology/connecteddevices-storm-topology/src/test/java/org/openkilda/wfm/topology/connecteddevices/service/PacketServiceTest.java
@@ -439,14 +439,14 @@ public class PacketServiceTest extends InMemoryGraphBasedTest {
 
     private void assertLldpConnectedDeviceExistInDatabase(LldpInfoData data) {
         Optional<SwitchConnectedDevice> switchConnectedDevice = switchConnectedDeviceRepository
-                .findLldpByUniqueIndex(packetService.createUniqueLldpIndex(data, data.getVlans().get(0)));
+                .findLldpByUniqueIndex(packetService.createLldpUniqueIndex(data, data.getVlans().get(0)));
         assertTrue(switchConnectedDevice.isPresent());
         assertLldpInfoDataDataEqualsSwitchConnectedDevice(data, switchConnectedDevice.get());
     }
 
     private void assertArpConnectedDeviceExistInDatabase(ArpInfoData data) {
         Optional<SwitchConnectedDevice> switchConnectedDevice = switchConnectedDeviceRepository
-                .findArpByUniqueIndex(packetService.createUniqueArpIndex(data, data.getVlans().get(0)));
+                .findArpByUniqueIndex(packetService.createArpUniqueIndex(data, data.getVlans().get(0)));
         assertTrue(switchConnectedDevice.isPresent());
         assertArpInfoDataEqualsSwitchConnectedDevice(data, switchConnectedDevice.get());
     }

--- a/src-java/connecteddevices-topology/connecteddevices-storm-topology/src/test/java/org/openkilda/wfm/topology/connecteddevices/service/PacketServiceTest.java
+++ b/src-java/connecteddevices-topology/connecteddevices-storm-topology/src/test/java/org/openkilda/wfm/topology/connecteddevices/service/PacketServiceTest.java
@@ -439,14 +439,14 @@ public class PacketServiceTest extends InMemoryGraphBasedTest {
 
     private void assertLldpConnectedDeviceExistInDatabase(LldpInfoData data) {
         Optional<SwitchConnectedDevice> switchConnectedDevice = switchConnectedDeviceRepository
-                .findLldpByUniqueIndex(packetService.createLldpUniqueIndex(data, data.getVlans().get(0)));
+                .findLldpByUniqueIndex(packetService.buildLldpUniqueIndex(data, data.getVlans().get(0)));
         assertTrue(switchConnectedDevice.isPresent());
         assertLldpInfoDataDataEqualsSwitchConnectedDevice(data, switchConnectedDevice.get());
     }
 
     private void assertArpConnectedDeviceExistInDatabase(ArpInfoData data) {
         Optional<SwitchConnectedDevice> switchConnectedDevice = switchConnectedDeviceRepository
-                .findArpByUniqueIndex(packetService.createArpUniqueIndex(data, data.getVlans().get(0)));
+                .findArpByUniqueIndex(packetService.buildArpUniqueIndex(data, data.getVlans().get(0)));
         assertTrue(switchConnectedDevice.isPresent());
         assertArpInfoDataEqualsSwitchConnectedDevice(data, switchConnectedDevice.get());
     }

--- a/src-java/connecteddevices-topology/connecteddevices-storm-topology/src/test/java/org/openkilda/wfm/topology/connecteddevices/service/PacketServiceTest.java
+++ b/src-java/connecteddevices-topology/connecteddevices-storm-topology/src/test/java/org/openkilda/wfm/topology/connecteddevices/service/PacketServiceTest.java
@@ -19,8 +19,6 @@ import static com.google.common.collect.Lists.newArrayList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
-import static org.openkilda.model.ConnectedDeviceType.ARP;
-import static org.openkilda.model.ConnectedDeviceType.LLDP;
 import static org.openkilda.model.cookie.Cookie.ARP_INPUT_PRE_DROP_COOKIE;
 import static org.openkilda.model.cookie.Cookie.LLDP_INPUT_PRE_DROP_COOKIE;
 
@@ -441,14 +439,14 @@ public class PacketServiceTest extends InMemoryGraphBasedTest {
 
     private void assertLldpConnectedDeviceExistInDatabase(LldpInfoData data) {
         Optional<SwitchConnectedDevice> switchConnectedDevice = switchConnectedDeviceRepository
-                .findLldpByUniqueIndex(createUniqueLldpIndex(data, data.getVlans().get(0)));
+                .findLldpByUniqueIndex(packetService.createUniqueLldpIndex(data, data.getVlans().get(0)));
         assertTrue(switchConnectedDevice.isPresent());
         assertLldpInfoDataDataEqualsSwitchConnectedDevice(data, switchConnectedDevice.get());
     }
 
     private void assertArpConnectedDeviceExistInDatabase(ArpInfoData data) {
         Optional<SwitchConnectedDevice> switchConnectedDevice = switchConnectedDeviceRepository
-                .findArpByUniqueIndex(createUniqueArpIndex(data, data.getVlans().get(0)));
+                .findArpByUniqueIndex(packetService.createUniqueArpIndex(data, data.getVlans().get(0)));
         assertTrue(switchConnectedDevice.isPresent());
         assertArpInfoDataEqualsSwitchConnectedDevice(data, switchConnectedDevice.get());
     }
@@ -509,15 +507,5 @@ public class PacketServiceTest extends InMemoryGraphBasedTest {
     private ArpInfoData createArpInfoData() {
         return new ArpInfoData(SWITCH_ID_1, PORT_NUMBER_1, newArrayList(VLAN_1), ARP_INPUT_PRE_DROP_COOKIE,
                 MAC_ADDRESS_1, IP_ADDRESS_1);
-    }
-
-    private String createUniqueLldpIndex(LldpInfoData data, int vlan) {
-        return String.format("%s_%s_%s_%s_%s_%s_%s", data.getSwitchId(), data.getPortNumber(), LLDP,
-                vlan, data.getMacAddress(), data.getChassisId(), data.getPortId());
-    }
-
-    private String createUniqueArpIndex(ArpInfoData data, int vlan) {
-        return String.format("%s_%s_%s_%s_%s_%s", data.getSwitchId(), data.getPortNumber(), ARP,
-                vlan, data.getMacAddress(), data.getIpAddress());
     }
 }

--- a/src-java/connecteddevices-topology/connecteddevices-storm-topology/src/test/java/org/openkilda/wfm/topology/connecteddevices/service/PacketServiceTest.java
+++ b/src-java/connecteddevices-topology/connecteddevices-storm-topology/src/test/java/org/openkilda/wfm/topology/connecteddevices/service/PacketServiceTest.java
@@ -1,4 +1,4 @@
-/* Copyright 2019 Telstra Open Source
+/* Copyright 2023 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ import static com.google.common.collect.Lists.newArrayList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.openkilda.model.ConnectedDeviceType.ARP;
+import static org.openkilda.model.ConnectedDeviceType.LLDP;
 import static org.openkilda.model.cookie.Cookie.ARP_INPUT_PRE_DROP_COOKIE;
 import static org.openkilda.model.cookie.Cookie.LLDP_INPUT_PRE_DROP_COOKIE;
 
@@ -95,11 +97,11 @@ public class PacketServiceTest extends InMemoryGraphBasedTest {
         switchRepository = persistenceManager.getRepositoryFactory().createSwitchRepository();
         flowRepository = persistenceManager.getRepositoryFactory().createFlowRepository();
         transitVlanRepository = persistenceManager.getRepositoryFactory().createTransitVlanRepository();
-        packetService = new PacketService(persistenceManager);
     }
 
     @Before
     public void setUp() {
+        packetService = new PacketService(persistenceManager);
         switchRepository.add(Switch.builder().switchId(SWITCH_ID_1).build());
         switchRepository.add(Switch.builder().switchId(SWITCH_ID_2).build());
     }
@@ -439,16 +441,14 @@ public class PacketServiceTest extends InMemoryGraphBasedTest {
 
     private void assertLldpConnectedDeviceExistInDatabase(LldpInfoData data) {
         Optional<SwitchConnectedDevice> switchConnectedDevice = switchConnectedDeviceRepository
-                .findLldpByUniqueFieldCombination(data.getSwitchId(), data.getPortNumber(), data.getVlans().get(0),
-                        data.getMacAddress(), data.getChassisId(), data.getPortId());
+                .findLldpByUniqueIndex(createUniqueLldpIndex(data, data.getVlans().get(0)));
         assertTrue(switchConnectedDevice.isPresent());
         assertLldpInfoDataDataEqualsSwitchConnectedDevice(data, switchConnectedDevice.get());
     }
 
     private void assertArpConnectedDeviceExistInDatabase(ArpInfoData data) {
         Optional<SwitchConnectedDevice> switchConnectedDevice = switchConnectedDeviceRepository
-                .findArpByUniqueFieldCombination(data.getSwitchId(), data.getPortNumber(), data.getVlans().get(0),
-                        data.getMacAddress(), data.getIpAddress());
+                .findArpByUniqueIndex(createUniqueArpIndex(data, data.getVlans().get(0)));
         assertTrue(switchConnectedDevice.isPresent());
         assertArpInfoDataEqualsSwitchConnectedDevice(data, switchConnectedDevice.get());
     }
@@ -509,5 +509,15 @@ public class PacketServiceTest extends InMemoryGraphBasedTest {
     private ArpInfoData createArpInfoData() {
         return new ArpInfoData(SWITCH_ID_1, PORT_NUMBER_1, newArrayList(VLAN_1), ARP_INPUT_PRE_DROP_COOKIE,
                 MAC_ADDRESS_1, IP_ADDRESS_1);
+    }
+
+    private String createUniqueLldpIndex(LldpInfoData data, int vlan) {
+        return String.format("%s_%s_%s_%s_%s_%s_%s", data.getSwitchId(), data.getPortNumber(), LLDP,
+                vlan, data.getMacAddress(), data.getChassisId(), data.getPortId());
+    }
+
+    private String createUniqueArpIndex(ArpInfoData data, int vlan) {
+        return String.format("%s_%s_%s_%s_%s_%s", data.getSwitchId(), data.getPortNumber(), ARP,
+                vlan, data.getMacAddress(), data.getIpAddress());
     }
 }

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/SwitchConnectedDevice.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/SwitchConnectedDevice.java
@@ -84,12 +84,12 @@ public class SwitchConnectedDevice implements CompositeDataEntity<SwitchConnecte
         this.data = data;
     }
 
-    public static String createUniqueLldpIndex(
+    public static String buildUniqueLldpIndex(
             SwitchId switchId, int portNumber, int vlan, String macAddress, String chassisId, String portId) {
         return String.format("%s_%s_%s_%s_%s_%s_%s", switchId, portNumber, LLDP, vlan, macAddress, chassisId, portId);
     }
 
-    public static String createUniqueArpIndex(
+    public static String buildUniqueArpIndex(
             SwitchId switchId, int portNumber, int vlan, String macAddress, String ipAddress) {
         return String.format("%s_%s_%s_%s_%s_%s", switchId, portNumber, ARP, vlan, macAddress, ipAddress);
     }

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/SwitchConnectedDevice.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/SwitchConnectedDevice.java
@@ -1,4 +1,4 @@
-/* Copyright 2019 Telstra Open Source
+/* Copyright 2023 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@
  */
 
 package org.openkilda.model;
+
+import static org.openkilda.model.ConnectedDeviceType.ARP;
+import static org.openkilda.model.ConnectedDeviceType.LLDP;
 
 import com.esotericsoftware.kryo.DefaultSerializer;
 import com.esotericsoftware.kryo.serializers.BeanSerializer;
@@ -79,6 +82,16 @@ public class SwitchConnectedDevice implements CompositeDataEntity<SwitchConnecte
 
     public SwitchConnectedDevice(@NonNull SwitchConnectedDeviceData data) {
         this.data = data;
+    }
+
+    public static String createUniqueLldpIndex(
+            SwitchId switchId, int portNumber, int vlan, String macAddress, String chassisId, String portId) {
+        return String.format("%s_%s_%s_%s_%s_%s_%s", switchId, portNumber, LLDP, vlan, macAddress, chassisId, portId);
+    }
+
+    public static String createUniqueArpIndex(
+            SwitchId switchId, int portNumber, int vlan, String macAddress, String ipAddress) {
+        return String.format("%s_%s_%s_%s_%s_%s", switchId, portNumber, ARP, vlan, macAddress, ipAddress);
     }
 
     @Override

--- a/src-java/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/SwitchConnectedDeviceRepository.java
+++ b/src-java/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/SwitchConnectedDeviceRepository.java
@@ -1,4 +1,4 @@
-/* Copyright 2019 Telstra Open Source
+/* Copyright 2023 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -26,11 +26,9 @@ public interface SwitchConnectedDeviceRepository extends Repository<SwitchConnec
 
     Collection<SwitchConnectedDevice> findBySwitchId(SwitchId switchId);
 
-    Optional<SwitchConnectedDevice> findLldpByUniqueFieldCombination(
-            SwitchId switchId, int portNumber, int vlan, String macAddress, String chassisId, String portId);
+    Optional<SwitchConnectedDevice> findLldpByUniqueIndex(String uniqueIndex);
 
-    Optional<SwitchConnectedDevice> findArpByUniqueFieldCombination(
-            SwitchId switchId, int portNumber, int vlan, String macAddress, String ipAddress);
+    Optional<SwitchConnectedDevice> findArpByUniqueIndex(String uniqueIndex);
 
     Collection<SwitchConnectedDevice> findByFlowId(String flowId);
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/frames/SwitchConnectedDeviceFrame.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/frames/SwitchConnectedDeviceFrame.java
@@ -16,8 +16,8 @@
 package org.openkilda.persistence.ferma.frames;
 
 import static java.lang.String.format;
-import static org.openkilda.model.SwitchConnectedDevice.createUniqueArpIndex;
-import static org.openkilda.model.SwitchConnectedDevice.createUniqueLldpIndex;
+import static org.openkilda.model.SwitchConnectedDevice.buildUniqueArpIndex;
+import static org.openkilda.model.SwitchConnectedDevice.buildUniqueLldpIndex;
 
 import org.openkilda.model.ConnectedDeviceType;
 import org.openkilda.model.Switch;
@@ -97,11 +97,11 @@ public abstract class SwitchConnectedDeviceFrame extends KildaBaseVertexFrame im
             String newUniqueIndex;
             switch (getType()) {
                 case LLDP:
-                    newUniqueIndex = createUniqueLldpIndex(getSwitchId(), getPortNumber(), getVlan(), getMacAddress(),
+                    newUniqueIndex = buildUniqueLldpIndex(getSwitchId(), getPortNumber(), getVlan(), getMacAddress(),
                             getChassisId(), getPortId());
                     break;
                 case ARP:
-                    newUniqueIndex = createUniqueArpIndex(
+                    newUniqueIndex = buildUniqueArpIndex(
                             getSwitchId(), getPortNumber(), getVlan(), getMacAddress(), getIpAddress());
                     break;
                 default:

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/frames/SwitchConnectedDeviceFrame.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/frames/SwitchConnectedDeviceFrame.java
@@ -1,4 +1,4 @@
-/* Copyright 2020 Telstra Open Source
+/* Copyright 2023 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 package org.openkilda.persistence.ferma.frames;
 
 import static java.lang.String.format;
+import static org.openkilda.model.SwitchConnectedDevice.createUniqueArpIndex;
+import static org.openkilda.model.SwitchConnectedDevice.createUniqueLldpIndex;
 
 import org.openkilda.model.ConnectedDeviceType;
 import org.openkilda.model.Switch;
@@ -95,13 +97,12 @@ public abstract class SwitchConnectedDeviceFrame extends KildaBaseVertexFrame im
             String newUniqueIndex;
             switch (getType()) {
                 case LLDP:
-                    newUniqueIndex = format("%s_%s_%s_%s_%s_%s_%s",
-                            getSwitchId(), getPortNumber(), getType(), getVlan(), getMacAddress(),
+                    newUniqueIndex = createUniqueLldpIndex(getSwitchId(), getPortNumber(), getVlan(), getMacAddress(),
                             getChassisId(), getPortId());
                     break;
                 case ARP:
-                    newUniqueIndex = format("%s_%s_%s_%s_%s_%s",
-                            getSwitchId(), getPortNumber(), getType(), getVlan(), getMacAddress(), getIpAddress());
+                    newUniqueIndex = createUniqueArpIndex(
+                            getSwitchId(), getPortNumber(), getVlan(), getMacAddress(), getIpAddress());
                     break;
                 default:
                     throw new IllegalArgumentException(format("Unknown connected device type %s", getType()));

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaSwitchConnectedDevicesRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaSwitchConnectedDevicesRepository.java
@@ -16,14 +16,8 @@
 package org.openkilda.persistence.ferma.repositories;
 
 import static java.lang.String.format;
-import static org.openkilda.model.ConnectedDeviceType.ARP;
-import static org.openkilda.persistence.ferma.frames.SwitchConnectedDeviceFrame.IP_ADDRESS_PROPERTY;
-import static org.openkilda.persistence.ferma.frames.SwitchConnectedDeviceFrame.MAC_ADDRESS_PROPERTY;
-import static org.openkilda.persistence.ferma.frames.SwitchConnectedDeviceFrame.PORT_NUMBER_PROPERTY;
 import static org.openkilda.persistence.ferma.frames.SwitchConnectedDeviceFrame.SWITCH_ID_PROPERTY;
-import static org.openkilda.persistence.ferma.frames.SwitchConnectedDeviceFrame.TYPE_PROPERTY;
 import static org.openkilda.persistence.ferma.frames.SwitchConnectedDeviceFrame.UNIQUE_INDEX_PROPERTY;
-import static org.openkilda.persistence.ferma.frames.SwitchConnectedDeviceFrame.VLAN_PROPERTY;
 
 import org.openkilda.model.SwitchConnectedDevice;
 import org.openkilda.model.SwitchConnectedDevice.SwitchConnectedDeviceData;
@@ -32,7 +26,6 @@ import org.openkilda.persistence.exceptions.PersistenceException;
 import org.openkilda.persistence.ferma.FermaPersistentImplementation;
 import org.openkilda.persistence.ferma.frames.KildaBaseVertexFrame;
 import org.openkilda.persistence.ferma.frames.SwitchConnectedDeviceFrame;
-import org.openkilda.persistence.ferma.frames.converters.ConnectedDeviceTypeConverter;
 import org.openkilda.persistence.ferma.frames.converters.SwitchIdConverter;
 import org.openkilda.persistence.repositories.SwitchConnectedDeviceRepository;
 

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaSwitchConnectedDevicesRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaSwitchConnectedDevicesRepositoryTest.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.openkilda.model.ConnectedDeviceType.ARP;
 import static org.openkilda.model.ConnectedDeviceType.LLDP;
+import static org.openkilda.model.SwitchConnectedDevice.createUniqueArpIndex;
+import static org.openkilda.model.SwitchConnectedDevice.createUniqueLldpIndex;
 import static org.openkilda.persistence.ferma.frames.SwitchConnectedDeviceFrame.UNIQUE_INDEX_PROPERTY;
 
 import org.openkilda.model.Switch;
@@ -255,15 +257,5 @@ public class FermaSwitchConnectedDevicesRepositoryTest extends InMemoryGraphBase
                             device.getType(), device.getVlan(), device.getMacAddress(), device.getIpAddress()),
                     frame.getProperty(UNIQUE_INDEX_PROPERTY));
         }
-    }
-
-    private String createUniqueLldpIndex(
-            SwitchId switchId, int portNumber, int vlan, String macAddress, String chassisId, String portId) {
-        return String.format("%s_%s_%s_%s_%s_%s_%s", switchId, portNumber, LLDP, vlan, macAddress, chassisId, portId);
-    }
-
-    private String createUniqueArpIndex(
-            SwitchId switchId, int portNumber, int vlan, String macAddress, String ipAddress) {
-        return String.format("%s_%s_%s_%s_%s_%s", switchId, portNumber, ARP, vlan, macAddress, ipAddress);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaSwitchConnectedDevicesRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaSwitchConnectedDevicesRepositoryTest.java
@@ -1,4 +1,4 @@
-/* Copyright 2020 Telstra Open Source
+/* Copyright 2023 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -179,14 +179,14 @@ public class FermaSwitchConnectedDevicesRepositoryTest extends InMemoryGraphBase
         runFindByLldpUniqueFields(lldpConnectedDeviceF);
         runFindByLldpUniqueFields(arpConnectedDeviceC);
 
-        assertFalse(connectedDeviceRepository.findLldpByUniqueFieldCombination(
-                firstSwitch.getSwitchId(), 999, 999, "fake", CHASSIS_ID, PORT_ID).isPresent());
+        assertFalse(connectedDeviceRepository.findLldpByUniqueIndex(createUniqueLldpIndex(
+                firstSwitch.getSwitchId(), 999, 999, "fake", CHASSIS_ID, PORT_ID)).isPresent());
     }
 
     private void runFindByLldpUniqueFields(SwitchConnectedDevice device) {
-        Optional<SwitchConnectedDevice> foundDevice = connectedDeviceRepository.findLldpByUniqueFieldCombination(
-                device.getSwitchId(), device.getPortNumber(), device.getVlan(), device.getMacAddress(),
-                device.getChassisId(), device.getPortId());
+        Optional<SwitchConnectedDevice> foundDevice = connectedDeviceRepository.findLldpByUniqueIndex(
+                createUniqueLldpIndex(device.getSwitchId(), device.getPortNumber(), device.getVlan(),
+                        device.getMacAddress(), device.getChassisId(), device.getPortId()));
 
         if (LLDP.equals(device.getType())) {
             assertTrue(foundDevice.isPresent());
@@ -208,14 +208,14 @@ public class FermaSwitchConnectedDevicesRepositoryTest extends InMemoryGraphBase
         runFindByArpUniqueFields(arpConnectedDeviceD);
         runFindByArpUniqueFields(arpConnectedDeviceE);
 
-        assertFalse(connectedDeviceRepository.findLldpByUniqueFieldCombination(
-                firstSwitch.getSwitchId(), 999, 999, "fake", CHASSIS_ID, PORT_ID).isPresent());
+        assertFalse(connectedDeviceRepository.findLldpByUniqueIndex(createUniqueLldpIndex(
+                firstSwitch.getSwitchId(), 999, 999, "fake", CHASSIS_ID, PORT_ID)).isPresent());
     }
 
     private void runFindByArpUniqueFields(SwitchConnectedDevice device) {
-        Optional<SwitchConnectedDevice> foundDevice = connectedDeviceRepository.findArpByUniqueFieldCombination(
-                device.getSwitchId(), device.getPortNumber(), device.getVlan(), device.getMacAddress(),
-                device.getIpAddress());
+        Optional<SwitchConnectedDevice> foundDevice = connectedDeviceRepository.findArpByUniqueIndex(
+                createUniqueArpIndex(device.getSwitchId(), device.getPortNumber(), device.getVlan(),
+                        device.getMacAddress(), device.getIpAddress()));
 
         if (ARP.equals(device.getType())) {
             assertTrue(foundDevice.isPresent());
@@ -233,9 +233,9 @@ public class FermaSwitchConnectedDevicesRepositoryTest extends InMemoryGraphBase
         connectedDeviceRepository.add(arpConnectedDeviceE);
 
         for (SwitchConnectedDevice device : Lists.newArrayList(lldpConnectedDeviceA, lldpConnectedDeviceF)) {
-            Optional<SwitchConnectedDevice> foundDevice = connectedDeviceRepository.findLldpByUniqueFieldCombination(
-                    device.getSwitchId(), device.getPortNumber(), device.getVlan(), device.getMacAddress(),
-                    device.getChassisId(), device.getPortId());
+            Optional<SwitchConnectedDevice> foundDevice = connectedDeviceRepository.findLldpByUniqueIndex(
+                    createUniqueLldpIndex(device.getSwitchId(), device.getPortNumber(), device.getVlan(),
+                            device.getMacAddress(), device.getChassisId(), device.getPortId()));
             assertTrue(foundDevice.isPresent());
             SwitchConnectedDeviceFrame frame = (SwitchConnectedDeviceFrame) foundDevice.get().getData();
 
@@ -245,15 +245,25 @@ public class FermaSwitchConnectedDevicesRepositoryTest extends InMemoryGraphBase
         }
 
         for (SwitchConnectedDevice device : Lists.newArrayList(arpConnectedDeviceC, arpConnectedDeviceE)) {
-            Optional<SwitchConnectedDevice> foundDevice = connectedDeviceRepository.findArpByUniqueFieldCombination(
-                    device.getSwitchId(), device.getPortNumber(), device.getVlan(), device.getMacAddress(),
-                    device.getIpAddress());
+            Optional<SwitchConnectedDevice> foundDevice = connectedDeviceRepository.findArpByUniqueIndex(
+                    createUniqueArpIndex(device.getSwitchId(), device.getPortNumber(), device.getVlan(),
+                            device.getMacAddress(), device.getIpAddress()));
             assertTrue(foundDevice.isPresent());
             SwitchConnectedDeviceFrame frame = (SwitchConnectedDeviceFrame) foundDevice.get().getData();
 
             assertEquals(String.format("%s_%s_%s_%s_%s_%s", device.getSwitchId(), device.getPortNumber(),
-                    device.getType(), device.getVlan(), device.getMacAddress(), device.getIpAddress()),
+                            device.getType(), device.getVlan(), device.getMacAddress(), device.getIpAddress()),
                     frame.getProperty(UNIQUE_INDEX_PROPERTY));
         }
+    }
+
+    private String createUniqueLldpIndex(
+            SwitchId switchId, int portNumber, int vlan, String macAddress, String chassisId, String portId) {
+        return String.format("%s_%s_%s_%s_%s_%s_%s", switchId, portNumber, LLDP, vlan, macAddress, chassisId, portId);
+    }
+
+    private String createUniqueArpIndex(
+            SwitchId switchId, int portNumber, int vlan, String macAddress, String ipAddress) {
+        return String.format("%s_%s_%s_%s_%s_%s", switchId, portNumber, ARP, vlan, macAddress, ipAddress);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaSwitchConnectedDevicesRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaSwitchConnectedDevicesRepositoryTest.java
@@ -22,8 +22,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.openkilda.model.ConnectedDeviceType.ARP;
 import static org.openkilda.model.ConnectedDeviceType.LLDP;
-import static org.openkilda.model.SwitchConnectedDevice.createUniqueArpIndex;
-import static org.openkilda.model.SwitchConnectedDevice.createUniqueLldpIndex;
+import static org.openkilda.model.SwitchConnectedDevice.buildUniqueArpIndex;
+import static org.openkilda.model.SwitchConnectedDevice.buildUniqueLldpIndex;
 import static org.openkilda.persistence.ferma.frames.SwitchConnectedDeviceFrame.UNIQUE_INDEX_PROPERTY;
 
 import org.openkilda.model.Switch;
@@ -181,13 +181,13 @@ public class FermaSwitchConnectedDevicesRepositoryTest extends InMemoryGraphBase
         runFindByLldpUniqueFields(lldpConnectedDeviceF);
         runFindByLldpUniqueFields(arpConnectedDeviceC);
 
-        assertFalse(connectedDeviceRepository.findLldpByUniqueIndex(createUniqueLldpIndex(
+        assertFalse(connectedDeviceRepository.findLldpByUniqueIndex(buildUniqueLldpIndex(
                 firstSwitch.getSwitchId(), 999, 999, "fake", CHASSIS_ID, PORT_ID)).isPresent());
     }
 
     private void runFindByLldpUniqueFields(SwitchConnectedDevice device) {
         Optional<SwitchConnectedDevice> foundDevice = connectedDeviceRepository.findLldpByUniqueIndex(
-                createUniqueLldpIndex(device.getSwitchId(), device.getPortNumber(), device.getVlan(),
+                buildUniqueLldpIndex(device.getSwitchId(), device.getPortNumber(), device.getVlan(),
                         device.getMacAddress(), device.getChassisId(), device.getPortId()));
 
         if (LLDP.equals(device.getType())) {
@@ -210,13 +210,13 @@ public class FermaSwitchConnectedDevicesRepositoryTest extends InMemoryGraphBase
         runFindByArpUniqueFields(arpConnectedDeviceD);
         runFindByArpUniqueFields(arpConnectedDeviceE);
 
-        assertFalse(connectedDeviceRepository.findLldpByUniqueIndex(createUniqueLldpIndex(
+        assertFalse(connectedDeviceRepository.findLldpByUniqueIndex(buildUniqueLldpIndex(
                 firstSwitch.getSwitchId(), 999, 999, "fake", CHASSIS_ID, PORT_ID)).isPresent());
     }
 
     private void runFindByArpUniqueFields(SwitchConnectedDevice device) {
         Optional<SwitchConnectedDevice> foundDevice = connectedDeviceRepository.findArpByUniqueIndex(
-                createUniqueArpIndex(device.getSwitchId(), device.getPortNumber(), device.getVlan(),
+                buildUniqueArpIndex(device.getSwitchId(), device.getPortNumber(), device.getVlan(),
                         device.getMacAddress(), device.getIpAddress()));
 
         if (ARP.equals(device.getType())) {
@@ -236,7 +236,7 @@ public class FermaSwitchConnectedDevicesRepositoryTest extends InMemoryGraphBase
 
         for (SwitchConnectedDevice device : Lists.newArrayList(lldpConnectedDeviceA, lldpConnectedDeviceF)) {
             Optional<SwitchConnectedDevice> foundDevice = connectedDeviceRepository.findLldpByUniqueIndex(
-                    createUniqueLldpIndex(device.getSwitchId(), device.getPortNumber(), device.getVlan(),
+                    buildUniqueLldpIndex(device.getSwitchId(), device.getPortNumber(), device.getVlan(),
                             device.getMacAddress(), device.getChassisId(), device.getPortId()));
             assertTrue(foundDevice.isPresent());
             SwitchConnectedDeviceFrame frame = (SwitchConnectedDeviceFrame) foundDevice.get().getData();
@@ -248,7 +248,7 @@ public class FermaSwitchConnectedDevicesRepositoryTest extends InMemoryGraphBase
 
         for (SwitchConnectedDevice device : Lists.newArrayList(arpConnectedDeviceC, arpConnectedDeviceE)) {
             Optional<SwitchConnectedDevice> foundDevice = connectedDeviceRepository.findArpByUniqueIndex(
-                    createUniqueArpIndex(device.getSwitchId(), device.getPortNumber(), device.getVlan(),
+                    buildUniqueArpIndex(device.getSwitchId(), device.getPortNumber(), device.getVlan(),
                             device.getMacAddress(), device.getIpAddress()));
             assertTrue(foundDevice.isPresent());
             SwitchConnectedDeviceFrame frame = (SwitchConnectedDeviceFrame) foundDevice.get().getData();


### PR DESCRIPTION
Closes #5051
In this PR we:
- removes redundant indexes in DB
- updates Oversize property for switch_connected_device class
- add cache and update logic for SwitchConnectedDevice entity to reduce the number of transactions  

For measure, we used 100 connected devices with ≈100 update messages per device (10000 messages).
Initially, the processing time was ≈24-25 seconds after the changes ≈12.5 seconds.