### PR TITLE
Feature/5025use rule manager for flow validation

### DIFF
--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/flow/FlowDumpResponse.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/flow/FlowDumpResponse.java
@@ -20,10 +20,12 @@ import static org.openkilda.messaging.Utils.joinLists;
 import org.openkilda.messaging.Chunkable;
 import org.openkilda.messaging.Utils;
 import org.openkilda.messaging.info.InfoData;
+import org.openkilda.model.SwitchId;
 import org.openkilda.rulemanager.FlowSpeakerData;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -33,21 +35,20 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Data
+@Builder
+@AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
+@JsonNaming(value = SnakeCaseStrategy.class)
 public class FlowDumpResponse extends InfoData implements Chunkable<FlowDumpResponse> {
-    @JsonProperty("flow_speaker_data")
+
     List<FlowSpeakerData> flowSpeakerData;
 
-    @JsonCreator
-    @Builder
-    public FlowDumpResponse(@JsonProperty("flow_speaker_data") List<FlowSpeakerData> flowSpeakerData) {
-        this.flowSpeakerData = flowSpeakerData;
-    }
+    SwitchId switchId;
 
     @Override
     public List<FlowDumpResponse> split(int chunkSize) {
         return Utils.split(flowSpeakerData, chunkSize).stream()
-                .map(FlowDumpResponse::new)
+                .map(flowSpeakerDataList -> new FlowDumpResponse(flowSpeakerDataList, this.switchId))
                 .collect(Collectors.toList());
     }
 
@@ -58,8 +59,10 @@ public class FlowDumpResponse extends InfoData implements Chunkable<FlowDumpResp
         if (dataList == null) {
             return null;
         }
+
         return new FlowDumpResponse(joinLists(dataList.stream()
                 .filter(Objects::nonNull)
-                .map(FlowDumpResponse::getFlowSpeakerData)));
+                .map(FlowDumpResponse::getFlowSpeakerData)),
+                dataList.stream().findFirst().map(FlowDumpResponse::getSwitchId).orElse(null));
     }
 }

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/rulemanager/SwitchDataProvider.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/rulemanager/SwitchDataProvider.java
@@ -87,7 +87,8 @@ public class SwitchDataProvider {
                     List<MeterSpeakerData> switchMeters = new ArrayList<>();
                     if (replies != null) {
                         replies.forEach(reply -> switchMeters.addAll(
-                                OfMeterConverter.INSTANCE.convertToMeterSpeakerData(reply, inaccurate)));
+                                OfMeterConverter.INSTANCE.convertToMeterSpeakerData(reply, inaccurate,
+                                        new SwitchId(iofSwitch.getId().getLong()))));
                     }
                     return CompletableFuture.completedFuture(switchMeters);
                 })

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/converter/rulemanager/OfMeterConverter.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/converter/rulemanager/OfMeterConverter.java
@@ -18,6 +18,7 @@ package org.openkilda.floodlight.converter.rulemanager;
 import static org.projectfloodlight.openflow.protocol.OFVersion.OF_13;
 
 import org.openkilda.model.MeterId;
+import org.openkilda.model.SwitchId;
 import org.openkilda.rulemanager.MeterFlag;
 import org.openkilda.rulemanager.MeterSpeakerData;
 
