### PR TITLE
restructuring and extending tests for maxLatency (tier2) update on patch endpoint

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
@@ -1343,7 +1343,6 @@ class FlowCrudSpec extends HealthCheckSpecification {
 
         cleanup: "Remove the flow"
         flowHelperV2.deleteFlow(flow.flowId)
-
     }
 
     @Shared

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PartialUpdateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PartialUpdateSpec.groovy
@@ -126,10 +126,7 @@ class PartialUpdateSpec extends HealthCheckSpecification {
         given: "A flow"
         def swPair = topologyHelper.switchPairs.first()
         def flow = flowHelperV2.randomFlow(swPair)
-        flow.tap{
-            pathComputationStrategy = "cost"
-            maxLatency = 1234
-        }
+
         flowHelperV2.addFlow(flow)
         def originalCookies = northbound.getSwitchRules(swPair.src.dpId).flowEntries.findAll {
             def cookie = new Cookie(it.cookie)
@@ -830,7 +827,6 @@ class PartialUpdateSpec extends HealthCheckSpecification {
         maxLatencyBefore | maxLatencyT2Before | maxLatencyAfter | maxLatencyT2After
         null             | null               | null            | 1
         2                | 3                  | null            | 1
-        2                | null               | null            | 4
     }
 
     @Shared

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PartialUpdateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PartialUpdateSpec.groovy
@@ -802,7 +802,7 @@ class PartialUpdateSpec extends HealthCheckSpecification {
         given: "Two potential flows"
         def flow = flowHelperV2.randomFlow(topologyHelper.switchPairs[0]).tap {
             maxLatency = maxLatencyBefore
-            maxLatencyT2Before
+            maxLatencyTier2 = maxLatencyT2Before
 
         }
         flowHelperV2.addFlow(flow)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PartialUpdateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PartialUpdateSpec.groovy
@@ -53,6 +53,10 @@ class PartialUpdateSpec extends HealthCheckSpecification {
         given: "A flow"
         def swPair = topologyHelper.switchPairs.first()
         def flow = flowHelperV2.randomFlow(swPair)
+        flow.tap{
+            pathComputationStrategy = "cost"
+            maxLatency = 1000
+        }
         flowHelperV2.addFlow(flow)
         def originalCookies = northbound.getSwitchRules(swPair.src.dpId).flowEntries.findAll {
             def cookie = new Cookie(it.cookie)
@@ -83,6 +87,10 @@ class PartialUpdateSpec extends HealthCheckSpecification {
         data << [
                 [
                         field   : "maxLatency",
+                        newValue: 12345
+                ],
+                [
+                        field   : "maxLatencyTier2",
                         newValue: 12345
                 ],
                 [
@@ -118,6 +126,10 @@ class PartialUpdateSpec extends HealthCheckSpecification {
         given: "A flow"
         def swPair = topologyHelper.switchPairs.first()
         def flow = flowHelperV2.randomFlow(swPair)
+        flow.tap{
+            pathComputationStrategy = "cost"
+            maxLatency = 1234
+        }
         flowHelperV2.addFlow(flow)
         def originalCookies = northbound.getSwitchRules(swPair.src.dpId).flowEntries.findAll {
             def cookie = new Cookie(it.cookie)
@@ -818,6 +830,7 @@ class PartialUpdateSpec extends HealthCheckSpecification {
         maxLatencyBefore | maxLatencyT2Before | maxLatencyAfter | maxLatencyT2After
         null             | null               | null            | 1
         2                | 3                  | null            | 1
+        2                | null               | null            | 4
     }
 
     @Shared

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PartialUpdateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PartialUpdateSpec.groovy
@@ -126,7 +126,6 @@ class PartialUpdateSpec extends HealthCheckSpecification {
         given: "A flow"
         def swPair = topologyHelper.switchPairs.first()
         def flow = flowHelperV2.randomFlow(swPair)
-
         flowHelperV2.addFlow(flow)
         def originalCookies = northbound.getSwitchRules(swPair.src.dpId).flowEntries.findAll {
             def cookie = new Cookie(it.cookie)


### PR DESCRIPTION
also removed partial update for one of the tests (coverage was kept by other)