### PR TITLE
feat(ha-flow-ping): add ha flow periodic pings

### DIFF
--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/Ping.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/Ping.java
@@ -70,8 +70,7 @@ public class Ping implements Serializable {
 
     public Ping(NetworkEndpoint source, NetworkEndpoint dest,
                 FlowTransitEncapsulation transitEncapsulation, int islPort) {
-
-        this(generatePingId(source, dest, transitEncapsulation, islPort), source, dest, transitEncapsulation, islPort);
+        this(UUID.randomUUID(), source, dest, transitEncapsulation, islPort);
     }
 
     @Override
@@ -87,12 +86,4 @@ public class Ping implements Serializable {
         return String.format("%s-%d", swId, portNumber);
     }
 
-    /**
-     * Generate ping id based on source, dest, transit encapsulation and isl port.
-     */
-    private static UUID generatePingId(NetworkEndpoint source, NetworkEndpoint dest,
-                                      FlowTransitEncapsulation transitEncapsulation, int islPort) {
-        return UUID.nameUUIDFromBytes(
-                String.format("%s-%s-%s-%d", source, dest, transitEncapsulation, islPort).getBytes());
-    }
 }

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/AbstractBolt.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/AbstractBolt.java
@@ -316,6 +316,15 @@ public abstract class AbstractBolt extends BaseRichBolt {
         return value;
     }
 
