### PR TITLE
fix ping rule bug

### DIFF
--- a/docs/design/multi-table-pipelines/cookies.md
+++ b/docs/design/multi-table-pipelines/cookies.md
@@ -45,14 +45,14 @@ _FR_____ ____LMY0 00000000 00000000 00000000 0000IIII IIIIIIII IIIIIIII
 * I - FLOW_EFFECTIVE_ID_FIELD (20 bits): a unique numeric kilda-flow identifier (equal across all paths)
 * R - FLOW_REVERSE_DIRECTION_FLAG (1 bit): if set, OF flow belongs to a reverse (Z-to-A) kilda-flow path
 * F - FLOW_FORWARD_DIRECTION_FLAG (1 bit): if set, OF flow belongs to a forward (A-to-Z) kilda-flow path
-* L - FLOW_LOOP_FLAG (1 bit): if set, this is a OF flow that "makes" a loop on a kilda-flow 
+* L - FLOW_LOOP_FLAG (1 bit): if set, this is a OF flow that "makes" a loop on a kilda-flow
 * M - MIRROR_LOOP_FLAG (1 bit): if set, this is a OF flow that mirrors a kilda-flow
 * Y - Y_FLOW_FLAG (1 bit): if set, this is a OF flow that is used by y-flows to share the same meter
 
 Constraints:
 * SERVICE_FLAG == 0
 * TYPE_FIELD one of {SERVICE_OR_FLOW_SEGMENT(0x000), SERVER_42_FLOW_RTT_INGRESS(0x00C)}
-* FLOW_REVERSE_DIRECTION_FLAG or FLOW_FORWARD_DIRECTION_FLAG must be set, but not both of them 
+* FLOW_REVERSE_DIRECTION_FLAG or FLOW_FORWARD_DIRECTION_FLAG must be set, but not both of them
 
 ## Kilda-flow's shared segment cookies (org.openkilda.model.cookie.FlowSharedSegmentCookie)
 Refers to the OF flows used by several (at least one) kilda-flows.
@@ -64,7 +64,7 @@ _00_____ ____SSSS 00000000 00000000 0000VVVV VVVVVVVV PPPPPPPP PPPPPPPP
 `- 63 bit                                                             `- 0 bit
 ```
 
-* S - SHARED_TYPE_FIELD (4 bits): shared segment type 
+* S - SHARED_TYPE_FIELD (4 bits): shared segment type
 * p - PORT_NUMBER_FIELD (16 bits): a switch port number with the OF flow belongs to this port
 * V - VLAN_ID_FIELD (12 bits): vlanId this OF flow matches
 
@@ -92,14 +92,16 @@ _00_____ ____0000 00000000 00000000 PPPPPPPP PPPPPPPP PPPPPPPP PPPPPPPP
 Constraints:
 * SERVICE_FLAG == 1
 * TYPE_FIELD one of {
-  LLDP_INPUT_CUSTOMER_TYPE(0x001), 
-  MULTI_TABLE_ISL_VLAN_EGRESS_RULES(0x002), 
-  MULTI_TABLE_ISL_VXLAN_EGRESS_RULES(0x003), 
-  MULTI_TABLE_ISL_VXLAN_TRANSIT_RULES(0x004), 
-  MULTI_TABLE_INGRESS_RULES(0x005), 
-  ARP_INPUT_CUSTOMER_TYPE(0x006), 
+  LLDP_INPUT_CUSTOMER_TYPE(0x001),
+  MULTI_TABLE_ISL_VLAN_EGRESS_RULES(0x002),
+  MULTI_TABLE_ISL_VXLAN_EGRESS_RULES(0x003),
+  MULTI_TABLE_ISL_VXLAN_TRANSIT_RULES(0x004),
+  MULTI_TABLE_INGRESS_RULES(0x005),
+  ARP_INPUT_CUSTOMER_TYPE(0x006),
   SERVER_42_FLOW_RTT_INPUT(0x009),
-  SERVER_42_ISL_RTT_INPUT(0x00D)}
+  SERVER_42_ISL_RTT_INPUT(0x00D),
+  LACP_REPLY_INPUT(0x00E),
+  PING_INPUT(0x00F)}
 
 ## Exclusion cookies (org.openkilda.model.cookie.ExclusionCookie)
 Fields:
@@ -110,8 +112,8 @@ _FR_____ ____0000 00000000 00000000 00000000 0000EEEE EEEEEEEE EEEEEEEE
 `- 63 bit                                                             `- 0 bit
 ```
 
