### PR TITLE
[TEST] Improve post-test cleanups

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
@@ -1370,10 +1370,11 @@ class FlowCrudSpec extends HealthCheckSpecification {
     def "Unable to update flow with incorrect id in request body"() {
         given:"A flow"
         def flow = flowHelperV2.randomFlow(topologyHelper.switchPairs[0])
-        flowHelperV2.addFlow(flow)
+        def oldFlowId = flowHelperV2.addFlow(flow).getFlowId()
+        def newFlowId = "new_flow_id"
 
         when: "Try to update flow with incorrect flow id in request body"
-        northboundV2.updateFlow(flow.flowId, flow.tap {flowId = "new_flow_id"})
+        northboundV2.updateFlow(flow.flowId, flow.tap {flowId = newFlowId})
 
         then: "Bad Request response is returned"
         def error = thrown(HttpClientErrorException)
@@ -1382,7 +1383,9 @@ class FlowCrudSpec extends HealthCheckSpecification {
         errorDetails.errorMessage == "flow_id from body and from path are different"
 
         cleanup:
-        !error && flowHelperV2.deleteFlow(flow.flowId)
+        Wrappers.silent {
+            flowHelperV2.deleteFlow(oldFlowId)
+        }
     }
 
     @Tidy
@@ -1391,9 +1394,10 @@ class FlowCrudSpec extends HealthCheckSpecification {
         given: "A flow"
         def flow = flowHelperV2.randomFlow(topologyHelper.switchPairs[0])
         flowHelperV2.addFlow(flow)
+        def newFlowId = "new_flow_id"
 
         when: "Try to update flow with incorrect flow id in request path"
-        northboundV2.updateFlow("new_flow_id", flow.tap { maximumBandwidth = maximumBandwidth + 1 })
+        northboundV2.updateFlow(newFlowId, flow.tap { maximumBandwidth = maximumBandwidth + 1 })
 
         then: "Bad Request response is returned"
         def error = thrown(HttpClientErrorException)
@@ -1402,7 +1406,9 @@ class FlowCrudSpec extends HealthCheckSpecification {
         errorDetails.errorMessage == "flow_id from body and from path are different"
 
         cleanup:
-        !error && flowHelperV2.deleteFlow(flow.flowId)
+        Wrappers.silent {
+            flowHelperV2.deleteFlow(flow.flowId)
+        }
     }
 
     @Ignore ("https://github.com/telstra/open-kilda/issues/5141")

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowLoopSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowLoopSpec.groovy
@@ -659,7 +659,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
         getFlowLoopRules(switchPair.dst.dpId).empty
 
         when: "Delete the flow with created flowLoop"
-        northboundV2.deleteFlow(flow.flowId)
+        flowHelperV2.deleteFlow(flow.flowId)
         def flowIsDeleted = true
 
         then: "FlowLoop rules are deleted"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowCreateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowCreateSpec.groovy
@@ -395,6 +395,11 @@ source: switchId="${flow.sharedEndpoint.switchId}" port=${flow.sharedEndpoint.po
 
         cleanup:
         yFlowResponse && !exc && yFlowHelper.deleteYFlow(yFlowResponse.YFlowId)
+        Wrappers.wait(WAIT_OFFSET) {
+            /*Sometimes test is too fast, so one of subflows stays in 'In Progress' at this stage.
+            Let's wait for it to be removed */
+            northboundV2.getAllFlows().find {it.getStatus() == FlowState.IN_PROGRESS.toString()} == null
+        }
     }
 
     @Tidy

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/multitable/MultitableFlowsSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/multitable/MultitableFlowsSpec.groovy
@@ -1,5 +1,6 @@
 package org.openkilda.functionaltests.spec.multitable
 
+import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.functionaltests.helpers.model.SwitchPair
 import org.openkilda.northbound.dto.v2.flows.FlowRequestV2
 
@@ -1523,9 +1524,11 @@ class MultitableFlowsSpec extends HealthCheckSpecification {
     //TODO: move to wrapper class SwitchList.getGarbageRules() (from test package, not product itself)
     Boolean 'every switch has only expected rules?'(List<Switch> switchesToValidate) {
         return withPool {
-            switchesToValidate.collectParallel {Switch sw -> northboundV2.validateSwitch(sw.dpId).asExpected}.collect()
-        }.every()
-
+            wait(RULES_INSTALLATION_TIME) {
+                assert switchesToValidate.collectParallel { northboundV2.validateSwitch(it.dpId) }
+                        .findAll { !it.asExpected }.isEmpty()
+            }
+        }
     }
 
     //TODO: move to Flow.isPingable() (from test package, not product itself)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/YFlowStatSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/YFlowStatSpec.groovy
@@ -45,7 +45,7 @@ class YFlowStatSpec extends HealthCheckSpecification {
             it.ep1 != it.ep2 && it.ep1 != it.shared && it.ep2 != it.shared &&
                     [it.shared, it.ep1, it.ep2].every { it.traffGens }
         } ?: assumeTrue(false, "No suiting switches found")
-        def yFlow = yFlowHelper.addYFlow(yFlowHelper.randomYFlow(switchTriplet))
+        yFlow = yFlowHelper.addYFlow(yFlowHelper.randomYFlow(switchTriplet))
         def beforeTraffic = new Date()
         def traffExam = traffExamProvider.get()
         def exam = new FlowTrafficExamBuilder(topology, traffExam)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesFlowsV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesFlowsV2Spec.groovy
@@ -146,7 +146,7 @@ class SwitchesFlowsV2Spec extends HealthCheckSpecification {
         switchHelper.getFlowsV2(switchUnderTest, [freePort]).getFlowsByPort().isEmpty()
 
         cleanup:
-        Wrappers.silent(northboundV2.deleteMirrorPoint(flowId, mirrorEndpoint.getMirrorPointId()))
+        Wrappers.silent {northboundV2.deleteMirrorPoint(flowId, mirrorEndpoint.getMirrorPointId())}
     }
 
     @Tidy
@@ -175,6 +175,9 @@ class SwitchesFlowsV2Spec extends HealthCheckSpecification {
         then: "Ports used by subflows on the switch are in response"
         flows.flowsByPort.collectMany { it.value }*.flowId
                 .containsAll(yFlow.subFlows*.flowId)
+
+        cleanup:
+        yFlow && yFlowHelper.deleteYFlow(yFlow.getYFlowId())
     }
 
     def cleanupSpec() {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/ChaosSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/ChaosSpec.groovy
@@ -1,4 +1,4 @@
-package org.openkilda.functionaltests.spec.resilience
+package org.openkilda.functionaltests.spec.xresilience
 
 import static org.openkilda.model.MeterId.MAX_SYSTEM_RULE_METER_ID
 import static org.openkilda.testing.Constants.PATH_INSTALLATION_TIME
@@ -16,7 +16,6 @@ import org.openkilda.northbound.dto.v2.flows.FlowRequestV2
 
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Value
-import spock.lang.Ignore
 import spock.lang.Narrative
 
 import java.util.concurrent.TimeUnit
@@ -68,7 +67,7 @@ class ChaosSpec extends HealthCheckSpecification {
             }
         }
 
-        and: "Cleanup: remove flows and reset costs"
+        cleanup:
         flows.each { northboundV2.deleteFlow(it.flowId) }
         // Wait for meters deletion from all OF_13 switches since it impacts other tests.
         Wrappers.wait(WAIT_OFFSET * 2 + flowsAmount * RULES_DELETION_TIME) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/ContentionSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/ContentionSpec.groovy
@@ -1,4 +1,4 @@
-package org.openkilda.functionaltests.spec.resilience
+package org.openkilda.functionaltests.spec.xresilience
 
 import static groovyx.gpars.GParsPool.withPool
 import static org.openkilda.testing.Constants.WAIT_OFFSET

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/FloodlightKafkaConnectionSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/FloodlightKafkaConnectionSpec.groovy
@@ -1,4 +1,4 @@
-package org.openkilda.functionaltests.spec.resilience
+package org.openkilda.functionaltests.spec.xresilience
 
 import static groovyx.gpars.dataflow.Dataflow.task
 import static org.junit.jupiter.api.Assumptions.assumeTrue

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/RetriesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/RetriesSpec.groovy
@@ -1,4 +1,4 @@
-package org.openkilda.functionaltests.spec.resilience
+package org.openkilda.functionaltests.spec.xresilience
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.LOCKKEEPER

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/StormHeavyLoadSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/StormHeavyLoadSpec.groovy
@@ -1,4 +1,4 @@
-package org.openkilda.functionaltests.spec.resilience
+package org.openkilda.functionaltests.spec.xresilience
 
 import static groovyx.gpars.GParsPool.withPool
 import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/StormLcmSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/StormLcmSpec.groovy
@@ -1,4 +1,6 @@
-package org.openkilda.functionaltests.spec.resilience
+package org.openkilda.functionaltests.spec.xresilience
+
+import org.openkilda.model.IslStatus
 
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
@@ -138,9 +140,8 @@ class StormLcmSpec extends HealthCheckSpecification {
         srcBlockData && lockKeeper.reviveSwitch(islUnderTest.srcSwitch, srcBlockData)
         dstBlockData && lockKeeper.reviveSwitch(islUnderTest.dstSwitch, dstBlockData)
         Wrappers.wait(WAIT_OFFSET + discoveryInterval) {
-            def allIsls = northbound.getAllLinks()
-            assert islUtils.getIslInfo(allIsls, islUnderTest).get().state == IslChangeType.DISCOVERED
-            assert islUtils.getIslInfo(allIsls, islUnderTest.reversed).get().state == IslChangeType.DISCOVERED
+            assert database.getIsls(topology.getIsls()).every {it.status == IslStatus.ACTIVE}
+            assert northbound.getAllLinks().every {it.state == IslChangeType.DISCOVERED}
         }
     }
 }


### PR DESCRIPTION
* Fixed several logical/syntax mistakes in tests which caused overall environment instability
* Moved 'resilience' test package to the end of test execution to minimize possible env damage.