@@ -94,6 +95,7 @@ public class OfMeterConverter {
 
     /**
      * Convert Meter Install Command.
+     *
      * @param commandData data
      * @param ofFactory factory
      * @return mod
@@ -135,6 +137,7 @@ public class OfMeterConverter {
 
     /**
      * Convert Meter Delete Command.
+     *
      * @param commandData data
      * @param ofFactory factory
      * @return mod
@@ -164,16 +167,17 @@ public class OfMeterConverter {
      * Convert meter stats reply.
      */
     public List<MeterSpeakerData> convertToMeterSpeakerData(OFMeterConfigStatsReply statsReply,
-                                                            boolean inaccurate) {
+                                                            boolean inaccurate, SwitchId switchId) {
         return statsReply.getEntries().stream()
-                .map(entry -> convertToMeterSpeakerData(entry, inaccurate))
+                .map(entry -> convertToMeterSpeakerData(entry, inaccurate, switchId))
                 .collect(Collectors.toList());
     }
 
     /**
      * Convert meter config.
      */
-    public MeterSpeakerData convertToMeterSpeakerData(OFMeterConfig meterConfig, boolean inaccurate) {
+    public MeterSpeakerData convertToMeterSpeakerData(OFMeterConfig meterConfig, boolean inaccurate,
+                                                      SwitchId switchId) {
         MeterId meterId = new MeterId(meterConfig.getMeterId());
         long rate = 0;
         long burst = 0;
@@ -186,6 +190,7 @@ public class OfMeterConverter {
         return MeterSpeakerData.builder()
                 .meterId(meterId)
                 .burst(burst)
+                .switchId(switchId)
                 .rate(rate)
                 .flags(fromOfMeterFlags(meterConfig.getFlags()))
                 .inaccurate(inaccurate)

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
@@ -468,7 +468,7 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
     }
 
     @Override
-    public List<OFGroupDescStatsEntry> dumpGroups(DatapathId dpid) throws SwitchOperationException {
+    public List<OFGroupDescStatsEntry> dumpGroups(DatapathId dpid) throws SwitchNotFoundException {
         IOFSwitch sw = lookupSwitch(dpid);
         return dumpGroups(sw);
     }

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/info/flow/FlowValidationResponse.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/info/flow/FlowValidationResponse.java
@@ -16,6 +16,7 @@
 package org.openkilda.messaging.info.flow;
 
 import org.openkilda.messaging.info.InfoData;
+import org.openkilda.messaging.model.FlowDirectionType;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -32,6 +33,7 @@ import java.util.List;
 public class FlowValidationResponse extends InfoData {
 
     String flowId;
+    FlowDirectionType direction;
     Boolean asExpected;
     List<Long> pktCounts;
     List<Long> byteCounts;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/model/FlowDirectionType.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/model/FlowDirectionType.java
@@ -1,0 +1,33 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.messaging.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public enum FlowDirectionType {
+    FORWARD,
+    REVERSE,
+    PROTECTED_FORWARD,
+    PROTECTED_REVERSE;
+
+    @Override
+    public String toString() {
+        return this.name().toLowerCase();
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/validation/FlowValidationService.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/validation/FlowValidationService.java
@@ -15,14 +15,18 @@
 
 package org.openkilda.wfm.topology.flowhs.fsm.validation;
 
+import static org.openkilda.messaging.model.FlowDirectionType.FORWARD;
+import static org.openkilda.messaging.model.FlowDirectionType.PROTECTED_FORWARD;
+import static org.openkilda.messaging.model.FlowDirectionType.PROTECTED_REVERSE;
+import static org.openkilda.messaging.model.FlowDirectionType.REVERSE;
+
+import org.openkilda.messaging.info.flow.FlowDumpResponse;
 import org.openkilda.messaging.info.flow.FlowValidationResponse;
 import org.openkilda.messaging.info.flow.PathDiscrepancyEntity;
-import org.openkilda.messaging.info.meter.SwitchMeterEntries;
-import org.openkilda.messaging.info.rule.SwitchFlowEntries;
-import org.openkilda.messaging.info.rule.SwitchGroupEntries;
-import org.openkilda.model.EncapsulationId;
+import org.openkilda.messaging.info.group.GroupDumpResponse;
+import org.openkilda.messaging.info.meter.MeterDumpResponse;
+import org.openkilda.messaging.model.FlowDirectionType;
 import org.openkilda.model.Flow;
-import org.openkilda.model.FlowPath;
 import org.openkilda.model.FlowStatus;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchId;
@@ -30,43 +34,42 @@ import org.openkilda.model.cookie.FlowSegmentCookie;
 import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.persistence.repositories.FlowRepository;
 import org.openkilda.persistence.repositories.SwitchRepository;
+import org.openkilda.rulemanager.RuleManager;
+import org.openkilda.rulemanager.SpeakerData;
+import org.openkilda.rulemanager.adapter.PersistenceDataAdapter;
 import org.openkilda.wfm.error.FlowNotFoundException;
 import org.openkilda.wfm.error.IllegalFlowStateException;
 import org.openkilda.wfm.error.SwitchNotFoundException;
-import org.openkilda.wfm.share.flow.resources.EncapsulationResources;
-import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
 
+import com.google.common.collect.Sets;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 import java.nio.file.InvalidPathException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
 public class FlowValidationService {
     private final SwitchRepository switchRepository;
     private final FlowRepository flowRepository;
-    private final FlowResourcesManager flowResourcesManager;
 
     private final SimpleSwitchRuleConverter simpleSwitchRuleConverter = new SimpleSwitchRuleConverter();
     private final SimpleSwitchRuleComparator simpleSwitchRuleComparator;
-
-    private final long flowMeterMinBurstSizeInKbits;
-    private final double flowMeterBurstCoefficient;
+    private final RuleManager ruleManager;
+    private final PersistenceManager persistenceManager;
 
     public FlowValidationService(@NonNull PersistenceManager persistenceManager,
-                                 @NonNull FlowResourcesManager flowResourcesManager,
-                                 long flowMeterMinBurstSizeInKbits, double flowMeterBurstCoefficient) {
+                                 RuleManager ruleManager) {
         this.switchRepository = persistenceManager.getRepositoryFactory().createSwitchRepository();
         this.flowRepository = persistenceManager.getRepositoryFactory().createFlowRepository();
-        this.flowResourcesManager = flowResourcesManager;
-        this.flowMeterMinBurstSizeInKbits = flowMeterMinBurstSizeInKbits;
-        this.flowMeterBurstCoefficient = flowMeterBurstCoefficient;
+        this.ruleManager = ruleManager;
+        this.persistenceManager = persistenceManager;
 
         this.simpleSwitchRuleComparator = new SimpleSwitchRuleComparator(switchRepository);
     }
@@ -94,36 +97,11 @@ public class FlowValidationService {
     /**
      * Validate flow.
      */
-    public List<FlowValidationResponse> validateFlow(String flowId, List<SwitchFlowEntries> switchFlowEntries,
-                                                     List<SwitchMeterEntries> switchMeterEntries,
-                                                     List<SwitchGroupEntries> switchGroupEntries)
+    public List<FlowValidationResponse> validateFlow(String flowId, List<FlowDumpResponse> flowDumpResponses,
+                                                     List<MeterDumpResponse> metersDumpResponses,
+                                                     List<GroupDumpResponse> groupDumpResponses,
+                                                     Set<SwitchId> switchIdSet)
             throws FlowNotFoundException, SwitchNotFoundException {
-
-        Map<SwitchId, List<SimpleSwitchRule>> switchRules = new HashMap<>();
-        int rulesCount = 0;
-        int metersCount = 0;
-        for (SwitchFlowEntries switchRulesEntries : switchFlowEntries) {
-            SwitchMeterEntries switchMeters = switchMeterEntries.stream()
-                    .filter(meterEntries -> switchRulesEntries.getSwitchId().equals(meterEntries.getSwitchId()))
-                    .findFirst()
-                    .orElse(null);
-            SwitchGroupEntries switchGroup = switchGroupEntries.stream()
-                    .filter(groupEntries -> switchRulesEntries.getSwitchId().equals(groupEntries.getSwitchId()))
-                    .findFirst()
-                    .orElse(null);
-
-            List<SimpleSwitchRule> simpleSwitchRules = simpleSwitchRuleConverter
-                    .convertSwitchFlowEntriesToSimpleSwitchRules(switchRulesEntries, switchMeters, switchGroup);
-            switchRules.put(switchRulesEntries.getSwitchId(), simpleSwitchRules);
-
-            rulesCount += Optional.ofNullable(switchRulesEntries.getFlowEntries())
-                    .map(List::size)
-                    .orElse(0);
-            metersCount += Optional.ofNullable(switchMeters)
-                    .map(SwitchMeterEntries::getMeterEntries)
-                    .map(List::size)
-                    .orElse(0);
-        }
 
         Optional<Flow> foundFlow = flowRepository.findById(flowId);
         if (!foundFlow.isPresent()) {
@@ -138,84 +116,129 @@ public class FlowValidationService {
             throw new InvalidPathException(flowId, "Reverse path was not returned.");
         }
 
+        List<SpeakerData> actualSpeakerData = flowDumpResponses.stream()
+                .flatMap(e -> e.getFlowSpeakerData().stream()).collect(Collectors.toList());
+        int rulesCount = actualSpeakerData.size();
+        actualSpeakerData.addAll(metersDumpResponses.stream()
+                .flatMap(e -> e.getMeterSpeakerData().stream()).collect(Collectors.toList()));
+        int metersCount = new Long(metersDumpResponses.stream()
+                .mapToLong(e -> e.getMeterSpeakerData().size()).sum()).intValue();
+        actualSpeakerData.addAll(groupDumpResponses.stream()
+                .flatMap(e -> e.getGroupSpeakerData().stream()).collect(Collectors.toList()));
+
+        Map<SwitchId, List<SimpleSwitchRule>> actualSimpleSwitchRulesBySwitchId
+                = simpleSwitchRuleConverter.convertSpeakerDataToSimpleSwitchRulesAndGroupBySwitchId(actualSpeakerData);
+
+        PersistenceDataAdapter dataAdapter = PersistenceDataAdapter.builder()
+                .persistenceManager(persistenceManager)
+                .switchIds(switchIdSet)
+                .pathIds(Sets.newHashSet(flow.getForwardPathId(),
+                        flow.getReversePathId(),
+                        flow.getProtectedForwardPathId(),
+                        flow.getProtectedReversePathId()))
+                .keepMultitableForFlow(true)
+                .build();
         List<FlowValidationResponse> flowValidationResponse = new ArrayList<>();
 
-        List<SimpleSwitchRule> forwardRules = getSimpleSwitchRules(flow, flow.getForwardPath(), flow.getReversePath());
-        flowValidationResponse.add(compare(switchRules, forwardRules, flowId, rulesCount, metersCount));
+        boolean filterOutUsedSharedRules = false;
+        List<SpeakerData> expectedForwardRules = ruleManager.buildRulesForFlowPath(flow.getForwardPath(),
+                filterOutUsedSharedRules, dataAdapter);
+        flowValidationResponse.add(compareAndGetDiscrepancies(
+                actualSimpleSwitchRulesBySwitchId,
+                simpleSwitchRuleConverter.convertSpeakerDataToSimpleSwitchRulesAndGroupBySwitchId(expectedForwardRules)
+                        .values().stream().flatMap(Collection::stream).collect(Collectors.toList()),
+                flowId,
+                rulesCount,
+                metersCount,
+                FORWARD));
 
-        List<SimpleSwitchRule> reverseRules = getSimpleSwitchRules(flow, flow.getReversePath(), flow.getForwardPath());
-        flowValidationResponse.add(compare(switchRules, reverseRules, flowId, rulesCount, metersCount));
+        List<SpeakerData> expectedReversRules = ruleManager.buildRulesForFlowPath(flow.getReversePath(),
+                filterOutUsedSharedRules, dataAdapter);
+        flowValidationResponse.add(compareAndGetDiscrepancies(
+                actualSimpleSwitchRulesBySwitchId,
+                simpleSwitchRuleConverter.convertSpeakerDataToSimpleSwitchRulesAndGroupBySwitchId(expectedReversRules)
+                        .values().stream().flatMap(Collection::stream).collect(Collectors.toList()),
+                flowId,
+                rulesCount,
+                metersCount,
+                REVERSE));
 
         if (flow.getProtectedForwardPath() != null) {
-            List<SimpleSwitchRule> forwardProtectedRules = getSimpleSwitchRules(flow, flow.getProtectedForwardPath(),
-                    flow.getProtectedReversePath());
-            flowValidationResponse.add(compare(switchRules, forwardProtectedRules, flowId, rulesCount, metersCount));
+            List<SpeakerData> expectProtectedForwardRules = ruleManager.buildRulesForFlowPath(
+                    flow.getProtectedForwardPath(),
+                    filterOutUsedSharedRules,
+                    dataAdapter);
+
+            flowValidationResponse.add(compareAndGetDiscrepancies(
+                    actualSimpleSwitchRulesBySwitchId,
+                    simpleSwitchRuleConverter.convertSpeakerDataToSimpleSwitchRulesAndGroupBySwitchId(
+                                    expectProtectedForwardRules)
+                            .values().stream().flatMap(Collection::stream).collect(Collectors.toList()),
+                    flowId,
+                    rulesCount,
+                    metersCount,
+                    PROTECTED_FORWARD));
         }
 
         if (flow.getProtectedReversePath() != null) {
-            List<SimpleSwitchRule> reverseProtectedRules = getSimpleSwitchRules(flow, flow.getProtectedReversePath(),
-                    flow.getProtectedForwardPath());
-            flowValidationResponse.add(compare(switchRules, reverseProtectedRules, flowId, rulesCount, metersCount));
+            List<SpeakerData> expectProtectedReversRules =
+                    ruleManager.buildRulesForFlowPath(flow.getProtectedReversePath(),
+                            filterOutUsedSharedRules, dataAdapter);
+            flowValidationResponse.add(compareAndGetDiscrepancies(
+                    actualSimpleSwitchRulesBySwitchId,
+                    simpleSwitchRuleConverter.convertSpeakerDataToSimpleSwitchRulesAndGroupBySwitchId(
+                                    expectProtectedReversRules)
+                            .values().stream().flatMap(Collection::stream).collect(Collectors.toList()),
+                    flowId,
+                    rulesCount,
+                    metersCount,
+                    PROTECTED_REVERSE));
         }
 
         return flowValidationResponse;
     }
 
-    private FlowValidationResponse compare(Map<SwitchId, List<SimpleSwitchRule>> rulesPerSwitch,
-                                           List<SimpleSwitchRule> rulesFromDb, String flowId,
-                                           int totalSwitchRules, int metersCount) throws SwitchNotFoundException {
+    private FlowValidationResponse compareAndGetDiscrepancies(Map<SwitchId, List<SimpleSwitchRule>> actualRules,
+                                                              List<SimpleSwitchRule> expectedRulesFromDb,
+                                                              String flowId,
+                                                              int totalSwitchRules,
+                                                              int metersCount,
+                                                              FlowDirectionType flowDirectionType)
+            throws SwitchNotFoundException {
 
         List<PathDiscrepancyEntity> discrepancies = new ArrayList<>();
         List<Long> pktCounts = new ArrayList<>();
         List<Long> byteCounts = new ArrayList<>();
         boolean ingressMirrorFlowIsPresent = false;
         boolean egressMirrorFlowIsPresent = false;
-        for (SimpleSwitchRule simpleRule : rulesFromDb) {
-            discrepancies.addAll(simpleSwitchRuleComparator.findDiscrepancy(simpleRule,
-                    rulesPerSwitch.get(simpleRule.getSwitchId()), pktCounts, byteCounts));
+        for (SimpleSwitchRule expectedSimpleRule : expectedRulesFromDb) {
+            discrepancies.addAll(simpleSwitchRuleComparator.findDiscrepancy(expectedSimpleRule,
+                    actualRules.get(expectedSimpleRule.getSwitchId()), pktCounts, byteCounts));
 
-            if (new FlowSegmentCookie(simpleRule.getCookie()).isMirror() && simpleRule.isIngressRule()) {
+            if (new FlowSegmentCookie(expectedSimpleRule.getCookie()).isMirror()
+                    && expectedSimpleRule.isIngressRule()) {
                 ingressMirrorFlowIsPresent = true;
             }
 
-            if (new FlowSegmentCookie(simpleRule.getCookie()).isMirror() && simpleRule.isEgressRule()) {
+            if (new FlowSegmentCookie(expectedSimpleRule.getCookie()).isMirror() && expectedSimpleRule.isEgressRule()) {
                 egressMirrorFlowIsPresent = true;
             }
         }
-        int flowMetersCount = (int) rulesFromDb.stream().filter(rule -> rule.getMeterId() != null).count();
+        int flowMetersCount = (int) expectedRulesFromDb.stream().filter(rule -> rule.getMeterId() != null).count();
 
         return FlowValidationResponse.builder()
                 .flowId(flowId)
+                .direction(flowDirectionType)
                 .discrepancies(discrepancies)
                 .asExpected(discrepancies.isEmpty())
                 .pktCounts(pktCounts)
                 .byteCounts(byteCounts)
-                .flowRulesTotal(rulesFromDb.size())
+                .flowRulesTotal(expectedRulesFromDb.size())
                 .switchRulesTotal(totalSwitchRules)
                 .flowMetersTotal(flowMetersCount)
                 .switchMetersTotal(metersCount)
                 .ingressMirrorFlowIsPresent(ingressMirrorFlowIsPresent)
                 .egressMirrorFlowIsPresent(egressMirrorFlowIsPresent)
                 .build();
-    }
-
-    private List<SimpleSwitchRule> getSimpleSwitchRules(Flow flow, FlowPath flowPath, FlowPath oppositePath) {
-
-        EncapsulationId encapsulationId = null;
-
-        if (!flow.isOneSwitchFlow()) {
-            Optional<? extends EncapsulationResources> encapsulationResources =
-                    flowResourcesManager.getEncapsulationResources(flowPath.getPathId(), oppositePath.getPathId(),
-                            flow.getEncapsulationType());
-            if (encapsulationResources.isPresent()) {
-                encapsulationId = encapsulationResources.get().getEncapsulation();
-            } else {
-                throw new IllegalStateException(
-                        String.format("Encapsulation id was not found, pathId: %s", flowPath.getPathId()));
-            }
-        }
-
-        return simpleSwitchRuleConverter.convertFlowPathToSimpleSwitchRules(flow, flowPath, encapsulationId,
-                flowMeterMinBurstSizeInKbits, flowMeterBurstCoefficient);
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/validation/SimpleSwitchRuleComparator.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/validation/SimpleSwitchRuleComparator.java
@@ -21,12 +21,15 @@ import org.openkilda.model.Switch;
 import org.openkilda.persistence.repositories.SwitchRepository;
 import org.openkilda.wfm.error.SwitchNotFoundException;
 
+import com.google.common.collect.Sets;
 import lombok.NonNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 
 public class SimpleSwitchRuleComparator {
     private final SwitchRepository switchRepository;
@@ -139,7 +142,12 @@ public class SimpleSwitchRuleComparator {
                     discrepancies.add(new PathDiscrepancyEntity(expected.toString(), "meterBurstSize",
                             String.valueOf(expected.getMeterBurstSize()), String.valueOf(matched.getMeterBurstSize())));
                 }
-                if (!Arrays.equals(matched.getMeterFlags(), expected.getMeterFlags())) {
+                Set<String> matchedFlags = Optional.ofNullable(matched.getMeterFlags())
+                        .map(Sets::newHashSet).orElse(Sets.newHashSet());
+                Set<String> expectedFlags = Optional.ofNullable(expected.getMeterFlags())
+                        .map(Sets::newHashSet).orElse(Sets.newHashSet());
+
+                if (!matchedFlags.equals(expectedFlags)) {
                     discrepancies.add(new PathDiscrepancyEntity(expected.toString(), "meterFlags",
                             Arrays.toString(expected.getMeterFlags()), Arrays.toString(matched.getMeterFlags())));
                 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/validation/YFlowValidationFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/validation/YFlowValidationFsm.java
@@ -15,9 +15,9 @@
 
 package org.openkilda.wfm.topology.flowhs.fsm.yflow.validation;
 
+import org.openkilda.messaging.info.flow.FlowDumpResponse;
 import org.openkilda.messaging.info.flow.FlowValidationResponse;
-import org.openkilda.messaging.info.meter.SwitchMeterEntries;
-import org.openkilda.messaging.info.rule.SwitchFlowEntries;
+import org.openkilda.messaging.info.meter.MeterDumpResponse;
 import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.wfm.CommandContext;
 import org.openkilda.wfm.share.metrics.MeterRegistryHolder;
@@ -66,8 +66,8 @@ public final class YFlowValidationFsm extends NbTrackableFlowProcessingFsm<YFlow
 
     private int awaitingRules;
     private int awaitingMeters;
-    private final List<SwitchFlowEntries> receivedRules = new ArrayList<>();
-    private final List<SwitchMeterEntries> receivedMeters = new ArrayList<>();
+    private final List<FlowDumpResponse> receivedRules = new ArrayList<>();
+    private final List<MeterDumpResponse> receivedMeters = new ArrayList<>();
 
     private YFlowValidationFsm(@NonNull CommandContext commandContext, @NonNull YFlowValidationHubCarrier carrier,
                                @NonNull String yFlowId, @NonNull Collection<YFlowEventListener> eventListeners) {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/validation/actions/OnReceivedYFlowResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/validation/actions/OnReceivedYFlowResourcesAction.java
@@ -19,9 +19,9 @@ import static java.lang.String.format;
 
 import org.openkilda.messaging.MessageData;
 import org.openkilda.messaging.error.ErrorData;
-import org.openkilda.messaging.info.meter.SwitchMeterEntries;
+import org.openkilda.messaging.info.flow.FlowDumpResponse;
+import org.openkilda.messaging.info.meter.MeterDumpResponse;
 import org.openkilda.messaging.info.meter.SwitchMeterUnsupported;
-import org.openkilda.messaging.info.rule.SwitchFlowEntries;
 import org.openkilda.wfm.topology.flowhs.fsm.common.actions.FlowProcessingAction;
 import org.openkilda.wfm.topology.flowhs.fsm.yflow.validation.YFlowValidationContext;
 import org.openkilda.wfm.topology.flowhs.fsm.yflow.validation.YFlowValidationFsm;
@@ -40,24 +40,24 @@ public class OnReceivedYFlowResourcesAction extends
     public void perform(State from, State to, Event event, YFlowValidationContext context,
                         YFlowValidationFsm stateMachine) {
         MessageData data = context.getSpeakerResponse();
-        if (data instanceof SwitchFlowEntries) {
-            SwitchFlowEntries switchFlowEntries = (SwitchFlowEntries) data;
-            log.info("Switch rules received for switch {}", switchFlowEntries.getSwitchId());
-            stateMachine.getReceivedRules().add(switchFlowEntries);
+        if (data instanceof FlowDumpResponse) {
+            FlowDumpResponse flowDumpResponse = (FlowDumpResponse) data;
+            log.info("Switch rules received for switch {}", flowDumpResponse.getSwitchId());
+            stateMachine.getReceivedRules().add(flowDumpResponse);
             stateMachine.setAwaitingRules(stateMachine.getAwaitingRules() - 1);
             checkOfCompleteDataCollection(stateMachine);
-        } else if (data instanceof SwitchMeterEntries) {
-            SwitchMeterEntries switchMeterEntries = (SwitchMeterEntries) data;
-            log.info("Switch meters received for switch {}", switchMeterEntries.getSwitchId());
-            stateMachine.getReceivedMeters().add(switchMeterEntries);
+        } else if (data instanceof MeterDumpResponse) {
+            MeterDumpResponse meterDumpResponse = (MeterDumpResponse) data;
+            log.info("Switch meters received for switch {}", meterDumpResponse.getSwitchId());
+            stateMachine.getReceivedMeters().add(meterDumpResponse);
             stateMachine.setAwaitingMeters(stateMachine.getAwaitingMeters() - 1);
             checkOfCompleteDataCollection(stateMachine);
         } else if (data instanceof SwitchMeterUnsupported) {
             SwitchMeterUnsupported meterUnsupported = (SwitchMeterUnsupported) data;
             log.info("Meters unsupported for switch {}", meterUnsupported.getSwitchId());
-            stateMachine.getReceivedMeters().add(SwitchMeterEntries.builder()
+            stateMachine.getReceivedMeters().add(MeterDumpResponse.builder()
                     .switchId(meterUnsupported.getSwitchId())
-                    .meterEntries(Collections.emptyList())
+                    .meterSpeakerData(Collections.emptyList())
                     .build());
             stateMachine.setAwaitingMeters(stateMachine.getAwaitingMeters() - 1);
             checkOfCompleteDataCollection(stateMachine);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/fsm/validation/FlowValidationServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/fsm/validation/FlowValidationServiceTest.java
@@ -19,34 +19,38 @@ import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.openkilda.messaging.info.flow.FlowDumpResponse;
 import org.openkilda.messaging.info.flow.FlowValidationResponse;
 import org.openkilda.messaging.info.flow.PathDiscrepancyEntity;
-import org.openkilda.messaging.info.meter.SwitchMeterEntries;
-import org.openkilda.messaging.info.rule.SwitchFlowEntries;
+import org.openkilda.messaging.info.meter.MeterDumpResponse;
 import org.openkilda.model.SwitchId;
+import org.openkilda.rulemanager.RuleManagerConfig;
+import org.openkilda.rulemanager.RuleManagerImpl;
 import org.openkilda.wfm.error.FlowNotFoundException;
 import org.openkilda.wfm.error.SwitchNotFoundException;
-import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
 
+import com.google.common.collect.Sets;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class FlowValidationServiceTest extends FlowValidationTestBase {
     private static FlowValidationService service;
 
+
     @BeforeClass
     public static void setUpOnce() {
         FlowValidationTestBase.setUpOnce();
-        FlowResourcesManager flowResourcesManager = new FlowResourcesManager(persistenceManager, flowResourcesConfig);
-        service = new FlowValidationService(persistenceManager, flowResourcesManager,
-                MIN_BURST_SIZE_IN_KBITS, BURST_COEFFICIENT);
+        RuleManagerConfig ruleManagerConfig = configurationProvider.getConfiguration(RuleManagerConfig.class);
+        service = new FlowValidationService(persistenceManager,
+                new RuleManagerImpl(ruleManagerConfig));
     }
 
     @Test
-    public void shouldGetSwitchIdListByFlowId() {
+    public void validateGetSwitchIdListByFlowId() {
         buildTransitVlanFlow("");
         List<SwitchId> switchIds = service.getSwitchIdListByFlowId(TEST_FLOW_ID_A);
         assertEquals(4, switchIds.size());
@@ -57,23 +61,27 @@ public class FlowValidationServiceTest extends FlowValidationTestBase {
     }
 
     @Test
-    public void shouldValidateFlowWithTransitVlanEncapsulation() throws FlowNotFoundException, SwitchNotFoundException {
+    public void validateFlowWithTransitVlanEncapsulation() throws FlowNotFoundException, SwitchNotFoundException {
         buildTransitVlanFlow("");
         validateFlow(true);
     }
 
     @Test
-    public void shouldValidateFlowWithVxlanEncapsulation() throws FlowNotFoundException, SwitchNotFoundException {
+    public void validateFlowWithVxlanEncapsulation() throws FlowNotFoundException, SwitchNotFoundException {
         buildVxlanFlow();
         validateFlow(false);
     }
 
-    private void validateFlow(boolean isTransitVlan) throws FlowNotFoundException, SwitchNotFoundException {
-        List<SwitchFlowEntries> flowEntries =
-                isTransitVlan ? getSwitchFlowEntriesWithTransitVlan() : getSwitchFlowEntriesWithVxlan();
-        List<SwitchMeterEntries> meterEntries = getSwitchMeterEntries();
+    private void validateFlow(boolean isTransitVlan)
+            throws FlowNotFoundException, SwitchNotFoundException {
+
+        List<FlowDumpResponse> flowEntries =
+                isTransitVlan ? getFlowDumpResponseWithTransitVlan() : getSwitchFlowEntriesWithVxlan();
+        List<MeterDumpResponse> meterEntries = getMeterDumpResponses();
+
+        Set<SwitchId> switchIdSet = Sets.newHashSet(service.getSwitchIdListByFlowId(TEST_FLOW_ID_A));
         List<FlowValidationResponse> result = service.validateFlow(TEST_FLOW_ID_A, flowEntries, meterEntries,
-                emptyList());
+                emptyList(), switchIdSet);
         assertEquals(4, result.size());
         assertEquals(0, result.get(0).getDiscrepancies().size());
         assertEquals(0, result.get(1).getDiscrepancies().size());
@@ -91,7 +99,7 @@ public class FlowValidationServiceTest extends FlowValidationTestBase {
         flowEntries =
                 isTransitVlan ? getWrongSwitchFlowEntriesWithTransitVlan() : getWrongSwitchFlowEntriesWithVxlan();
         meterEntries = getWrongSwitchMeterEntries();
-        result = service.validateFlow(TEST_FLOW_ID_A, flowEntries, meterEntries, emptyList());
+        result = service.validateFlow(TEST_FLOW_ID_A, flowEntries, meterEntries, emptyList(), switchIdSet);
         assertEquals(4, result.size());
         assertEquals(6, result.get(0).getDiscrepancies().size());
         assertEquals(3, result.get(1).getDiscrepancies().size());
@@ -129,31 +137,36 @@ public class FlowValidationServiceTest extends FlowValidationTestBase {
     }
 
     @Test
-    public void shouldValidateOneSwitchFlow() throws FlowNotFoundException, SwitchNotFoundException {
+    public void validateOneSwitchFlow() throws FlowNotFoundException, SwitchNotFoundException {
         buildOneSwitchPortFlow();
-        List<SwitchFlowEntries> switchEntries = getSwitchFlowEntriesOneSwitchFlow();
-        List<SwitchMeterEntries> meterEntries = getSwitchMeterEntriesOneSwitchFlow();
+        List<FlowDumpResponse> switchEntries = getSwitchFlowEntriesOneSwitchFlow();
+        List<MeterDumpResponse> meterEntries = getSwitchMeterEntriesOneSwitchFlow();
+
+        Set<SwitchId> switchIdSet = Sets.newHashSet(service.getSwitchIdListByFlowId(TEST_FLOW_ID_B));
+
         List<FlowValidationResponse> result = service.validateFlow(TEST_FLOW_ID_B, switchEntries, meterEntries,
-                emptyList());
+                emptyList(), switchIdSet);
         assertEquals(2, result.size());
         assertEquals(0, result.get(0).getDiscrepancies().size());
         assertEquals(0, result.get(1).getDiscrepancies().size());
     }
 
     @Test(expected = FlowNotFoundException.class)
-    public void shouldValidateFlowUsingNotExistingFlow() throws FlowNotFoundException, SwitchNotFoundException {
-        service.validateFlow("test",  emptyList(),  emptyList(),  emptyList());
+    public void validateFlowUsingNotExistingFlow() throws FlowNotFoundException, SwitchNotFoundException {
+        service.validateFlow("test", emptyList(), emptyList(), emptyList(), Sets.newHashSet());
     }
 
     @Test
-    public void shouldValidateFlowWithTransitVlanEncapsulationESwitch()
+    public void validateFlowWithTransitVlanEncapsulationESwitch()
             throws FlowNotFoundException, SwitchNotFoundException {
         buildTransitVlanFlow("E");
 
-        List<SwitchFlowEntries> flowEntries = getSwitchFlowEntriesWithTransitVlan();
-        List<SwitchMeterEntries> meterEntries = getSwitchMeterEntriesWithESwitch();
+        List<FlowDumpResponse> flowEntries = getFlowDumpResponseWithTransitVlan();
+        List<MeterDumpResponse> meterEntries = getSwitchMeterEntriesWithESwitch();
+
+        Set<SwitchId> switchIdSet = Sets.newHashSet(service.getSwitchIdListByFlowId(TEST_FLOW_ID_A));
         List<FlowValidationResponse> result = service.validateFlow(TEST_FLOW_ID_A, flowEntries, meterEntries,
-                emptyList());
+                emptyList(), switchIdSet);
         assertEquals(4, result.size());
         assertEquals(0, result.get(0).getDiscrepancies().size());
         assertEquals(0, result.get(1).getDiscrepancies().size());

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/fsm/validation/FlowValidationTestBase.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/fsm/validation/FlowValidationTestBase.java
@@ -15,44 +15,65 @@
 
 package org.openkilda.wfm.topology.flowhs.fsm.validation;
 
-import org.openkilda.messaging.info.meter.MeterEntry;
-import org.openkilda.messaging.info.meter.SwitchMeterEntries;
-import org.openkilda.messaging.info.rule.FlowApplyActions;
-import org.openkilda.messaging.info.rule.FlowEntry;
-import org.openkilda.messaging.info.rule.FlowInstructions;
-import org.openkilda.messaging.info.rule.FlowMatchField;
-import org.openkilda.messaging.info.rule.FlowSetFieldAction;
-import org.openkilda.messaging.info.rule.GroupBucket;
-import org.openkilda.messaging.info.rule.GroupEntry;
-import org.openkilda.messaging.info.rule.SwitchFlowEntries;
-import org.openkilda.messaging.info.rule.SwitchGroupEntries;
+import static org.openkilda.rulemanager.action.ActionType.PUSH_VXLAN_NOVIFLOW;
+
+import org.openkilda.messaging.info.flow.FlowDumpResponse;
+import org.openkilda.messaging.info.group.GroupDumpResponse;
+import org.openkilda.messaging.info.meter.MeterDumpResponse;
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.FlowPath;
 import org.openkilda.model.FlowPathDirection;
 import org.openkilda.model.FlowPathStatus;
 import org.openkilda.model.FlowStatus;
+import org.openkilda.model.GroupId;
 import org.openkilda.model.Meter;
 import org.openkilda.model.MeterId;
 import org.openkilda.model.PathId;
 import org.openkilda.model.PathSegment;
 import org.openkilda.model.Switch;
+import org.openkilda.model.SwitchFeature;
 import org.openkilda.model.SwitchId;
 import org.openkilda.model.TransitVlan;
 import org.openkilda.model.Vxlan;
+import org.openkilda.model.cookie.Cookie;
 import org.openkilda.model.cookie.FlowSegmentCookie;
 import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.FlowRepository;
 import org.openkilda.persistence.repositories.SwitchRepository;
 import org.openkilda.persistence.repositories.TransitVlanRepository;
 import org.openkilda.persistence.repositories.VxlanRepository;
+import org.openkilda.rulemanager.Field;
+import org.openkilda.rulemanager.FlowSpeakerData;
+import org.openkilda.rulemanager.GroupSpeakerData;
+import org.openkilda.rulemanager.Instructions;
+import org.openkilda.rulemanager.MeterFlag;
+import org.openkilda.rulemanager.MeterSpeakerData;
+import org.openkilda.rulemanager.OfVersion;
+import org.openkilda.rulemanager.ProtoConstants.PortNumber;
+import org.openkilda.rulemanager.ProtoConstants.PortNumber.SpecialPortType;
+import org.openkilda.rulemanager.SpeakerData;
+import org.openkilda.rulemanager.action.Action;
+import org.openkilda.rulemanager.action.PortOutAction;
+import org.openkilda.rulemanager.action.PushVxlanAction;
+import org.openkilda.rulemanager.action.SetFieldAction;
+import org.openkilda.rulemanager.group.Bucket;
+import org.openkilda.rulemanager.group.WatchPort;
+import org.openkilda.rulemanager.match.FieldMatch;
 import org.openkilda.wfm.share.flow.resources.FlowResourcesConfig;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.apache.commons.lang3.math.NumberUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class FlowValidationTestBase extends InMemoryGraphBasedTest {
     protected static final SwitchId TEST_SWITCH_ID_A = new SwitchId(1);
@@ -158,14 +179,15 @@ public class FlowValidationTestBase extends InMemoryGraphBasedTest {
     }
 
     protected void buildFlow(FlowEncapsulationType flowEncapsulationType, String endpointSwitchManufacturer) {
-        Switch switchA = Switch.builder().switchId(TEST_SWITCH_ID_A).description("").build();
+        Switch switchA = buildSwitch(TEST_SWITCH_ID_A);
         switchRepository.add(switchA);
         switchA.setOfDescriptionManufacturer(endpointSwitchManufacturer);
-        Switch switchB = Switch.builder().switchId(TEST_SWITCH_ID_B).description("").build();
+
+        Switch switchB = buildSwitch(TEST_SWITCH_ID_B);
         switchRepository.add(switchB);
-        Switch switchC = Switch.builder().switchId(TEST_SWITCH_ID_C).description("").build();
+        Switch switchC = buildSwitch(TEST_SWITCH_ID_C);
         switchRepository.add(switchC);
-        Switch switchE = Switch.builder().switchId(TEST_SWITCH_ID_E).description("").build();
+        Switch switchE = buildSwitch(TEST_SWITCH_ID_E);
         switchRepository.add(switchE);
 
         Flow flow = Flow.builder()
@@ -298,7 +320,8 @@ public class FlowValidationTestBase extends InMemoryGraphBasedTest {
     }
 
     protected void buildOneSwitchPortFlow() {
-        Switch switchD = Switch.builder().switchId(TEST_SWITCH_ID_D).description("").build();
+        Switch switchD = buildSwitch(TEST_SWITCH_ID_D);
+
         switchRepository.add(switchD);
 
         Flow flow = Flow.builder()
@@ -339,346 +362,436 @@ public class FlowValidationTestBase extends InMemoryGraphBasedTest {
         flowRepository.add(flow);
     }
 
-    protected List<SwitchFlowEntries> getSwitchFlowEntriesWithTransitVlan() {
-        List<SwitchFlowEntries> switchEntries = new ArrayList<>();
+    private static Switch buildSwitch(SwitchId switchId) {
+        return Switch.builder().switchId(switchId).ofVersion("OF_13")
+                .features(ImmutableSet.of(SwitchFeature.NOVIFLOW_PUSH_POP_VXLAN, SwitchFeature.METERS))
+                .ofDescriptionSoftware("").ofDescriptionManufacturer("").description("").build();
+    }
 
-        switchEntries.add(getSwitchFlowEntries(TEST_SWITCH_ID_A,
-                getFlowEntry(FLOW_A_FORWARD_COOKIE, FLOW_A_SRC_PORT, FLOW_A_SRC_VLAN,
-                        String.valueOf(FLOW_A_SEGMENT_A_SRC_PORT), 0, getFlowSetFieldAction(FLOW_A_ENCAP_ID),
+    protected List<FlowDumpResponse> getFlowDumpResponseWithTransitVlan() {
+        List<FlowDumpResponse> switchEntries = new ArrayList<>();
+
+        switchEntries.add(getFlowDumpResponse(
+                getFlowSpeakerData(TEST_SWITCH_ID_A, FLOW_A_FORWARD_COOKIE, FLOW_A_SRC_PORT, FLOW_A_SRC_VLAN,
+                        String.valueOf(FLOW_A_SEGMENT_A_SRC_PORT), 0, getSetFieldAction(FLOW_A_ENCAP_ID),
                         (long) FLOW_A_FORWARD_METER_ID, false),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE, FLOW_A_SEGMENT_A_SRC_PORT, FLOW_A_ENCAP_ID,
-                        String.valueOf(FLOW_A_SRC_PORT), 0, getFlowSetFieldAction(FLOW_A_SRC_VLAN), null, false),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE_PROTECTED, FLOW_A_SEGMENT_A_SRC_PORT_PROTECTED,
+                getFlowSpeakerData(TEST_SWITCH_ID_A, FLOW_A_REVERSE_COOKIE, FLOW_A_SEGMENT_A_SRC_PORT, FLOW_A_ENCAP_ID,
+                        String.valueOf(FLOW_A_SRC_PORT), 0, getSetFieldAction(FLOW_A_SRC_VLAN),
+                        null, false),
+                getFlowSpeakerData(TEST_SWITCH_ID_A, FLOW_A_REVERSE_COOKIE_PROTECTED,
+                        FLOW_A_SEGMENT_A_SRC_PORT_PROTECTED,
                         FLOW_A_ENCAP_ID_PROTECTED, String.valueOf(FLOW_A_SRC_PORT), 0,
-                        getFlowSetFieldAction(FLOW_A_SRC_VLAN), null, false)));
+                        getSetFieldAction(FLOW_A_SRC_VLAN), null, false)));
 
-        switchEntries.add(getSwitchFlowEntries(TEST_SWITCH_ID_B,
-                getFlowEntry(FLOW_A_FORWARD_COOKIE, FLOW_A_SEGMENT_A_DST_PORT, FLOW_A_ENCAP_ID,
-                        String.valueOf(FLOW_A_SEGMENT_B_SRC_PORT), 0, null, null, false),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE, FLOW_A_SEGMENT_B_SRC_PORT, FLOW_A_ENCAP_ID,
-                        String.valueOf(FLOW_A_SEGMENT_A_DST_PORT), 0, null, null, false)));
+        switchEntries.add(getFlowDumpResponse(
+                getFlowSpeakerData(TEST_SWITCH_ID_B, FLOW_A_FORWARD_COOKIE, FLOW_A_SEGMENT_A_DST_PORT, FLOW_A_ENCAP_ID,
+                        String.valueOf(FLOW_A_SEGMENT_B_SRC_PORT), 0, null,
+                        null, false),
+                getFlowSpeakerData(TEST_SWITCH_ID_B, FLOW_A_REVERSE_COOKIE, FLOW_A_SEGMENT_B_SRC_PORT, FLOW_A_ENCAP_ID,
+                        String.valueOf(FLOW_A_SEGMENT_A_DST_PORT), 0, null,
+                        null, false)));
 
-        switchEntries.add(getSwitchFlowEntries(TEST_SWITCH_ID_C,
-                getFlowEntry(FLOW_A_FORWARD_COOKIE, FLOW_A_SEGMENT_B_DST_PORT, FLOW_A_ENCAP_ID,
-                        String.valueOf(FLOW_A_DST_PORT), 0, getFlowSetFieldAction(FLOW_A_DST_VLAN), null, false),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE, FLOW_A_DST_PORT, FLOW_A_DST_VLAN,
-                        String.valueOf(FLOW_A_SEGMENT_B_DST_PORT), 0, getFlowSetFieldAction(FLOW_A_ENCAP_ID),
+        switchEntries.add(getFlowDumpResponse(
+                getFlowSpeakerData(TEST_SWITCH_ID_C, FLOW_A_FORWARD_COOKIE, FLOW_A_SEGMENT_B_DST_PORT, FLOW_A_ENCAP_ID,
+                        String.valueOf(FLOW_A_DST_PORT), 0, getSetFieldAction(FLOW_A_DST_VLAN),
+                        null, false),
+                getFlowSpeakerData(TEST_SWITCH_ID_C, FLOW_A_REVERSE_COOKIE, FLOW_A_DST_PORT, FLOW_A_DST_VLAN,
+                        String.valueOf(FLOW_A_SEGMENT_B_DST_PORT), 0, getSetFieldAction(FLOW_A_ENCAP_ID),
                         (long) FLOW_A_REVERSE_METER_ID, false),
-                getFlowEntry(FLOW_A_FORWARD_COOKIE_PROTECTED, FLOW_A_SEGMENT_B_DST_PORT_PROTECTED,
+                getFlowSpeakerData(TEST_SWITCH_ID_C, FLOW_A_FORWARD_COOKIE_PROTECTED,
+                        FLOW_A_SEGMENT_B_DST_PORT_PROTECTED,
                         FLOW_A_ENCAP_ID_PROTECTED, String.valueOf(FLOW_A_DST_PORT), 0,
-                        getFlowSetFieldAction(FLOW_A_DST_VLAN), null, false)));
+                        getSetFieldAction(FLOW_A_DST_VLAN), null, false)));
 
-        switchEntries.add(getSwitchFlowEntries(TEST_SWITCH_ID_E,
-                getFlowEntry(FLOW_A_FORWARD_COOKIE_PROTECTED, FLOW_A_SEGMENT_A_DST_PORT_PROTECTED,
+        switchEntries.add(getFlowDumpResponse(
+                getFlowSpeakerData(TEST_SWITCH_ID_E, FLOW_A_FORWARD_COOKIE_PROTECTED,
+                        FLOW_A_SEGMENT_A_DST_PORT_PROTECTED,
                         FLOW_A_ENCAP_ID_PROTECTED, String.valueOf(FLOW_A_SEGMENT_B_SRC_PORT_PROTECTED), 0,
                         null, null, false),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE_PROTECTED, FLOW_A_SEGMENT_B_SRC_PORT_PROTECTED,
+                getFlowSpeakerData(TEST_SWITCH_ID_E, FLOW_A_REVERSE_COOKIE_PROTECTED,
+                        FLOW_A_SEGMENT_B_SRC_PORT_PROTECTED,
                         FLOW_A_ENCAP_ID_PROTECTED, String.valueOf(FLOW_A_SEGMENT_A_DST_PORT_PROTECTED), 0,
                         null, null, false)));
 
         return switchEntries;
     }
 
-    protected List<SwitchFlowEntries> getWrongSwitchFlowEntriesWithTransitVlan() {
-        List<SwitchFlowEntries> switchEntries = new ArrayList<>();
+    protected List<FlowDumpResponse> getWrongSwitchFlowEntriesWithTransitVlan() {
+        List<FlowDumpResponse> switchEntries = new ArrayList<>();
 
-        switchEntries.add(getSwitchFlowEntries(TEST_SWITCH_ID_A,
-                getFlowEntry(123, FLOW_A_SRC_PORT, FLOW_A_SRC_VLAN, String.valueOf(FLOW_A_SEGMENT_A_SRC_PORT), 0,
-                        getFlowSetFieldAction(FLOW_A_ENCAP_ID), (long) FLOW_A_FORWARD_METER_ID, false),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE, 123, FLOW_A_ENCAP_ID,
-                        String.valueOf(FLOW_A_SRC_PORT), 0, getFlowSetFieldAction(FLOW_A_SRC_VLAN), null, false),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE_PROTECTED, 123, FLOW_A_ENCAP_ID_PROTECTED,
-                        String.valueOf(FLOW_A_SRC_PORT), 0, getFlowSetFieldAction(FLOW_A_SRC_VLAN), null, false)));
+        switchEntries.add(getFlowDumpResponse(
+                getFlowSpeakerData(TEST_SWITCH_ID_A, 123, FLOW_A_SRC_PORT, FLOW_A_SRC_VLAN,
+                        String.valueOf(FLOW_A_SEGMENT_A_SRC_PORT), 0,
+                        getSetFieldAction(FLOW_A_ENCAP_ID), (long) FLOW_A_FORWARD_METER_ID, false),
+                getFlowSpeakerData(TEST_SWITCH_ID_A, FLOW_A_REVERSE_COOKIE, 123, FLOW_A_ENCAP_ID,
+                        String.valueOf(FLOW_A_SRC_PORT), 0, getSetFieldAction(FLOW_A_SRC_VLAN),
+                        null, false),
+                getFlowSpeakerData(TEST_SWITCH_ID_A, FLOW_A_REVERSE_COOKIE_PROTECTED,
+                        123, FLOW_A_ENCAP_ID_PROTECTED,
+                        String.valueOf(FLOW_A_SRC_PORT), 0, getSetFieldAction(FLOW_A_SRC_VLAN),
+                        null, false)));
 
-        switchEntries.add(getSwitchFlowEntries(TEST_SWITCH_ID_B,
-                getFlowEntry(FLOW_A_FORWARD_COOKIE, FLOW_A_SEGMENT_A_DST_PORT, 123,
-                        String.valueOf(FLOW_A_SEGMENT_B_SRC_PORT), 0, null, null, false),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE, FLOW_A_SEGMENT_B_SRC_PORT, FLOW_A_ENCAP_ID,
+        switchEntries.add(getFlowDumpResponse(
+                getFlowSpeakerData(TEST_SWITCH_ID_B, FLOW_A_FORWARD_COOKIE, FLOW_A_SEGMENT_A_DST_PORT, 123,
+                        String.valueOf(FLOW_A_SEGMENT_B_SRC_PORT), 0, null,
+                        null, false),
+                getFlowSpeakerData(TEST_SWITCH_ID_B, FLOW_A_REVERSE_COOKIE, FLOW_A_SEGMENT_B_SRC_PORT, FLOW_A_ENCAP_ID,
                         String.valueOf(123), 0, null, null, false)));
 
-        switchEntries.add(getSwitchFlowEntries(TEST_SWITCH_ID_C,
-                getFlowEntry(FLOW_A_FORWARD_COOKIE, FLOW_A_SEGMENT_B_DST_PORT, FLOW_A_ENCAP_ID,
-                        String.valueOf(FLOW_A_DST_PORT), 0, getFlowSetFieldAction(123), null, false),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE, FLOW_A_DST_PORT, FLOW_A_DST_VLAN,
-                        String.valueOf(FLOW_A_SEGMENT_B_DST_PORT), 0, getFlowSetFieldAction(FLOW_A_ENCAP_ID),
+        switchEntries.add(getFlowDumpResponse(
+                getFlowSpeakerData(TEST_SWITCH_ID_C, FLOW_A_FORWARD_COOKIE,
+                        FLOW_A_SEGMENT_B_DST_PORT, FLOW_A_ENCAP_ID,
+                        String.valueOf(FLOW_A_DST_PORT), 0, getSetFieldAction(123),
+                        null, false),
+                getFlowSpeakerData(TEST_SWITCH_ID_C, FLOW_A_REVERSE_COOKIE, FLOW_A_DST_PORT, FLOW_A_DST_VLAN,
+                        String.valueOf(FLOW_A_SEGMENT_B_DST_PORT), 0, getSetFieldAction(FLOW_A_ENCAP_ID),
                         123L, false),
-                getFlowEntry(FLOW_A_FORWARD_COOKIE_PROTECTED, FLOW_A_SEGMENT_B_DST_PORT_PROTECTED,
+                getFlowSpeakerData(TEST_SWITCH_ID_C, FLOW_A_FORWARD_COOKIE_PROTECTED,
+                        FLOW_A_SEGMENT_B_DST_PORT_PROTECTED,
                         FLOW_A_ENCAP_ID_PROTECTED, String.valueOf(FLOW_A_DST_PORT), 0,
-                        getFlowSetFieldAction(123), null, false)));
+                        getSetFieldAction(123), null, false)));
 
-        switchEntries.add(getSwitchFlowEntries(TEST_SWITCH_ID_E,
-                getFlowEntry(FLOW_A_FORWARD_COOKIE_PROTECTED, FLOW_A_SEGMENT_A_DST_PORT_PROTECTED, 123,
-                        String.valueOf(FLOW_A_SEGMENT_B_SRC_PORT_PROTECTED), 0, null, null, false),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE_PROTECTED, FLOW_A_SEGMENT_B_SRC_PORT_PROTECTED,
-                        FLOW_A_ENCAP_ID_PROTECTED, String.valueOf(123), 0, null, null, false)));
+        switchEntries.add(getFlowDumpResponse(
+                getFlowSpeakerData(TEST_SWITCH_ID_E, FLOW_A_FORWARD_COOKIE_PROTECTED,
+                        FLOW_A_SEGMENT_A_DST_PORT_PROTECTED, 123,
+                        String.valueOf(FLOW_A_SEGMENT_B_SRC_PORT_PROTECTED), 0,
+                        null, null, false),
+                getFlowSpeakerData(TEST_SWITCH_ID_E, FLOW_A_REVERSE_COOKIE_PROTECTED,
+                        FLOW_A_SEGMENT_B_SRC_PORT_PROTECTED,
+                        FLOW_A_ENCAP_ID_PROTECTED, String.valueOf(123), 0, null,
+                        null, false)));
 
         return switchEntries;
     }
 
-    protected List<SwitchFlowEntries> getSwitchFlowEntriesWithVxlan() {
-        List<SwitchFlowEntries> switchEntries = new ArrayList<>();
+    protected List<FlowDumpResponse> getSwitchFlowEntriesWithVxlan() {
+        List<FlowDumpResponse> switchEntries = new ArrayList<>();
 
-        switchEntries.add(getSwitchFlowEntries(TEST_SWITCH_ID_A,
-                getFlowEntry(FLOW_A_FORWARD_COOKIE, FLOW_A_SRC_PORT, FLOW_A_SRC_VLAN,
+        switchEntries.add(getFlowDumpResponse(
+                getFlowSpeakerData(TEST_SWITCH_ID_A, FLOW_A_FORWARD_COOKIE, FLOW_A_SRC_PORT, FLOW_A_SRC_VLAN,
                         String.valueOf(FLOW_A_SEGMENT_A_SRC_PORT), FLOW_A_ENCAP_ID, null,
                         (long) FLOW_A_FORWARD_METER_ID, true),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE, FLOW_A_SEGMENT_A_SRC_PORT, 0, String.valueOf(FLOW_A_SRC_PORT),
-                        FLOW_A_ENCAP_ID, getFlowSetFieldAction(FLOW_A_SRC_VLAN), null, false),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE_PROTECTED, FLOW_A_SEGMENT_A_SRC_PORT_PROTECTED,
+                getFlowSpeakerData(TEST_SWITCH_ID_A, FLOW_A_REVERSE_COOKIE, FLOW_A_SEGMENT_A_SRC_PORT,
+                        0, String.valueOf(FLOW_A_SRC_PORT),
+                        FLOW_A_ENCAP_ID, getSetFieldAction(FLOW_A_SRC_VLAN), null, false),
+                getFlowSpeakerData(TEST_SWITCH_ID_A, FLOW_A_REVERSE_COOKIE_PROTECTED,
+                        FLOW_A_SEGMENT_A_SRC_PORT_PROTECTED,
                         0, String.valueOf(FLOW_A_SRC_PORT), FLOW_A_ENCAP_ID_PROTECTED,
-                        getFlowSetFieldAction(FLOW_A_SRC_VLAN), null, false)));
+                        getSetFieldAction(FLOW_A_SRC_VLAN), null, false)));
 
-        switchEntries.add(getSwitchFlowEntries(TEST_SWITCH_ID_B,
-                getFlowEntry(FLOW_A_FORWARD_COOKIE, FLOW_A_SEGMENT_A_DST_PORT, 0,
-                        String.valueOf(FLOW_A_SEGMENT_B_SRC_PORT), FLOW_A_ENCAP_ID, null, null, false),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE, FLOW_A_SEGMENT_B_SRC_PORT, 0,
-                        String.valueOf(FLOW_A_SEGMENT_A_DST_PORT), FLOW_A_ENCAP_ID, null, null, false)));
+        switchEntries.add(getFlowDumpResponse(
+                getFlowSpeakerData(TEST_SWITCH_ID_B, FLOW_A_FORWARD_COOKIE, FLOW_A_SEGMENT_A_DST_PORT, 0,
+                        String.valueOf(FLOW_A_SEGMENT_B_SRC_PORT), FLOW_A_ENCAP_ID, null,
+                        null, false),
+                getFlowSpeakerData(TEST_SWITCH_ID_B, FLOW_A_REVERSE_COOKIE, FLOW_A_SEGMENT_B_SRC_PORT, 0,
+                        String.valueOf(FLOW_A_SEGMENT_A_DST_PORT), FLOW_A_ENCAP_ID, null,
+                        null, false)));
 
-        switchEntries.add(getSwitchFlowEntries(TEST_SWITCH_ID_C,
-                getFlowEntry(FLOW_A_FORWARD_COOKIE, FLOW_A_SEGMENT_B_DST_PORT, 0, String.valueOf(FLOW_A_DST_PORT),
-                        FLOW_A_ENCAP_ID, getFlowSetFieldAction(FLOW_A_DST_VLAN), null, false),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE, FLOW_A_DST_PORT, FLOW_A_DST_VLAN,
+        switchEntries.add(getFlowDumpResponse(
+                getFlowSpeakerData(TEST_SWITCH_ID_C, FLOW_A_FORWARD_COOKIE, FLOW_A_SEGMENT_B_DST_PORT,
+                        0, String.valueOf(FLOW_A_DST_PORT),
+                        FLOW_A_ENCAP_ID, getSetFieldAction(FLOW_A_DST_VLAN), null, false),
+                getFlowSpeakerData(TEST_SWITCH_ID_C, FLOW_A_REVERSE_COOKIE, FLOW_A_DST_PORT, FLOW_A_DST_VLAN,
                         String.valueOf(FLOW_A_SEGMENT_B_DST_PORT), FLOW_A_ENCAP_ID, null,
                         (long) FLOW_A_REVERSE_METER_ID, true),
-                getFlowEntry(FLOW_A_FORWARD_COOKIE_PROTECTED, FLOW_A_SEGMENT_B_DST_PORT_PROTECTED,
+                getFlowSpeakerData(TEST_SWITCH_ID_C, FLOW_A_FORWARD_COOKIE_PROTECTED,
+                        FLOW_A_SEGMENT_B_DST_PORT_PROTECTED,
                         0, String.valueOf(FLOW_A_DST_PORT), FLOW_A_ENCAP_ID_PROTECTED,
-                        getFlowSetFieldAction(FLOW_A_DST_VLAN), null, false)));
+                        getSetFieldAction(FLOW_A_DST_VLAN), null, false)));
 
-        switchEntries.add(getSwitchFlowEntries(TEST_SWITCH_ID_E,
-                getFlowEntry(FLOW_A_FORWARD_COOKIE_PROTECTED, FLOW_A_SEGMENT_A_DST_PORT_PROTECTED,
-                        0, String.valueOf(FLOW_A_SEGMENT_B_SRC_PORT_PROTECTED), FLOW_A_ENCAP_ID_PROTECTED,
+        switchEntries.add(getFlowDumpResponse(
+                getFlowSpeakerData(TEST_SWITCH_ID_E, FLOW_A_FORWARD_COOKIE_PROTECTED,
+                        FLOW_A_SEGMENT_A_DST_PORT_PROTECTED, 0,
+                        String.valueOf(FLOW_A_SEGMENT_B_SRC_PORT_PROTECTED), FLOW_A_ENCAP_ID_PROTECTED,
                         null, null, false),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE_PROTECTED, FLOW_A_SEGMENT_B_SRC_PORT_PROTECTED,
-                        0, String.valueOf(FLOW_A_SEGMENT_A_DST_PORT_PROTECTED), FLOW_A_ENCAP_ID_PROTECTED,
+                getFlowSpeakerData(TEST_SWITCH_ID_E, FLOW_A_REVERSE_COOKIE_PROTECTED,
+                        FLOW_A_SEGMENT_B_SRC_PORT_PROTECTED, 0,
+                        String.valueOf(FLOW_A_SEGMENT_A_DST_PORT_PROTECTED), FLOW_A_ENCAP_ID_PROTECTED,
                         null, null, false)));
 
         return switchEntries;
     }
 
-    protected List<SwitchFlowEntries> getWrongSwitchFlowEntriesWithVxlan() {
-        List<SwitchFlowEntries> switchEntries = new ArrayList<>();
+    protected List<FlowDumpResponse> getWrongSwitchFlowEntriesWithVxlan() {
+        List<FlowDumpResponse> switchEntries = new ArrayList<>();
 
-        switchEntries.add(getSwitchFlowEntries(TEST_SWITCH_ID_A,
-                getFlowEntry(123, FLOW_A_SRC_PORT, FLOW_A_SRC_VLAN, String.valueOf(FLOW_A_SEGMENT_A_SRC_PORT),
-                        FLOW_A_ENCAP_ID, null, (long) FLOW_A_FORWARD_METER_ID, true),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE, 123, 0, String.valueOf(FLOW_A_SRC_PORT), FLOW_A_ENCAP_ID,
-                        getFlowSetFieldAction(FLOW_A_SRC_VLAN), null, false),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE_PROTECTED, 123, 0, String.valueOf(FLOW_A_SRC_PORT),
-                        FLOW_A_ENCAP_ID_PROTECTED, getFlowSetFieldAction(FLOW_A_SRC_VLAN), null, false)));
+        switchEntries.add(getFlowDumpResponse(
+                getFlowSpeakerData(TEST_SWITCH_ID_A, 123, FLOW_A_SRC_PORT,
+                        FLOW_A_SRC_VLAN,
+                        String.valueOf(FLOW_A_SEGMENT_A_SRC_PORT),
+                        FLOW_A_ENCAP_ID,
+                        null,
+                        (long) FLOW_A_FORWARD_METER_ID,
+                        true),
+                getFlowSpeakerData(TEST_SWITCH_ID_A, FLOW_A_REVERSE_COOKIE,
+                        123, 0, String.valueOf(FLOW_A_SRC_PORT),
+                        FLOW_A_ENCAP_ID, getSetFieldAction(FLOW_A_SRC_VLAN),
+                        null, false),
+                getFlowSpeakerData(TEST_SWITCH_ID_A, FLOW_A_REVERSE_COOKIE_PROTECTED,
+                        123, 0, String.valueOf(FLOW_A_SRC_PORT),
+                        FLOW_A_ENCAP_ID_PROTECTED, getSetFieldAction(FLOW_A_SRC_VLAN),
+                        null, false)));
 
-        switchEntries.add(getSwitchFlowEntries(TEST_SWITCH_ID_B,
-                getFlowEntry(FLOW_A_FORWARD_COOKIE, FLOW_A_SEGMENT_A_DST_PORT, 0,
-                        String.valueOf(FLOW_A_SEGMENT_B_SRC_PORT), 123, null, null, false),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE, FLOW_A_SEGMENT_B_SRC_PORT, 0,
-                        String.valueOf(123), FLOW_A_ENCAP_ID, null, null, false)));
+        switchEntries.add(getFlowDumpResponse(
+                getFlowSpeakerData(TEST_SWITCH_ID_B, FLOW_A_FORWARD_COOKIE,
+                        FLOW_A_SEGMENT_A_DST_PORT, 0, String.valueOf(FLOW_A_SEGMENT_B_SRC_PORT),
+                        123, null,
+                        null, false),
+                getFlowSpeakerData(TEST_SWITCH_ID_B, FLOW_A_REVERSE_COOKIE,
+                        FLOW_A_SEGMENT_B_SRC_PORT, 0, String.valueOf(123),
+                        FLOW_A_ENCAP_ID, null,
+                        null, false)));
 
-        switchEntries.add(getSwitchFlowEntries(TEST_SWITCH_ID_C,
-                getFlowEntry(FLOW_A_FORWARD_COOKIE, FLOW_A_SEGMENT_B_DST_PORT, 0,
-                        String.valueOf(FLOW_A_DST_PORT), FLOW_A_ENCAP_ID, getFlowSetFieldAction(123), null, false),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE, FLOW_A_DST_PORT, FLOW_A_DST_VLAN,
-                        String.valueOf(FLOW_A_SEGMENT_B_DST_PORT), FLOW_A_ENCAP_ID, null,
+        switchEntries.add(getFlowDumpResponse(
+                getFlowSpeakerData(TEST_SWITCH_ID_C, FLOW_A_FORWARD_COOKIE,
+                        FLOW_A_SEGMENT_B_DST_PORT, 0, String.valueOf(FLOW_A_DST_PORT),
+                        FLOW_A_ENCAP_ID, getSetFieldAction(123),
+                        null, false),
+                getFlowSpeakerData(TEST_SWITCH_ID_C, FLOW_A_REVERSE_COOKIE,
+                        FLOW_A_DST_PORT, FLOW_A_DST_VLAN, String.valueOf(FLOW_A_SEGMENT_B_DST_PORT),
+                        FLOW_A_ENCAP_ID, null,
                         123L, true),
-                getFlowEntry(FLOW_A_FORWARD_COOKIE_PROTECTED, FLOW_A_SEGMENT_B_DST_PORT_PROTECTED,
-                        0, String.valueOf(FLOW_A_DST_PORT), FLOW_A_ENCAP_ID_PROTECTED,
-                        getFlowSetFieldAction(123), null, false)));
+                getFlowSpeakerData(TEST_SWITCH_ID_C, FLOW_A_FORWARD_COOKIE_PROTECTED,
+                        FLOW_A_SEGMENT_B_DST_PORT_PROTECTED, 0, String.valueOf(FLOW_A_DST_PORT),
+                        FLOW_A_ENCAP_ID_PROTECTED, getSetFieldAction(123),
+                        null, false)));
 
-        switchEntries.add(getSwitchFlowEntries(TEST_SWITCH_ID_E,
-                getFlowEntry(FLOW_A_FORWARD_COOKIE_PROTECTED, FLOW_A_SEGMENT_A_DST_PORT_PROTECTED, 0,
-                        String.valueOf(FLOW_A_SEGMENT_B_SRC_PORT_PROTECTED), 123, null, null, false),
-                getFlowEntry(FLOW_A_REVERSE_COOKIE_PROTECTED, FLOW_A_SEGMENT_B_SRC_PORT_PROTECTED,
-                        0, String.valueOf(123), FLOW_A_ENCAP_ID_PROTECTED, null, null, false)));
+        switchEntries.add(getFlowDumpResponse(
+                getFlowSpeakerData(TEST_SWITCH_ID_E, FLOW_A_FORWARD_COOKIE_PROTECTED,
+                        FLOW_A_SEGMENT_A_DST_PORT_PROTECTED, 0, String.valueOf(FLOW_A_SEGMENT_B_SRC_PORT_PROTECTED),
+                        123, null,
+                        null, false),
+                getFlowSpeakerData(TEST_SWITCH_ID_E, FLOW_A_REVERSE_COOKIE_PROTECTED,
+                        FLOW_A_SEGMENT_B_SRC_PORT_PROTECTED, 0, String.valueOf(123),
+                        FLOW_A_ENCAP_ID_PROTECTED, null,
+                        null, false)));
 
         return switchEntries;
     }
 
-    protected List<SwitchMeterEntries> getSwitchMeterEntries() {
-        List<SwitchMeterEntries> switchMeterEntries = new ArrayList<>();
-        switchMeterEntries.add(SwitchMeterEntries.builder()
+    protected List<MeterDumpResponse> getMeterDumpResponses() {
+        List<MeterDumpResponse> meterDumpResponses = new ArrayList<>();
+        meterDumpResponses.add(MeterDumpResponse.builder()
                 .switchId(TEST_SWITCH_ID_A)
-                .meterEntries(Collections.singletonList(MeterEntry.builder()
-                        .meterId(FLOW_A_FORWARD_METER_ID)
+                .meterSpeakerData(Collections.singletonList(MeterSpeakerData.builder()
+                        .switchId(TEST_SWITCH_ID_A)
+                        .meterId(new MeterId(FLOW_A_FORWARD_METER_ID))
                         .rate(FLOW_A_BANDWIDTH)
-                        .burstSize(Meter
-                                .calculateBurstSize(FLOW_A_BANDWIDTH, MIN_BURST_SIZE_IN_KBITS, BURST_COEFFICIENT, ""))
-                        .flags(Meter.getMeterKbpsFlags())
-                        .build()))
-                .build());
-
-        switchMeterEntries.add(SwitchMeterEntries.builder()
-                .switchId(TEST_SWITCH_ID_C)
-                .meterEntries(Collections.singletonList(MeterEntry.builder()
-                        .meterId(FLOW_A_REVERSE_METER_ID)
-                        .rate(FLOW_A_BANDWIDTH)
-                        .burstSize(Meter
-                                .calculateBurstSize(FLOW_A_BANDWIDTH, MIN_BURST_SIZE_IN_KBITS, BURST_COEFFICIENT, ""))
-                        .flags(Meter.getMeterKbpsFlags())
-                        .build()))
-                .build());
-
-        return switchMeterEntries;
-    }
-
-    protected List<SwitchMeterEntries> getWrongSwitchMeterEntries() {
-        List<SwitchMeterEntries> switchMeterEntries = new ArrayList<>();
-        int delta = 5000;
-        switchMeterEntries.add(SwitchMeterEntries.builder()
-                .switchId(TEST_SWITCH_ID_A)
-                .meterEntries(Collections.singletonList(MeterEntry.builder()
-                        .meterId(FLOW_A_FORWARD_METER_ID)
-                        .rate(FLOW_A_BANDWIDTH + delta)
-                        .burstSize(Meter.calculateBurstSize(FLOW_A_BANDWIDTH + delta, MIN_BURST_SIZE_IN_KBITS,
+                        .burst(Meter.calculateBurstSize(FLOW_A_BANDWIDTH, MIN_BURST_SIZE_IN_KBITS,
                                 BURST_COEFFICIENT, ""))
-                        .flags(new String[]{"PKTPS", "BURST", "STATS"})
+                        .flags(Sets.newHashSet(Meter.getMeterKbpsFlags()).stream().map(MeterFlag::valueOf)
+                                .collect(Collectors.toSet()))
                         .build()))
                 .build());
 
-        switchMeterEntries.add(SwitchMeterEntries.builder()
-                .switchId(TEST_SWITCH_ID_B)
-                .meterEntries(Collections.emptyList())
-                .build());
-
-        switchMeterEntries.add(SwitchMeterEntries.builder()
+        meterDumpResponses.add(MeterDumpResponse.builder()
                 .switchId(TEST_SWITCH_ID_C)
-                .meterEntries(Collections.singletonList(MeterEntry.builder()
-                        .meterId(FLOW_A_REVERSE_METER_ID)
+                .meterSpeakerData(Collections.singletonList(MeterSpeakerData.builder()
+                        .switchId(TEST_SWITCH_ID_C)
+                        .meterId(new MeterId(FLOW_A_REVERSE_METER_ID))
                         .rate(FLOW_A_BANDWIDTH)
-                        .burstSize(Meter
-                                .calculateBurstSize(FLOW_A_BANDWIDTH, MIN_BURST_SIZE_IN_KBITS, BURST_COEFFICIENT, ""))
-                        .flags(Meter.getMeterKbpsFlags())
+                        .burst(Meter.calculateBurstSize(FLOW_A_BANDWIDTH, MIN_BURST_SIZE_IN_KBITS,
+                                BURST_COEFFICIENT, ""))
+                        .flags(Sets.newHashSet(Meter.getMeterKbpsFlags()).stream().map(MeterFlag::valueOf)
+                                .collect(Collectors.toSet()))
                         .build()))
                 .build());
 
-        return switchMeterEntries;
+
+        return meterDumpResponses;
     }
 
-    protected List<SwitchMeterEntries> getSwitchMeterEntriesWithESwitch() {
+    protected List<MeterDumpResponse> getWrongSwitchMeterEntries() {
+        List<MeterDumpResponse> meterDumpResponses = new ArrayList<>();
+        int delta = 5000;
+        meterDumpResponses.add(MeterDumpResponse.builder()
+                .switchId(TEST_SWITCH_ID_A)
+                .meterSpeakerData(Collections.singletonList(MeterSpeakerData.builder()
+                        .switchId(TEST_SWITCH_ID_A)
+                        .meterId(new MeterId(FLOW_A_FORWARD_METER_ID))
+                        .rate(FLOW_A_BANDWIDTH + delta)
+                        .burst(Meter.calculateBurstSize(FLOW_A_BANDWIDTH + delta, MIN_BURST_SIZE_IN_KBITS,
+                                BURST_COEFFICIENT, ""))
+                        .flags(Stream.of("PKTPS", "BURST", "STATS")
+                                .map(MeterFlag::valueOf).collect(Collectors.toSet()))
+                        .build()))
+                .build());
+
+        meterDumpResponses.add(MeterDumpResponse.builder()
+                .switchId(TEST_SWITCH_ID_B)
+                .meterSpeakerData(Collections.emptyList())
+                .build());
+
+        meterDumpResponses.add(MeterDumpResponse.builder()
+                .switchId(TEST_SWITCH_ID_C)
+                .meterSpeakerData(Collections.singletonList(MeterSpeakerData.builder()
+                        .switchId(TEST_SWITCH_ID_C)
+                        .meterId(new MeterId(FLOW_A_REVERSE_METER_ID))
+                        .rate(FLOW_A_BANDWIDTH)
+                        .burst(Meter.calculateBurstSize(FLOW_A_BANDWIDTH,
+                                MIN_BURST_SIZE_IN_KBITS, BURST_COEFFICIENT, ""))
+                        .flags(Sets.newHashSet(Meter.getMeterKbpsFlags()).stream().map(MeterFlag::valueOf)
+                                .collect(Collectors.toSet()))
+                        .build()))
+                .build());
+
+        return meterDumpResponses;
+    }
+
+    protected List<MeterDumpResponse> getSwitchMeterEntriesWithESwitch() {
         long rateESwitch = FLOW_A_BANDWIDTH + (long) (FLOW_A_BANDWIDTH * 0.01) - 1;
         long burstSize = (long) (FLOW_A_BANDWIDTH * 1.05);
         long burstSizeESwitch = burstSize + (long) (burstSize * 0.01) - 1;
 
-        List<SwitchMeterEntries> switchMeterEntries = new ArrayList<>();
-        switchMeterEntries.add(SwitchMeterEntries.builder()
+        List<MeterDumpResponse> switchMeterEntries = new ArrayList<>();
+        switchMeterEntries.add(MeterDumpResponse.builder()
                 .switchId(TEST_SWITCH_ID_A)
-                .meterEntries(Collections.singletonList(MeterEntry.builder()
-                        .meterId(FLOW_A_FORWARD_METER_ID)
+                .meterSpeakerData(Collections.singletonList(MeterSpeakerData.builder()
+                        .switchId(TEST_SWITCH_ID_A)
+                        .meterId(new MeterId(FLOW_A_FORWARD_METER_ID))
                         .rate(rateESwitch)
-                        .burstSize(burstSizeESwitch)
-                        .flags(Meter.getMeterKbpsFlags())
+                        .burst(burstSizeESwitch)
+                        .flags(Sets.newHashSet(Meter.getMeterKbpsFlags()).stream().map(MeterFlag::valueOf)
+                                .collect(Collectors.toSet()))
                         .build()))
                 .build());
 
-        switchMeterEntries.add(SwitchMeterEntries.builder()
+        switchMeterEntries.add(MeterDumpResponse.builder()
                 .switchId(TEST_SWITCH_ID_B)
-                .meterEntries(Collections.emptyList())
+                .meterSpeakerData(Collections.emptyList())
                 .build());
 
-        switchMeterEntries.add(SwitchMeterEntries.builder()
+        switchMeterEntries.add(MeterDumpResponse.builder()
                 .switchId(TEST_SWITCH_ID_C)
-                .meterEntries(Collections.singletonList(MeterEntry.builder()
-                        .meterId(FLOW_A_REVERSE_METER_ID)
+                .meterSpeakerData(Collections.singletonList(MeterSpeakerData.builder()
+                        .switchId(TEST_SWITCH_ID_C)
+                        .meterId(new MeterId(FLOW_A_REVERSE_METER_ID))
                         .rate(FLOW_A_BANDWIDTH)
-                        .burstSize(Meter
+                        .burst(Meter
                                 .calculateBurstSize(FLOW_A_BANDWIDTH, MIN_BURST_SIZE_IN_KBITS, BURST_COEFFICIENT, ""))
-                        .flags(Meter.getMeterKbpsFlags())
+                        .flags(Sets.newHashSet(Meter.getMeterKbpsFlags()).stream().map(MeterFlag::valueOf)
+                                .collect(Collectors.toSet()))
                         .build()))
                 .build());
 
         return switchMeterEntries;
     }
 
-    protected List<SwitchFlowEntries> getSwitchFlowEntriesOneSwitchFlow() {
-        List<SwitchFlowEntries> switchEntries = new ArrayList<>();
+    protected List<FlowDumpResponse> getSwitchFlowEntriesOneSwitchFlow() {
+        List<FlowDumpResponse> flowDumpResponses = new ArrayList<>();
 
-        switchEntries.add(getSwitchFlowEntries(TEST_SWITCH_ID_D,
-                getFlowEntry(FLOW_B_FORWARD_COOKIE, FLOW_B_SRC_PORT, FLOW_B_SRC_VLAN, "in_port", 0,
-                        getFlowSetFieldAction(FLOW_B_DST_VLAN), (long) FLOW_B_FORWARD_METER_ID, false),
-                getFlowEntry(FLOW_B_REVERSE_COOKIE, FLOW_B_SRC_PORT, FLOW_B_DST_VLAN, "in_port", 0,
-                        getFlowSetFieldAction(FLOW_B_SRC_VLAN), (long) FLOW_B_REVERSE_METER_ID, false)));
+        flowDumpResponses.add(getFlowDumpResponse(
+                getFlowSpeakerData(TEST_SWITCH_ID_D, FLOW_B_FORWARD_COOKIE,
+                        FLOW_B_SRC_PORT, FLOW_B_SRC_VLAN, "in_port", 0,
+                        getSetFieldAction(FLOW_B_DST_VLAN), (long) FLOW_B_FORWARD_METER_ID, false),
+                getFlowSpeakerData(TEST_SWITCH_ID_D, FLOW_B_REVERSE_COOKIE,
+                        FLOW_B_SRC_PORT, FLOW_B_DST_VLAN, "in_port", 0,
+                        getSetFieldAction(FLOW_B_SRC_VLAN), (long) FLOW_B_REVERSE_METER_ID, false)));
 
-        return switchEntries;
+        return flowDumpResponses;
     }
 
-    protected List<SwitchMeterEntries> getSwitchMeterEntriesOneSwitchFlow() {
-        List<MeterEntry> meterEntries = new ArrayList<>();
-        meterEntries.add(MeterEntry.builder()
-                .meterId(FLOW_B_FORWARD_METER_ID)
-                .rate(FLOW_B_BANDWIDTH)
-                .burstSize(Meter
-                        .calculateBurstSize(FLOW_B_BANDWIDTH, MIN_BURST_SIZE_IN_KBITS, BURST_COEFFICIENT, ""))
-                .flags(Meter.getMeterKbpsFlags())
-                .build());
-        meterEntries.add(MeterEntry.builder()
-                .meterId(FLOW_B_REVERSE_METER_ID)
-                .rate(FLOW_B_BANDWIDTH)
-                .burstSize(Meter
-                        .calculateBurstSize(FLOW_B_BANDWIDTH, MIN_BURST_SIZE_IN_KBITS, BURST_COEFFICIENT, ""))
-                .flags(Meter.getMeterKbpsFlags())
-                .build());
-
-        return Collections.singletonList(SwitchMeterEntries.builder()
+    protected List<MeterDumpResponse> getSwitchMeterEntriesOneSwitchFlow() {
+        List<MeterSpeakerData> meterEntries = new ArrayList<>();
+        meterEntries.add(MeterSpeakerData.builder()
                 .switchId(TEST_SWITCH_ID_D)
-                .meterEntries(meterEntries)
+                .meterId(new MeterId(FLOW_B_FORWARD_METER_ID))
+                .rate(FLOW_B_BANDWIDTH)
+                .burst(Meter
+                        .calculateBurstSize(FLOW_B_BANDWIDTH, MIN_BURST_SIZE_IN_KBITS, BURST_COEFFICIENT, ""))
+                .flags(Sets.newHashSet(Meter.getMeterKbpsFlags()).stream().map(MeterFlag::valueOf)
+                        .collect(Collectors.toSet()))
+                .build());
+        meterEntries.add(MeterSpeakerData.builder()
+                .switchId(TEST_SWITCH_ID_D)
+                .meterId(new MeterId(FLOW_B_REVERSE_METER_ID))
+                .rate(FLOW_B_BANDWIDTH)
+                .burst(Meter
+                        .calculateBurstSize(FLOW_B_BANDWIDTH,
+                                MIN_BURST_SIZE_IN_KBITS, BURST_COEFFICIENT, ""))
+                .flags(Sets.newHashSet(Meter.getMeterKbpsFlags()).stream().map(MeterFlag::valueOf)
+                        .collect(Collectors.toSet()))
+                .build());
+
+        return Collections.singletonList(MeterDumpResponse.builder()
+                .switchId(TEST_SWITCH_ID_D)
+                .meterSpeakerData(meterEntries)
                 .build());
     }
 
-    private SwitchFlowEntries getSwitchFlowEntries(SwitchId switchId, FlowEntry... flowEntries) {
-        return SwitchFlowEntries.builder()
-                .switchId(switchId)
-                .flowEntries(Lists.newArrayList(flowEntries))
+    private FlowDumpResponse getFlowDumpResponse(FlowSpeakerData... flowSpeakerData) {
+        return FlowDumpResponse.builder()
+                .switchId(Arrays.stream(flowSpeakerData).findFirst().map(SpeakerData::getSwitchId).orElse(null))
+                .flowSpeakerData(Lists.newArrayList(flowSpeakerData))
                 .build();
     }
 
-    private FlowEntry getFlowEntry(long cookie, int srcPort, int srcVlan, String dstPort, int tunnelId,
-                                   FlowSetFieldAction flowSetFieldAction, Long meterId, boolean tunnelIdIngressRule) {
-        return FlowEntry.builder()
-                .cookie(cookie)
+    private FlowSpeakerData getFlowSpeakerData(SwitchId switchId, long cookie,
+                                               int srcPort, int srcVlan,
+                                               String dstPort, int tunnelId,
+                                               SetFieldAction setFieldAction,
+                                               Long meterId, boolean tunnelIdIngressRule) {
+
+        Set<FieldMatch> fieldMatchSet
+                = Sets.newHashSet(FieldMatch.builder().field(Field.IN_PORT).value(srcPort).build(),
+                FieldMatch.builder().field(Field.VLAN_VID).value(srcVlan).build());
+        if (!tunnelIdIngressRule) {
+            fieldMatchSet.add(FieldMatch.builder().field(Field.NOVIFLOW_TUNNEL_ID).value(tunnelId).build());
+        }
+        List<Action> actions = new ArrayList<>();
+        PortNumber portNumber = NumberUtils.isParsable(dstPort)
+                ? new PortNumber(NumberUtils.toInt(dstPort)) :
+                new PortNumber(SpecialPortType.valueOf(dstPort.toUpperCase()));
+        actions.add(new PortOutAction(portNumber));
+        if (setFieldAction != null) {
+            actions.add(setFieldAction);
+        }
+        if (tunnelIdIngressRule) {
+            actions.add(PushVxlanAction.builder().vni(tunnelId).type(PUSH_VXLAN_NOVIFLOW).build());
+        }
+
+        return FlowSpeakerData.builder()
+                .switchId(switchId)
+                .cookie(new Cookie(cookie))
                 .packetCount(7)
                 .byteCount(480)
-                .version("OF_13")
-                .match(FlowMatchField.builder()
-                        .inPort(String.valueOf(srcPort))
-                        .vlanVid(String.valueOf(srcVlan))
-                        .tunnelId(!tunnelIdIngressRule ? String.valueOf(tunnelId) : null)
-                        .build())
-                .instructions(FlowInstructions.builder()
-                        .applyActions(FlowApplyActions.builder()
-                                .flowOutput(dstPort)
-                                .setFieldActions(flowSetFieldAction == null
-                                        ? Lists.newArrayList() : Lists.newArrayList(flowSetFieldAction))
-                                .pushVxlan(tunnelIdIngressRule ? String.valueOf(tunnelId) : null)
-                                .build())
-                        .goToMeter(meterId)
+                .ofVersion(OfVersion.OF_13)
+                .match(fieldMatchSet)
+                .instructions(Instructions.builder()
+                        .applyActions(actions)
+                        .goToMeter(meterId == null ? null : new MeterId(meterId))
                         .build())
                 .build();
     }
 
-    private FlowSetFieldAction getFlowSetFieldAction(int dstVlan) {
-        return FlowSetFieldAction.builder()
-                .fieldName("vlan_vid")
-                .fieldValue(String.valueOf(dstVlan))
+    private SetFieldAction getSetFieldAction(int dstVlan) {
+        return SetFieldAction.builder()
+                .field(Field.VLAN_VID)
+                .value(dstVlan)
                 .build();
     }
 
-    protected List<SwitchGroupEntries> getSwitchGroupEntries() {
-        List<SwitchGroupEntries> switchGroupEntries = new ArrayList<>();
-        switchGroupEntries.add(SwitchGroupEntries.builder()
+    protected List<GroupDumpResponse> getSwitchGroupEntries() {
+        List<GroupDumpResponse> switchGroupEntries = new ArrayList<>();
+        switchGroupEntries.add(GroupDumpResponse.builder()
                 .switchId(TEST_SWITCH_ID_A)
-                .groupEntries(Lists.newArrayList(GroupEntry.builder()
-                        .groupId(FLOW_GROUP_ID_A)
-                        .buckets(Lists.newArrayList(new GroupBucket(0, FlowApplyActions.builder()
-                                        .flowOutput(String.valueOf(FLOW_GROUP_ID_A_OUT_PORT))
-                                        .setFieldActions(Collections.singletonList(
-                                                getFlowSetFieldAction(FLOW_GROUP_ID_A_OUT_VLAN)))
-                                        .build()),
-                                new GroupBucket(0, FlowApplyActions.builder()
-                                        .flowOutput(String.valueOf(FLOW_A_SEGMENT_B_DST_PORT_PROTECTED))
-                                        .build())))
+                .groupSpeakerData(Lists.newArrayList(GroupSpeakerData.builder()
+                        .groupId(new GroupId(FLOW_GROUP_ID_A))
+                        .buckets(Lists.newArrayList(
+                                Bucket.builder().watchPort(WatchPort.ANY).writeActions(
+                                        Sets.newHashSet(new PortOutAction(new PortNumber(FLOW_GROUP_ID_A_OUT_PORT)),
+                                                getSetFieldAction(FLOW_GROUP_ID_A_OUT_VLAN))
+                                ).build(),
+                                Bucket.builder().watchPort(WatchPort.ANY).writeActions(
+                                        Sets.newHashSet(
+                                                new PortOutAction(new PortNumber(FLOW_A_SEGMENT_B_DST_PORT_PROTECTED)))
+                                ).build()))
                         .build()))
                 .build());
 
-        switchGroupEntries.add(SwitchGroupEntries.builder()
+        switchGroupEntries.add(GroupDumpResponse.builder()
                 .switchId(TEST_SWITCH_ID_C)
-                .groupEntries(Collections.emptyList())
+                .groupSpeakerData(Collections.emptyList())
                 .build());
 
         return switchGroupEntries;

--- a/src-java/kilda-persistence-api/src/test/java/org/openkilda/persistence/dummy/IdProvider.java
+++ b/src-java/kilda-persistence-api/src/test/java/org/openkilda/persistence/dummy/IdProvider.java
@@ -29,8 +29,8 @@ class IdProvider {
     private long flowEffectiveIdCounter = 0;
     private long pathCounter = 0;
 
-    private int transitVlanCounter = 0;
-    private int transitVxLanCounter = 0;
+    private int transitVlanCounter = 1;
+    private int transitVxLanCounter = 1;
 
     private Map<SwitchId, Integer> meterCounters = new HashMap<>();
 

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/flows/FlowValidationDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/flows/FlowValidationDto.java
@@ -35,6 +35,9 @@ public class FlowValidationDto {
     @JsonProperty("flow_id")
     private String flowId;
 
+    @JsonProperty("direction")
+    private String direction;
+
     @JsonProperty("as_expected")
     private Boolean asExpected;
 

--- a/src-java/northbound-service/northbound-api/src/test/java/org/openkilda/northbound/dto/JsonSerializationTest.java
+++ b/src-java/northbound-service/northbound-api/src/test/java/org/openkilda/northbound/dto/JsonSerializationTest.java
@@ -20,6 +20,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 
 import org.openkilda.messaging.info.event.SwitchChangeType;
+import org.openkilda.model.FlowPathDirection;
 import org.openkilda.model.SwitchId;
 import org.openkilda.northbound.dto.v1.flows.FlowValidationDto;
 import org.openkilda.northbound.dto.v1.flows.PathDiscrepancyDto;
@@ -74,7 +75,9 @@ public class JsonSerializationTest {
     public void flowValidationDtoTest() throws IOException {
         PathDiscrepancyDto discrepancyDto = new PathDiscrepancyDto("rule", "field", "expected", "actual");
         FlowValidationDto dto = new FlowValidationDto(
-                FLOW_ID, true, singletonList(0L), singletonList(1L), singletonList(discrepancyDto), 10, 11, 2, 4,
+                FLOW_ID, FlowPathDirection.FORWARD.name().toLowerCase(),
+                true, singletonList(0L), singletonList(1L), singletonList(discrepancyDto),
+                10, 11, 2, 4,
                 true, true);
         assertEquals(dto, pass(dto, FlowValidationDto.class));
     }

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/converter/FlowDirectionMapper.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/converter/FlowDirectionMapper.java
@@ -1,0 +1,34 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.northbound.converter;
+
+import org.openkilda.messaging.model.FlowDirectionType;
+
+import org.mapstruct.Mapper;
+
+import java.util.Optional;
+
+@Mapper(componentModel = "spring")
+public class FlowDirectionMapper {
+    /**
+     * Convert {@link FlowDirectionType} to {@link String}.
+     */
+    public String map(FlowDirectionType direction) {
+        return Optional.ofNullable(direction).map(FlowDirectionType::toString)
+                .orElse(null);
+
+    }
+}

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/converter/FlowMapper.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/converter/FlowMapper.java
@@ -73,7 +73,7 @@ import org.mapstruct.MappingTarget;
 
 @Mapper(componentModel = "spring", uses = {
         FlowEncapsulationTypeMapper.class, FlowStatusMapper.class, PathComputationStrategyMapper.class,
-        KildaTypeMapper.class, TimeMapper.class, PingMapper.class})
+        KildaTypeMapper.class, TimeMapper.class, PingMapper.class, FlowDirectionMapper.class})
 public abstract class FlowMapper {
     /**
      * Map {@link FlowDto} into {@link FlowPayload}.

--- a/src-java/rule-manager/rule-manager-implementation/src/main/java/org/openkilda/rulemanager/RuleManagerImpl.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/main/java/org/openkilda/rulemanager/RuleManagerImpl.java
@@ -96,9 +96,9 @@ public class RuleManagerImpl implements RuleManager {
             if (filterOutUsedSharedRules) {
                 overlappingAdapters = getOverlappingMultiTableIngressAdapters(flowPath, adapter);
             }
-            buildIngressCommands(adapter.getSwitch(flowPath.getSrcSwitchId()), flowPath, flow, encapsulation,
-                    overlappingAdapters, adapter.getSwitchProperties(flowPath.getSrcSwitchId()),
-                    adapter.getFeatureToggles());
+            result.addAll(buildIngressCommands(adapter.getSwitch(flowPath.getSrcSwitchId()), flowPath, flow,
+                    encapsulation, overlappingAdapters, adapter.getSwitchProperties(flowPath.getSrcSwitchId()),
+                    adapter.getFeatureToggles()));
         }
 
         if (flowPath.isOneSwitchPath()) {
@@ -115,7 +115,7 @@ public class RuleManagerImpl implements RuleManager {
                     flowPath, encapsulation, firstSegment, secondSegment));
         }
 
-        if (flow.isLooped()) {
+        if (flow.isLooped() && !flow.isProtectedPath(flowPath.getPathId())) {
             Switch loopedSwitch = adapter.getSwitch(flow.getLoopSwitchId());
             result.addAll(buildTransitLoopCommands(loopedSwitch, flowPath, flow, encapsulation));
         }

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/main/java/org/openkilda/wfm/topology/switchmanager/mappers/FlowEntryConverter.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/main/java/org/openkilda/wfm/topology/switchmanager/mappers/FlowEntryConverter.java
@@ -131,6 +131,9 @@ public class FlowEntryConverter {
         return builder.build();
     }
 
+    /**
+     *  Convert {@link Action} to the {@link FlowApplyActions} and add it to the builder.
+     */
     private void addAction(FlowApplyActionsBuilder builder, Action action) {
         switch (action.getType()) {
             case GROUP:

--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/FlowHelperV2.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/FlowHelperV2.groovy
@@ -65,7 +65,7 @@ class FlowHelperV2 {
      * @param existingFlows returned flow is guaranteed not to be in conflict with these flows
      */
     FlowRequestV2 randomFlow(Switch srcSwitch, Switch dstSwitch, boolean useTraffgenPorts = true,
-            List<FlowRequestV2> existingFlows = []) {
+                             List<FlowRequestV2> existingFlows = []) {
         if (srcSwitch.dpId == dstSwitch.dpId) {
             return singleSwitchFlow(srcSwitch, useTraffgenPorts, existingFlows)
         } else {
@@ -74,12 +74,12 @@ class FlowHelperV2 {
     }
 
     FlowRequestV2 randomFlow(SwitchPair switchPair, boolean useTraffgenPorts = true,
-            List<FlowRequestV2> existingFlows = []) {
+                             List<FlowRequestV2> existingFlows = []) {
         randomFlow(switchPair.src, switchPair.dst, useTraffgenPorts, existingFlows)
     }
 
     FlowRequestV2 randomMultiSwitchFlow(Switch srcSwitch, Switch dstSwitch, boolean useTraffgenPorts = true,
-            List<FlowRequestV2> existingFlows = []) {
+                                        List<FlowRequestV2> existingFlows = []) {
         Wrappers.retry(3, 0) {
             def newFlow = FlowRequestV2.builder()
                     .flowId(generateFlowId())
@@ -106,7 +106,7 @@ class FlowHelperV2 {
      * examination certain switch should have at least 2 traffgens connected to different ports.
      */
     FlowRequestV2 singleSwitchFlow(Switch sw, boolean useTraffgenPorts = true,
-            List<FlowRequestV2> existingFlows = []) {
+                                   List<FlowRequestV2> existingFlows = []) {
         Wrappers.retry(3, 0) {
             def srcEndpoint = getFlowEndpoint(sw, [], useTraffgenPorts)
             def dstEndpoint = getFlowEndpoint(sw, [srcEndpoint.portNumber], useTraffgenPorts)
@@ -143,12 +143,12 @@ class FlowHelperV2 {
             dstEndpoint.vlanId--
         }
         return FlowRequestV2.builder()
-                            .flowId(generateFlowId())
-                            .source(srcEndpoint)
-                            .destination(dstEndpoint)
-                            .maximumBandwidth(500)
-                            .description(generateDescription())
-                            .build()
+                .flowId(generateFlowId())
+                .source(srcEndpoint)
+                .destination(dstEndpoint)
+                .maximumBandwidth(500)
+                .description(generateDescription())
+                .build()
     }
 
     /**
@@ -259,19 +259,19 @@ class FlowHelperV2 {
 
     static FlowPayload toV1(FlowRequestV2 flow) {
         FlowPayload.builder()
-                   .id(flow.flowId)
-                   .description(flow.description)
-                   .maximumBandwidth(flow.maximumBandwidth)
-                   .ignoreBandwidth(flow.ignoreBandwidth)
-                   .allocateProtectedPath(flow.allocateProtectedPath)
-                   .periodicPings(flow.periodicPings)
-                   .encapsulationType(flow.encapsulationType)
-                   .maxLatency(flow.maxLatency)
-                   .pinned(flow.pinned)
-                   .priority(flow.priority)
-                   .source(toV1(flow.source))
-                   .destination(toV1(flow.destination))
-                   .build()
+                .id(flow.flowId)
+                .description(flow.description)
+                .maximumBandwidth(flow.maximumBandwidth)
+                .ignoreBandwidth(flow.ignoreBandwidth)
+                .allocateProtectedPath(flow.allocateProtectedPath)
+                .periodicPings(flow.periodicPings)
+                .encapsulationType(flow.encapsulationType)
+                .maxLatency(flow.maxLatency)
+                .pinned(flow.pinned)
+                .priority(flow.priority)
+                .source(toV1(flow.source))
+                .destination(toV1(flow.destination))
+                .build()
     }
 
     static FlowEndpointPayload toV1(FlowEndpointV2 ep) {
@@ -281,19 +281,19 @@ class FlowHelperV2 {
 
     static FlowRequestV2 toV2(FlowPayload flow) {
         FlowRequestV2.builder()
-                     .flowId(flow.id)
-                     .description(flow.description)
-                     .maximumBandwidth(flow.maximumBandwidth)
-                     .ignoreBandwidth(flow.ignoreBandwidth)
-                     .allocateProtectedPath(flow.allocateProtectedPath)
-                     .periodicPings(flow.periodicPings)
-                     .encapsulationType(flow.encapsulationType)
-                     .maxLatency(flow.maxLatency)
-                     .pinned(flow.pinned)
-                     .priority(flow.priority)
-                     .source(toV2(flow.source))
-                     .destination(toV2(flow.destination))
-                     .build()
+                .flowId(flow.id)
+                .description(flow.description)
+                .maximumBandwidth(flow.maximumBandwidth)
+                .ignoreBandwidth(flow.ignoreBandwidth)
+                .allocateProtectedPath(flow.allocateProtectedPath)
+                .periodicPings(flow.periodicPings)
+                .encapsulationType(flow.encapsulationType)
+                .maxLatency(flow.maxLatency)
+                .pinned(flow.pinned)
+                .priority(flow.priority)
+                .source(toV2(flow.source))
+                .destination(toV2(flow.destination))
+                .build()
     }
 
     static FlowRequestV2 toV2(FlowCreatePayload flow) {
@@ -304,11 +304,11 @@ class FlowHelperV2 {
 
     static FlowEndpointV2 toV2(FlowEndpointPayload ep) {
         FlowEndpointV2.builder()
-                      .switchId(ep.getSwitchDpId())
-                      .portNumber(ep.getPortId())
-                      .vlanId(ep.getVlanId())
-                      .detectConnectedDevices(toV2(ep.detectConnectedDevices))
-                      .build()
+                .switchId(ep.getSwitchDpId())
+                .portNumber(ep.getPortId())
+                .vlanId(ep.getVlanId())
+                .detectConnectedDevices(toV2(ep.detectConnectedDevices))
+                .build()
     }
 
     static DetectConnectedDevicesV2 toV2(DetectConnectedDevicesPayload payload) {
@@ -317,21 +317,62 @@ class FlowHelperV2 {
 
     static FlowRequestV2 toRequest(FlowResponseV2 flow) {
         return FlowRequestV2.builder()
-                            .flowId(flow.flowId)
-                            .source(flow.source)
-                            .destination(flow.destination)
-                            .maximumBandwidth(flow.maximumBandwidth)
-                            .ignoreBandwidth(flow.ignoreBandwidth)
-                            .periodicPings(flow.periodicPings)
-                            .description(flow.description)
-                            .maxLatency(flow.maxLatency)
-                            .maxLatencyTier2(flow.maxLatencyTier2)
-                            .priority(flow.priority)
-                            .pinned(flow.pinned)
-                            .allocateProtectedPath(flow.allocateProtectedPath)
-                            .encapsulationType(flow.encapsulationType)
-                            .pathComputationStrategy(flow.pathComputationStrategy)
-                            .build()
+                .flowId(flow.flowId)
+                .source(flow.source)
+                .destination(flow.destination)
+                .maximumBandwidth(flow.maximumBandwidth)
+                .ignoreBandwidth(flow.ignoreBandwidth)
+                .periodicPings(flow.periodicPings)
+                .description(flow.description)
+                .maxLatency(flow.maxLatency)
+                .maxLatencyTier2(flow.maxLatencyTier2)
+                .priority(flow.priority)
+                .pinned(flow.pinned)
+                .allocateProtectedPath(flow.allocateProtectedPath)
+                .encapsulationType(flow.encapsulationType)
+                .pathComputationStrategy(flow.pathComputationStrategy)
+                .build()
+    }
+
+    int getFlowRulesCountBySwitch(FlowResponseV2 flow, boolean isForward, int involvedSwitchesCount) {
+        def endpoint = isForward ? flow.source : flow.destination
+        def swProps = northbound.getSwitchProperties(endpoint.getSwitchId())
+        def featureToggles = northbound.getFeatureToggles()
+        int count = involvedSwitchesCount-1;
+        def server42 = swProps.server42FlowRtt && featureToggles.server42FlowRtt
+                && flow.source.switchId != flow.destination.switchId
+
+        if (swProps.multiTable) {
+            count++ // customer input rule
+
+            if (endpoint.vlanId != 0) {
+                count++; // pre ingress rule
+            }
+            count++ // multi table ingress rule
+
+            if (server42) {
+                if (endpoint.vlanId != 0) {
+                    count++ //shared server42 rule
+                }
+                count++ // ingress server42 rule
+                count++ // server42 input rule
+            }
+
+            if (swProps.switchLldp || endpoint.detectConnectedDevices.lldp) {
+                count++  // lldp rule
+            }
+            if (swProps.switchArp || endpoint.detectConnectedDevices.arp) {
+                count++ // arp rule
+            }
+
+        } else { // single table
+            if (server42) {
+                count++;  // server42 ingress rule
+            }
+
+            count++; // single table ingress rule
+        }
+        return count
     }
 
     /**


### PR DESCRIPTION
--Made flowValidation process to use RuleManager in order to gather all the expected entities from DB.
--Along with the main changes, changed the floodLight SwitchFlowEntries, SwitchMeterEntries, SwitchGroupEntries to the FlowDumpResponse, MeterDumpResponse, GroupDumpResponse DTOs..
-- fixed corresponding unit tests
-- minor changes for SimpleSwitchRuleComparator, particularly for two meterFlags array comparison, not to take into account the arrays orders.
-- vlan fix. Vlan ids are no longer could be 0 for the test data.

-- SimpleSwitchRuleConverterTest fixed.
-- YFlowValidationHubServiceTest fixes


closes #5025