-* E - EXCLUSION_ID_FIELD (20 bits): a unique exclusion numeric identifier 
-* R - FLOW_REVERSE_DIRECTION_FLAG (1 bit): refer to a kilda-flow's reverse path (Z-to-A) 
+* E - EXCLUSION_ID_FIELD (20 bits): a unique exclusion numeric identifier
+* R - FLOW_REVERSE_DIRECTION_FLAG (1 bit): refer to a kilda-flow's reverse path (Z-to-A)
 * F - FLOW_FORWARD_DIRECTION_FLAG (1 bit): refer to a kilda-flow's forward path (Z-to-A)
 
 Constraints:
@@ -166,6 +168,7 @@ Constraints:
 | `0x80A0_0000_0000_0000` | `APPLICATION_MIRROR_FLOW`                 | Mirrors traffic for application purposes.                                                                                                                                                                                                                                |
 | `0x80D0_0000_XXXX_XXXX` | `SERVER_42_ISL_RTT_INPUT`                 | Forwards server42 ISL RTT packet to ISL port XXX.                                                                                                                                                                                                                        |
 | `0x80E0_0000_XXXX_XXXX` | `LACP_REPLY_INPUT`                        | Catches LACP request packets from port XXX, sends it to Floodlight for modification, and then return it back to the port.                                                                                                                                                |
+| `0x80F0_0000_XXXX_XXXX` | `INPUT_PING`                              | Copies the functionality of MULTI_TABLE_ISL_VLAN_EGRESS but adding a new match entry (ETH_SRC=ping_magic_mac_address) and sends the packet directly to the transit table.                                                                                                 |
 | `0x4000_0000_000X_XXXX` | `INGRESS_FORWARD`                         | Receives Customer packets, push transit encapsulation if needed, and sends it to the port. Path direction is forward. XXX is a path unmasked cookie.                                                                                                                     |
 | `0x2000_0000_000X_XXXX` | `INGRESS_REVERSE`                         | Receives Customer packets, push transit encapsulation if needed, and sends it to the port. Path direction is reverse. XXX is a path unmasked cookie.                                                                                                                     |
 | `0x4008_0000_000X_XXXX` | `FLOW_LOOP_FORWARD`                       | Makes flow loop for forward direction (sends all customer traffic back to IN_PORT). XXX - path unmasked cookie.                                                                                                                                                          |
