### PR TITLE
Decrease stats pull timeout in Stats topology test

### DIFF
--- a/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java
+++ b/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java
@@ -110,7 +110,7 @@ import java.util.stream.IntStream;
 public class StatsTopologyTest extends AbstractStormTest {
 
     private static final long timestamp = System.currentTimeMillis();
-    private static final int POLL_TIMEOUT = 1000;
+    private static final int POLL_TIMEOUT = 100;
     private static final String POLL_DATAPOINT_ASSERT_MESSAGE = "Could not poll all %d datapoints, got only %d records";
     private static final String METRIC_PREFIX = "kilda.";
     private static final int ENCAPSULATION_ID = 123;


### PR DESCRIPTION
Pull timeout was decreased from 1 second to 100 ms.
It must be enough and it saves ~1m for running the test (3m43s vs 2m48s).