### PR TITLE
open-kilda-5226 Remove `yFlow.shared.*` Opentsdb metrics

### DIFF
--- a/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/FlowEndpointStatsEntryHandler.java
+++ b/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/FlowEndpointStatsEntryHandler.java
@@ -81,16 +81,8 @@ public final class FlowEndpointStatsEntryHandler extends BaseFlowStatsEntryHandl
     public void handleStatsEntry(YFlowDescriptor descriptor) {
         TagsFormatter tags = initTags(false);
         tags.addYFlowIdTag(descriptor.getYFlowId());
-
-        switch (descriptor.getMeasurePoint()) {
-            case Y_FLOW_SHARED:
-                emitYFlowSharedPoints(tags);
-                break;
-            case Y_FLOW_Y_POINT:
-                emitYFlowYPointPoints(tags);
-                break;
-            default:
-                // nothing to do here
+        if (descriptor.getMeasurePoint() == MeasurePoint.Y_FLOW_Y_POINT) {
+            emitYFlowYPointPoints(tags);
         }
     }
 
@@ -172,15 +164,9 @@ public final class FlowEndpointStatsEntryHandler extends BaseFlowStatsEntryHandl
                 statsEntry.getPacketCount(), statsEntry.getByteCount(), tags.getTags());
     }
 
-    private void emitYFlowSharedPoints(TagsFormatter tags) {
-        meterEmitter.emitPacketAndBytePoints(
-                new MetricFormatter("yFlow.shared."), timestamp,
-                statsEntry.getPacketCount(), statsEntry.getByteCount(), tags.getTags());
-    }
-
     private void emitYFlowYPointPoints(TagsFormatter tags) {
         meterEmitter.emitPacketAndBytePoints(
-                new MetricFormatter("yFlow.yPoint."), timestamp,
+                new MetricFormatter("yflow.ypoint."), timestamp,
                 statsEntry.getPacketCount(), statsEntry.getByteCount(), tags.getTags());
     }
 

--- a/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/MeterStatsHandler.java
+++ b/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/MeterStatsHandler.java
@@ -146,13 +146,13 @@ public final class MeterStatsHandler extends BaseStatsEntryHandler {
 
     private void emitYFlowSharedMeterPoints(TagsFormatter tagsFormatter) {
         meterEmitter.emitPacketAndBytePoints(
-                new MetricFormatter("yFlow.meter.shared."), timestamp,
+                new MetricFormatter("yflow.meter.shared."), timestamp,
                 statsEntry.getPacketsInCount(), statsEntry.getByteInCount(), tagsFormatter.getTags());
     }
 
     private void emitYFlowYPointMeterPoints(TagsFormatter tagsFormatter) {
         meterEmitter.emitPacketAndBytePoints(
-                new MetricFormatter("yFlow.meter.yPoint."), timestamp,
+                new MetricFormatter("yflow.meter.ypoint."), timestamp,
                 statsEntry.getPacketsInCount(), statsEntry.getByteInCount(), tagsFormatter.getTags());
     }
 

--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/StatsHelper.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/StatsHelper.groovy
@@ -51,8 +51,8 @@ class StatsHelper {
         "force kilda to collect stats"(yFlow.getYFlowId())
         Wrappers.wait(STATS_LOGGING_TIMEOUT) {
             def yFlowId = yFlow.YFlowId
-            def dpsShared = otsdb.query(from, metricPrefix + "yFlow.meter.shared.bytes", ["y_flow_id": yFlowId]).dps
-            def dpsYPoint = otsdb.query(from, metricPrefix + "yFlow.meter.yPoint.bytes", ["y_flow_id": yFlowId]).dps
+            def dpsShared = otsdb.query(from, metricPrefix + "yflow.meter.shared.bytes", ["y_flow_id": yFlowId]).dps
+            def dpsYPoint = otsdb.query(from, metricPrefix + "yflow.meter.ypoint.bytes", ["y_flow_id": yFlowId]).dps
             def dpsSubFlows = otsdb.query(from,
                     metricPrefix + "flow.raw.bytes",
                     ["flowid": "${yFlow.subFlows[0].flowId}|${yFlow.subFlows[1].flowId}"]).dps

--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/model/stats/StatsMetric.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/model/stats/StatsMetric.groovy
@@ -3,8 +3,8 @@ package org.openkilda.functionaltests.model.stats
 import org.openkilda.testing.service.otsdb.model.StatsResult
 
 enum StatsMetric {
-    Y_FLOW_SHARED_PACKETS("yFlow.meter.shared.packets"),
-    Y_FLOW_Y_POINT_PACKETS("yFlow.meter.yPoint.packets"),
+    Y_FLOW_SHARED_PACKETS("yflow.meter.shared.packets"),
+    Y_FLOW_Y_POINT_PACKETS("yflow.meter.ypoint.packets"),
     FLOW_INGRESS_PACKETS("flow.ingress.packets"),
     FLOW_EGRESS_PACKETS("flow.packets")
 


### PR DESCRIPTION
the following metrics do not exist in the doc, but present in the code:

 flow.vlan.
 switch.flow.system.meter.

closes #5226