### PR TITLE
Updated to support special purpose vlan 4095

### DIFF
--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/kafka/RecordHandler.java
@@ -117,6 +117,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -272,6 +273,12 @@ class RecordHandler implements Runnable {
                     .withTopic(replyToTopic)
                     .withKey(record.key())
                     .sendVia(producerService);
+        } catch (IllegalArgumentException e) {
+            logger.error(format("Failed to delete switch rules. %s", e.getMessage()), e);
+            SwitchRulesResponse response = new SwitchRulesResponse(Collections.emptyList());
+            InfoMessage infoMessage = new InfoMessage(response,
+                    System.currentTimeMillis(), message.getCorrelationId());
+            producerService.sendMessageAndTrack(replyToTopic, record.key(), infoMessage);
         }
     }
 

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/switchmanager/SwitchManager.java
@@ -649,6 +649,9 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
     }
 
     private void matchVlan(final OFFactory ofFactory, final Match.Builder matchBuilder, final int vlanId) {
+        if ((vlanId & OF10_VLAN_MASK) != vlanId) {
+            throw new IllegalArgumentException(String.format("Illegal VLAN value: 0x%x", vlanId));
+        }
         if (0 <= OF_12.compareTo(ofFactory.getVersion())) {
             matchBuilder.setMasked(MatchField.VLAN_VID, OFVlanVidMatch.ofVlan(vlanId),
                     OFVlanVidMatch.ofRawVid(OF10_VLAN_MASK));
@@ -671,8 +674,8 @@ public class SwitchManager implements IFloodlightModule, IFloodlightService, ISw
     /**
      * Pushes a single flow modification command to the switch with the given datapath ID.
      *
-     * @param sw open flow switch descriptor
-     * @param flowId flow name, for logging
+     * @param sw      open flow switch descriptor
+     * @param flowId  flow name, for logging
      * @param flowMod command to send
      * @return OF transaction Id (???)
      * @throws OfInstallException openflow install exception

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/validation/FlowValidator.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/validation/FlowValidator.java
@@ -74,7 +74,7 @@ public class FlowValidator {
     static final int STATS_VLAN_LOWER_BOUND = 1;
 
     @VisibleForTesting
-    static final int STATS_VLAN_UPPER_BOUND = 4094;
+    static final int STATS_VLAN_UPPER_BOUND = 4095;
 
     private final FlowRepository flowRepository;
     private final YFlowRepository yFlowRepository;

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/validation/FlowValidator.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/validation/FlowValidator.java
@@ -227,12 +227,12 @@ public class FlowValidator {
         }
 
         boolean isAnyVlanOutsideOfBounds = vlanStatistics.stream()
-                .anyMatch(it -> it < STATS_VLAN_LOWER_BOUND || it > STATS_VLAN_UPPER_BOUND);
+                .anyMatch(vlan -> vlan < STATS_VLAN_LOWER_BOUND || vlan > STATS_VLAN_UPPER_BOUND);
 
         if (isAnyVlanOutsideOfBounds) {
             throw new InvalidFlowException(
                     format(
-                            "To collect vlan statistics, the vlan IDs must be from %d up to %d",
+                            "To collect vlan statistics, the vlan IDs must be from %d up to %d inclusive",
                             STATS_VLAN_LOWER_BOUND,
                             STATS_VLAN_UPPER_BOUND),
                     ErrorType.PARAMETERS_INVALID);

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/controller/v2/validator/BaseFlowEndpointV2Validator.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/controller/v2/validator/BaseFlowEndpointV2Validator.java
@@ -77,8 +77,8 @@ public final class BaseFlowEndpointV2Validator {
         }
 
         //validate baseFlowEndpointV2 vlanId is not more than 4095
-        if (baseFlowEndpointV2.getVlanId() > 4094) {
-            return Optional.of("VlanId must be less than 4095");
+        if (baseFlowEndpointV2.getVlanId() > 4095) {
+            return Optional.of("VlanId must be less than 4096");
         }
         return Optional.empty();
     }
@@ -95,8 +95,8 @@ public final class BaseFlowEndpointV2Validator {
         }
 
         //validate baseFlowEndpointV2 innerVlanId is not more than 4095
-        if (baseFlowEndpointV2.getInnerVlanId() > 4094) {
-            return Optional.of("InnerVlanId must be less than 4095");
+        if (baseFlowEndpointV2.getInnerVlanId() > 4095) {
+            return Optional.of("InnerVlanId must be less than 4096");
         }
         return Optional.empty();
     }

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/controller/v2/validator/YFlowSharedEndpointEncapsulationValidator.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/controller/v2/validator/YFlowSharedEndpointEncapsulationValidator.java
@@ -51,8 +51,8 @@ public final class YFlowSharedEndpointEncapsulationValidator {
         }
 
         //validate flowSharedEndpointEncapsulation vlanId is not more than 4095
-        if (flowSharedEndpointEncapsulation.getVlanId() > 4094) {
-            return Optional.of("VlanId must be less than 4095");
+        if (flowSharedEndpointEncapsulation.getVlanId() > 4095) {
+            return Optional.of("VlanId must be less than 4096");
         }
         return Optional.empty();
     }
@@ -65,8 +65,8 @@ public final class YFlowSharedEndpointEncapsulationValidator {
         }
 
         //validate flowSharedEndpointEncapsulation innerVlanId is not more than 4095
-        if (flowSharedEndpointEncapsulation.getInnerVlanId() > 4094) {
-            return Optional.of("InnerVlanId must be less than 4095");
+        if (flowSharedEndpointEncapsulation.getInnerVlanId() > 4095) {
+            return Optional.of("InnerVlanId must be less than 4096");
         }
         return Optional.empty();
     }

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/main/java/org/openkilda/wfm/topology/switchmanager/service/SwitchRuleService.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/main/java/org/openkilda/wfm/topology/switchmanager/service/SwitchRuleService.java
@@ -123,7 +123,14 @@ public class SwitchRuleService implements SwitchManagerHubService {
 
     @Override
     public void dispatchErrorMessage(ErrorData payload, MessageCookie cookie) {
-        // FIXME(surabujin): the service completely ignores error responses
+        carrier.cancelTimeoutCallback(cookie.getValue());
+        ErrorMessage errorMessage = new ErrorMessage(payload, System.currentTimeMillis(), cookie.getNested() != null
+                ? cookie.getNested().getValue() : cookie.getValue());
+        carrier.response(cookie.getValue(), errorMessage);
+        isOperationCompleted = true;
+        if (!active) {
+            carrier.sendInactive();
+        }
         log.error("Got speaker error response: {} (request key: {})", payload, cookie.getValue());
     }
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
@@ -624,7 +624,7 @@ class FlowCrudSpec extends HealthCheckSpecification {
                     flowToSpoil.setSource(source)
                     return flowToSpoil
                 }                                                                                          |
-                new FlowNotCreatedExpectedError(~/To collect vlan statistics, the vlan IDs must be from 1 up to 4094/)
+                new FlowNotCreatedExpectedError(~/To collect vlan statistics, the vlan IDs must be from 1 up to 4095/)
     }
 
     @Tidy

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/QinQFlowSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/QinQFlowSpec.groovy
@@ -344,7 +344,7 @@ class QinQFlowSpec extends HealthCheckSpecification {
 
         where:
         srcInnerVlanId | dstInnerVlanId | expectedErrorDescription
-        4096           | 10             | ~/Errors: InnerVlanId must be less than 4095/
+        4096           | 10             | ~/Errors: InnerVlanId must be less than 4096/
         10             | -1             | ~/Errors: InnerVlanId must be non-negative/
     }
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/FlowRulesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/FlowRulesSpec.groovy
@@ -447,7 +447,7 @@ class FlowRulesSpec extends HealthCheckSpecification {
                   switch           : srcSwitch,
                   defaultRules     : srcSwDefaultRules,
                   inPort           : null,
-                  inVlan           : 4095,
+                  inVlan           : 4096,
                   encapsulationType: "TRANSIT_VLAN",
                   outPort          : null
                  ],
@@ -455,7 +455,7 @@ class FlowRulesSpec extends HealthCheckSpecification {
                   switch           : srcSwitch,
                   defaultRules     : srcSwDefaultRules,
                   inPort           : Integer.MAX_VALUE - 1,
-                  inVlan           : 4095,
+                  inVlan           : 4096,
                   encapsulationType: "TRANSIT_VLAN",
                   outPort          : null
                  ],


### PR DESCRIPTION
Allow 1 and 4095 vlan numbers to be used.

Fixed timeout problem while sending wrong vlan with the following request: 


` curl -X DELETE "http://vm:8080/api/v1/switches/00%3A00%3A00%3A00%3A00%3A00%3A00%3A02/rules?encapsulation-type=TRANSIT_VLAN&in-port=1001&in-vlan=4096" -H "accept: */*" -H "correlation_id: asd" -H "EXTRA_AUTH: 1693410243785" -u "user:pass"
`
For now the response should be the similar to the following one: 
`{"correlation_id":"bdf67fdb-690e-4e80-86b8-c45b84f13207 : asd","timestamp":1693410263425,"error-type":"Invalid request data","error-message":"Illegal VLAN value: 0x1000","error-description":"00:00:00:00:00:00:00:02"}`

timeout problem has been fixed not only for the request above, but for all the requests that go through the SwitchRuleService. added dispatchErrorMessage implementation.

#5230