### PR TITLE
add flow monitoring cache activation and deactivation

### DIFF
--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/bolt/FlowCacheBolt.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/bolt/FlowCacheBolt.java
@@ -24,6 +24,7 @@ import static org.openkilda.wfm.topology.flowmonitoring.bolt.FlowSplitterBolt.IN
 import static org.openkilda.wfm.topology.flowmonitoring.bolt.IslDataSplitterBolt.ISL_KEY_FIELD;
 import static org.openkilda.wfm.topology.flowmonitoring.bolt.IslDataSplitterBolt.getIslKey;
 
+import org.openkilda.bluegreen.LifecycleEvent;
 import org.openkilda.messaging.Utils;
 import org.openkilda.messaging.info.Datapoint;
 import org.openkilda.messaging.info.flow.UpdateFlowCommand;
@@ -115,6 +116,12 @@ public class FlowCacheBolt extends AbstractBolt implements FlowCacheBoltCarrier 
             FlowRttStatsData flowRttStatsData = pullValue(input, INFO_DATA_FIELD, FlowRttStatsData.class);
             flowCacheService.processFlowRttStatsData(flowRttStatsData);
         }
+    }
+
+    @Override
+    protected boolean deactivate(LifecycleEvent event) {
+        flowCacheService.deactivate();
+        return true;
     }
 
     @Override

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/bolt/FlowCacheBolt.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/bolt/FlowCacheBolt.java
@@ -86,6 +86,17 @@ public class FlowCacheBolt extends AbstractBolt implements FlowCacheBoltCarrier 
     }
 
     @Override
