### PR TITLE
[TEST] Add initial mechanism to unify work with paths

### DIFF
--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/model/Path.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/model/Path.groovy
@@ -1,0 +1,45 @@
+package org.openkilda.functionaltests.helpers.model
+
+import groovy.transform.EqualsAndHashCode
+import org.openkilda.testing.model.topology.TopologyDefinition.Isl
+import org.openkilda.northbound.dto.v2.flows.FlowPathV2
+import org.openkilda.testing.model.topology.TopologyDefinition
+
+/* This class represent any kind of flow path and is intended to help compare/manipulate paths
+(presented as lists of nodes), received from different endpoints in the same manner.
+To add the new way to represent the path, just add the one into PathFactory.get() method
+Usage example:
+def nodesFromRerouteResponse = haFlowHelper.reroute(haFlowId).getSharedPath().getNodes()
+def nodesFromPathsResponse = haPathHelper.get(haFlowId).getSharedPath().getForward()
+assert pathFactory.get(nodesFromRerouteResponse) == pathFactory.get(nodesFromPathsResponse)
+
+This class has to replace *PathHelper in future
+ */
+@EqualsAndHashCode(excludes = "topologyDefinition")
+class Path {
+    List<FlowPathV2.PathNodeV2> nodes
+    TopologyDefinition topologyDefinition
+
+    Path(List<FlowPathV2.PathNodeV2> nodes, TopologyDefinition topologyDefinition) {
+        if (nodes.size() % 2 != 0) {
+            throw new IllegalArgumentException("Path should have even amount of nodes")
+        }
+        this.nodes = nodes
+        this.topologyDefinition = topologyDefinition
+    }
+
+    List<Isl> getInvolvedIsls() {
+        def isls = topologyDefinition.getIsls() + topologyDefinition.getIsls().collect { it.reversed }
+        nodes.collate(2).collect { List<FlowPathV2.PathNodeV2> pathNodes ->
+            isls.find {
+                it.srcSwitch.dpId == pathNodes[0].switchId &&
+                        it.srcPort == pathNodes[0].portNo &&
+                        it.dstSwitch.dpId == pathNodes[1].switchId &&
+                        it.dstPort == pathNodes[1].portNo
+            }
+        }
+        /* TODO: add 'heavy' method to convert path to ISLs, which takes ISLs from Database, not from topology
+        Such a method would be able to return ISLs which are not originated from topology, but were added in
+        test runtime (e.g. by 're-plugging cable') */
+    }
+}

--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/model/PathFactory.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/model/PathFactory.groovy
@@ -1,0 +1,34 @@
+package org.openkilda.functionaltests.helpers.model
+
+import org.openkilda.messaging.info.event.PathNode
+import org.openkilda.messaging.payload.flow.PathNodePayload
+import org.openkilda.northbound.dto.v2.flows.FlowPathV2
+import org.openkilda.testing.model.topology.TopologyDefinition
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+class PathFactory {
+    @Autowired
+    TopologyDefinition topologyDefinition
+
+    Path get(List nodes) {
+        if (nodes.isEmpty()) {
+            return new Path([], topologyDefinition)
+        }
+        if (nodes.get(0) instanceof PathNode || nodes.get(0) instanceof FlowPathV2.PathNodeV2) {
+            return new Path(nodes.collect { new FlowPathV2.PathNodeV2(it.getSwitchId(), it.getPortNo(), 0) }, topologyDefinition)
+        }
+        if (nodes.get(0) instanceof PathNodePayload) {
+            def convertedNodes = nodes.collectMany {
+                [new FlowPathV2.PathNodeV2(it.switchId, it.inputPort ?: 0, 0),
+                 new FlowPathV2.PathNodeV2(it.switchId, it.outputPort ?: 0, 0)]
+            }
+            if (convertedNodes.size() > 2) {
+                convertedNodes = convertedNodes[1..-2]
+            }
+            return new Path(convertedNodes, topologyDefinition)
+        }
+        throw new IllegalArgumentException("Can't create Path object from List of what you provided")
+    }
+}


### PR DESCRIPTION
* Introduced new classes to work with paths (lists of nodes) in the same way over all the tests (not used in tests yet)