### PR TITLE
Bugfix/4574 switch validation fail for grpc timeout

### DIFF
--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/LogicalPortsValidationEntryV2.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/LogicalPortsValidationEntryV2.java
@@ -75,6 +75,7 @@ public class LogicalPortsValidationEntryV2 implements Serializable {
                     .excess(entry.getExcess())
                     .proper(entry.getProper())
                     .misconfigured(entry.getMisconfigured())
+                    .error(error)
                     .build());
         }
         return result;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/LogicalPortsValidationEntryV2.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/LogicalPortsValidationEntryV2.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -59,6 +60,8 @@ public class LogicalPortsValidationEntryV2 implements Serializable {
         builder.proper(joinLists(nonNullEntries.stream().map(LogicalPortsValidationEntryV2::getProper)));
         builder.missing(joinLists(nonNullEntries.stream().map(LogicalPortsValidationEntryV2::getMissing)));
         builder.misconfigured(joinLists(nonNullEntries.stream().map(LogicalPortsValidationEntryV2::getMisconfigured)));
+        nonNullEntries.stream().filter(e -> StringUtils.isNoneBlank(e.error)).findFirst()
+                .map(LogicalPortsValidationEntryV2::getError).ifPresent(builder::error);
         return builder.build();
     }
 

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/info/switches/v2/LogicalPortsValidationEntryV2Test.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/info/switches/v2/LogicalPortsValidationEntryV2Test.java
@@ -43,6 +43,22 @@ public class LogicalPortsValidationEntryV2Test {
     }
 
     @Test
+    public void splitAndUniteEmptyLogicalPortEntryWithErrorTest() {
+        LogicalPortsValidationEntryV2 entry = LogicalPortsValidationEntryV2.builder()
+                .asExpected(false)
+                .error("Timeout for waiting response on DumpLogicalPortsRequest() Details: Error in SpeakerWorkerService")
+                .missing(new ArrayList<>())
+                .misconfigured(new ArrayList<>())
+                .excess(new ArrayList<>())
+                .proper(new ArrayList<>())
+                .build();
+        List<LogicalPortsValidationEntryV2> list = entry.split(4, 4);
+        assertEquals(1, list.size());
+        LogicalPortsValidationEntryV2 united = LogicalPortsValidationEntryV2.join(list);
+        assertEquals(entry, united);
+    }
+
+    @Test
     public void splitAndUniteNullLogicalPortEntryTest() {
         LogicalPortsValidationEntryV2 entry = LogicalPortsValidationEntryV2.builder()
                 .asExpected(true)

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/main/java/org/openkilda/wfm/topology/switchmanager/SwitchManagerTopology.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/main/java/org/openkilda/wfm/topology/switchmanager/SwitchManagerTopology.java
@@ -72,7 +72,8 @@ public class SwitchManagerTopology extends AbstractTopology<SwitchManagerTopolog
         declareSpout(builder, new CoordinatorSpout(), CoordinatorSpout.ID);
         declareBolt(builder, new CoordinatorBolt(), CoordinatorBolt.ID)
                 .allGrouping(CoordinatorSpout.ID)
-                .fieldsGrouping(SwitchManagerHub.ID, CoordinatorBolt.INCOME_STREAM, FIELDS_KEY);
+                .fieldsGrouping(SwitchManagerHub.ID, CoordinatorBolt.INCOME_STREAM, FIELDS_KEY)
+                .fieldsGrouping(SpeakerWorkerBolt.ID, CoordinatorBolt.INCOME_STREAM, FIELDS_KEY);
 
         PersistenceManager persistenceManager = new PersistenceManager(configurationProvider);
 


### PR DESCRIPTION
Fix for SwitchManagerTopology:
set coordinator bolt to listen SpeakerWorkerBolt, now it should listen call back registration tasks and register this "subtasks" from SwitchValidationFsm. 
As result it fixes the problem with switch validation fail during grpc downtime.. 
Fixed error field, now error field for logical ports entity should be populated correctly in case of any errors from grpc(e.g. timeout)

Added unit test for LogicalPortsValidationEntryV2Test