### PR TITLE
HA flows Part 9: Add H&S delete operation

### DIFF
--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/system/FeatureTogglesDto.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/system/FeatureTogglesDto.java
@@ -71,6 +71,9 @@ public class FeatureTogglesDto implements Serializable {
     @JsonProperty("modify_ha_flow_enabled")
     private Boolean modifyHaFlowEnabled;
 
+    @JsonProperty("delete_ha_flow_enabled")
+    private Boolean deleteHaFlowEnabled;
+
     @JsonProperty("sync_switch_on_connect")
     private Boolean syncSwitchOnConnect;
 
@@ -94,6 +97,7 @@ public class FeatureTogglesDto implements Serializable {
                              @JsonProperty("modify_y_flow_enabled") Boolean modifyYFlowEnabled,
                              @JsonProperty("create_ha_flow_enabled") Boolean createHaFlowEnabled,
                              @JsonProperty("modify_ha_flow_enabled") Boolean modifyHaFlowEnabled,
+                             @JsonProperty("delete_ha_flow_enabled") Boolean deleteHaFlowEnabled,
                              @JsonProperty("sync_switch_on_connect") Boolean syncSwitchOnConnect,
                              @JsonProperty("discover_new_isls_in_under_maintenance_mode")
                                  Boolean discoverNewIslsInUnderMaintenanceMode) {
@@ -111,6 +115,7 @@ public class FeatureTogglesDto implements Serializable {
         this.modifyYFlowEnabled = modifyYFlowEnabled;
         this.createHaFlowEnabled = createHaFlowEnabled;
         this.modifyHaFlowEnabled = modifyHaFlowEnabled;
+        this.deleteHaFlowEnabled = deleteHaFlowEnabled;
         this.syncSwitchOnConnect = syncSwitchOnConnect;
         this.discoverNewIslsInUnderMaintenanceMode = discoverNewIslsInUnderMaintenanceMode;
     }

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/logger/FlowOperationsDashboardLogger.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/logger/FlowOperationsDashboardLogger.java
@@ -66,6 +66,8 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
 
     private static final String HA_FLOW_CREATE_EVENT = "ha_flow_create";
     private static final String HA_FLOW_CREATE_RESULT_EVENT = "ha_flow_create_result";
+    private static final String HA_FLOW_DELETE_EVENT = "ha_flow_delete";
+    private static final String HA_FLOW_DELETE_RESULT_EVENT = "ha_flow_delete_result";
 
     private static final String TAG = "FLOW_OPERATIONS_DASHBOARD";
     private static final String DASHBOARD = "dashboard";
@@ -752,6 +754,43 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put("create-result", "failed");
         data.put("failure-reason", failureReason);
         invokeLogger(Level.WARN, String.format("Failed create of the ha-flow %s, reason: %s", haFlowId, failureReason),
+                data);
+    }
+
+    /**
+     * Log an ha-flow-delete event.
+     */
+    public void onHaFlowDelete(String haFlowId) {
+        Map<String, String> data = new HashMap<>();
+        data.put(TAG, "ha-flow-delete");
+        data.put(FLOW_ID, haFlowId);
+        data.put(EVENT_TYPE, HA_FLOW_DELETE_EVENT);
+        invokeLogger(Level.INFO, String.format("Delete the ha-flow %s", haFlowId), data);
+    }
+
+    /**
+     * Log a ha-flow-delete-successful event.
+     */
+    public void onSuccessfulHaFlowDelete(String haFlowId) {
+        Map<String, String> data = new HashMap<>();
+        data.put(TAG, "ha-flow-delete-successful");
+        data.put(FLOW_ID, haFlowId);
+        data.put(EVENT_TYPE, HA_FLOW_DELETE_RESULT_EVENT);
+        data.put("delete-result", "successful");
+        invokeLogger(Level.INFO, String.format("Successful delete of the ha-flow %s", haFlowId), data);
+    }
+
+    /**
+     * Log a flow-delete-failed event.
+     */
+    public void onFailedHaFlowDelete(String haFlowId, String failureReason) {
+        Map<String, String> data = new HashMap<>();
+        data.put(TAG, "ha-flow-delete-failed");
+        data.put(FLOW_ID, haFlowId);
+        data.put(EVENT_TYPE, HA_FLOW_DELETE_RESULT_EVENT);
+        data.put("delete-result", "failed");
+        data.put("failure-reason", failureReason);
+        invokeLogger(Level.WARN, String.format("Failed delete of the ha-flow %s, reason: %s", haFlowId, failureReason),
                 data);
     }
 }

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/logger/FlowOperationsDashboardLogger.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/logger/FlowOperationsDashboardLogger.java
@@ -72,6 +72,11 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
     private static final String TAG = "FLOW_OPERATIONS_DASHBOARD";
     private static final String DASHBOARD = "dashboard";
 
+    public static final String DELETE_RESULT = "delete-result";
+    public static final String SUCCESSFUL_RESULT = "successful";
+
+    public static final String FAILED_RESULT = "failed";
+
     public FlowOperationsDashboardLogger(Logger logger) {
         super(logger);
     }
@@ -175,7 +180,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "flow-create-successful");
         data.put(FLOW_ID, flowId);
         data.put(EVENT_TYPE, CREATE_RESULT_EVENT);
-        data.put("create-result", "successful");
+        data.put("create-result", SUCCESSFUL_RESULT);
         invokeLogger(Level.INFO, String.format("Successful create of the flow %s", flowId), data);
     }
 
@@ -187,7 +192,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "flow-create-failed");
         data.put(FLOW_ID, flowId);
         data.put(EVENT_TYPE, CREATE_RESULT_EVENT);
-        data.put("update-result", "failed");
+        data.put("update-result", FAILED_RESULT);
         data.put("failure-reason", failureReason);
         invokeLogger(Level.WARN, String.format("Failed create of the flow %s, reason: %s", flowId, failureReason),
                 data);
@@ -251,7 +256,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "flow-update-successful");
         data.put(FLOW_ID, flowId);
         data.put(EVENT_TYPE, UPDATE_RESULT_EVENT);
-        data.put("update-result", "successful");
+        data.put("update-result", SUCCESSFUL_RESULT);
         invokeLogger(Level.INFO, String.format("Successful update of the flow %s", flowId), data);
     }
 
@@ -263,7 +268,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "flow-update-failed");
         data.put(FLOW_ID, flowId);
         data.put(EVENT_TYPE, UPDATE_RESULT_EVENT);
-        data.put("update-result", "failed");
+        data.put("update-result", FAILED_RESULT);
         data.put("failure-reason", failureReason);
         invokeLogger(Level.WARN, String.format("Failed update of the flow %s, reason: %s", flowId, failureReason),
                 data);
@@ -299,7 +304,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "flow-delete-successful");
         data.put(FLOW_ID, flowId);
         data.put(EVENT_TYPE, DELETE_RESULT_EVENT);
-        data.put("delete-result", "successful");
+        data.put(DELETE_RESULT, SUCCESSFUL_RESULT);
         invokeLogger(Level.INFO, String.format("Successful delete of the flow %s", flowId), data);
     }
 
@@ -311,7 +316,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "flow-delete-failed");
         data.put(FLOW_ID, flowId);
         data.put(EVENT_TYPE, DELETE_RESULT_EVENT);
-        data.put("delete-result", "failed");
+        data.put(DELETE_RESULT, FAILED_RESULT);
         data.put("failure-reason", failureReason);
         invokeLogger(Level.WARN, String.format("Failed delete of the flow %s, reason: %s", flowId, failureReason),
                 data);
@@ -336,7 +341,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "flow-sync-success");
         data.put(FLOW_ID, flowId);
         data.put(EVENT_TYPE, FLOW_SYNC_EVENT);
-        data.put("sync-result", "successful");
+        data.put("sync-result", SUCCESSFUL_RESULT);
         invokeLogger(Level.INFO, String.format("Flow \"%s\" SYNC success", flowId), data);
     }
 
@@ -348,7 +353,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "flow-sync-failed");
         data.put(FLOW_ID, flowId);
         data.put(EVENT_TYPE, FLOW_SYNC_EVENT);
-        data.put("sync-result", "failed");
+        data.put("sync-result", FAILED_RESULT);
         invokeLogger(
                 Level.INFO, String.format(
                         "Flow \"%s\" SYNC failed - %d of %d path have failed to sync",
@@ -398,7 +403,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "flow-reroute-successful");
         data.put(FLOW_ID, flowId);
         data.put(EVENT_TYPE, REROUTE_RESULT_EVENT);
-        data.put("reroute-result", "successful");
+        data.put("reroute-result", SUCCESSFUL_RESULT);
         invokeLogger(Level.INFO, String.format("Successful reroute of the flow %s", flowId), data);
     }
 
@@ -410,7 +415,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "flow-reroute-failed");
         data.put(FLOW_ID, flowId);
         data.put(EVENT_TYPE, REROUTE_RESULT_EVENT);
-        data.put("reroute-result", "failed");
+        data.put("reroute-result", FAILED_RESULT);
         data.put("failure-reason", failureReason);
         invokeLogger(
                 Level.WARN, String.format("Failed reroute of the flow %s, reason: %s", flowId, failureReason), data);
@@ -441,7 +446,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "flow-mirror-point-create-successful");
         data.put(FLOW_ID, flowId);
         data.put(EVENT_TYPE, FLOW_MIRROR_POINT_CREATE_RESULT_EVENT);
-        data.put("flow-mirror-point-create-result", "successful");
+        data.put("flow-mirror-point-create-result", SUCCESSFUL_RESULT);
         invokeLogger(Level.INFO, String.format("Successful create a mirror point for the flow %s: source switch %s, "
                         + "destination endpoint %s_%d_%d, direction %s",
                 flowId, srcSwitch, destSwitch, destPort, destVlan, direction), data);
@@ -457,7 +462,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "flow-mirror-point-create-failed");
         data.put(FLOW_ID, flowId);
         data.put(EVENT_TYPE, FLOW_MIRROR_POINT_CREATE_RESULT_EVENT);
-        data.put("flow-mirror-point-create-result", "failed");
+        data.put("flow-mirror-point-create-result", FAILED_RESULT);
         data.put("failure-reason", failureReason);
         invokeLogger(Level.WARN, String.format("Failed create a mirror point for the flow %s: source switch %s, "
                         + "destination endpoint %s_%d_%d, direction %s, reason: %s",
@@ -486,7 +491,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "flow-mirror-point-delete-successful");
         data.put(FLOW_ID, flowId);
         data.put(EVENT_TYPE, FLOW_MIRROR_POINT_DELETE_RESULT_EVENT);
-        data.put("delete-result", "successful");
+        data.put(DELETE_RESULT, SUCCESSFUL_RESULT);
         invokeLogger(Level.INFO, String.format("Successful delete of the flow mirror point %s for the flow %s",
                 flowMirrorPointId, flowId), data);
     }
@@ -500,7 +505,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "flow-mirror-point-delete-failed");
         data.put(FLOW_ID, flowId);
         data.put(EVENT_TYPE, FLOW_MIRROR_POINT_DELETE_RESULT_EVENT);
-        data.put("delete-result", "failed");
+        data.put(DELETE_RESULT, FAILED_RESULT);
         data.put("failure-reason", failureReason);
         invokeLogger(Level.WARN, String.format("Failed delete of the flow mirror point %s for the flow %s, reason: %s",
                 flowMirrorPointId, flowId, failureReason), data);
@@ -530,7 +535,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "y-flow-create-successful");
         data.put(FLOW_ID, yFlowId);
         data.put(EVENT_TYPE, YFLOW_CREATE_RESULT_EVENT);