@@ -180,3 +183,4 @@ Constraints:
 | `0x20C0_0000_000X_XXXX` | `SERVER_42_FLOW_RTT_INGRESS_REVERSE`      | Receives server42 flow RTT packets from SERVER_42_FLOW_RTT_INPUT, pushes transit encapsulation, and sends them to ISL port. (It's a copy of a regular flow INGRESS_REVERSE rule, but with the matching by server42 input port). XXX is a path unmasked cookie.           |
 | `0x4070_0000_YYYX_XXXX` | `STAT_VLAN_FORWARD`                       | Receives Customer packets with a specific VLAN YYY for full port flow and sends them to the ingress table. The path direction is forward. XXX is a path unmasked cookie. This rule is needed to collect statistics about packet's VLANs which go through full port flow. |
 | `0x2070_0000_YYYX_XXXX` | `STAT_VLAN_REVERSE`                       | Receives Customer packets with a specific VLAN YYY for full port flow and sends them to the ingress table. The path direction id reverse. XXX is a path unmasked cookie. This rule is needed to collect statistics about packet's VLANs which go through full port flow. |
+

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/cookie/Cookie.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/cookie/Cookie.java
@@ -88,8 +88,6 @@ public class Cookie extends CookieBase implements Comparable<Cookie> {
             ServiceCookieTag.SERVER_42_FLOW_RTT_VXLAN_TURNING_COOKIE).getValue();
     public static final long DROP_SLOW_PROTOCOLS_LOOP_COOKIE = new ServiceCookie(
             ServiceCookieTag.DROP_SLOW_PROTOCOLS_LOOP_COOKIE).getValue();
-    public static final long SKIP_EGRESS_FLOW_PING_COOKIE = new ServiceCookie(
-            ServiceCookieTag.SKIP_EGRESS_FLOW_PING_COOKIE).getValue();
 
     @JsonCreator
     public Cookie(long value) {

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/cookie/CookieBase.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/cookie/CookieBase.java
@@ -157,6 +157,7 @@ public abstract class CookieBase implements Serializable {
         SERVER_42_FLOW_RTT_INGRESS(0x00C),
         SERVER_42_ISL_RTT_INPUT(0x00D),
         LACP_REPLY_INPUT(0x00E),
+        PING_INPUT(0x00F),
 
         // This do not consume any value from allowed address space - you can define another field with -1 value.
         // (must be last entry)

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/cookie/PortColourCookie.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/cookie/PortColourCookie.java
@@ -33,7 +33,8 @@ public class PortColourCookie extends CookieBase implements Comparable<PortColou
             CookieType.ARP_INPUT_CUSTOMER_TYPE,
             CookieType.SERVER_42_FLOW_RTT_INPUT,
             CookieType.SERVER_42_ISL_RTT_INPUT,
-            CookieType.LACP_REPLY_INPUT
+            CookieType.LACP_REPLY_INPUT,
+            CookieType.PING_INPUT
     );
 
     // update ALL_FIELDS if modify fields list

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/cookie/ServiceCookie.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/cookie/ServiceCookie.java
@@ -140,7 +140,6 @@ public class ServiceCookie extends CookieBase implements Comparable<ServiceCooki
         SERVER_42_ISL_RTT_TURNING_COOKIE(0x1D),
         SERVER_42_FLOW_RTT_VXLAN_TURNING_COOKIE(0x1E),
         DROP_SLOW_PROTOCOLS_LOOP_COOKIE(0x1F),
-        SKIP_EGRESS_FLOW_PING_COOKIE(0x20),
 
         // This do not consume any value from allowed address space - you can define another field with -1 value
         // (must be last entry)

--- a/src-java/rule-manager/rule-manager-implementation/src/main/java/org/openkilda/rulemanager/Constants.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/main/java/org/openkilda/rulemanager/Constants.java
@@ -75,6 +75,7 @@ public final class Constants {
         public static final int DROP_DISCOVERY_LOOP_RULE_PRIORITY = DISCOVERY_RULE_PRIORITY + 1;
         public static final int CATCH_BFD_RULE_PRIORITY = DROP_DISCOVERY_LOOP_RULE_PRIORITY + 1;
         public static final int ROUND_TRIP_LATENCY_RULE_PRIORITY = DROP_DISCOVERY_LOOP_RULE_PRIORITY + 1;
+        public static final int PING_INPUT_PRIORITY = FLOW_PRIORITY - 1;
         public static final int ISL_EGRESS_VXLAN_RULE_PRIORITY_MULTITABLE = FLOW_PRIORITY - 2;
         public static final int ISL_TRANSIT_VXLAN_RULE_PRIORITY_MULTITABLE = FLOW_PRIORITY - 3;
         public static final int INGRESS_CUSTOMER_PORT_RULE_PRIORITY_MULTITABLE = FLOW_PRIORITY - 2;
@@ -84,8 +85,6 @@ public final class Constants {
         public static final int DOUBLE_VLAN_FLOW_PRIORITY = FLOW_PRIORITY + 10;
         public static final int LACP_RULE_PRIORITY = INGRESS_CUSTOMER_PORT_RULE_PRIORITY_MULTITABLE + 200;
         public static final int DROP_LOOP_SLOW_PROTOCOLS_PRIORITY = LACP_RULE_PRIORITY + 10;
-        public static final int SKIP_EGRESS_FLOW_PING_PRIORITY = DISCOVERY_RULE_PRIORITY + 10;
-
 
         public static final int MIRROR_FLOW_PRIORITY = FLOW_PRIORITY + 50;
         public static final int MIRROR_DOUBLE_VLAN_FLOW_PRIORITY = MIRROR_FLOW_PRIORITY + 10;

--- a/src-java/rule-manager/rule-manager-implementation/src/main/java/org/openkilda/rulemanager/RuleManagerImpl.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/main/java/org/openkilda/rulemanager/RuleManagerImpl.java
@@ -217,7 +217,6 @@ public class RuleManagerImpl implements RuleManager {
             generators.add(serviceRulesFactory.getArpPostIngressRuleGenerator());
             generators.add(serviceRulesFactory.getArpPostIngressVxlanRuleGenerator());
             generators.add(serviceRulesFactory.getArpPostIngressOneSwitchRuleGenerator());
-            generators.add(serviceRulesFactory.getSkipEgressPingRuleGenerator());
 
             if (switchProperties.isSwitchLldp()) {
                 generators.add(serviceRulesFactory.getLldpTransitRuleGenerator());
@@ -287,6 +286,7 @@ public class RuleManagerImpl implements RuleManager {
         result.add(serviceRulesFactory.getEgressIslVxlanRuleGenerator(port));
         result.add(serviceRulesFactory.getEgressIslVlanRuleGenerator(port));
         result.add(serviceRulesFactory.getTransitIslVxlanRuleGenerator(port));
+        result.add(serviceRulesFactory.getInputPingRuleGenerator(port));
         return result;
     }
 

--- a/src-java/rule-manager/rule-manager-implementation/src/main/java/org/openkilda/rulemanager/factory/ServiceRulesGeneratorFactory.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/main/java/org/openkilda/rulemanager/factory/ServiceRulesGeneratorFactory.java
@@ -19,7 +19,6 @@ import org.openkilda.model.MacAddress;
 import org.openkilda.model.cookie.Cookie;
 import org.openkilda.rulemanager.OfTable;
 import org.openkilda.rulemanager.RuleManagerConfig;
-import org.openkilda.rulemanager.factory.generator.flow.haflow.SkipEgressPingRuleGenerator;
 import org.openkilda.rulemanager.factory.generator.service.BfdCatchRuleGenerator;
 import org.openkilda.rulemanager.factory.generator.service.BroadCastDiscoveryRuleGenerator;
 import org.openkilda.rulemanager.factory.generator.service.DropDiscoveryLoopRuleGenerator;
@@ -35,6 +34,7 @@ import org.openkilda.rulemanager.factory.generator.service.arp.ArpPostIngressVxl
 import org.openkilda.rulemanager.factory.generator.service.arp.ArpTransitRuleGenerator;
 import org.openkilda.rulemanager.factory.generator.service.isl.EgressIslVlanRuleGenerator;
 import org.openkilda.rulemanager.factory.generator.service.isl.EgressIslVxlanRuleGenerator;
+import org.openkilda.rulemanager.factory.generator.service.isl.InputPingRuleGenerator;
 import org.openkilda.rulemanager.factory.generator.service.isl.TransitIslVxlanRuleGenerator;
 import org.openkilda.rulemanager.factory.generator.service.lacp.DropSlowProtocolsLoopRuleGenerator;
 import org.openkilda.rulemanager.factory.generator.service.lacp.LacpReplyRuleGenerator;
@@ -333,6 +333,16 @@ public class ServiceRulesGeneratorFactory {
     }
 
     /**
+     * Get input Ping rule generator.
+     */
+    public InputPingRuleGenerator getInputPingRuleGenerator(int islPort) {
+        return InputPingRuleGenerator.builder()
+                .islPort(islPort)
+                .flowPingMagicSrcMacAddress(config.getFlowPingMagicSrcMacAddress())
+                .build();
+    }
+
+    /**
      * Get transit ISL VLAN rule generator.
      */
     public TransitIslVxlanRuleGenerator getTransitIslVxlanRuleGenerator(int islPort) {
@@ -359,12 +369,4 @@ public class ServiceRulesGeneratorFactory {
         return DropSlowProtocolsLoopRuleGenerator.builder().build();
     }
 
-    /**
-     * Get skip egress ping rule generator.
-     */
-    public SkipEgressPingRuleGenerator getSkipEgressPingRuleGenerator() {
-        return SkipEgressPingRuleGenerator.builder()
-                .flowPingMagicSrcMacAddress(config.getFlowPingMagicSrcMacAddress())
-                .build();
-    }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/RuleManagerServiceRulesTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/RuleManagerServiceRulesTest.java
@@ -47,7 +47,6 @@ import org.openkilda.model.YFlow.SharedEndpoint;
 import org.openkilda.model.cookie.FlowSegmentCookie;
 import org.openkilda.rulemanager.adapter.InMemoryDataAdapter;
 import org.openkilda.rulemanager.factory.RuleGenerator;
-import org.openkilda.rulemanager.factory.generator.flow.haflow.SkipEgressPingRuleGenerator;
 import org.openkilda.rulemanager.factory.generator.service.BfdCatchRuleGenerator;
 import org.openkilda.rulemanager.factory.generator.service.BroadCastDiscoveryRuleGenerator;
 import org.openkilda.rulemanager.factory.generator.service.DropDiscoveryLoopRuleGenerator;
@@ -61,6 +60,10 @@ import org.openkilda.rulemanager.factory.generator.service.arp.ArpPostIngressOne
 import org.openkilda.rulemanager.factory.generator.service.arp.ArpPostIngressRuleGenerator;
 import org.openkilda.rulemanager.factory.generator.service.arp.ArpPostIngressVxlanRuleGenerator;
 import org.openkilda.rulemanager.factory.generator.service.arp.ArpTransitRuleGenerator;
+import org.openkilda.rulemanager.factory.generator.service.isl.EgressIslVlanRuleGenerator;
+import org.openkilda.rulemanager.factory.generator.service.isl.EgressIslVxlanRuleGenerator;
+import org.openkilda.rulemanager.factory.generator.service.isl.InputPingRuleGenerator;
+import org.openkilda.rulemanager.factory.generator.service.isl.TransitIslVxlanRuleGenerator;
 import org.openkilda.rulemanager.factory.generator.service.lacp.DropSlowProtocolsLoopRuleGenerator;
 import org.openkilda.rulemanager.factory.generator.service.lacp.LacpReplyRuleGenerator;
 import org.openkilda.rulemanager.factory.generator.service.lldp.LldpIngressRuleGenerator;
@@ -224,7 +227,7 @@ public class RuleManagerServiceRulesTest {
         List<RuleGenerator> generators = ruleManager.getServiceRuleGenerators(
                 switchId, buildAdapter(switchId, switchProperties, new HashSet<>(), false, LAG_PORTS));
 
-        assertEquals(22, generators.size());
+        assertEquals(21, generators.size());
         assertTrue(generators.stream().anyMatch(g -> g instanceof BroadCastDiscoveryRuleGenerator));
         assertTrue(generators.stream().anyMatch(g -> g instanceof UniCastDiscoveryRuleGenerator));
         assertTrue(generators.stream().anyMatch(g -> g instanceof DropDiscoveryLoopRuleGenerator));
@@ -243,8 +246,6 @@ public class RuleManagerServiceRulesTest {
         assertTrue(generators.stream().anyMatch(g -> g instanceof ArpPostIngressRuleGenerator));
         assertTrue(generators.stream().anyMatch(g -> g instanceof ArpPostIngressVxlanRuleGenerator));
         assertTrue(generators.stream().anyMatch(g -> g instanceof ArpPostIngressOneSwitchRuleGenerator));
-
-        assertTrue(generators.stream().anyMatch(g -> g instanceof SkipEgressPingRuleGenerator));
     }
 
     @Test
@@ -256,7 +257,7 @@ public class RuleManagerServiceRulesTest {
         List<RuleGenerator> generators = ruleManager.getServiceRuleGenerators(
                 switchId, buildAdapter(switchId, switchProperties, new HashSet<>(), false, null));
 
-        assertEquals(25, generators.size());
+        assertEquals(24, generators.size());
         assertTrue(generators.stream().anyMatch(g -> g instanceof BroadCastDiscoveryRuleGenerator));
         assertTrue(generators.stream().anyMatch(g -> g instanceof UniCastDiscoveryRuleGenerator));
 
@@ -278,7 +279,6 @@ public class RuleManagerServiceRulesTest {
         assertTrue(generators.stream().anyMatch(g -> g instanceof ArpInputPreDropRuleGenerator));
         assertTrue(generators.stream().anyMatch(g -> g instanceof ArpIngressRuleGenerator));
 
-        assertTrue(generators.stream().anyMatch(g -> g instanceof SkipEgressPingRuleGenerator));
     }
 
     @Test
@@ -324,7 +324,10 @@ public class RuleManagerServiceRulesTest {
         assertTrue(generators.stream().anyMatch(g -> g instanceof Server42IslRttTurningRuleGenerator));
         assertTrue(generators.stream().anyMatch(g -> g instanceof Server42IslRttOutputRuleGenerator));
 
-        assertTrue(generators.stream().anyMatch(g -> g instanceof SkipEgressPingRuleGenerator));
+        assertTrue(generators.stream().anyMatch(g -> g instanceof EgressIslVlanRuleGenerator));
+        assertTrue(generators.stream().anyMatch(g -> g instanceof EgressIslVxlanRuleGenerator));
+        assertTrue(generators.stream().anyMatch(g -> g instanceof TransitIslVxlanRuleGenerator));
+        assertTrue(generators.stream().anyMatch(g -> g instanceof InputPingRuleGenerator));
     }
 
     private DataAdapter buildAdapter(

--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/SwitchHelper.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/SwitchHelper.groovy
@@ -1,7 +1,5 @@
 package org.openkilda.functionaltests.helpers
 
-import org.openkilda.northbound.dto.v2.switches.SwitchFlowsPerPortResponse
-
 import static groovyx.gpars.GParsPool.withPool
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.hasItem
@@ -35,7 +33,6 @@ import static org.openkilda.model.cookie.Cookie.SERVER_42_FLOW_RTT_TURNING_COOKI
 import static org.openkilda.model.cookie.Cookie.SERVER_42_FLOW_RTT_VXLAN_TURNING_COOKIE
 import static org.openkilda.model.cookie.Cookie.SERVER_42_ISL_RTT_OUTPUT_COOKIE
 import static org.openkilda.model.cookie.Cookie.SERVER_42_ISL_RTT_TURNING_COOKIE
-import static org.openkilda.model.cookie.Cookie.SKIP_EGRESS_FLOW_PING_COOKIE
 import static org.openkilda.model.cookie.Cookie.VERIFICATION_BROADCAST_RULE_COOKIE
 import static org.openkilda.model.cookie.Cookie.VERIFICATION_UNICAST_RULE_COOKIE
 import static org.openkilda.model.cookie.Cookie.VERIFICATION_UNICAST_VXLAN_RULE_COOKIE
@@ -58,6 +55,7 @@ import org.openkilda.northbound.dto.v1.switches.SwitchDto
 import org.openkilda.northbound.dto.v1.switches.SwitchPropertiesDto
 import org.openkilda.northbound.dto.v2.switches.MeterInfoDtoV2
 import org.openkilda.northbound.dto.v2.switches.SwitchDtoV2
+import org.openkilda.northbound.dto.v2.switches.SwitchFlowsPerPortResponse
 import org.openkilda.testing.Constants
 import org.openkilda.testing.model.topology.TopologyDefinition
 import org.openkilda.testing.model.topology.TopologyDefinition.Switch
@@ -178,7 +176,7 @@ class SwitchHelper {
             multiTableRules = [MULTITABLE_PRE_INGRESS_PASS_THROUGH_COOKIE, MULTITABLE_INGRESS_DROP_COOKIE,
                                MULTITABLE_POST_INGRESS_DROP_COOKIE, MULTITABLE_EGRESS_PASS_THROUGH_COOKIE,
                                MULTITABLE_TRANSIT_DROP_COOKIE, LLDP_POST_INGRESS_COOKIE, LLDP_POST_INGRESS_ONE_SWITCH_COOKIE,
-                               ARP_POST_INGRESS_COOKIE, ARP_POST_INGRESS_ONE_SWITCH_COOKIE, SKIP_EGRESS_FLOW_PING_COOKIE]
+                               ARP_POST_INGRESS_COOKIE, ARP_POST_INGRESS_ONE_SWITCH_COOKIE]
             if (sw.features.contains(NOVIFLOW_PUSH_POP_VXLAN) || sw.features.contains(KILDA_OVS_PUSH_POP_MATCH_VXLAN)) {
                 multiTableRules.addAll([LLDP_POST_INGRESS_VXLAN_COOKIE, ARP_POST_INGRESS_VXLAN_COOKIE])
             }
@@ -188,6 +186,7 @@ class SwitchHelper {
                     multiTableRules.add(new PortColourCookie(CookieType.MULTI_TABLE_ISL_VXLAN_TRANSIT_RULES, it.source.portNo).getValue())
                 }
                 multiTableRules.add(new PortColourCookie(CookieType.MULTI_TABLE_ISL_VLAN_EGRESS_RULES, it.source.portNo).getValue())
+                multiTableRules.add(new PortColourCookie(CookieType.PING_INPUT, it.source.portNo).getValue())
             }
             northbound.get().getSwitchFlows(sw.dpId).each {
                 if (it.source.datapath.equals(sw.dpId)) {


### PR DESCRIPTION
This commit updates the functionality of skipping a ping packet in the egress
table. Now the packet that doesn't belong to this switch is sent directly to
the transit table.

This is done in the ingress table. To achieve this, the current
EgressIslVlanRuleGenerator functionality has been copied, but with the
addition of matching the eth_src=ping_magic_mac and sending the packet to transit.

This change was necessary because the current hardware switches do not support
matching src_mac and dst_mac in tables other than 0.

Closes https://github.com/telstra/open-kilda/issues/5232