### PR TITLE
fix logstash container build

### DIFF
--- a/docker/logstash/Dockerfile
+++ b/docker/logstash/Dockerfile
@@ -5,6 +5,7 @@ COPY . /
 
 RUN \
     export DEBIAN_FRONTEND=noninteractive && \
+    echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list && \
     apt -y update && \
     apt -y install net-tools telnet netcat && \
     rm -rfv /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Debian stretch repos have been archieved so the repo list should be updated to be used with the apt tool.

This commit adds a line in the Dockerfile that overwrites the existent apt repo.

Closes #5177