-        data.put("create-result", "successful");
+        data.put("create-result", SUCCESSFUL_RESULT);
         invokeLogger(Level.INFO, String.format("Successful create of the y-flow %s", yFlowId), data);
     }
 
@@ -542,7 +547,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "y-flow-create-failed");
         data.put(FLOW_ID, yFlowId);
         data.put(EVENT_TYPE, YFLOW_CREATE_RESULT_EVENT);
-        data.put("create-result", "failed");
+        data.put("create-result", FAILED_RESULT);
         data.put("failure-reason", failureReason);
         invokeLogger(Level.WARN, String.format("Failed create of the y-flow %s, reason: %s", yFlowId, failureReason),
                 data);
@@ -572,7 +577,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "y-flow-update-successful");
         data.put(FLOW_ID, yFlowId);
         data.put(EVENT_TYPE, YFLOW_UPDATE_RESULT_EVENT);
-        data.put("update-result", "successful");
+        data.put("update-result", SUCCESSFUL_RESULT);
         invokeLogger(Level.INFO, String.format("Successful update of the y-flow %s", yFlowId), data);
     }
 
@@ -584,7 +589,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "y-flow-update-failed");
         data.put(FLOW_ID, yFlowId);
         data.put(EVENT_TYPE, YFLOW_UPDATE_RESULT_EVENT);
-        data.put("update-result", "failed");
+        data.put("update-result", FAILED_RESULT);
         data.put("failure-reason", failureReason);
         invokeLogger(Level.WARN, String.format("Failed update of the y-flow %s, reason: %s", yFlowId, failureReason),
                 data);
@@ -611,7 +616,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "y-flow-reroute-successful");
         data.put(FLOW_ID, yFlowId);
         data.put(EVENT_TYPE, YFLOW_REROUTE_RESULT_EVENT);
-        data.put("reroute-result", "successful");
+        data.put("reroute-result", SUCCESSFUL_RESULT);
         invokeLogger(Level.INFO, String.format("Successful reroute of the y-flow %s", yFlowId), data);
     }
 
@@ -623,7 +628,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "y-flow-reroute-failed");
         data.put(FLOW_ID, yFlowId);
         data.put(EVENT_TYPE, YFLOW_REROUTE_RESULT_EVENT);
-        data.put("reroute-result", "failed");
+        data.put("reroute-result", FAILED_RESULT);
         data.put("failure-reason", failureReason);
         invokeLogger(Level.WARN, String.format("Failed reroute of the y-flow %s, reason: %s", yFlowId, failureReason),
                 data);
@@ -660,7 +665,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "y-flow-delete-successful");
         data.put(FLOW_ID, yFlowId);
         data.put(EVENT_TYPE, YFLOW_DELETE_RESULT_EVENT);
-        data.put("delete-result", "successful");
+        data.put(DELETE_RESULT, SUCCESSFUL_RESULT);
         invokeLogger(Level.INFO, String.format("Successful delete of the y-flow %s", yFlowId), data);
     }
 
@@ -672,7 +677,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "y-flow-delete-failed");
         data.put(FLOW_ID, yFlowId);
         data.put(EVENT_TYPE, YFLOW_DELETE_RESULT_EVENT);
-        data.put("delete-result", "failed");
+        data.put(DELETE_RESULT, FAILED_RESULT);
         data.put("failure-reason", failureReason);
         invokeLogger(Level.WARN, String.format("Failed delete of the y-flow %s, reason: %s", yFlowId, failureReason),
                 data);
@@ -697,7 +702,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "y-flow-paths-swap-successful");
         data.put(FLOW_ID, yFlowId);
         data.put(EVENT_TYPE, YFLOW_PATHS_SWAP_RESULT_EVENT);
-        data.put("swap-result", "successful");
+        data.put("swap-result", SUCCESSFUL_RESULT);
         invokeLogger(Level.INFO, String.format("Successful path swap of the y-flow %s", yFlowId), data);
     }
 
@@ -709,7 +714,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "y-flow-paths-swap-failed");
         data.put(FLOW_ID, yFlowId);
         data.put(EVENT_TYPE, YFLOW_PATHS_SWAP_RESULT_EVENT);
-        data.put("swap-result", "failed");
+        data.put("swap-result", FAILED_RESULT);
         data.put("failure-reason", failureReason);
         invokeLogger(Level.WARN, String.format("Failed path swap of the y-flow %s, reason: %s", yFlowId, failureReason),
                 data);
@@ -739,7 +744,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "ha-flow-create-successful");
         data.put(FLOW_ID, haFlowId);
         data.put(EVENT_TYPE, HA_FLOW_CREATE_RESULT_EVENT);
-        data.put("create-result", "successful");
+        data.put("create-result", SUCCESSFUL_RESULT);
         invokeLogger(Level.INFO, String.format("Successful create of the ha-flow %s", haFlowId), data);
     }
 
@@ -751,7 +756,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "ha-flow-create-failed");
         data.put(FLOW_ID, haFlowId);
         data.put(EVENT_TYPE, HA_FLOW_CREATE_RESULT_EVENT);
-        data.put("create-result", "failed");
+        data.put("create-result", FAILED_RESULT);
         data.put("failure-reason", failureReason);
         invokeLogger(Level.WARN, String.format("Failed create of the ha-flow %s, reason: %s", haFlowId, failureReason),
                 data);
@@ -776,7 +781,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "ha-flow-delete-successful");
         data.put(FLOW_ID, haFlowId);
         data.put(EVENT_TYPE, HA_FLOW_DELETE_RESULT_EVENT);
-        data.put("delete-result", "successful");
+        data.put(DELETE_RESULT, SUCCESSFUL_RESULT);
         invokeLogger(Level.INFO, String.format("Successful delete of the ha-flow %s", haFlowId), data);
     }
 