+    protected <T> boolean hasValue(Tuple input, String field, Class<T> klass) {
+        try {
+            klass.cast(input.getValueByField(field));
+        } catch (ClassCastException e) {
+            return false;
+        }
+        return true;
+    }
+
     private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
         stream.defaultReadObject();
 

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/topology/TestKafkaConsumer.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/topology/TestKafkaConsumer.java
@@ -112,11 +112,23 @@ public class TestKafkaConsumer extends Thread {
      * @return list of messages
      */
     public <T> List<T> assertNAndPoll(final int expectedCount, Class<T> clazz) {
+        return assertNAndPoll(expectedCount, kafkaMessagePollTimeout, clazz);
+    }
+
+    /**
+     * Polls messages from Kafka until expectedCount is reached.
+     *
+     * @param expectedCount expected count of messages
+     * @param pollTimeout timeout for poll
+     * @param clazz class of messages
+     * @return list of messages
+     */
+    public <T> List<T> assertNAndPoll(final int expectedCount, final long pollTimeout, Class<T> clazz) {
         List<T> messages = new ArrayList<>();
         ConsumerRecord<String, String> record = null;
         for (int i = 0; i < expectedCount; i++) {
             try {
-                record = pollMessage();
+                record = pollMessage(pollTimeout);
                 if (record == null) {
                     throw new AssertionError(format("Could not get %d records. %d records gotten",
                             expectedCount, messages.size()));

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowCreateHubBolt.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowCreateHubBolt.java
@@ -31,6 +31,7 @@ import org.openkilda.floodlight.api.response.rulemanager.SpeakerCommandResponse;
 import org.openkilda.messaging.Message;
 import org.openkilda.messaging.command.CommandData;
 import org.openkilda.messaging.command.CommandMessage;
+import org.openkilda.messaging.command.flow.PeriodicHaPingCommand;
 import org.openkilda.messaging.command.haflow.HaFlowRequest;
 import org.openkilda.messaging.info.InfoMessage;
 import org.openkilda.messaging.info.stats.RemoveFlowPathInfo;
@@ -186,9 +187,11 @@ public class HaFlowCreateHubBolt extends HubBolt implements FlowGenericCarrier {
 
     @Override
     public void sendPeriodicPingNotification(String haFlowId, boolean enabled) {
-        //TODO implement periodic pings https://github.com/telstra/open-kilda/issues/5153
-        log.info("Periodic pings are not implemented for ha-flow create operation yet. Skipping for the ha-flow {}",
-                haFlowId);
+        log.debug("Periodic ping ha-flow create operation. haFlowId={}", haFlowId);
+        PeriodicHaPingCommand payload = new PeriodicHaPingCommand(haFlowId, enabled);
+        Message message = new CommandMessage(payload, getCommandContext().getCreateTime(),
+                getCommandContext().getCorrelationId());
+        emitWithContext(Stream.HUB_TO_PING_SENDER.name(), getCurrentTuple(), new Values(currentKey, message));
     }
 
     @Override

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowDeleteHubBolt.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowDeleteHubBolt.java
@@ -31,6 +31,7 @@ import org.openkilda.floodlight.api.response.rulemanager.SpeakerCommandResponse;
 import org.openkilda.messaging.Message;
 import org.openkilda.messaging.command.CommandData;
 import org.openkilda.messaging.command.CommandMessage;
+import org.openkilda.messaging.command.flow.PeriodicHaPingCommand;
 import org.openkilda.messaging.command.haflow.HaFlowDeleteRequest;
 import org.openkilda.messaging.info.InfoMessage;
 import org.openkilda.messaging.info.stats.RemoveFlowPathInfo;
@@ -174,9 +175,11 @@ public class HaFlowDeleteHubBolt extends HubBolt implements FlowGenericCarrier {
 
     @Override
     public void sendPeriodicPingNotification(String haFlowId, boolean enabled) {
-        //TODO implement periodic pings https://github.com/telstra/open-kilda/issues/5153
-        log.info("Periodic pings are not implemented for ha-flow delete operation yet. Skipping for the ha-flow {}",
-                haFlowId);
+        log.debug("Periodic ping ha-flow delete operation. haFlowId={}", haFlowId);
+        PeriodicHaPingCommand payload = new PeriodicHaPingCommand(haFlowId, enabled);
+        Message message = new CommandMessage(payload, getCommandContext().getCreateTime(),
+                getCommandContext().getCorrelationId());
+        emitWithContext(Stream.HUB_TO_PING_SENDER.name(), getCurrentTuple(), new Values(currentKey, message));
     }
 
     @Override

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowPathSwapHubBolt.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowPathSwapHubBolt.java
@@ -30,6 +30,7 @@ import org.openkilda.floodlight.api.response.rulemanager.SpeakerCommandResponse;
 import org.openkilda.messaging.Message;
 import org.openkilda.messaging.command.CommandData;
 import org.openkilda.messaging.command.CommandMessage;
+import org.openkilda.messaging.command.flow.PeriodicHaPingCommand;
 import org.openkilda.messaging.command.haflow.HaFlowPathSwapRequest;
 import org.openkilda.messaging.info.InfoMessage;
 import org.openkilda.persistence.PersistenceManager;
@@ -132,9 +133,11 @@ public class HaFlowPathSwapHubBolt extends HubBolt implements FlowPathSwapHubCar
 
     @Override
     public void sendPeriodicPingNotification(String haFlowId, boolean enabled) {
-        //TODO implement periodic pings https://github.com/telstra/open-kilda/issues/5153
-        log.info("Periodic pings are not implemented for ha-flow swap path operation yet. Skipping for the ha-flow {}",
-                haFlowId);
+        log.debug("Periodic ping ha-flow path swap operation. haFlowId={}", haFlowId);
+        PeriodicHaPingCommand payload = new PeriodicHaPingCommand(haFlowId, enabled);
+        Message message = new CommandMessage(payload, getCommandContext().getCreateTime(),
+                getCommandContext().getCorrelationId());
+        emitWithContext(Stream.HUB_TO_PING_SENDER.name(), getCurrentTuple(), new Values(currentKey, message));
     }
 
     @Override

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowRerouteHubBolt.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowRerouteHubBolt.java
@@ -32,6 +32,7 @@ import org.openkilda.floodlight.api.response.rulemanager.SpeakerCommandResponse;
 import org.openkilda.messaging.Message;
 import org.openkilda.messaging.command.CommandData;
 import org.openkilda.messaging.command.CommandMessage;
+import org.openkilda.messaging.command.flow.PeriodicHaPingCommand;
 import org.openkilda.messaging.command.haflow.HaFlowRerouteRequest;
 import org.openkilda.messaging.info.InfoMessage;
 import org.openkilda.messaging.info.reroute.FlowType;
@@ -188,9 +189,11 @@ public class HaFlowRerouteHubBolt extends HubBolt implements FlowRerouteHubCarri
 
     @Override
     public void sendPeriodicPingNotification(String haFlowId, boolean enabled) {
-        //TODO implement periodic pings https://github.com/telstra/open-kilda/issues/5153
-        log.info("Periodic pings are not implemented for ha-flow update operation yet. Skipping for the ha-flow {}",
-                haFlowId);
+        log.debug("Periodic ping ha-flow reroute operation. haFlowId={}", haFlowId);
+        PeriodicHaPingCommand payload = new PeriodicHaPingCommand(haFlowId, enabled);
+        Message message = new CommandMessage(payload, getCommandContext().getCreateTime(),
+                getCommandContext().getCorrelationId());
+        emitWithContext(Stream.HUB_TO_PING_SENDER.name(), getCurrentTuple(), new Values(currentKey, message));
     }
 
     @Override

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowUpdateHubBolt.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/HaFlowUpdateHubBolt.java
@@ -31,6 +31,7 @@ import org.openkilda.floodlight.api.response.rulemanager.SpeakerCommandResponse;
 import org.openkilda.messaging.Message;
 import org.openkilda.messaging.command.CommandData;
 import org.openkilda.messaging.command.CommandMessage;
+import org.openkilda.messaging.command.flow.PeriodicHaPingCommand;
 import org.openkilda.messaging.command.haflow.HaFlowPartialUpdateRequest;
 import org.openkilda.messaging.command.haflow.HaFlowRequest;
 import org.openkilda.messaging.error.ErrorData;
@@ -208,9 +209,11 @@ public class HaFlowUpdateHubBolt extends HubBolt implements FlowGenericCarrier {
 
     @Override
     public void sendPeriodicPingNotification(String haFlowId, boolean enabled) {
-        //TODO implement periodic pings https://github.com/telstra/open-kilda/issues/5153
-        log.info("Periodic pings are not implemented for ha-flow update operation yet. Skipping for the ha-flow {}",
-                haFlowId);
+        log.debug("Periodic ping ha-flow update operation. haFlowId={}", haFlowId);
+        PeriodicHaPingCommand payload = new PeriodicHaPingCommand(haFlowId, enabled);
+        Message message = new CommandMessage(payload, getCommandContext().getCreateTime(),
+                getCommandContext().getCorrelationId());
+        emitWithContext(Stream.HUB_TO_PING_SENDER.name(), getCurrentTuple(), new Values(currentKey, message));
     }
 
     @Override

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/create/actions/OnFinishedAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/create/actions/OnFinishedAction.java
@@ -15,6 +15,7 @@
 
 package org.openkilda.wfm.topology.flowhs.fsm.haflow.create.actions;
 
+import org.openkilda.messaging.command.haflow.HaFlowRequest;
 import org.openkilda.wfm.share.logger.FlowOperationsDashboardLogger;
 import org.openkilda.wfm.topology.flowhs.fsm.common.actions.HistoryRecordingAction;
 import org.openkilda.wfm.topology.flowhs.fsm.haflow.create.HaFlowCreateContext;
@@ -34,9 +35,15 @@ public class OnFinishedAction extends HistoryRecordingAction<HaFlowCreateFsm, St
 
     @Override
     public void perform(State from, State to, Event event, HaFlowCreateContext context, HaFlowCreateFsm stateMachine) {
-        //TODO periodic pings
         //TODO activate server42 monitoring
+        sendPeriodicPingNotification(stateMachine);
         dashboardLogger.onSuccessfulHaFlowCreate(stateMachine.getHaFlowId());
         stateMachine.saveActionToHistory("HA-flow was created successfully");
+    }
+
+    private void sendPeriodicPingNotification(HaFlowCreateFsm stateMachine) {
+        HaFlowRequest requestedFlow = stateMachine.getTargetFlow();
+        stateMachine.getCarrier().sendPeriodicPingNotification(
+                requestedFlow.getHaFlowId(), requestedFlow.isPeriodicPings());
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/OnFinishedAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/OnFinishedAction.java
@@ -34,9 +34,10 @@ public class OnFinishedAction extends HistoryRecordingAction<HaFlowDeleteFsm, St
 
     @Override
     public void perform(State from, State to, Event event, HaFlowDeleteContext context, HaFlowDeleteFsm stateMachine) {
-        //TODO periodic pings
         //TODO deactivate flow monitoring
+        stateMachine.getCarrier().sendPeriodicPingNotification(stateMachine.getHaFlowId(), false);
         dashboardLogger.onSuccessfulHaFlowDelete(stateMachine.getHaFlowId());
         stateMachine.saveActionToHistory("Flow was deleted successfully");
     }
+
 }

--- a/src-java/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/HaFlowRepository.java
+++ b/src-java/kilda-persistence-api/src/main/java/org/openkilda/persistence/repositories/HaFlowRepository.java
@@ -33,6 +33,8 @@ public interface HaFlowRepository extends Repository<HaFlow> {
 
     Collection<HaFlow> findByEndpoint(SwitchId switchId, int port, int vlan, int innerVLan);
 
+    Collection<HaFlow> findWithPeriodicPingsEnabled();
+
     Collection<String> findHaFlowIdsByDiverseGroupId(String diverseGroupId);
 
     Collection<String> findHaFlowIdsByAffinityGroupId(String affinityGroupId);

--- a/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaHaFlowRepository.java
+++ b/src-java/kilda-persistence-tinkerpop/src/main/java/org/openkilda/persistence/ferma/repositories/FermaHaFlowRepository.java
@@ -84,6 +84,16 @@ public class FermaHaFlowRepository extends FermaGenericRepository<HaFlow, HaFlow
     }
 
     @Override
+    public Collection<HaFlow> findWithPeriodicPingsEnabled() {
+        return framedGraph().traverse(g -> g.V()
+                        .hasLabel(HaFlowFrame.FRAME_LABEL)
+                        .has(HaFlowFrame.PERIODIC_PINGS_PROPERTY, true))
+                .toListExplicit(HaFlowFrame.class).stream()
+                .map(HaFlow::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
     public Optional<HaFlow> findById(String haFlowId) {
         return HaFlowFrame.load(framedGraph(), haFlowId).map(HaFlow::new);
     }

--- a/src-java/ping-topology/ping-storm-topology/src/main/java/org/openkilda/wfm/topology/ping/PingTopology.java
+++ b/src-java/ping-topology/ping-storm-topology/src/main/java/org/openkilda/wfm/topology/ping/PingTopology.java
@@ -180,8 +180,7 @@ public class PingTopology extends AbstractTopology<PingTopologyConfig> {
                 .shuffleGrouping(PingProducer.BOLT_ID)
                 .shuffleGrouping(Blacklist.BOLT_ID)
                 .shuffleGrouping(InputRouter.BOLT_ID, InputRouter.STREAM_SPEAKER_PING_RESPONSE_ID)
-                .shuffleGrouping(
-                        PeriodicResultManager.BOLT_ID, PeriodicResultManager.STREAM_BLACKLIST_ID);
+                .shuffleGrouping(PeriodicResultManager.BOLT_ID, PeriodicResultManager.STREAM_BLACKLIST_ID);
     }
 
     private void blacklist(TopologyBuilder topology) {

--- a/src-java/ping-topology/ping-storm-topology/src/main/java/org/openkilda/wfm/topology/ping/bolt/InputRouter.java
+++ b/src-java/ping-topology/ping-storm-topology/src/main/java/org/openkilda/wfm/topology/ping/bolt/InputRouter.java
@@ -22,6 +22,7 @@ import org.openkilda.messaging.command.CommandData;
 import org.openkilda.messaging.command.CommandMessage;
 import org.openkilda.messaging.command.flow.FlowPingRequest;
 import org.openkilda.messaging.command.flow.HaFlowPingRequest;
+import org.openkilda.messaging.command.flow.PeriodicHaPingCommand;
 import org.openkilda.messaging.command.flow.PeriodicPingCommand;
 import org.openkilda.messaging.command.flow.YFlowPingRequest;
 import org.openkilda.messaging.floodlight.response.PingResponse;
@@ -94,7 +95,7 @@ public class InputRouter extends Abstract {
             emit(input, new Values(data), STREAM_ON_DEMAND_Y_FLOW_REQUEST_ID);
         } else if (data instanceof HaFlowPingRequest) {
             emit(input, new Values(data), STREAM_ON_DEMAND_HA_FLOW_REQUEST_ID);
-        } else if (data instanceof PeriodicPingCommand) {
+        } else if (data instanceof PeriodicPingCommand || data instanceof PeriodicHaPingCommand) {
             emit(input, new Values(data), STREAM_PERIODIC_PING_UPDATE_REQUEST_ID);
         } else {
             unhandledInput(input);

--- a/src-java/ping-topology/ping-storm-topology/src/main/java/org/openkilda/wfm/topology/ping/bolt/StatsProducer.java
+++ b/src-java/ping-topology/ping-storm-topology/src/main/java/org/openkilda/wfm/topology/ping/bolt/StatsProducer.java
@@ -52,11 +52,15 @@ public class StatsProducer extends Abstract {
         PingContext pingContext = pullPingContext(input);
 
         HashMap<String, String> tags = new HashMap<>();
-        tags.put("flowid", pingContext.getFlowId());
-        if (pingContext.getYFlowId() != null) {
-            tags.put("y_flow_id", pingContext.getYFlowId());
+        if (pingContext.isHaFlow()) {
+            tags.put("ha_flow_id", pingContext.getHaFlowId());
+            tags.put("flowid", pingContext.getHaSubFlowId());
+        } else {
+            tags.put("flowid", pingContext.getFlowId());
+            if (pingContext.getYFlowId() != null) {
+                tags.put("y_flow_id", pingContext.getYFlowId());
+            }
         }
-
         produceMetersStats(input, tags, pingContext);
     }
 

--- a/src-java/ping-topology/ping-storm-topology/src/main/java/org/openkilda/wfm/topology/ping/model/Expirable.java
+++ b/src-java/ping-topology/ping-storm-topology/src/main/java/org/openkilda/wfm/topology/ping/model/Expirable.java
@@ -16,8 +16,10 @@
 package org.openkilda.wfm.topology.ping.model;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode
 public abstract class Expirable<K> {
     private boolean active = true;
     private final long expireAt;

--- a/src-java/ping-topology/ping-storm-topology/src/main/java/org/openkilda/wfm/topology/ping/model/PingContext.java
+++ b/src-java/ping-topology/ping-storm-topology/src/main/java/org/openkilda/wfm/topology/ping/model/PingContext.java
@@ -112,6 +112,13 @@ public class PingContext implements Serializable {
      * <p>It use direction value to determine which(forward, reverse, of flagless) cookie should be returned.
      */
     public long getCookie() {
+        if (isHaFlow()) {
+            return getHaFlowCookie();
+        }
+        return getFlowCookie();
+    }
+
+    private long getFlowCookie() {
         long value;
         if (direction == null) {
             value = flow.getForwardPath().getCookie().getFlowEffectiveId();
@@ -126,12 +133,28 @@ public class PingContext implements Serializable {
         return value;
     }
 
+    private long getHaFlowCookie() {
+        long value;
+        if (direction == null) {
+            value = haFlow.getForwardPath().getCookie().getFlowEffectiveId();
+        } else if (direction == FlowDirection.FORWARD) {
+            value = haFlow.getForwardPath().getCookie().getValue();
+        } else if (direction == FlowDirection.REVERSE) {
+            value = haFlow.getReversePath().getCookie().getValue();
+        } else {
+            throw new IllegalArgumentException(String.format(
+                    "Unsupported %s.%s value", FlowDirection.class.getName(), direction));
+        }
+        return value;
+    }
+
+
     public String getHaFlowId() {
         return haFlowId != null ? haFlowId : haFlow.getHaFlowId();
     }
 
     public boolean isHaFlow() {
-        return haFlow != null && kind.equals(Kinds.ON_DEMAND_HA_FLOW);
+        return haFlow != null;
     }
 
     @Override


### PR DESCRIPTION
This commit introduces the HA Flow periodic ping feature, enabling
the ability to periodically check HA flows that are flagged with
'periodic_pings' set to true. This functionality operates similarly
to the current periodic ping for Flows and Y-Flows.

The ping results are stored in a time-series database, with the
default metric being "kilda.flow.latency" and tagged with the
corresponding "ha_flow_id".

Part of #5153