+    protected boolean activateAndConfirm() {
+        try {
+            flowCacheService.activate();
+        } catch (Exception e) {
+            log.error(String.format("Error on flow cache initialization: %s", e.getMessage()), e);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
     protected void handleInput(Tuple input) throws PipelineException {
         if (active) {
             if (ComponentId.FLOW_STATE_CACHE_BOLT.name().equals(input.getSourceComponent())) {

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/bolt/IslCacheBolt.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/bolt/IslCacheBolt.java
@@ -22,6 +22,7 @@ import static org.openkilda.wfm.topology.flowmonitoring.bolt.FlowCacheBolt.LINK_
 import static org.openkilda.wfm.topology.flowmonitoring.bolt.FlowCacheBolt.REQUEST_ID_FIELD;
 import static org.openkilda.wfm.topology.flowmonitoring.bolt.IslDataSplitterBolt.INFO_DATA_FIELD;
 
+import org.openkilda.bluegreen.LifecycleEvent;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.event.IslChangedInfoData;
 import org.openkilda.messaging.info.event.IslOneWayLatency;
@@ -97,6 +98,12 @@ public class IslCacheBolt extends AbstractBolt {
     }
 
     @Override
+    protected boolean deactivate(LifecycleEvent event) {
+        islCacheService.deactivate();
+        return true;
+    }
+
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields(REQUEST_ID_FIELD, FLOW_ID_FIELD, LINK_FIELD, LATENCY_FIELD, FIELD_ID_CONTEXT));
         declarer.declareStream(ZkStreams.ZK.toString(), new Fields(ZooKeeperBolt.FIELD_ID_STATE,
@@ -107,4 +114,6 @@ public class IslCacheBolt extends AbstractBolt {
     private IslCacheService newIslCacheService() {
         return new IslCacheService(persistenceManager, Clock.systemUTC(), islRttLatencyExpiration);
     }
+
+
 }

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/bolt/IslCacheBolt.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/bolt/IslCacheBolt.java
@@ -57,8 +57,18 @@ public class IslCacheBolt extends AbstractBolt {
     }
 
     protected void init() {
-        super.init();
         islCacheService = newIslCacheService();
+    }
+
+    @Override
+    protected boolean activateAndConfirm() {
+        try {
+            islCacheService.activate();
+        } catch (Exception e) {
+            log.error(String.format("Error on Isl cache initialization: %s", e.getMessage()), e);
+            return false;
+        }
+        return true;
     }
 
     @Override
@@ -114,6 +124,4 @@ public class IslCacheBolt extends AbstractBolt {
     private IslCacheService newIslCacheService() {
         return new IslCacheService(persistenceManager, Clock.systemUTC(), islRttLatencyExpiration);
     }
-
-
 }

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/service/FlowCacheService.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/service/FlowCacheService.java
@@ -26,6 +26,7 @@ import org.openkilda.server42.messaging.FlowDirection;
 import org.openkilda.wfm.topology.flowmonitoring.mapper.FlowMapper;
 import org.openkilda.wfm.topology.flowmonitoring.model.FlowState;
 
+import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Clock;
@@ -41,6 +42,8 @@ public class FlowCacheService {
     private Clock clock;
     private Duration flowRttStatsExpirationTime;
     private FlowCacheBoltCarrier carrier;
+    private boolean active = false;
+    private final FlowRepository flowRepository;
 
     private final Map<String, FlowState> flowStates = new HashMap<>();
 
@@ -49,9 +52,8 @@ public class FlowCacheService {
         this.clock = clock;
         this.flowRttStatsExpirationTime = flowRttStatsExpirationTime;
         this.carrier = carrier;
-
-        FlowRepository flowRepository = persistenceManager.getRepositoryFactory().createFlowRepository();
-        initCache(flowRepository);
+        flowRepository = persistenceManager.getRepositoryFactory().createFlowRepository();
+        activate();
     }
 
     private void initCache(FlowRepository flowRepository) {
@@ -121,6 +123,27 @@ public class FlowCacheService {
         }
     }
 
+    /**
+     * Activate the service. Init cache.
+     */
+    public void activate() {
+        if (!active) {
+            initCache(flowRepository);
+            active = true;
+        }
+    }
+
+    /**
+     * Deactivate the service. Clears cache.
+     */
+    public void deactivate() {
+        if (active) {
+            flowStates.clear();
+            log.info("Flow cache cleared.");
+            active = false;
+        }
+    }
+
     private void checkFlowLatency(String flowId, FlowState flowState) {
         Instant current = clock.instant();
         if (isExpired(flowState.getForwardPathLatency().getTimestamp(), current)) {
@@ -143,5 +166,13 @@ public class FlowCacheService {
 
     private boolean isIncompleteFlow(Flow flow) {
         return flow.getForwardPathId() == null || flow.getReversePathId() == null;
+    }
+
+    /**
+     * Check if flowState is empty.
+     */
+    @VisibleForTesting
+    public boolean flowStatesIsEmpty() {
+        return flowStates.isEmpty();
     }
 }

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/service/IslCacheService.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/service/IslCacheService.java
@@ -42,26 +42,21 @@ public class IslCacheService {
     private Clock clock;
     private Duration islRttLatencyExpiration;
     private Map<Link, LinkState> linkStates;
-    private boolean active = false;
+    private boolean active;
     private final IslRepository islRepository;
 
     public IslCacheService(PersistenceManager persistenceManager, Clock clock, Duration islRttLatencyExpiration) {
         this.clock = clock;
         this.islRttLatencyExpiration = islRttLatencyExpiration;
-
+        active = false;
+        linkStates = new HashMap<>();
         islRepository = persistenceManager.getRepositoryFactory().createIslRepository();
-        activate();
     }
 
     private void initCache(IslRepository islRepository) {
-        try {
-            linkStates = islRepository.findAll().stream()
-                    .collect(Collectors.toMap(LinkMapper.INSTANCE::toLink, (link) -> LinkState.builder().build()));
-            log.info("Isl cache initialized successfully.");
-        } catch (Exception e) {
-            log.error("Isl cache initialization exception. Empty cache is used.", e);
-            linkStates = new HashMap<>();
-        }
+        linkStates = islRepository.findAll().stream()
+                .collect(Collectors.toMap(LinkMapper.INSTANCE::toLink, (link) -> LinkState.builder().build()));
+        log.info("Isl cache initialized successfully.");
     }
 
     /**
@@ -170,7 +165,7 @@ public class IslCacheService {
      * Check if linkStates is empty.
      */
     @VisibleForTesting
-    public boolean linkStatesIsEmpty() {
+    protected boolean linkStatesIsEmpty() {
         return linkStates.isEmpty();
     }
 }

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/test/java/org/openkilda/wfm/topology/flowmonitoring/service/FlowCacheServiceTest.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/test/java/org/openkilda/wfm/topology/flowmonitoring/service/FlowCacheServiceTest.java
@@ -15,6 +15,8 @@
 
 package org.openkilda.wfm.topology.flowmonitoring.service;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -169,6 +171,22 @@ public class FlowCacheServiceTest extends InMemoryGraphBasedTest {
         verify(carrier).emitCalculateFlowLatencyRequest(flow.getFlowId(), FlowDirection.REVERSE, expectedReversePath);
 
         verifyNoMoreInteractions(carrier);
+    }
+
+    @Test
+    public void serviceActivationDeactivationAndReactivation() {
+        createFlow();
+        service = new FlowCacheService(persistenceManager, clock, FLOW_RTT_STATS_EXPIRATION_TIME, carrier);
+        //check service.flowStates is not empty
+        assertFalse(service.flowStatesIsEmpty());
+        // deactivate service
+        service.deactivate();
+        //check service.flowStates is empty
+        assertTrue(service.flowStatesIsEmpty());
+        // reactivate service
+        service.activate();
+        //check service.flowStates is not empty
+        assertFalse(service.flowStatesIsEmpty());
     }
 
     private void createIsl(Switch srcSwitch, int srcPort, Switch dstSwitch, int dstPort) {

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/test/java/org/openkilda/wfm/topology/flowmonitoring/service/FlowCacheServiceTest.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/test/java/org/openkilda/wfm/topology/flowmonitoring/service/FlowCacheServiceTest.java
@@ -97,6 +97,7 @@ public class FlowCacheServiceTest extends InMemoryGraphBasedTest {
         dummyFactory.makeFlow(new FlowEndpoint(SRC_SWITCH, 8), new FlowEndpoint(SRC_SWITCH, 9));
         Flow flow = createFlow();
         service = new FlowCacheService(persistenceManager, clock, FLOW_RTT_STATS_EXPIRATION_TIME, carrier);
+        service.activate();
 
         service.processFlowLatencyCheck(flow.getFlowId());
 
@@ -112,6 +113,8 @@ public class FlowCacheServiceTest extends InMemoryGraphBasedTest {
     public void shouldRemoveFlowFromCache() {
         Flow flow = createFlow();
         service = new FlowCacheService(persistenceManager, clock, FLOW_RTT_STATS_EXPIRATION_TIME, carrier);
+        service.activate();
+
         service.removeFlowInfo(flow.getFlowId());
 
         service.processFlowLatencyCheck(flow.getFlowId());
@@ -121,12 +124,14 @@ public class FlowCacheServiceTest extends InMemoryGraphBasedTest {
 
     @Test
     public void shouldChangeFlowPathInCache() {
-        Flow flow = createFlow();
         when(clock.instant()).thenReturn(Instant.now());
         service = new FlowCacheService(persistenceManager, clock, FLOW_RTT_STATS_EXPIRATION_TIME, carrier);
+        service.activate();
 
         Long maxLatency = 100L;
         Long maxLatencyTier2 = 200L;
+
+        Flow flow = createFlow();
         UpdateFlowCommand updateFlowCommand = new UpdateFlowCommand(flow.getFlowId(), FlowPathDto.builder()
                 .id(flow.getFlowId())
                 .forwardPath(Arrays.asList(new PathNodePayload(SRC_SWITCH, IN_PORT, ISL_SRC_PORT_2),
@@ -148,10 +153,12 @@ public class FlowCacheServiceTest extends InMemoryGraphBasedTest {
 
     @Test
     public void shouldSendCheckFlowSlaRequests() {
-        Flow flow = createFlow();
         Instant now = Instant.now();
         when(clock.instant()).thenReturn(now);
+
+        Flow flow = createFlow();
         service = new FlowCacheService(persistenceManager, clock, FLOW_RTT_STATS_EXPIRATION_TIME, carrier);
+        service.activate();
 
         long t0 = (now.getEpochSecond() << 32) + 1234;
         long t1 = (now.getEpochSecond() << 32) + 2345;
@@ -177,6 +184,7 @@ public class FlowCacheServiceTest extends InMemoryGraphBasedTest {
     public void serviceActivationDeactivationAndReactivation() {
         createFlow();
         service = new FlowCacheService(persistenceManager, clock, FLOW_RTT_STATS_EXPIRATION_TIME, carrier);
+        service.activate();
         //check service.flowStates is not empty
         assertFalse(service.flowStatesIsEmpty());
         // deactivate service

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/test/java/org/openkilda/wfm/topology/flowmonitoring/service/IslCacheServiceTest.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/test/java/org/openkilda/wfm/topology/flowmonitoring/service/IslCacheServiceTest.java
@@ -16,6 +16,8 @@
 package org.openkilda.wfm.topology.flowmonitoring.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.IslStatus.ACTIVE;
 
@@ -175,6 +177,20 @@ public class IslCacheServiceTest extends InMemoryGraphBasedTest {
                 .build()).getNano();
 
         assertEquals(rttLatency, actual);
+    }
+
+    @Test
+    public void serviceActivationDeactivationAndReactivation() {
+        //check service.linkStates is not empty
+        assertFalse(service.linkStatesIsEmpty());
+        // deactivate service
+        service.deactivate();
+        //check service.linkStates is empty
+        assertTrue(service.linkStatesIsEmpty());
+        // reactivate service
+        service.activate();
+        //check service.linkStates is not empty
+        assertFalse(service.linkStatesIsEmpty());
     }
 
     private void createIsl(Switch srcSwitch, int srcPort, Switch dstSwitch, int dstPort) {

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/test/java/org/openkilda/wfm/topology/flowmonitoring/service/IslCacheServiceTest.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/test/java/org/openkilda/wfm/topology/flowmonitoring/service/IslCacheServiceTest.java
@@ -83,6 +83,7 @@ public class IslCacheServiceTest extends InMemoryGraphBasedTest {
         createIsl(thirdSwitch, ISL_DST_PORT_2, secondSwitch, ISL_SRC_PORT_2);
 
         service = new IslCacheService(persistenceManager, clock, ISL_RTT_LATENCY_EXPIRATION);
+        service.activate();
     }
 
     @Test


### PR DESCRIPTION
The monitoring cache of flow and ISL are cleared after a deactivation of the flow monitoring service and recreated during activation.

Closes #5117