@@ -788,7 +793,7 @@ public class FlowOperationsDashboardLogger extends AbstractDashboardLogger {
         data.put(TAG, "ha-flow-delete-failed");
         data.put(FLOW_ID, haFlowId);
         data.put(EVENT_TYPE, HA_FLOW_DELETE_RESULT_EVENT);
-        data.put("delete-result", "failed");
+        data.put(DELETE_RESULT, FAILED_RESULT);
         data.put("failure-reason", failureReason);
         invokeLogger(Level.WARN, String.format("Failed delete of the ha-flow %s, reason: %s", haFlowId, failureReason),
                 data);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowDeleteHubBolt.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowDeleteHubBolt.java
@@ -106,7 +106,7 @@ public class HaFlowDeleteHubBolt extends HubBolt implements FlowGenericCarrier {
         try {
             service.handleRequest(currentKey, getCommandContext(), request.getHaFlowId());
         } catch (DuplicateKeyException e) {
-            log.error("Failed to handle a request with key {}. {}", currentKey, e.getMessage());
+            log.error("Failed to handle a request due to the duplicated key {}. {}", currentKey, e.getMessage());
         }
     }
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowDeleteHubBolt.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowDeleteHubBolt.java
@@ -15,93 +15,190 @@
 
 package org.openkilda.wfm.topology.flowhs.bolts;
 
+import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.HUB_TO_HISTORY_TOPOLOGY_SENDER;
+import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.HUB_TO_METRICS_BOLT;
 import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.HUB_TO_NB_RESPONSE_SENDER;
+import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.HUB_TO_PING_SENDER;
+import static org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream.HUB_TO_SPEAKER_WORKER;
 import static org.openkilda.wfm.topology.utils.KafkaRecordTranslator.FIELD_ID_PAYLOAD;
 
+import org.openkilda.bluegreen.LifecycleEvent;
+import org.openkilda.floodlight.api.request.SpeakerRequest;
+import org.openkilda.floodlight.api.response.SpeakerResponse;
+import org.openkilda.floodlight.api.response.rulemanager.SpeakerCommandResponse;
 import org.openkilda.messaging.Message;
+import org.openkilda.messaging.command.CommandData;
 import org.openkilda.messaging.command.haflow.HaFlowDeleteRequest;
-import org.openkilda.messaging.command.haflow.HaFlowResponse;
-import org.openkilda.messaging.error.ErrorData;
-import org.openkilda.messaging.error.ErrorMessage;
-import org.openkilda.messaging.error.ErrorType;
-import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.InfoMessage;
-import org.openkilda.model.HaFlow;
+import org.openkilda.messaging.info.stats.RemoveFlowPathInfo;
 import org.openkilda.persistence.PersistenceManager;
-import org.openkilda.persistence.repositories.FlowRepository;
-import org.openkilda.persistence.repositories.HaFlowRepository;
-import org.openkilda.wfm.AbstractBolt;
-import org.openkilda.wfm.CommandContext;
+import org.openkilda.rulemanager.RuleManager;
+import org.openkilda.rulemanager.RuleManagerConfig;
+import org.openkilda.rulemanager.RuleManagerImpl;
 import org.openkilda.wfm.error.PipelineException;
+import org.openkilda.wfm.share.flow.resources.FlowResourcesConfig;
+import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
+import org.openkilda.wfm.share.history.model.FlowHistoryHolder;
+import org.openkilda.wfm.share.hubandspoke.HubBolt;
+import org.openkilda.wfm.share.utils.KeyProvider;
+import org.openkilda.wfm.share.zk.ZkStreams;
+import org.openkilda.wfm.share.zk.ZooKeeperBolt;
 import org.openkilda.wfm.topology.flowhs.FlowHsTopology.Stream;
-import org.openkilda.wfm.topology.flowhs.exception.FlowProcessingException;
-import org.openkilda.wfm.topology.flowhs.mapper.HaFlowMapper;
+import org.openkilda.wfm.topology.flowhs.exception.DuplicateKeyException;
+import org.openkilda.wfm.topology.flowhs.service.FlowGenericCarrier;
+import org.openkilda.wfm.topology.flowhs.service.haflow.HaFlowDeleteService;
 import org.openkilda.wfm.topology.utils.MessageKafkaTranslator;
 
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
 import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 
-import java.util.Optional;
+public class HaFlowDeleteHubBolt extends HubBolt implements FlowGenericCarrier {
+    private final HaFlowDeleteConfig config;
+    private final FlowResourcesConfig flowResourcesConfig;
+    private final RuleManagerConfig ruleManagerConfig;
 
-/**
- * This implementation of the class is temporary.
- * It only works with DB. Switch rules wouldn't be modified.
- * Class is just a stub to give an API for users. It will be modified later.
- */
-public class HaFlowDeleteHubBolt extends AbstractBolt {
-    public static final String COMMON_ERROR_MESSAGE = "Couldn't delete HA-flow";
-    private transient HaFlowRepository haFlowRepository;
-    private transient FlowRepository flowRepository;
+    private transient HaFlowDeleteService service;
+    private String currentKey;
 
-    public HaFlowDeleteHubBolt(PersistenceManager persistenceManager) {
-        super(persistenceManager);
+    private LifecycleEvent deferredShutdownEvent;
+
+    public HaFlowDeleteHubBolt(
+            @NonNull HaFlowDeleteHubBolt.HaFlowDeleteConfig config, @NonNull PersistenceManager persistenceManager,
+            @NonNull FlowResourcesConfig flowResourcesConfig, @NonNull RuleManagerConfig ruleManagerConfig) {
+        super(persistenceManager, config);
+        this.config = config;
+        this.flowResourcesConfig = flowResourcesConfig;
+        this.ruleManagerConfig = ruleManagerConfig;
+        enableMeterRegistry("kilda.ha_flow_delete", HUB_TO_METRICS_BOLT.name());
     }
 
     @Override
     protected void init() {
-        haFlowRepository = persistenceManager.getRepositoryFactory().createHaFlowRepository();
-        flowRepository = persistenceManager.getRepositoryFactory().createFlowRepository();
+        FlowResourcesManager resourcesManager = new FlowResourcesManager(persistenceManager, flowResourcesConfig);
+        RuleManager ruleManager = new RuleManagerImpl(ruleManagerConfig);
+        service = new HaFlowDeleteService(this, persistenceManager, resourcesManager, ruleManager,
+                config.getSpeakerCommandRetriesLimit());
     }
 
     @Override
-    protected void handleInput(Tuple input) throws PipelineException {
-        String key = pullValue(input, MessageKafkaTranslator.FIELD_ID_KEY, String.class);
-        HaFlowDeleteRequest payload = pullValue(input, FIELD_ID_PAYLOAD, HaFlowDeleteRequest.class);
+    protected boolean deactivate(LifecycleEvent event) {
+        if (service.deactivate()) {
+            return true;
+        }
+        deferredShutdownEvent = event;
+        return false;
+    }
 
+    @Override
+    protected void activate() {
+        service.activate();
+    }
+
+    @Override
+    protected void onRequest(Tuple input) throws PipelineException {
+        currentKey = pullKey(input);
+        HaFlowDeleteRequest request = pullValue(input, FIELD_ID_PAYLOAD, HaFlowDeleteRequest.class);
         try {
-            handleHaFlowDelete(key, payload);
-        } catch (FlowProcessingException e) {
-            emitErrorMessage(e.getErrorType(), COMMON_ERROR_MESSAGE, e.getMessage());
-        } catch (Exception e) {
-            emitErrorMessage(ErrorType.INTERNAL_ERROR, COMMON_ERROR_MESSAGE, e.getMessage());
+            service.handleRequest(currentKey, getCommandContext(), request.getHaFlowId());
+        } catch (DuplicateKeyException e) {
+            log.error("Failed to handle a request with key {}. {}", currentKey, e.getMessage());
         }
     }
 
-    private void handleHaFlowDelete(String key, HaFlowDeleteRequest payload) {
-        CommandContext context = getCommandContext();
-        Optional<HaFlow> haFlow = haFlowRepository.remove(payload.getHaFlowId());
-        if (haFlow.isPresent()) {
-            InfoData response = new HaFlowResponse(HaFlowMapper.INSTANCE.toHaFlowDto(
-                    haFlow.get(), flowRepository, haFlowRepository));
-            Message message = new InfoMessage(response, System.currentTimeMillis(), context.getCorrelationId());
-            emitWithContext(Stream.HUB_TO_NB_RESPONSE_SENDER.name(), getCurrentTuple(), new Values(key, message));
+    @Override
+    protected void onWorkerResponse(Tuple input) throws PipelineException {
+        String operationKey = pullKey(input);
+        currentKey = KeyProvider.getParentKey(operationKey);
+        SpeakerResponse speakerResponse = pullValue(input, FIELD_ID_PAYLOAD, SpeakerResponse.class);
+        if (speakerResponse instanceof SpeakerCommandResponse) {
+            service.handleAsyncResponse(currentKey, (SpeakerCommandResponse) speakerResponse);
         } else {
-            throw new FlowProcessingException(ErrorType.DATA_INVALID,
-                    String.format("Couldn't delete non existent HA-flow %s", payload.getHaFlowId()));
+            unhandledInput(input);
         }
     }
 
-    private void emitErrorMessage(ErrorType type, String message, String description) {
-        String requestId = getCommandContext().getCorrelationId();
-        ErrorData errorData = new ErrorData(type, message, description);
-        emitWithContext(Stream.HUB_TO_NB_RESPONSE_SENDER.name(), getCurrentTuple(), new Values(requestId,
-                new ErrorMessage(errorData, System.currentTimeMillis(), requestId)));
+    @Override
+    public void onTimeout(String key, Tuple tuple) {
+        currentKey = key;
+        service.handleTimeout(key);
     }
+
+    @Override
+    public void sendSpeakerRequest(@NonNull SpeakerRequest command) {
+        String commandKey = KeyProvider.joinKeys(command.getCommandId().toString(), currentKey);
+        Values values = new Values(commandKey, command);
+        emitWithContext(HUB_TO_SPEAKER_WORKER.name(), getCurrentTuple(), values);
+    }
+
+    @Override
+    public void sendNorthboundResponse(@NonNull Message message) {
+        emitWithContext(Stream.HUB_TO_NB_RESPONSE_SENDER.name(), getCurrentTuple(), new Values(currentKey, message));
+    }
+
+    @Override
+    public void sendHistoryUpdate(@NonNull FlowHistoryHolder historyHolder) {
+        //TODO check history
+        InfoMessage message = new InfoMessage(historyHolder, getCommandContext().getCreateTime(),
+                getCommandContext().getCorrelationId());
+        emitWithContext(Stream.HUB_TO_HISTORY_TOPOLOGY_SENDER.name(), getCurrentTuple(),
+                new Values(historyHolder.getTaskId(), message));
+    }
+
+    @Override
+    public void sendNotifyFlowStats(@NonNull RemoveFlowPathInfo flowPathInfo) {
+        //TODO implement
+    }
+
+    @Override
+    public void sendNotifyFlowMonitor(@NonNull CommandData flowCommand) {
+        //TODO implement
+    }
+
+    @Override
+    public void sendPeriodicPingNotification(String haFlowId, boolean enabled) {
+        //TODO implement periodic pings
+        log.info("Periodic pings are not implemented for ha-flow delete operation yet. Skipping for the ha-flow {}",
+                haFlowId);
+    }
+
+    @Override
+    public void cancelTimeoutCallback(String key) {
+        cancelCallback(key);
+    }
+
+    @Override
+    public void sendInactive() {
+        getOutput().emit(ZkStreams.ZK.toString(), new Values(deferredShutdownEvent, getCommandContext()));
+        deferredShutdownEvent = null;
+    }
+
 
     @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         super.declareOutputFields(declarer);
+        declarer.declareStream(HUB_TO_SPEAKER_WORKER.name(), MessageKafkaTranslator.STREAM_FIELDS);
         declarer.declareStream(HUB_TO_NB_RESPONSE_SENDER.name(), MessageKafkaTranslator.STREAM_FIELDS);
+        declarer.declareStream(HUB_TO_HISTORY_TOPOLOGY_SENDER.name(), MessageKafkaTranslator.STREAM_FIELDS);
+        declarer.declareStream(HUB_TO_PING_SENDER.name(), MessageKafkaTranslator.STREAM_FIELDS);
+        declarer.declareStream(ZkStreams.ZK.toString(),
+                new Fields(ZooKeeperBolt.FIELD_ID_STATE, ZooKeeperBolt.FIELD_ID_CONTEXT));
+    }
+
+    @Getter
+    public static class HaFlowDeleteConfig extends Config {
+        private final int speakerCommandRetriesLimit;
+
+        @Builder(builderMethodName = "haFlowDeleteBuilder", builderClassName = "haFlowDeleteBuild")
+        public HaFlowDeleteConfig(
+                String requestSenderComponent, String workerComponent, String lifeCycleEventComponent, int timeoutMs,
+                boolean autoAck, int speakerCommandRetriesLimit) {
+            super(requestSenderComponent, workerComponent, lifeCycleEventComponent, timeoutMs, autoAck);
+            this.speakerCommandRetriesLimit = speakerCommandRetriesLimit;
+        }
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/HaFlowProcessingFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/HaFlowProcessingFsm.java
@@ -49,7 +49,7 @@ public abstract class HaFlowProcessingFsm<T extends AbstractStateMachine<T, S, E
     private final Map<UUID, BaseSpeakerCommandsRequest> speakerCommands = new HashMap<>();
 
     @Setter
-    private FlowStatus originalYFlowStatus;
+    private FlowStatus originalHaFlowStatus;
     @Setter
     private HaFlowResources newPrimaryResources;
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/FlowProcessingWithHistorySupportAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/FlowProcessingWithHistorySupportAction.java
@@ -30,6 +30,7 @@ import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowMirrorPath;
 import org.openkilda.model.FlowMirrorPoints;
 import org.openkilda.model.FlowPath;
+import org.openkilda.model.HaFlow;
 import org.openkilda.model.HaSubFlow;
 import org.openkilda.model.PathId;
 import org.openkilda.model.SwitchId;
@@ -102,6 +103,12 @@ public abstract class FlowProcessingWithHistorySupportAction<T extends FlowProce
         return flowRepository.findById(flowId)
                 .orElseThrow(() -> new FlowProcessingException(ErrorType.NOT_FOUND,
                         format("Flow %s not found", flowId)));
+    }
+
+    protected HaFlow getHaFlow(String haFlowId) {
+        return haFlowRepository.findById(haFlowId)
+                .orElseThrow(() -> new FlowProcessingException(ErrorType.NOT_FOUND,
+                        format("HA-flow %s not found", haFlowId)));
     }
 
     protected FlowPath getFlowPath(Flow flow, PathId pathId) {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/create/actions/ResourcesAllocationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/create/actions/ResourcesAllocationAction.java
@@ -378,12 +378,6 @@ public class ResourcesAllocationAction extends
                 listener.onFailed(stateMachine.getHaFlowId(), stateMachine.getErrorReason(), errorType));
     }
 
-    protected HaFlow getHaFlow(String haFlowId) {
-        return haFlowRepository.findById(haFlowId)
-                .orElseThrow(() -> new FlowProcessingException(ErrorType.NOT_FOUND,
-                        format("HA-flow %s not found", haFlowId)));
-    }
-
     private FlowSubType getSubType(int id) {
         //TODO find a better way
         switch (id) {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/create/actions/ResourcesDeallocationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/create/actions/ResourcesDeallocationAction.java
@@ -18,7 +18,6 @@ package org.openkilda.wfm.topology.flowhs.fsm.haflow.create.actions;
 import static java.lang.String.format;
 
 import org.openkilda.model.PathSegment;
-import org.openkilda.model.SwitchId;
 import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.persistence.repositories.FlowPathRepository;
 import org.openkilda.persistence.repositories.HaFlowPathRepository;
@@ -30,8 +29,8 @@ import org.openkilda.wfm.topology.flowhs.fsm.haflow.create.HaFlowCreateContext;
 import org.openkilda.wfm.topology.flowhs.fsm.haflow.create.HaFlowCreateFsm;
 import org.openkilda.wfm.topology.flowhs.fsm.haflow.create.HaFlowCreateFsm.Event;
 import org.openkilda.wfm.topology.flowhs.fsm.haflow.create.HaFlowCreateFsm.State;
+import org.openkilda.wfm.topology.flowhs.model.Segment;
 
-import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
@@ -97,20 +96,5 @@ public class ResourcesDeallocationAction extends
                         islRepository.updateAvailableBandwidth(
                                 segment.getSrcSwitchId(), segment.getSrcPort(),
                                 segment.getDstSwitchId(), segment.getDstPort())));
-    }
-
-    @Value
-    private static class Segment {
-        public Segment(PathSegment pathSegment) {
-            this.srcSwitchId = pathSegment.getSrcSwitchId();
-            this.srcPort = pathSegment.getSrcPort();
-            this.dstSwitchId = pathSegment.getDestSwitchId();
-            this.dstPort = pathSegment.getDestPort();
-        }
-
-        SwitchId srcSwitchId;
-        int srcPort;
-        SwitchId dstSwitchId;
-        int dstPort;
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/HaFlowDeleteContext.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/HaFlowDeleteContext.java
@@ -1,0 +1,27 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.fsm.haflow.delete;
+
+import org.openkilda.floodlight.api.response.rulemanager.SpeakerCommandResponse;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class HaFlowDeleteContext {
+    SpeakerCommandResponse speakerResponse;
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/HaFlowDeleteFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/HaFlowDeleteFsm.java
@@ -1,0 +1,252 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.fsm.haflow.delete;
+
+import org.openkilda.messaging.error.ErrorType;
+import org.openkilda.model.FlowStatus;
+import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.rulemanager.RuleManager;
+import org.openkilda.wfm.CommandContext;
+import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
+import org.openkilda.wfm.share.flow.resources.HaFlowResources;
+import org.openkilda.wfm.share.logger.FlowOperationsDashboardLogger;
+import org.openkilda.wfm.share.metrics.MeterRegistryHolder;
+import org.openkilda.wfm.topology.flowhs.fsm.common.HaFlowProcessingFsm;
+import org.openkilda.wfm.topology.flowhs.fsm.common.actions.NotifyHaFlowMonitorAction;
+import org.openkilda.wfm.topology.flowhs.fsm.common.actions.ReportErrorAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.Event;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.State;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions.CompleteHaFlowPathRemovalAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions.DeallocateResourcesAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions.HandleNotCompletedCommandsAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions.HandleNotDeallocatedResourcesAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions.HandleNotRemovedPathsAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions.NotifyHaFlowStatsAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions.OnFinishedAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions.OnFinishedWithErrorAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions.OnReceivedResponseAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions.RemoveHaFlowAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions.RemoveRulesAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions.RevertHaFlowStatusAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions.ValidateHaFlowAction;
+import org.openkilda.wfm.topology.flowhs.service.FlowGenericCarrier;
+import org.openkilda.wfm.topology.flowhs.service.FlowProcessingEventListener;
+
+import io.micrometer.core.instrument.LongTaskTimer;
+import io.micrometer.core.instrument.LongTaskTimer.Sample;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.squirrelframework.foundation.fsm.StateMachineBuilder;
+import org.squirrelframework.foundation.fsm.StateMachineBuilderFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Getter
+@Setter
+@Slf4j
+public final class HaFlowDeleteFsm extends HaFlowProcessingFsm<HaFlowDeleteFsm, State, Event,
+        HaFlowDeleteContext, FlowGenericCarrier, FlowProcessingEventListener> {
+    private FlowStatus originalFlowStatus;
+
+    private final List<HaFlowResources> haFlowResources = new ArrayList<>();
+
+    public HaFlowDeleteFsm(
+            @NonNull CommandContext commandContext, @NonNull FlowGenericCarrier carrier, @NonNull String haFlowId,
+            @NonNull Collection<FlowProcessingEventListener> eventListeners) {
+        super(Event.NEXT, Event.ERROR, commandContext, carrier, haFlowId, eventListeners);
+    }
+
+    @Override
+    protected String getCrudActionName() {
+        return "delete";
+    }
+
+    public static class Factory {
+        private final StateMachineBuilder<HaFlowDeleteFsm, State, Event, HaFlowDeleteContext> builder;
+        private final FlowGenericCarrier carrier;
+
+        public Factory(@NonNull FlowGenericCarrier carrier, @NonNull PersistenceManager persistenceManager,
+                       @NonNull FlowResourcesManager resourcesManager, @NonNull RuleManager ruleManager,
+                       int speakerCommandRetriesLimit) {
+            this.carrier = carrier;
+
+            builder = StateMachineBuilderFactory.create(HaFlowDeleteFsm.class, State.class, Event.class,
+                    HaFlowDeleteContext.class, CommandContext.class, FlowGenericCarrier.class, String.class,
+                    Collection.class);
+
+            final FlowOperationsDashboardLogger dashboardLogger = new FlowOperationsDashboardLogger(log);
+            final ReportErrorAction<HaFlowDeleteFsm, State, Event, HaFlowDeleteContext>
+                    reportErrorAction = new ReportErrorAction<>(Event.TIMEOUT);
+
+            builder.transition().from(State.INITIALIZED).to(State.HA_FLOW_VALIDATED).on(Event.NEXT)
+                    .perform(new ValidateHaFlowAction(persistenceManager, dashboardLogger));
+            builder.transition().from(State.INITIALIZED).to(State.FINISHED_WITH_ERROR).on(Event.TIMEOUT);
+
+            builder.transition().from(State.HA_FLOW_VALIDATED).to(State.REMOVING_RULES).on(Event.NEXT)
+                    .perform(new RemoveRulesAction(persistenceManager, resourcesManager, ruleManager));
+            builder.transitions().from(State.HA_FLOW_VALIDATED)
+                    .toAmong(State.REVERTING_HA_FLOW_STATUS, State.REVERTING_HA_FLOW_STATUS)
+                    .onEach(Event.TIMEOUT, Event.ERROR);
+
+            builder.internalTransition().within(State.REMOVING_RULES).on(Event.RESPONSE_RECEIVED)
+                    .perform(new OnReceivedResponseAction(speakerCommandRetriesLimit));
+            builder.transition().from(State.REMOVING_RULES).to(State.RULES_REMOVED)
+                    .on(Event.RULES_REMOVED);
+            builder.transition().from(State.REMOVING_RULES).to(State.REVERTING_HA_FLOW_STATUS)
+                    .on(Event.ERROR)
+                    .perform(new HandleNotCompletedCommandsAction());
+
+            builder.transition()
+                    .from(State.RULES_REMOVED)
+                    .to(State.NOTIFY_HA_FLOW_STATS)
+                    .on(Event.NEXT)
+                    .perform(new NotifyHaFlowStatsAction(persistenceManager, carrier));
+
+            builder.transition().from(State.NOTIFY_HA_FLOW_STATS).to(State.PATHS_REMOVED).on(Event.NEXT)
+                    .perform(new CompleteHaFlowPathRemovalAction(persistenceManager));
+
+            builder.transition().from(State.PATHS_REMOVED).to(State.DEALLOCATING_RESOURCES)
+                    .on(Event.NEXT);
+            builder.transition().from(State.PATHS_REMOVED).to(State.DEALLOCATING_RESOURCES)
+                    .on(Event.ERROR)
+                    .perform(new HandleNotRemovedPathsAction(persistenceManager));
+
+            builder.transition().from(State.DEALLOCATING_RESOURCES).to(State.RESOURCES_DEALLOCATED).on(Event.NEXT)
+                    .perform(new DeallocateResourcesAction(persistenceManager, resourcesManager));
+
+            builder.transition().from(State.RESOURCES_DEALLOCATED).to(State.REMOVING_HA_FLOW).on(Event.NEXT);
+            builder.transition().from(State.RESOURCES_DEALLOCATED).to(State.REMOVING_HA_FLOW)
+                    .on(Event.ERROR)
+                    .perform(new HandleNotDeallocatedResourcesAction());
+
+            builder.transition().from(State.REMOVING_HA_FLOW).to(State.HA_FLOW_REMOVED).on(Event.NEXT)
+                    .perform(new RemoveHaFlowAction(persistenceManager));
+
+            builder.transition().from(State.HA_FLOW_REMOVED).to(State.NOTIFY_FLOW_MONITOR).on(Event.NEXT);
+            builder.transition().from(State.HA_FLOW_REMOVED).to(State.NOTIFY_FLOW_MONITOR_WITH_ERROR).on(Event.ERROR);
+
+            builder.onEntry(State.REVERTING_HA_FLOW_STATUS)
+                    .perform(reportErrorAction);
+            builder.transition().from(State.REVERTING_HA_FLOW_STATUS)
+                    .to(State.NOTIFY_FLOW_MONITOR_WITH_ERROR)
+                    .on(Event.NEXT)
+                    .perform(new RevertHaFlowStatusAction(persistenceManager));
+
+            builder.onEntry(State.FINISHED_WITH_ERROR)
+                    .perform(reportErrorAction);
+
+            builder.transition()
+                    .from(State.NOTIFY_FLOW_MONITOR)
+                    .to(State.FINISHED)
+                    .on(Event.NEXT)
+                    .perform(new NotifyHaFlowMonitorAction<>(persistenceManager, carrier));
+            builder.transition()
+                    .from(State.NOTIFY_FLOW_MONITOR_WITH_ERROR)
+                    .to(State.FINISHED_WITH_ERROR)
+                    .on(Event.NEXT)
+                    .perform(new NotifyHaFlowMonitorAction<>(persistenceManager, carrier));
+
+            builder.defineFinalState(State.FINISHED)
+                    .addEntryAction(new OnFinishedAction(dashboardLogger));
+            builder.defineFinalState(State.FINISHED_WITH_ERROR)
+                    .addEntryAction(new OnFinishedWithErrorAction(dashboardLogger));
+        }
+
+        public HaFlowDeleteFsm newInstance(@NonNull CommandContext commandContext, @NonNull String haFlowId,
+                                           @NonNull Collection<FlowProcessingEventListener> eventListeners) {
+            HaFlowDeleteFsm fsm = builder.newStateMachine(State.INITIALIZED, commandContext, carrier, haFlowId,
+                    eventListeners);
+
+            fsm.addTransitionCompleteListener(event ->
+                    log.debug("HaFlowDeleteFsm, transition to {} on {}", event.getTargetState(), event.getCause()));
+
+            if (!eventListeners.isEmpty()) {
+                fsm.addTransitionCompleteListener(event -> {
+                    switch (event.getTargetState()) {
+                        case FINISHED:
+                            fsm.notifyEventListeners(listener -> listener.onCompleted(haFlowId));
+                            break;
+                        case FINISHED_WITH_ERROR:
+                            fsm.notifyEventListeners(listener ->
+                                    listener.onFailed(haFlowId, fsm.getErrorReason(), ErrorType.INTERNAL_ERROR));
+                            break;
+                        default:
+                            // ignore
+                    }
+                });
+            }
+
+            MeterRegistryHolder.getRegistry().ifPresent(registry -> {
+                Sample sample = LongTaskTimer.builder("fsm.active_execution")
+                        .register(registry)
+                        .start();
+                fsm.addTerminateListener(e -> {
+                    long duration = sample.stop();
+                    if (fsm.getCurrentState() == State.FINISHED) {
+                        registry.timer("fsm.execution.success")
+                                .record(duration, TimeUnit.NANOSECONDS);
+                    } else if (fsm.getCurrentState() == State.FINISHED_WITH_ERROR) {
+                        registry.timer("fsm.execution.failed")
+                                .record(duration, TimeUnit.NANOSECONDS);
+                    }
+                });
+            });
+            return fsm;
+        }
+    }
+
+    public enum State {
+        INITIALIZED,
+        HA_FLOW_VALIDATED,
+
+        REMOVING_RULES,
+        RULES_REMOVED,
+
+        PATHS_REMOVED,
+
+        DEALLOCATING_RESOURCES,
+        RESOURCES_DEALLOCATED,
+
+        REMOVING_HA_FLOW,
+        HA_FLOW_REMOVED,
+
+        FINISHED,
+
+        REVERTING_HA_FLOW_STATUS,
+
+        FINISHED_WITH_ERROR,
+
+        NOTIFY_FLOW_MONITOR,
+        NOTIFY_FLOW_MONITOR_WITH_ERROR,
+
+        NOTIFY_HA_FLOW_STATS
+    }
+
+    public enum Event {
+        NEXT,
+
+        RESPONSE_RECEIVED,
+        RULES_REMOVED,
+
+        TIMEOUT,
+        ERROR
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/CompleteHaFlowPathRemovalAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/CompleteHaFlowPathRemovalAction.java
@@ -1,0 +1,87 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions;
+
+import org.openkilda.model.FlowPath;
+import org.openkilda.model.HaFlow;
+import org.openkilda.model.HaFlowPath;
+import org.openkilda.model.PathId;
+import org.openkilda.model.PathSegment;
+import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.persistence.repositories.FlowPathRepository;
+import org.openkilda.persistence.repositories.HaFlowPathRepository;
+import org.openkilda.persistence.repositories.IslRepository;
+import org.openkilda.wfm.topology.flowhs.fsm.common.actions.HaFlowProcessingWithHistorySupportAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteContext;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.Event;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.State;
+import org.openkilda.wfm.topology.flowhs.model.Segment;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class CompleteHaFlowPathRemovalAction extends
+        HaFlowProcessingWithHistorySupportAction<HaFlowDeleteFsm, State, Event, HaFlowDeleteContext> {
+    private final IslRepository islRepository;
+    private final FlowPathRepository flowPathRepository;
+    private final HaFlowPathRepository haFlowPathRepository;
+
+    public CompleteHaFlowPathRemovalAction(PersistenceManager persistenceManager) {
+        super(persistenceManager);
+        this.islRepository = persistenceManager.getRepositoryFactory().createIslRepository();
+        this.flowPathRepository = persistenceManager.getRepositoryFactory().createFlowPathRepository();
+        this.haFlowPathRepository = persistenceManager.getRepositoryFactory().createHaFlowPathRepository();
+    }
+
+    @Override
+    protected void perform(
+            State from, State to, Event event, HaFlowDeleteContext context, HaFlowDeleteFsm stateMachine) {
+        List<PathSegment> removedSegments = new ArrayList<>();
+
+        Set<PathId> pathIds = transactionManager.doInTransaction(() -> {
+            HaFlow haFlow = getHaFlow(stateMachine.getHaFlowId());
+            for (HaFlowPath haFlowPath : haFlow.getPaths()) {
+                for (FlowPath subPath : haFlowPath.getSubPaths()) {
+                    // Flow path cascade remove will remove segments too
+                    removedSegments.addAll(subPath.getSegments());
+                    flowPathRepository.remove(subPath);
+                }
+            }
+            return haFlow.getPathIds();
+        });
+
+        for (PathId haFlowPathId : pathIds) {
+            haFlowPathRepository.remove(haFlowPathId);
+        }
+        updateIslsForSegments(removedSegments);
+        //TODO save info about removed paths into history
+    }
+
+    private void updateIslsForSegments(List<PathSegment> pathSegments) {
+        Set<Segment> uniqueSegments = pathSegments.stream().map(Segment::new).collect(Collectors.toSet());
+        uniqueSegments.forEach(segment ->
+                transactionManager.doInTransaction(() ->
+                        islRepository.updateAvailableBandwidth(
+                                segment.getSrcSwitchId(), segment.getSrcPort(),
+                                segment.getDstSwitchId(), segment.getDstPort())));
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/DeallocateResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/DeallocateResourcesAction.java
@@ -1,0 +1,51 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions;
+
+import static java.lang.String.format;
+
+import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
+import org.openkilda.wfm.topology.flowhs.fsm.common.actions.HaFlowProcessingWithHistorySupportAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteContext;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.Event;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.State;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class DeallocateResourcesAction extends
+        HaFlowProcessingWithHistorySupportAction<HaFlowDeleteFsm, State, Event, HaFlowDeleteContext> {
+    private final FlowResourcesManager resourcesManager;
+
+    public DeallocateResourcesAction(PersistenceManager persistenceManager,
+                                     FlowResourcesManager resourcesManager) {
+        super(persistenceManager);
+        this.resourcesManager = resourcesManager;
+    }
+
+    @Override
+    public void perform(State from, State to, Event event, HaFlowDeleteContext context, HaFlowDeleteFsm stateMachine) {
+        stateMachine.getHaFlowResources().forEach(resources -> {
+            transactionManager.doInTransaction(() ->
+                    resourcesManager.deallocateHaFlowResources(resources));
+            stateMachine.saveActionToHistory("Flow resources were deallocated",
+                    format("The ha-flow resources for %s / %s were deallocated",
+                            resources.getForward().getPathId(), resources.getReverse().getPathId()));
+        });
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/HandleNotCompletedCommandsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/HandleNotCompletedCommandsAction.java
@@ -1,0 +1,45 @@
+/* Copyright 2019 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions;
+
+import static java.lang.String.format;
+
+import org.openkilda.wfm.topology.flowhs.fsm.common.actions.HistoryRecordingAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteContext;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.Event;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.State;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.UUID;
+
+@Slf4j
+public class HandleNotCompletedCommandsAction extends
+        HistoryRecordingAction<HaFlowDeleteFsm, State, Event, HaFlowDeleteContext> {
+    @Override
+    public void perform(State from, State to, Event event, HaFlowDeleteContext context, HaFlowDeleteFsm stateMachine) {
+        for (UUID commandId : stateMachine.getPendingCommands().keySet()) {
+            stateMachine.saveErrorToHistory("Command is not finished yet",
+                    format("Completing the revert operation although the remove command may not be "
+                                    + "finished yet: commandId %s, switch %s", commandId,
+                            stateMachine.getPendingCommands().get(commandId)));
+        }
+
+        log.debug("Abandoning all pending commands: {}", stateMachine.getPendingCommands());
+        stateMachine.clearPendingCommands();
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/HandleNotDeallocatedResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/HandleNotDeallocatedResourcesAction.java
@@ -1,0 +1,37 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions;
+
+import static java.lang.String.format;
+
+import org.openkilda.wfm.topology.flowhs.fsm.common.actions.HistoryRecordingAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteContext;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.Event;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.State;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class HandleNotDeallocatedResourcesAction extends
+        HistoryRecordingAction<HaFlowDeleteFsm, State, Event, HaFlowDeleteContext> {
+    @Override
+    public void perform(State from, State to, Event event, HaFlowDeleteContext context, HaFlowDeleteFsm stateMachine) {
+        stateMachine.getHaFlowResources().forEach(resources ->
+                stateMachine.saveErrorToHistory("Failed to deallocate resources",
+                        format("Failed to deallocate resources: %s", resources)));
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/HandleNotRemovedPathsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/HandleNotRemovedPathsAction.java
@@ -1,0 +1,40 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions;
+
+import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.wfm.topology.flowhs.fsm.common.actions.HaFlowProcessingWithHistorySupportAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteContext;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.Event;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.State;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class HandleNotRemovedPathsAction extends
+        HaFlowProcessingWithHistorySupportAction<HaFlowDeleteFsm, State, Event, HaFlowDeleteContext> {
+
+    public HandleNotRemovedPathsAction(PersistenceManager persistenceManager) {
+        super(persistenceManager);
+    }
+
+    @Override
+    protected void perform(
+            State from, State to, Event event, HaFlowDeleteContext context, HaFlowDeleteFsm stateMachine) {
+        //TODO save failure in history
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/NotifyHaFlowStatsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/NotifyHaFlowStatsAction.java
@@ -1,0 +1,40 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions;
+
+import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.wfm.topology.flowhs.fsm.common.actions.HaFlowProcessingWithHistorySupportAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteContext;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.Event;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.State;
+import org.openkilda.wfm.topology.flowhs.service.FlowGenericCarrier;
+
+public class NotifyHaFlowStatsAction extends
+        HaFlowProcessingWithHistorySupportAction<HaFlowDeleteFsm, State, Event, HaFlowDeleteContext> {
+    private FlowGenericCarrier carrier;
+
+    public NotifyHaFlowStatsAction(PersistenceManager persistenceManager, FlowGenericCarrier carrier) {
+        super(persistenceManager);
+        this.carrier = carrier;
+    }
+
+    @Override
+    protected void perform(
+            State from, State to, Event event, HaFlowDeleteContext context, HaFlowDeleteFsm stateMachine) {
+        //TODO notify stats
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/OnFinishedAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/OnFinishedAction.java
@@ -1,0 +1,42 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions;
+
+import org.openkilda.wfm.share.logger.FlowOperationsDashboardLogger;
+import org.openkilda.wfm.topology.flowhs.fsm.common.actions.HistoryRecordingAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteContext;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.Event;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.State;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class OnFinishedAction extends HistoryRecordingAction<HaFlowDeleteFsm, State, Event, HaFlowDeleteContext> {
+    private final FlowOperationsDashboardLogger dashboardLogger;
+
+    public OnFinishedAction(FlowOperationsDashboardLogger dashboardLogger) {
+        this.dashboardLogger = dashboardLogger;
+    }
+
+    @Override
+    public void perform(State from, State to, Event event, HaFlowDeleteContext context, HaFlowDeleteFsm stateMachine) {
+        //TODO periodic pings
+        //TODO deactivate flow monitoring
+        dashboardLogger.onSuccessfulHaFlowDelete(stateMachine.getHaFlowId());
+        stateMachine.saveActionToHistory("Flow was deleted successfully");
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/OnFinishedWithErrorAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/OnFinishedWithErrorAction.java
@@ -1,0 +1,41 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions;
+
+import org.openkilda.wfm.share.logger.FlowOperationsDashboardLogger;
+import org.openkilda.wfm.topology.flowhs.fsm.common.actions.HistoryRecordingAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteContext;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.Event;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.State;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class OnFinishedWithErrorAction
+        extends HistoryRecordingAction<HaFlowDeleteFsm, State, Event, HaFlowDeleteContext> {
+    private final FlowOperationsDashboardLogger dashboardLogger;
+
+    public OnFinishedWithErrorAction(FlowOperationsDashboardLogger dashboardLogger) {
+        this.dashboardLogger = dashboardLogger;
+    }
+
+    @Override
+    public void perform(State from, State to, Event event, HaFlowDeleteContext context, HaFlowDeleteFsm stateMachine) {
+        dashboardLogger.onFailedHaFlowDelete(stateMachine.getHaFlowId(), stateMachine.getErrorReason());
+        stateMachine.saveActionToHistory("Failed to delete the ha-flow", stateMachine.getErrorReason());
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/OnReceivedResponseAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/OnReceivedResponseAction.java
@@ -1,0 +1,104 @@
+/* Copyright 2019 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions;
+
+import static java.lang.String.format;
+
+import org.openkilda.floodlight.api.request.rulemanager.BaseSpeakerCommandsRequest;
+import org.openkilda.floodlight.api.request.rulemanager.OfCommand;
+import org.openkilda.floodlight.api.response.rulemanager.SpeakerCommandResponse;
+import org.openkilda.wfm.topology.flowhs.fsm.common.actions.HistoryRecordingAction;
+import org.openkilda.wfm.topology.flowhs.fsm.common.converters.OfCommandConverter;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteContext;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.Event;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.State;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class OnReceivedResponseAction extends HistoryRecordingAction<
+        HaFlowDeleteFsm, State, Event, HaFlowDeleteContext> {
+    private static final String FAILED_TO_REMOVE_RULE_ACTION = "Failed to remove rule";
+
+    private final int speakerCommandRetriesLimit;
+
+    public OnReceivedResponseAction(int speakerCommandRetriesLimit) {
+        this.speakerCommandRetriesLimit = speakerCommandRetriesLimit;
+    }
+
+    @Override
+    protected void perform(
+            State from, State to, Event event, HaFlowDeleteContext context, HaFlowDeleteFsm stateMachine) {
+        SpeakerCommandResponse response = context.getSpeakerResponse();
+        UUID commandId = response.getCommandId();
+        if (!stateMachine.hasPendingCommand(commandId)) {
+            log.info("Received a response for unexpected command: {}", response);
+            return;
+        }
+
+        if (response.isSuccess()) {
+            stateMachine.removePendingCommand(commandId);
+            stateMachine.saveActionToHistory("Rule was deleted",
+                    format("The rule was removed: switch %s", response.getSwitchId()));
+        } else {
+            Optional<BaseSpeakerCommandsRequest> command = stateMachine.getSpeakerCommand(commandId);
+            int attempt = stateMachine.doRetryForCommand(commandId);
+            if (attempt <= speakerCommandRetriesLimit && command.isPresent()) {
+                response.getFailedCommandIds().forEach((uuid, message) ->
+                        stateMachine.saveErrorToHistory(FAILED_TO_REMOVE_RULE_ACTION,
+                                format("Failed to remove the rule: commandId %s, ruleId %s, switch %s. "
+                                                + "Error: %s. Retrying (attempt %d)",
+                                        commandId, uuid, response.getSwitchId(), message, attempt)));
+
+                Set<UUID> failedUuids = response.getFailedCommandIds().keySet();
+                BaseSpeakerCommandsRequest request = command.get();
+                List<OfCommand> failedCommands = request.getCommands().stream()
+                        .filter(ifCommand -> failedUuids.contains(ifCommand.getUuid()))
+                        .collect(Collectors.toList());
+                request.getCommands().clear();
+                request.getCommands().addAll(OfCommandConverter.INSTANCE.removeExcessDependencies(failedCommands));
+                stateMachine.getCarrier().sendSpeakerRequest(request);
+            } else {
+                stateMachine.addFailedCommand(commandId, response);
+                stateMachine.removePendingCommand(commandId);
+                response.getFailedCommandIds().forEach((uuid, message) ->
+                        stateMachine.saveErrorToHistory(FAILED_TO_REMOVE_RULE_ACTION,
+                                format("Failed to remove the rule: commandId %s, ruleId %s, switch %s. Error: %s",
+                                        commandId, uuid, response.getSwitchId(), message)));
+            }
+        }
+
+        if (stateMachine.getPendingCommands().isEmpty()) {
+            if (stateMachine.getFailedCommands().isEmpty()) {
+                log.debug("Received responses for all pending remove commands of ha-flow {}",
+                        stateMachine.getHaFlowId());
+                stateMachine.fire(Event.RULES_REMOVED);
+            } else {
+                String errorMessage = format("Received error response(s) for %d remove commands",
+                        stateMachine.getFailedCommands().size());
+                stateMachine.saveErrorToHistory(errorMessage);
+                stateMachine.fireError(errorMessage);
+            }
+        }
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/RemoveHaFlowAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/RemoveHaFlowAction.java
@@ -1,0 +1,69 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions;
+
+import org.openkilda.model.HaFlow;
+import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.persistence.repositories.FlowRepository;
+import org.openkilda.wfm.topology.flowhs.fsm.common.actions.HaFlowProcessingWithHistorySupportAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteContext;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.Event;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.State;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collection;
+
+@Slf4j
+public class RemoveHaFlowAction extends
+        HaFlowProcessingWithHistorySupportAction<HaFlowDeleteFsm, State, Event, HaFlowDeleteContext> {
+    FlowRepository flowRepository;
+
+    public RemoveHaFlowAction(PersistenceManager persistenceManager) {
+        super(persistenceManager);
+        flowRepository = persistenceManager.getRepositoryFactory().createFlowRepository();
+    }
+
+    @Override
+    protected void perform(
+            State from, State to, Event event, HaFlowDeleteContext context, HaFlowDeleteFsm stateMachine) {
+        String haFlowId = stateMachine.getFlowId();
+
+        String affinityGroup = transactionManager.doInTransaction(() -> {
+            HaFlow haFlow = getHaFlow(haFlowId);
+            log.debug("Removing the ha-flow {}", haFlowId);
+            haFlowRepository.remove(haFlow);
+            return haFlow.getAffinityGroupId();
+        });
+
+        stateMachine.saveActionToHistory("HA-flow was removed", String.format("The ha-flow %s was removed", haFlowId));
+        updateFlowGroups(haFlowId, affinityGroup);
+    }
+
+    private void updateFlowGroups(String haFlowId, String affinityGroupId) {
+        // TODO check there is no need to update diversity group
+        // TODO check what happen if only one affinity flow left
+        if (haFlowId.equals(affinityGroupId)) {
+            Collection<String> affinityHaFlowIds = haFlowRepository.findHaFlowIdsByAffinityGroupId(affinityGroupId);
+            affinityHaFlowIds
+                    .forEach(affinityHaFlowId -> haFlowRepository.updateAffinityFlowGroupId(affinityHaFlowId, null));
+            Collection<String> affinityFlowIds = flowRepository.findFlowsIdByAffinityGroupId(affinityGroupId);
+            affinityHaFlowIds
+                    .forEach(affinityFlowId -> flowRepository.updateAffinityFlowGroupId(affinityFlowId, null));
+        }
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/RemoveRulesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/RemoveRulesAction.java
@@ -1,0 +1,189 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions;
+
+import org.openkilda.floodlight.api.request.rulemanager.DeleteSpeakerCommandsRequest;
+import org.openkilda.model.FlowPath;
+import org.openkilda.model.HaFlow;
+import org.openkilda.model.HaFlowPath;
+import org.openkilda.model.MeterId;
+import org.openkilda.model.PathId;
+import org.openkilda.model.PathSegment;
+import org.openkilda.model.SwitchId;
+import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.persistence.repositories.FlowPathRepository;
+import org.openkilda.rulemanager.DataAdapter;
+import org.openkilda.rulemanager.RuleManager;
+import org.openkilda.rulemanager.SpeakerData;
+import org.openkilda.rulemanager.adapter.PersistenceDataAdapter;
+import org.openkilda.wfm.share.flow.resources.EncapsulationResources;
+import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
+import org.openkilda.wfm.share.flow.resources.HaFlowResources;
+import org.openkilda.wfm.share.flow.resources.HaFlowResources.HaPathResources;
+import org.openkilda.wfm.topology.flowhs.fsm.common.actions.HaFlowRuleManagerProcessingAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteContext;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.Event;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.State;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class RemoveRulesAction extends HaFlowRuleManagerProcessingAction<
+        HaFlowDeleteFsm, State, Event, HaFlowDeleteContext> {
+    private final FlowResourcesManager resourcesManager;
+    private final FlowPathRepository flowPathRepository;
+
+    public RemoveRulesAction(
+            PersistenceManager persistenceManager, FlowResourcesManager resourcesManager, RuleManager ruleManager) {
+        super(persistenceManager, ruleManager);
+        this.resourcesManager = resourcesManager;
+        this.flowPathRepository = persistenceManager.getRepositoryFactory().createFlowPathRepository();
+    }
+
+    @Override
+    protected void perform(
+            State from, State to, Event event, HaFlowDeleteContext context, HaFlowDeleteFsm stateMachine) {
+        HaFlow haFlow = getHaFlow(stateMachine.getFlowId());
+
+        Set<PathId> haFlowPathIds = new HashSet<>();
+        for (HaFlowPath path : haFlow.getPaths()) {
+            PathId pathId = path.getHaPathId();
+            if (haFlowPathIds.add(pathId)) {
+                HaFlowPath oppositePath = haFlow.getOppositePathId(pathId)
+                        .filter(oppPathId -> !pathId.equals(oppPathId))
+                        .flatMap(haFlow::getPath).orElse(null);
+                if (oppositePath != null) {
+                    haFlowPathIds.add(oppositePath.getHaPathId());
+                    stateMachine.getHaFlowResources().add(buildResources(haFlow, path, oppositePath));
+                } else {
+                    log.warn("No opposite ha-path found for {}, trying to delete as ha-unpaired path", pathId);
+                    stateMachine.getHaFlowResources().add(buildResources(haFlow, path, path));
+                }
+            }
+        }
+
+        DataAdapter adapter = buildDataAdapter(haFlow, haFlowPathIds);
+        List<SpeakerData> commands = buildSpeakerCommands(haFlow.getPaths(), adapter);
+        Collection<DeleteSpeakerCommandsRequest> deleteRequests = buildHaFlowDeleteRequests(
+                commands, stateMachine.getCommandContext());
+
+        if (deleteRequests.isEmpty()) {
+            stateMachine.saveActionToHistory("No requests to remove ha-flow rules");
+            stateMachine.fire(Event.RULES_REMOVED);
+        } else {
+            // emitting
+            deleteRequests.forEach(request -> {
+                stateMachine.getCarrier().sendSpeakerRequest(request);
+                stateMachine.addSpeakerCommand(request.getCommandId(), request);
+                stateMachine.addPendingCommand(request.getCommandId(), request.getSwitchId());
+            });
+
+            stateMachine.saveActionToHistory("Commands for removing ha-flow rules have been sent");
+        }
+    }
+
+    private HaFlowResources buildResources(HaFlow flow, HaFlowPath path, HaFlowPath oppositePath) {
+        HaFlowPath forwardPath;
+        HaFlowPath reversePath;
+
+        if (path.isForward()) {
+            forwardPath = path;
+            reversePath = oppositePath;
+        } else {
+            forwardPath = oppositePath;
+            reversePath = path;
+        }
+
+        EncapsulationResources encapsulationResources = resourcesManager.getEncapsulationResources(
+                    forwardPath.getHaPathId(), reversePath.getHaPathId(), flow.getEncapsulationType()).orElse(null);
+        return HaFlowResources.builder()
+                .unmaskedCookie(forwardPath.getCookie().getFlowEffectiveId())
+                .forward(HaPathResources.builder()
+                        .pathId(forwardPath.getHaPathId())
+                        .sharedMeterId(forwardPath.getSharedPointMeterId())
+                        .yPointMeterId(forwardPath.getYPointMeterId())
+                        .yPointGroupId(forwardPath.getYPointGroupId())
+                        .encapsulationResources(encapsulationResources)
+                        .subPathIds(buildSubPathIdMap(forwardPath.getSubPaths()))
+                        .subPathMeters(buildSubPathMeterIdMap(forwardPath.getSubPaths()))
+                        .build())
+                .reverse(HaPathResources.builder()
+                        .pathId(reversePath.getHaPathId())
+                        .sharedMeterId(reversePath.getSharedPointMeterId())
+                        .yPointMeterId(reversePath.getYPointMeterId())
+                        .yPointGroupId(reversePath.getYPointGroupId())
+                        .encapsulationResources(encapsulationResources)
+                        .subPathIds(buildSubPathIdMap(reversePath.getSubPaths()))
+                        .subPathMeters(buildSubPathMeterIdMap(reversePath.getSubPaths()))
+                        .build())
+                .build();
+    }
+
+    private Map<String, PathId> buildSubPathIdMap(List<FlowPath> subPaths) {
+        if (subPaths == null) {
+            return new HashMap<>();
+        }
+        return subPaths.stream().collect(Collectors.toMap(FlowPath::getHaSubFlowId, FlowPath::getPathId));
+    }
+
+    private Map<String, MeterId> buildSubPathMeterIdMap(List<FlowPath> subPaths) {
+        if (subPaths == null) {
+            return new HashMap<>();
+        }
+        return subPaths.stream()
+                .filter(path -> path.getMeterId() != null)
+                .collect(Collectors.toMap(FlowPath::getHaSubFlowId, FlowPath::getMeterId));
+    }
+
+    private DataAdapter buildDataAdapter(HaFlow haFlow, Set<PathId> haPathIds) {
+        Set<PathId> pathIds = new HashSet<>(haPathIds);
+        for (SwitchId switchId : haFlow.getEndpointSwitchIds()) {
+            pathIds.addAll(flowPathRepository.findByEndpointSwitch(switchId, false).stream()
+                    .map(FlowPath::getPathId)
+                    .collect(Collectors.toSet()));
+        }
+
+        Set<SwitchId> switchIds = haFlow.getEndpointSwitchIds();
+        for (HaFlowPath haFlowPath : haFlow.getPaths()) {
+            for (FlowPath subPath : haFlowPath.getSubPaths()) {
+                for (PathSegment segment : subPath.getSegments()) {
+                    switchIds.add(segment.getSrcSwitchId());
+                    switchIds.add(segment.getDestSwitchId());
+                }
+            }
+        }
+        return new PersistenceDataAdapter(persistenceManager, pathIds, switchIds, false);
+    }
+
+    private List<SpeakerData> buildSpeakerCommands(
+            Collection<HaFlowPath> paths, DataAdapter adapter) {
+        List<SpeakerData> result = new ArrayList<>();
+        for (HaFlowPath path : paths) {
+            result.addAll(ruleManager.buildRulesHaFlowPath(path, true, adapter));
+        }
+        return result;
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/RevertHaFlowStatusAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/RevertHaFlowStatusAction.java
@@ -1,0 +1,49 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions;
+
+import static java.lang.String.format;
+
+import org.openkilda.model.FlowStatus;
+import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.wfm.topology.flowhs.fsm.common.actions.HaFlowProcessingWithHistorySupportAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteContext;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.Event;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.State;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class RevertHaFlowStatusAction extends
+        HaFlowProcessingWithHistorySupportAction<HaFlowDeleteFsm, State, Event, HaFlowDeleteContext> {
+    public RevertHaFlowStatusAction(PersistenceManager persistenceManager) {
+        super(persistenceManager);
+    }
+
+    @Override
+    protected void perform(
+            State from, State to, Event event, HaFlowDeleteContext context, HaFlowDeleteFsm stateMachine) {
+        String haFlowId = stateMachine.getHaFlowId();
+        FlowStatus originalStatus = stateMachine.getOriginalFlowStatus();
+        if (originalStatus != null) {
+            log.debug("Reverting the ha-flow status of {} to {}", haFlowId, originalStatus);
+
+            haFlowRepository.updateStatus(haFlowId, originalStatus);
+            stateMachine.saveActionToHistory(format("The ha-flow status was reverted to %s", originalStatus));
+        }
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/ValidateHaFlowAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/ValidateHaFlowAction.java
@@ -1,0 +1,96 @@
+/* Copyright 2021 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.actions;
+
+import static java.lang.String.format;
+
+import org.openkilda.messaging.Message;
+import org.openkilda.messaging.command.haflow.HaFlowResponse;
+import org.openkilda.messaging.error.ErrorType;
+import org.openkilda.messaging.info.InfoMessage;
+import org.openkilda.model.FlowStatus;
+import org.openkilda.model.HaFlow;
+import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.persistence.repositories.KildaFeatureTogglesRepository;
+import org.openkilda.persistence.repositories.RepositoryFactory;
+import org.openkilda.wfm.CommandContext;
+import org.openkilda.wfm.share.history.model.FlowEventData;
+import org.openkilda.wfm.share.logger.FlowOperationsDashboardLogger;
+import org.openkilda.wfm.topology.flowhs.exception.FlowProcessingException;
+import org.openkilda.wfm.topology.flowhs.fsm.common.actions.NbTrackableWithHistorySupportAction;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteContext;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.Event;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.State;
+import org.openkilda.wfm.topology.flowhs.mapper.HaFlowMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+
+@Slf4j
+public class ValidateHaFlowAction extends
+        NbTrackableWithHistorySupportAction<HaFlowDeleteFsm, State, Event, HaFlowDeleteContext> {
+    private final KildaFeatureTogglesRepository featureTogglesRepository;
+    private final FlowOperationsDashboardLogger dashboardLogger;
+
+    public ValidateHaFlowAction(PersistenceManager persistenceManager, FlowOperationsDashboardLogger dashboardLogger) {
+        super(persistenceManager);
+        RepositoryFactory repositoryFactory = persistenceManager.getRepositoryFactory();
+        featureTogglesRepository = repositoryFactory.createFeatureTogglesRepository();
+        this.dashboardLogger = dashboardLogger;
+    }
+
+    @Override
+    protected Optional<Message> performWithResponse(State from, State to, Event event, HaFlowDeleteContext context,
+                                                    HaFlowDeleteFsm stateMachine) {
+        String flowId = stateMachine.getFlowId();
+        dashboardLogger.onFlowDelete(flowId);
+
+        boolean isOperationAllowed = featureTogglesRepository.getOrDefault().getDeleteHaFlowEnabled();
+        if (!isOperationAllowed) {
+            throw new FlowProcessingException(ErrorType.NOT_PERMITTED, "HA-flow delete feature is disabled");
+        }
+
+        HaFlow resultHaFlow = transactionManager.doInTransaction(() -> {
+            HaFlow haFlow = getHaFlow(flowId);
+            if (haFlow.getStatus() == FlowStatus.IN_PROGRESS) {
+                throw new FlowProcessingException(ErrorType.REQUEST_INVALID,
+                        format("HA-flow %s is in progress now", flowId));
+            }
+
+            // Keep it, just in case we have to revert it.
+            stateMachine.setOriginalFlowStatus(haFlow.getStatus());
+            haFlow.setStatus(FlowStatus.IN_PROGRESS);
+            return haFlow;
+        });
+
+        stateMachine.saveNewEventToHistory("HA-flow was validated successfully", FlowEventData.Event.DELETE);
+        return Optional.of(buildResponseMessage(resultHaFlow, stateMachine.getCommandContext()));
+    }
+
+    private Message buildResponseMessage(HaFlow haFlow, CommandContext commandContext) {
+        HaFlowResponse response = HaFlowResponse.builder()
+                .haFlow(HaFlowMapper.INSTANCE.toHaFlowDto(haFlow, flowRepository, haFlowRepository))
+                .build();
+        return new InfoMessage(response, commandContext.getCreateTime(), commandContext.getCorrelationId());
+    }
+
+    @Override
+    protected String getGenericErrorMessage() {
+        return "Could not delete ha-flow";
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/ValidateHaFlowAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/ValidateHaFlowAction.java
@@ -58,7 +58,7 @@ public class ValidateHaFlowAction extends
     protected Optional<Message> performWithResponse(State from, State to, Event event, HaFlowDeleteContext context,
                                                     HaFlowDeleteFsm stateMachine) {
         String flowId = stateMachine.getFlowId();
-        dashboardLogger.onFlowDelete(flowId);
+        dashboardLogger.onHaFlowDelete(flowId);
 
         boolean isOperationAllowed = featureTogglesRepository.getOrDefault().getDeleteHaFlowEnabled();
         if (!isOperationAllowed) {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/model/Segment.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/model/Segment.java
@@ -1,0 +1,36 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.model;
+
+import org.openkilda.model.PathSegment;
+import org.openkilda.model.SwitchId;
+
+import lombok.Value;
+
+@Value
+public class Segment {
+    public Segment(PathSegment pathSegment) {
+        this.srcSwitchId = pathSegment.getSrcSwitchId();
+        this.srcPort = pathSegment.getSrcPort();
+        this.dstSwitchId = pathSegment.getDestSwitchId();
+        this.dstPort = pathSegment.getDestPort();
+    }
+
+    SwitchId srcSwitchId;
+    int srcPort;
+    SwitchId dstSwitchId;
+    int dstPort;
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/haflow/HaFlowDeleteService.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/haflow/HaFlowDeleteService.java
@@ -1,0 +1,126 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.service.haflow;
+
+import static java.lang.String.format;
+
+import org.openkilda.floodlight.api.response.rulemanager.SpeakerCommandResponse;
+import org.openkilda.messaging.error.ErrorType;
+import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.rulemanager.RuleManager;
+import org.openkilda.wfm.CommandContext;
+import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
+import org.openkilda.wfm.share.utils.FsmExecutor;
+import org.openkilda.wfm.topology.flowhs.exception.DuplicateKeyException;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteContext;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm;
+import org.openkilda.wfm.topology.flowhs.fsm.haflow.delete.HaFlowDeleteFsm.Event;
+import org.openkilda.wfm.topology.flowhs.service.FlowGenericCarrier;
+import org.openkilda.wfm.topology.flowhs.service.FlowProcessingEventListener;
+import org.openkilda.wfm.topology.flowhs.service.common.FlowProcessingFsmRegister;
+import org.openkilda.wfm.topology.flowhs.service.common.FlowProcessingService;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class HaFlowDeleteService extends FlowProcessingService<HaFlowDeleteFsm, Event, HaFlowDeleteContext,
+        FlowGenericCarrier, FlowProcessingFsmRegister<HaFlowDeleteFsm>, FlowProcessingEventListener> {
+    private final HaFlowDeleteFsm.Factory fsmFactory;
+
+    public HaFlowDeleteService(
+            @NonNull FlowGenericCarrier carrier, @NonNull PersistenceManager persistenceManager,
+            @NonNull FlowResourcesManager flowResourcesManager, @NonNull RuleManager ruleManager,
+            int speakerCommandRetriesLimit) {
+        super(new FlowProcessingFsmRegister<>(), new FsmExecutor<>(Event.NEXT), carrier, persistenceManager);
+        fsmFactory = new HaFlowDeleteFsm.Factory(carrier, persistenceManager, flowResourcesManager, ruleManager,
+                speakerCommandRetriesLimit);
+    }
+
+    /**
+     * Handles request for ha-flow delete.
+     *
+     * @param key command identifier.
+     * @param haFlowId the flow to delete.
+     */
+    public void handleRequest(@NonNull String key, @NonNull CommandContext commandContext, @NonNull String haFlowId)
+            throws DuplicateKeyException {
+        log.debug("Handling ha-flow deletion request with key {} and ha-flow ID: {}", key, haFlowId);
+
+        if (fsmRegister.hasRegisteredFsmWithKey(key)) {
+            throw new DuplicateKeyException(key, "There's another active FSM with the same key");
+        }
+        if (fsmRegister.hasRegisteredFsmWithFlowId(haFlowId)) {
+            sendErrorResponseToNorthbound(ErrorType.REQUEST_INVALID, "Could not delete ha-flow",
+                    format("HA-flow %s is already deleting now", haFlowId), commandContext);
+            cancelProcessing(key);
+            throw new DuplicateKeyException(key, "There's another active FSM for the same ha-flowId " + haFlowId);
+        }
+
+        HaFlowDeleteFsm fsm = fsmFactory.newInstance(commandContext, haFlowId, eventListeners);
+        fsmRegister.registerFsm(key, fsm);
+
+        fsm.start();
+        fsmExecutor.fire(fsm, Event.NEXT, HaFlowDeleteContext.builder().build());
+
+        removeIfFinished(fsm, key);
+    }
+
+    /**
+     * Handles async response from worker.
+     *
+     * @param key command identifier.
+     */
+    public void handleAsyncResponse(@NonNull String key, @NonNull SpeakerCommandResponse speakerResponse) {
+        log.debug("Received speaker command response {}", speakerResponse);
+        HaFlowDeleteFsm fsm = fsmRegister.getFsmByKey(key).orElse(null);
+        if (fsm == null) {
+            log.warn("Received a response with unknown key {}.", key);
+            return;
+        }
+
+        HaFlowDeleteContext context = HaFlowDeleteContext.builder()
+                .speakerResponse(speakerResponse)
+                .build();
+        fsmExecutor.fire(fsm, Event.RESPONSE_RECEIVED, context);
+        removeIfFinished(fsm, key);
+    }
+
+    /**
+     * Handles timeout case.
+     *
+     * @param key command identifier.
+     */
+    public void handleTimeout(@NonNull String key) {
+        log.debug("Handling timeout for {}", key);
+        HaFlowDeleteFsm fsm = fsmRegister.getFsmByKey(key).orElse(null);
+        if (fsm == null) {
+            log.warn("Failed to find a FSM: timeout event for non pending FSM with key {}", key);
+            return;
+        }
+
+        fsmExecutor.fire(fsm, Event.TIMEOUT);
+        removeIfFinished(fsm, key);
+    }
+
+    private void removeIfFinished(HaFlowDeleteFsm fsm, String key) {
+        if (fsm.isTerminated()) {
+            log.debug("FSM with key {} is finished with state {}", key, fsm.getCurrentState());
+            fsmRegister.unregisterFsm(key);
+            cancelProcessing(key);
+        }
+    }
+}

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/KildaFeatureToggles.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/KildaFeatureToggles.java
@@ -56,6 +56,7 @@ public class KildaFeatureToggles implements CompositeDataEntity<KildaFeatureTogg
             .modifyYFlowEnabled(false)
             .createHaFlowEnabled(false)
             .modifyHaFlowEnabled(false)
+            .deleteHaFlowEnabled(false)
             .syncSwitchOnConnect(true)
             .discoverNewIslsInUnderMaintenanceMode(false)
             .build();
@@ -90,7 +91,7 @@ public class KildaFeatureToggles implements CompositeDataEntity<KildaFeatureTogg
                                Boolean flowsRerouteUsingDefaultEncapType, Boolean collectGrpcStats,
                                Boolean server42FlowRtt, Boolean flowLatencyMonitoringReactions,
                                Boolean server42IslRtt, Boolean modifyYFlowEnabled, Boolean createHaFlowEnabled,
-                               Boolean modifyHaFlowEnabled, Boolean syncSwitchOnConnect,
+                               Boolean modifyHaFlowEnabled, Boolean deleteHaFlowEnabled, Boolean syncSwitchOnConnect,
                                Boolean discoverNewIslsInUnderMaintenanceMode) {
         data = KildaFeatureTogglesDataImpl.builder()
                 .flowsRerouteOnIslDiscoveryEnabled(flowsRerouteOnIslDiscoveryEnabled)
@@ -105,6 +106,7 @@ public class KildaFeatureToggles implements CompositeDataEntity<KildaFeatureTogg
                 .modifyYFlowEnabled(modifyYFlowEnabled)
                 .createHaFlowEnabled(createHaFlowEnabled)
                 .modifyHaFlowEnabled(modifyHaFlowEnabled)
+                .deleteHaFlowEnabled(deleteHaFlowEnabled)
                 .syncSwitchOnConnect(syncSwitchOnConnect)
                 .discoverNewIslsInUnderMaintenanceMode(discoverNewIslsInUnderMaintenanceMode)
                 .build();
@@ -214,6 +216,10 @@ public class KildaFeatureToggles implements CompositeDataEntity<KildaFeatureTogg
 
         void setModifyHaFlowEnabled(Boolean modifyHaFlowEnabled);
 
+        Boolean getDeleteHaFlowEnabled();
+
+        void setDeleteHaFlowEnabled(Boolean deleteHaFlowEnabled);
+
         Boolean getSyncSwitchOnConnect();
 
         void setSyncSwitchOnConnect(Boolean syncSwitchOnConnect);
@@ -246,6 +252,7 @@ public class KildaFeatureToggles implements CompositeDataEntity<KildaFeatureTogg
         Boolean modifyYFlowEnabled;
         Boolean createHaFlowEnabled;
         Boolean modifyHaFlowEnabled;
+        Boolean deleteHaFlowEnabled;
         Boolean syncSwitchOnConnect;
         Boolean discoverNewIslsInUnderMaintenanceMode;
     }
@@ -317,6 +324,9 @@ public class KildaFeatureToggles implements CompositeDataEntity<KildaFeatureTogg
             }
             if (target.getModifyHaFlowEnabled() == null) {
                 target.setModifyHaFlowEnabled(source.getModifyHaFlowEnabled());
+            }
+            if (target.getDeleteHaFlowEnabled() == null) {
+                target.setDeleteHaFlowEnabled(source.getDeleteHaFlowEnabled());
             }
             if (target.getSyncSwitchOnConnect() == null) {
                 target.setSyncSwitchOnConnect(source.getSyncSwitchOnConnect());

--- a/src-java/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/HaFlowRepository.java
+++ b/src-java/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/HaFlowRepository.java
@@ -19,6 +19,8 @@ import org.openkilda.model.FlowStatus;
 import org.openkilda.model.HaFlow;
 import org.openkilda.model.SwitchId;
 
+import lombok.NonNull;
+
 import java.util.Collection;
 import java.util.Optional;
 
@@ -33,9 +35,13 @@ public interface HaFlowRepository extends Repository<HaFlow> {
 
     Collection<String> findHaFlowIdsByDiverseGroupId(String diverseGroupId);
 
+    Collection<String> findHaFlowIdsByAffinityGroupId(String affinityGroupId);
+
     Optional<String> getOrCreateDiverseHaFlowGroupId(String haFlowId);
 
     void updateStatus(String haFlowId, FlowStatus flowStatus);
+
+    void updateAffinityFlowGroupId(@NonNull String haFlowId, String affinityGroupId);
 
     Optional<HaFlow> remove(String haFlowId);
 }

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/frames/KildaFeatureTogglesFrame.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/frames/KildaFeatureTogglesFrame.java
@@ -24,6 +24,7 @@ public abstract class KildaFeatureTogglesFrame extends KildaBaseVertexFrame impl
     public static final String UNIQUE_PROPERTY = "unique";
     public static final String CREATE_HA_FLOW_ENABLED_PROPERTY = "create_ha_flow_enabled";
     public static final String MODIFY_HA_FLOW_ENABLED_PROPERTY = "modify_ha_flow_enabled";
+    public static final String DELETE_HA_FLOW_ENABLED_PROPERTY = "delete_ha_flow_enabled";
 
     @Override
     @Property("flows_reroute_on_isl_discovery")
@@ -135,6 +136,14 @@ public abstract class KildaFeatureTogglesFrame extends KildaBaseVertexFrame impl
     @Override
     @Property(MODIFY_HA_FLOW_ENABLED_PROPERTY)
     public abstract void setModifyHaFlowEnabled(Boolean modifyHaFlowEnabled);
+
+    @Override
+    @Property(DELETE_HA_FLOW_ENABLED_PROPERTY)
+    public abstract Boolean getDeleteHaFlowEnabled();
+
+    @Override
+    @Property(DELETE_HA_FLOW_ENABLED_PROPERTY)
+    public abstract void setDeleteHaFlowEnabled(Boolean modifyHaFlowEnabled);
 
     @Override
     @Property("sync_switch_on_connect")

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaHaFlowRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaHaFlowRepository.java
@@ -33,6 +33,7 @@ import org.openkilda.persistence.repositories.HaFlowRepository;
 import org.openkilda.persistence.repositories.HaSubFlowRepository;
 import org.openkilda.persistence.tx.TransactionManager;
 
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 
@@ -114,12 +115,21 @@ public class FermaHaFlowRepository extends FermaGenericRepository<HaFlow, HaFlow
 
     @Override
     public Collection<String> findHaFlowIdsByDiverseGroupId(String diverseGroupId) {
-        if (diverseGroupId == null) {
+        return findFlowsIdByGroupId(HaFlowFrame.DIVERSE_GROUP_ID_PROPERTY, diverseGroupId);
+    }
+
+    @Override
+    public Collection<String> findHaFlowIdsByAffinityGroupId(String affinityGroupId) {
+        return findFlowsIdByGroupId(HaFlowFrame.AFFINITY_GROUP_ID_PROPERTY, affinityGroupId);
+    }
+
+    private Collection<String> findFlowsIdByGroupId(String groupIdProperty, String groupId) {
+        if (groupId == null) {
             return new ArrayList<>();
         }
         return framedGraph().traverse(g -> g.V()
                         .hasLabel(HaFlowFrame.FRAME_LABEL)
-                        .has(HaFlowFrame.DIVERSE_GROUP_ID_PROPERTY, diverseGroupId)
+                        .has(groupIdProperty, groupId)
                         .values(HaFlowFrame.HA_FLOW_ID_PROPERTY))
                 .getRawTraversal().toStream()
                 .map(String.class::cast)
@@ -148,6 +158,18 @@ public class FermaHaFlowRepository extends FermaGenericRepository<HaFlow, HaFlow
                         .toListExplicit(FlowFrame.class)
                         .forEach(haFlowFrame -> {
                             haFlowFrame.setStatus(flowStatus);
+                        }));
+    }
+
+    @Override
+    public void updateAffinityFlowGroupId(@NonNull String haFlowId, String affinityGroupId) {
+        getTransactionManager().doInTransaction(() ->
+                framedGraph().traverse(g -> g.V()
+                                .hasLabel(HaFlowFrame.FRAME_LABEL)
+                                .has(HaFlowFrame.HA_FLOW_ID_PROPERTY, haFlowId))
+                        .toListExplicit(HaFlowFrame.class)
+                        .forEach(haFlowFrame -> {
+                            haFlowFrame.setAffinityGroupId(affinityGroupId);
                         }));
     }
 

--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/extension/env/EnvExtension.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/extension/env/EnvExtension.groovy
@@ -109,6 +109,7 @@ class EnvExtension extends AbstractGlobalExtension implements SpringContextListe
                 .modifyYFlowEnabled(true)
                 .createHaFlowEnabled(true)
                 .modifyHaFlowEnabled(true)
+                .deleteHaFlowEnabled(true)
                 .syncSwitchOnConnect(true)
                 .build()
         northbound.toggleFeature(features)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowCreateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowCreateSpec.groovy
@@ -21,14 +21,11 @@ import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.web.client.HttpClientErrorException
-import spock.lang.Ignore
 import spock.lang.Narrative
 import spock.lang.Shared
 
 @Slf4j
 @Narrative("Verify create operations on ha-flows.")
-@Ignore("""HA flow create operation allocates resources, but HA flow delete operation can't deallocate these resources 
-        yet. Need to be unignored when HA flow delete operation will be ready""")
 class HaFlowCreateSpec extends HealthCheckSpecification {
     @Autowired
     @Shared

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowDiversitySpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowDiversitySpec.groovy
@@ -9,14 +9,11 @@ import org.openkilda.functionaltests.helpers.YFlowHelper
 
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
-import spock.lang.Ignore
 import spock.lang.Narrative
 import spock.lang.Shared
 
 @Slf4j
 @Narrative("Verify the ability to create diverse ha-flows in the system.")
-@Ignore("""HA flow create operation allocates resources, but HA flow delete operation can't deallocate these resources 
-        yet. Need to be unignored when HA flow delete operation will be ready""")
 class HaFlowDiversitySpec extends HealthCheckSpecification {
     @Autowired
     @Shared

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowUpdateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowUpdateSpec.groovy
@@ -18,14 +18,11 @@ import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.web.client.HttpClientErrorException
-import spock.lang.Ignore
 import spock.lang.Narrative
 import spock.lang.Shared
 
 @Slf4j
 @Narrative("Verify update and partial update operations on ha-flows.")
-@Ignore("""HA flow create operation allocates resources, but HA flow delete operation can't deallocate these resources 
-        yet. Need to be unignored when HA flow delete operation will be ready""")
 class HaFlowUpdateSpec extends HealthCheckSpecification {
     @Autowired
     @Shared


### PR DESCRIPTION
API delete stub was replaced with HaFlowDeleteFSM. This FSM deallocates resources and pathes for ha-flows but doesn't rempve rules yet

Related To #5061