### PR TITLE
Fix HA-flow validation for protected path

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowCreateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowCreateSpec.groovy
@@ -46,11 +46,14 @@ class HaFlowCreateSpec extends HealthCheckSpecification {
         def haFlow = northboundV2.addHaFlow(haFlowRequest)
         def involvedSwitchIds = haFlowHelper.getInvolvedSwitches(haFlow.haFlowId)
 
-        then: "Y-flow is created and has UP status"
+        then: "HA-flow is created and has UP status"
         Wrappers.wait(FLOW_CRUD_TIMEOUT) {
             haFlow = northboundV2.getHaFlow(haFlow.haFlowId)
             assert haFlow && haFlow.status == FlowState.UP.toString()
         }
+
+        and: "HA-flow pass validation"
+        northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
 
         when: "Delete the ha-flow"
         northboundV2.deleteHaFlow(haFlow.haFlowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowProtectedSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowProtectedSpec.groovy
@@ -81,6 +81,9 @@ class HaFlowProtectedSpec extends HealthCheckSpecification {
             }
         }
 
+        and: "HA-flow pass validation"
+        northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
+
         cleanup:
         haFlow && haFlowHelper.deleteHaFlow(haFlow.haFlowId)
     }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowUpdateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowUpdateSpec.groovy
@@ -44,7 +44,6 @@ class HaFlowUpdateSpec extends HealthCheckSpecification {
         when: "Update the ha-flow"
         def updateResponse = haFlowHelper.updateHaFlow(haFlow.haFlowId, update)
         def ignores = ["subFlows.timeUpdate", "subFlows.status", "timeUpdate", "status"]
-        ignores.addAll(data.additionalIgnores)
 
         then: "Requested updates are reflected in the response and in 'get' API"
         expect updateResponse, sameBeanAs(haFlow, ignores)
@@ -56,6 +55,9 @@ class HaFlowUpdateSpec extends HealthCheckSpecification {
                 assert northboundV2.validateSwitch(switchId).isAsExpected()
             }
         }
+
+        and: "HA-flow pass validation"
+        northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
 
         cleanup:
         haFlow && haFlowHelper.deleteHaFlow(haFlow.haFlowId)
@@ -72,8 +74,7 @@ class HaFlowUpdateSpec extends HealthCheckSpecification {
                                         it.endpoint.switchId)) - it.endpoint.portNumber
                                 it.endpoint.portNumber = allowedPorts[0]
                             }
-                        },
-                        additionalIgnores: []
+                        }
                 ],
                 [
                         descr: "shared switch and subflow switches",
@@ -93,13 +94,11 @@ class HaFlowUpdateSpec extends HealthCheckSpecification {
                                     .getAllowedPortsForSwitch(topology.find(newSwT.ep1.dpId))[-1]
                             payload.subFlows[1].endpoint.portNumber = topology
                                     .getAllowedPortsForSwitch(topology.find(newSwT.ep2.dpId))[-1]
-                        },
-                        additionalIgnores: ["yPoint"]
+                        }
                 ],
                 [
                         descr: "[without any changes in update request]",
                         updateClosure: { },
-                        additionalIgnores: []
                 ]
         ]
     }
@@ -132,6 +131,9 @@ class HaFlowUpdateSpec extends HealthCheckSpecification {
             }
         }
 
+        and: "HA-flow pass validation"
+        northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
+
         cleanup:
         haFlow && haFlowHelper.deleteHaFlow(haFlow.haFlowId)
     }
@@ -159,6 +161,9 @@ class HaFlowUpdateSpec extends HealthCheckSpecification {
                 assert northboundV2.validateSwitch(switchId).isAsExpected()
             }
         }
+
+        and: "HA-flow pass validation"
+        northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
 
         cleanup:
         haFlow && haFlowHelper.deleteHaFlow(haFlow.haFlowId)
@@ -290,6 +295,9 @@ class HaFlowUpdateSpec extends HealthCheckSpecification {
             }
         }
 
+        and: "HA-flow pass validation"
+        northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
+
         cleanup:
         haFlow && haFlowHelper.deleteHaFlow(haFlow.haFlowId)
 
@@ -359,6 +367,9 @@ class HaFlowUpdateSpec extends HealthCheckSpecification {
                 assert northboundV2.validateSwitch(switchId).isAsExpected()
             }
         }
+
+        and: "HA-flow pass validation"
+        northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
 
         cleanup:
         haFlow && haFlowHelper.deleteHaFlow(haFlow.haFlowId)

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundServiceV2.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundServiceV2.java
@@ -34,6 +34,7 @@ import org.openkilda.northbound.dto.v2.haflows.HaFlowCreatePayload;
 import org.openkilda.northbound.dto.v2.haflows.HaFlowPatchPayload;
 import org.openkilda.northbound.dto.v2.haflows.HaFlowPaths;
 import org.openkilda.northbound.dto.v2.haflows.HaFlowUpdatePayload;
+import org.openkilda.northbound.dto.v2.haflows.HaFlowValidationResult;
 import org.openkilda.northbound.dto.v2.links.BfdProperties;
 import org.openkilda.northbound.dto.v2.links.BfdPropertiesPayload;
 import org.openkilda.northbound.dto.v2.switches.LagPortRequest;
@@ -197,6 +198,8 @@ public interface NorthboundServiceV2 {
     HaFlow partialUpdateHaFlow(String haFlowId, HaFlowPatchPayload request);
 
     HaFlow deleteHaFlow(String haFlowId);
+
+    HaFlowValidationResult validateHaFlow(String haFlowId);
 
     HaFlowPaths getHaFlowPaths(String haFlowId);
 }

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundServiceV2Impl.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundServiceV2Impl.java
@@ -38,6 +38,7 @@ import org.openkilda.northbound.dto.v2.haflows.HaFlowDump;
 import org.openkilda.northbound.dto.v2.haflows.HaFlowPatchPayload;
 import org.openkilda.northbound.dto.v2.haflows.HaFlowPaths;
 import org.openkilda.northbound.dto.v2.haflows.HaFlowUpdatePayload;
+import org.openkilda.northbound.dto.v2.haflows.HaFlowValidationResult;
 import org.openkilda.northbound.dto.v2.haflows.HaSubFlow;
 import org.openkilda.northbound.dto.v2.links.BfdProperties;
 import org.openkilda.northbound.dto.v2.links.BfdPropertiesPayload;
@@ -602,5 +603,15 @@ public class NorthboundServiceV2Impl implements NorthboundServiceV2 {
     public HaFlowPaths getHaFlowPaths(String haFlowId) {
         return restTemplate.exchange("/api/v2/ha-flows/{ha_flow_id}/paths", HttpMethod.GET,
                 new HttpEntity(buildHeadersWithCorrelationId()), HaFlowPaths.class, haFlowId).getBody();
+    }
+
+    @Override
+    public HaFlowValidationResult validateHaFlow(String haFlowId) {
+        return restTemplate.exchange("/api/v2/ha-flows/{ha_flow_id}/validate",
+                        HttpMethod.POST,
+                        new HttpEntity<>(buildHeadersWithCorrelationId()),
+                        HaFlowValidationResult.class,
+                        haFlowId)
+                .getBody();
     }
 }


### PR DESCRIPTION
HA-flow validation doesn't work if primary and protected Y-point is equal.

Closes #5197