### PR TITLE
Add HA-flow related parallelism options into FlowHs topology

### DIFF
--- a/confd/templates/flowhs-topology/flowhs-topology.tmpl
+++ b/confd/templates/flowhs-topology/flowhs-topology.tmpl
@@ -54,6 +54,14 @@ bolts:
     parallelism: {{ getv "/kilda_storm_flow_hs_y_flow_delete_hub_parallelism" }}
   - id: "YFLOW_READ_BOLT"
     parallelism: {{ getv "/kilda_storm_flow_hs_y_flow_read_hub_parallelism" }}
+  - id: "HA_FLOW_CREATE_HUB"
+    parallelism: {{ getv "/kilda_storm_flow_hs_ha_flow_create_hub_parallelism" }}
+  - id: "HA_FLOW_UPDATE_HUB"
+    parallelism: {{ getv "/kilda_storm_flow_hs_ha_flow_update_hub_parallelism" }}
+  - id: "HA_FLOW_DELETE_HUB"
+    parallelism: {{ getv "/kilda_storm_flow_hs_ha_flow_delete_hub_parallelism" }}
+  - id: "HA_FLOW_READ_BOLT"
+    parallelism: {{ getv "/kilda_storm_flow_hs_ha_flow_read_hub_parallelism" }}
   - id: "HISTORY_BOLT"
     parallelism: {{ getv "/kilda_storm_flow_hs_history_bolt_parallelism" }}
   - id: "METRICS_BOLT"
@@ -68,3 +76,9 @@ bolts:
     parallelism: {{ getv "/kilda_storm_flow_hs_dump_request_sender_parallelism" }}
   - id: "STATS_TOPOLOGY_SENDER"
     parallelism: {{ getv "/kilda_storm_flow_hs_stats_sender_parallelism" }}
+  - id: "FLOW_PING_SENDER"
+    parallelism: {{ getv "/kilda_storm_flow_hs_ping_sender_parallelism" }}
+  - id: "FLOW_MONITORING_TOPOLOGY_SENDER"
+    parallelism: {{ getv "/kilda_storm_flow_hs_monitoring_sender_parallelism" }}
+  - id: "SPEAKER_REQUEST_SENDER"
+    parallelism: {{ getv "/kilda_storm_flow_hs_speaker_request_sender_parallelism" }}

--- a/confd/vars/main.yaml
+++ b/confd/vars/main.yaml
@@ -192,6 +192,10 @@ kilda_storm_flow_hs_flow_delete_mirror_hub_parallelism: 2
 kilda_storm_flow_hs_y_flow_create_hub_parallelism: 2
 kilda_storm_flow_hs_y_flow_delete_hub_parallelism: 2
 kilda_storm_flow_hs_y_flow_read_hub_parallelism: 2
+kilda_storm_flow_hs_ha_flow_create_hub_parallelism: 2
+kilda_storm_flow_hs_ha_flow_update_hub_parallelism: 2
+kilda_storm_flow_hs_ha_flow_delete_hub_parallelism: 2
+kilda_storm_flow_hs_ha_flow_read_hub_parallelism: 2
 
 # Flow HS kafka bolts
 kilda_storm_flow_hs_history_bolt_parallelism: 2
@@ -201,6 +205,9 @@ kilda_storm_flow_hs_reroute_response_sender_parallelism: 2
 kilda_storm_flow_hs_server42_control_sender_parallelism: 2
 kilda_storm_flow_hs_dump_request_sender_parallelism: 2
 kilda_storm_flow_hs_stats_sender_parallelism: 2
+kilda_storm_flow_hs_ping_sender_parallelism: 2
+kilda_storm_flow_hs_monitoring_sender_parallelism: 2
+kilda_storm_flow_hs_speaker_request_sender_parallelism: 2
 
 kilda_storm_spout_parallelism: 2
 


### PR DESCRIPTION
This PR will help us to change parallelism of HA bolts. It is needed because be default they take parallelism from topology option and it is overkill, because these bolts is not highloaded. To save CPU and memory resources we should set low parallelism value for them.  

Related To #5061