### PR TITLE
[PART 1] Migrate all unit tests from JUnit4 to JUnit5 #5242

### DIFF
--- a/src-java/base-topology/base-messaging/build.gradle
+++ b/src-java/base-topology/base-messaging/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     implementation 'org.slf4j:slf4j-api'
     implementation 'javax.validation:validation-api'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/JsonSerializeAbstractTest.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/JsonSerializeAbstractTest.java
@@ -20,11 +20,11 @@ import org.openkilda.messaging.command.CommandMessage;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.InfoMessage;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public abstract class JsonSerializeAbstractTest {
-	StringSerializer serializer = new StringSerializer();
-	
+    StringSerializer serializer = new StringSerializer();
+
     protected void commandSerializeLoop(CommandData origin) throws Exception {
         CommandMessage wrapper = new CommandMessage(origin, 0, "serialize-loop");
         serializer.serialize(wrapper);
@@ -44,9 +44,7 @@ public abstract class JsonSerializeAbstractTest {
     }
 
     protected void validate(MessageData origin, MessageData decoded) {
-        Assert.assertEquals(
-                String.format("%s object have been mangled in serialisation/deserialization loop",
-                        origin.getClass().getName()),
-                origin, decoded);
+        Assertions.assertEquals(origin, decoded, String.format("%s object have been mangled in "
+                + "serialisation/deserialization loop", origin.getClass().getName()));
     }
 }

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/info/DatapointTest.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/info/DatapointTest.java
@@ -19,8 +19,8 @@ import org.openkilda.messaging.ByteArraySerializer;
 import org.openkilda.messaging.info.switches.v2.action.SetFieldActionEntry;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DatapointTest {
     ByteArraySerializer serializer = new ByteArraySerializer();
@@ -39,7 +39,7 @@ public class DatapointTest {
 
         Datapoint reconstruct = (Datapoint) ((InfoMessage) serializer.deserialize()).getData();
 
-        Assert.assertEquals(origin, reconstruct);
+        Assertions.assertEquals(origin, reconstruct);
     }
 
     @Test
@@ -50,6 +50,6 @@ public class DatapointTest {
 
         SetFieldActionEntry reconstruct = (SetFieldActionEntry) serializer.deserialize();
 
-        Assert.assertEquals(origin, reconstruct);
+        Assertions.assertEquals(origin, reconstruct);
     }
 }

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/info/event/IslInfoDataTest.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/info/event/IslInfoDataTest.java
@@ -15,12 +15,10 @@
 
 package org.openkilda.messaging.info.event;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import org.openkilda.model.SwitchId;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class IslInfoDataTest {
 
@@ -31,7 +29,7 @@ public class IslInfoDataTest {
         PathNode destination = new PathNode(switchId, 2, 1);
         IslInfoData isl = new IslInfoData(source, destination, IslChangeType.DISCOVERED, false);
 
-        assertTrue(isl.isSelfLooped());
+        Assertions.assertTrue(isl.isSelfLooped());
     }
 
     @Test
@@ -42,6 +40,6 @@ public class IslInfoDataTest {
         PathNode destination = new PathNode(dstSwitch, 2, 1);
         IslInfoData isl = new IslInfoData(source, destination, IslChangeType.DISCOVERED, false);
 
-        assertFalse(isl.isSelfLooped());
+        Assertions.assertFalse(isl.isSelfLooped());
     }
 }

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/info/switches/v2/GroupsValidationEntryV2Test.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/info/switches/v2/GroupsValidationEntryV2Test.java
@@ -15,12 +15,11 @@
 
 package org.openkilda.messaging.info.switches.v2;
 
-import static org.junit.Assert.assertEquals;
-
 import org.openkilda.messaging.info.switches.v2.GroupInfoEntryV2.BucketEntry;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,9 +36,9 @@ public class GroupsValidationEntryV2Test {
                 .proper(new ArrayList<>())
                 .build();
         List<GroupsValidationEntryV2> list = entry.split(4, 4);
-        assertEquals(1, list.size());
+        Assertions.assertEquals(1, list.size());
         GroupsValidationEntryV2 united = GroupsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -52,9 +51,9 @@ public class GroupsValidationEntryV2Test {
                 .proper(null)
                 .build();
         List<GroupsValidationEntryV2> list = entry.split(4, 4);
-        assertEquals(1, list.size());
+        Assertions.assertEquals(1, list.size());
         GroupsValidationEntryV2 united = GroupsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -67,9 +66,9 @@ public class GroupsValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredGroupsInfo(4, 1))
                 .build();
         List<GroupsValidationEntryV2> list = entry.split(4, 4);
-        assertEquals(1, list.size());
+        Assertions.assertEquals(1, list.size());
         GroupsValidationEntryV2 united = GroupsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -82,9 +81,9 @@ public class GroupsValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredGroupsInfo(4, 1))
                 .build();
         List<GroupsValidationEntryV2> list = entry.split(1, 1);
-        assertEquals(4, list.size());
+        Assertions.assertEquals(4, list.size());
         GroupsValidationEntryV2 united = GroupsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -97,9 +96,9 @@ public class GroupsValidationEntryV2Test {
                 .misconfigured(new ArrayList<>())
                 .build();
         List<GroupsValidationEntryV2> list = entry.split(2, 2);
-        assertEquals(3, list.size());
+        Assertions.assertEquals(3, list.size());
         GroupsValidationEntryV2 united = GroupsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -112,9 +111,9 @@ public class GroupsValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredGroupsInfo(4, 4))
                 .build();
         List<GroupsValidationEntryV2> list = entry.split(2, 3);
-        assertEquals(4, list.size());
+        Assertions.assertEquals(4, list.size());
         GroupsValidationEntryV2 united = GroupsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -127,9 +126,9 @@ public class GroupsValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredGroupsInfo(4, 4))
                 .build();
         List<GroupsValidationEntryV2> list = entry.split(100, 200);
-        assertEquals(1, list.size());
+        Assertions.assertEquals(1, list.size());
         GroupsValidationEntryV2 united = GroupsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -142,9 +141,9 @@ public class GroupsValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredGroupsInfo(3000, 800))
                 .build();
         List<GroupsValidationEntryV2> list = entry.split(100, 200);
-        assertEquals(14, list.size());
+        Assertions.assertEquals(14, list.size());
         GroupsValidationEntryV2 united = GroupsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -157,9 +156,9 @@ public class GroupsValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredGroupsInfo(3000, 800))
                 .build();
         List<GroupsValidationEntryV2> list = entry.split(1, 1);
-        assertEquals(2600, list.size());
+        Assertions.assertEquals(2600, list.size());
         GroupsValidationEntryV2 united = GroupsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     static List<GroupInfoEntryV2> buildGroupsInfo(int idBase, int count) {

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/info/switches/v2/LogicalPortsValidationEntryV2Test.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/info/switches/v2/LogicalPortsValidationEntryV2Test.java
@@ -16,11 +16,11 @@
 package org.openkilda.messaging.info.switches.v2;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.junit.Assert.assertEquals;
 
 import org.openkilda.messaging.info.switches.LogicalPortType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,9 +37,9 @@ public class LogicalPortsValidationEntryV2Test {
                 .proper(new ArrayList<>())
                 .build();
         List<LogicalPortsValidationEntryV2> list = entry.split(4, 4);
-        assertEquals("Method split should return the list with the length of 1", 1, list.size());
+        Assertions.assertEquals(1, list.size(), "Method split should return the list with the length of 1");
         LogicalPortsValidationEntryV2 united = LogicalPortsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -54,9 +54,9 @@ public class LogicalPortsValidationEntryV2Test {
                 .proper(new ArrayList<>())
                 .build();
         List<LogicalPortsValidationEntryV2> list = entry.split(4, 4);
-        assertEquals("Method split should return the list with the length of 1", 1, list.size());
+        Assertions.assertEquals(1, list.size(), "Method split should return the list with the length of 1");
         LogicalPortsValidationEntryV2 united = LogicalPortsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -69,9 +69,9 @@ public class LogicalPortsValidationEntryV2Test {
                 .proper(null)
                 .build();
         List<LogicalPortsValidationEntryV2> list = entry.split(4, 4);
-        assertEquals("Method split should return the list with the length of 1", 1, list.size());
+        Assertions.assertEquals(1, list.size(), "Method split should return the list with the length of 1");
         LogicalPortsValidationEntryV2 united = LogicalPortsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -84,9 +84,9 @@ public class LogicalPortsValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredLogicalPortsInfo(4, 1))
                 .build();
         List<LogicalPortsValidationEntryV2> list = entry.split(4, 4);
-        assertEquals("Method split should return the list with the length of 1", 1, list.size());
+        Assertions.assertEquals(1, list.size(), "Method split should return the list with the length of 1");
         LogicalPortsValidationEntryV2 united = LogicalPortsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -99,9 +99,9 @@ public class LogicalPortsValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredLogicalPortsInfo(4, 1))
                 .build();
         List<LogicalPortsValidationEntryV2> list = entry.split(1, 1);
-        assertEquals("Method split should return the list with the length of 4", 4, list.size());
+        Assertions.assertEquals(4, list.size(), "Method split should return the list with the length of 4");
         LogicalPortsValidationEntryV2 united = LogicalPortsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -114,9 +114,9 @@ public class LogicalPortsValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredLogicalPortsInfo(4, 4))
                 .build();
         List<LogicalPortsValidationEntryV2> list = entry.split(2, 3);
-        assertEquals("Method split should return the list with the length of 4", 4, list.size());
+        Assertions.assertEquals(4, list.size(), "Method split should return the list with the length of 4");
         LogicalPortsValidationEntryV2 united = LogicalPortsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -129,9 +129,9 @@ public class LogicalPortsValidationEntryV2Test {
                 .misconfigured(new ArrayList<>())
                 .build();
         List<LogicalPortsValidationEntryV2> list = entry.split(2, 2);
-        assertEquals("Method split should return the list with the length of 3", 3, list.size());
+        Assertions.assertEquals(3, list.size(), "Method split should return the list with the length of 3");
         LogicalPortsValidationEntryV2 united = LogicalPortsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -144,9 +144,9 @@ public class LogicalPortsValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredLogicalPortsInfo(4, 4))
                 .build();
         List<LogicalPortsValidationEntryV2> list = entry.split(100, 200);
-        assertEquals("Method split should return the list with the length of 1", 1, list.size());
+        Assertions.assertEquals(1, list.size(), "Method split should return the list with the length of 1");
         LogicalPortsValidationEntryV2 united = LogicalPortsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -159,9 +159,9 @@ public class LogicalPortsValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredLogicalPortsInfo(3000, 800))
                 .build();
         List<LogicalPortsValidationEntryV2> list = entry.split(100, 200);
-        assertEquals("Method split should return the list with the length of 14", 14, list.size());
+        Assertions.assertEquals(14, list.size(), "Method split should return the list with the length of 14");
         LogicalPortsValidationEntryV2 united = LogicalPortsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -175,9 +175,9 @@ public class LogicalPortsValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredLogicalPortsInfo(3000, 800))
                 .build();
         List<LogicalPortsValidationEntryV2> list = entry.split(100, 200);
-        assertEquals("Method split should return the list with the length of 14", 14, list.size());
+        Assertions.assertEquals(14, list.size(), "Method split should return the list with the length of 14");
         LogicalPortsValidationEntryV2 united = LogicalPortsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -190,9 +190,9 @@ public class LogicalPortsValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredLogicalPortsInfo(3000, 800))
                 .build();
         List<LogicalPortsValidationEntryV2> list = entry.split(1, 1);
-        assertEquals("Method split should return the list with the length of 2600", 2600, list.size());
+        Assertions.assertEquals(2600, list.size(), "Method split should return the list with the length of 2600");
         LogicalPortsValidationEntryV2 united = LogicalPortsValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     static List<LogicalPortInfoEntryV2> buildLogicalPortsInfo(int idBase, int count) {

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/info/switches/v2/MetersValidationEntryV2Test.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/info/switches/v2/MetersValidationEntryV2Test.java
@@ -15,10 +15,9 @@
 
 package org.openkilda.messaging.info.switches.v2;
 
-import static org.junit.Assert.assertEquals;
-
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,9 +34,9 @@ public class MetersValidationEntryV2Test {
                 .proper(new ArrayList<>())
                 .build();
         List<MetersValidationEntryV2> list = entry.split(4, 4);
-        assertEquals(1, list.size());
+        Assertions.assertEquals(1, list.size());
         MetersValidationEntryV2 united = MetersValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -50,9 +49,9 @@ public class MetersValidationEntryV2Test {
                 .proper(null)
                 .build();
         List<MetersValidationEntryV2> list = entry.split(4, 4);
-        assertEquals(1, list.size());
+        Assertions.assertEquals(1, list.size());
         MetersValidationEntryV2 united = MetersValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -65,9 +64,9 @@ public class MetersValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredMetersInfo(4, 1))
                 .build();
         List<MetersValidationEntryV2> list = entry.split(4, 4);
-        assertEquals(1, list.size());
+        Assertions.assertEquals(1, list.size());
         MetersValidationEntryV2 united = MetersValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -80,9 +79,9 @@ public class MetersValidationEntryV2Test {
                 .misconfigured(new ArrayList<>())
                 .build();
         List<MetersValidationEntryV2> list = entry.split(2, 2);
-        assertEquals(3, list.size());
+        Assertions.assertEquals(3, list.size());
         MetersValidationEntryV2 united = MetersValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -95,9 +94,9 @@ public class MetersValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredMetersInfo(4, 1))
                 .build();
         List<MetersValidationEntryV2> list = entry.split(1, 1);
-        assertEquals(4, list.size());
+        Assertions.assertEquals(4, list.size());
         MetersValidationEntryV2 united = MetersValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -110,9 +109,9 @@ public class MetersValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredMetersInfo(4, 4))
                 .build();
         List<MetersValidationEntryV2> list = entry.split(2, 3);
-        assertEquals(4, list.size());
+        Assertions.assertEquals(4, list.size());
         MetersValidationEntryV2 united = MetersValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -125,9 +124,9 @@ public class MetersValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredMetersInfo(4, 4))
                 .build();
         List<MetersValidationEntryV2> list = entry.split(100, 200);
-        assertEquals(1, list.size());
+        Assertions.assertEquals(1, list.size());
         MetersValidationEntryV2 united = MetersValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -140,9 +139,9 @@ public class MetersValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredMetersInfo(3000, 800))
                 .build();
         List<MetersValidationEntryV2> list = entry.split(100, 200);
-        assertEquals(14, list.size());
+        Assertions.assertEquals(14, list.size());
         MetersValidationEntryV2 united = MetersValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -155,9 +154,9 @@ public class MetersValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredMetersInfo(3000, 800))
                 .build();
         List<MetersValidationEntryV2> list = entry.split(1, 1);
-        assertEquals(2600, list.size());
+        Assertions.assertEquals(2600, list.size());
         MetersValidationEntryV2 united = MetersValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     static List<MeterInfoEntryV2> buildMetersInfo(int idBase, int count) {

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/info/switches/v2/RuleInfoEntryV2Test.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/info/switches/v2/RuleInfoEntryV2Test.java
@@ -30,8 +30,8 @@ import org.openkilda.model.MeterId;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RuleInfoEntryV2Test {
 
@@ -60,6 +60,6 @@ public class RuleInfoEntryV2Test {
         String json = mapper.writeValueAsString(origin);
 
         RuleInfoEntryV2 reconstructed = mapper.readValue(json, RuleInfoEntryV2.class);
-        Assert.assertEquals(origin, reconstructed);
+        Assertions.assertEquals(origin, reconstructed);
     }
 }

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/info/switches/v2/RulesValidationEntryV2Test.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/info/switches/v2/RulesValidationEntryV2Test.java
@@ -16,7 +16,6 @@
 package org.openkilda.messaging.info.switches.v2;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.junit.Assert.assertEquals;
 
 import org.openkilda.messaging.info.switches.v2.RuleInfoEntryV2.FieldMatch;
 import org.openkilda.messaging.info.switches.v2.RuleInfoEntryV2.Instructions;
@@ -24,7 +23,8 @@ import org.openkilda.messaging.info.switches.v2.RuleInfoEntryV2.WriteMetadata;
 import org.openkilda.messaging.info.switches.v2.action.PopVlanActionEntry;
 import org.openkilda.messaging.info.switches.v2.action.PortOutActionEntry;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,9 +43,9 @@ public class RulesValidationEntryV2Test {
                 .proper(new ArrayList<>())
                 .build();
         List<RulesValidationEntryV2> list = entry.split(4, 4);
-        assertEquals(1, list.size());
+        Assertions.assertEquals(1, list.size());
         RulesValidationEntryV2 united = RulesValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -58,9 +58,9 @@ public class RulesValidationEntryV2Test {
                 .proper(null)
                 .build();
         List<RulesValidationEntryV2> list = entry.split(4, 4);
-        assertEquals(1, list.size());
+        Assertions.assertEquals(1, list.size());
         RulesValidationEntryV2 united = RulesValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -73,9 +73,9 @@ public class RulesValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredRulesInfo(4, 1))
                 .build();
         List<RulesValidationEntryV2> list = entry.split(4, 4);
-        assertEquals(1, list.size());
+        Assertions.assertEquals(1, list.size());
         RulesValidationEntryV2 united = RulesValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -88,9 +88,9 @@ public class RulesValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredRulesInfo(4, 1))
                 .build();
         List<RulesValidationEntryV2> list = entry.split(1, 1);
-        assertEquals(4, list.size());
+        Assertions.assertEquals(4, list.size());
         RulesValidationEntryV2 united = RulesValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -103,9 +103,9 @@ public class RulesValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredRulesInfo(4, 4))
                 .build();
         List<RulesValidationEntryV2> list = entry.split(2, 3);
-        assertEquals(4, list.size());
+        Assertions.assertEquals(4, list.size());
         RulesValidationEntryV2 united = RulesValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -118,9 +118,9 @@ public class RulesValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredRulesInfo(4, 4))
                 .build();
         List<RulesValidationEntryV2> list = entry.split(100, 200);
-        assertEquals(1, list.size());
+        Assertions.assertEquals(1, list.size());
         RulesValidationEntryV2 united = RulesValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -133,9 +133,9 @@ public class RulesValidationEntryV2Test {
                 .misconfigured(new ArrayList<>())
                 .build();
         List<RulesValidationEntryV2> list = entry.split(2, 2);
-        assertEquals(3, list.size());
+        Assertions.assertEquals(3, list.size());
         RulesValidationEntryV2 united = RulesValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -148,9 +148,9 @@ public class RulesValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredRulesInfo(3000, 800))
                 .build();
         List<RulesValidationEntryV2> list = entry.split(100, 200);
-        assertEquals(14, list.size());
+        Assertions.assertEquals(14, list.size());
         RulesValidationEntryV2 united = RulesValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     @Test
@@ -163,9 +163,9 @@ public class RulesValidationEntryV2Test {
                 .misconfigured(buildMisconfiguredRulesInfo(3000, 800))
                 .build();
         List<RulesValidationEntryV2> list = entry.split(1, 1);
-        assertEquals(2600, list.size());
+        Assertions.assertEquals(2600, list.size());
         RulesValidationEntryV2 united = RulesValidationEntryV2.join(list);
-        assertEquals(entry, united);
+        Assertions.assertEquals(entry, united);
     }
 
     static List<RuleInfoEntryV2> buildRulesInfo(int idBase, int count) {

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/info/switches/v2/SwitchValidationResponseV2Test.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/info/switches/v2/SwitchValidationResponseV2Test.java
@@ -15,9 +15,8 @@
 
 package org.openkilda.messaging.info.switches.v2;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -34,9 +33,9 @@ public class SwitchValidationResponseV2Test {
                 .build();
 
         List<SwitchValidationResponseV2> list = response.split(1);
-        assertEquals(1, list.size());
+        Assertions.assertEquals(1, list.size());
         SwitchValidationResponseV2 united = SwitchValidationResponseV2.unite(list);
-        assertEquals(response, united);
+        Assertions.assertEquals(response, united);
     }
 
     @Test
@@ -50,9 +49,9 @@ public class SwitchValidationResponseV2Test {
                 .build();
 
         List<SwitchValidationResponseV2> list = response.split(1);
-        assertEquals(1, list.size());
+        Assertions.assertEquals(1, list.size());
         SwitchValidationResponseV2 united = SwitchValidationResponseV2.unite(list);
-        assertEquals(response, united);
+        Assertions.assertEquals(response, united);
     }
 
     @Test
@@ -66,9 +65,9 @@ public class SwitchValidationResponseV2Test {
                 .build();
 
         List<SwitchValidationResponseV2> list = response.split(1000);
-        assertEquals(1, list.size());
+        Assertions.assertEquals(1, list.size());
         SwitchValidationResponseV2 united = SwitchValidationResponseV2.unite(list);
-        assertEquals(response, united);
+        Assertions.assertEquals(response, united);
     }
 
     @Test
@@ -82,9 +81,9 @@ public class SwitchValidationResponseV2Test {
                 .build();
 
         List<SwitchValidationResponseV2> list = response.split(32);
-        assertEquals(1, list.size());
+        Assertions.assertEquals(1, list.size());
         SwitchValidationResponseV2 united = SwitchValidationResponseV2.unite(list);
-        assertEquals(response, united);
+        Assertions.assertEquals(response, united);
     }
 
     @Test
@@ -98,9 +97,9 @@ public class SwitchValidationResponseV2Test {
                 .build();
 
         List<SwitchValidationResponseV2> list = response.split(1);
-        assertEquals(176, list.size());
+        Assertions.assertEquals(176, list.size());
         SwitchValidationResponseV2 united = SwitchValidationResponseV2.unite(list);
-        assertEquals(response, united);
+        Assertions.assertEquals(response, united);
     }
 
     @Test
@@ -114,9 +113,9 @@ public class SwitchValidationResponseV2Test {
                 .build();
 
         List<SwitchValidationResponseV2> list = response.split(3);
-        assertEquals(59, list.size());
+        Assertions.assertEquals(59, list.size());
         SwitchValidationResponseV2 united = SwitchValidationResponseV2.unite(list);
-        assertEquals(response, united);
+        Assertions.assertEquals(response, united);
     }
 
     @Test
@@ -130,9 +129,9 @@ public class SwitchValidationResponseV2Test {
                 .build();
 
         List<SwitchValidationResponseV2> list = response.split(500);
-        assertEquals(4, list.size());
+        Assertions.assertEquals(4, list.size());
         SwitchValidationResponseV2 united = SwitchValidationResponseV2.unite(list);
-        assertEquals(response, united);
+        Assertions.assertEquals(response, united);
     }
 
     @Test
@@ -146,9 +145,9 @@ public class SwitchValidationResponseV2Test {
                 .build();
 
         List<SwitchValidationResponseV2> list = response.split(1);
-        assertEquals(1776, list.size());
+        Assertions.assertEquals(1776, list.size());
         SwitchValidationResponseV2 united = SwitchValidationResponseV2.unite(list);
-        assertEquals(response, united);
+        Assertions.assertEquals(response, united);
     }
 
     private MetersValidationEntryV2 buildMeterEntry(

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/model/LinkPropsMaskTest.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/model/LinkPropsMaskTest.java
@@ -18,8 +18,8 @@ package org.openkilda.messaging.model;
 import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LinkPropsMaskTest {
 
@@ -34,6 +34,6 @@ public class LinkPropsMaskTest {
         String json = mapper.writeValueAsString(origin);
 
         LinkPropsMask reconstructed = mapper.readValue(json, LinkPropsMask.class);
-        Assert.assertEquals(origin, reconstructed);
+        Assertions.assertEquals(origin, reconstructed);
     }
 }

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/model/LinkPropsTest.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/model/LinkPropsTest.java
@@ -19,8 +19,8 @@ import org.openkilda.messaging.StringSerializer;
 import org.openkilda.messaging.Utils;
 import org.openkilda.model.SwitchId;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -44,7 +44,7 @@ public class LinkPropsTest {
         serializer.serialize(origin);
 
         LinkPropsDto reconstructed = (LinkPropsDto) serializer.deserialize();
-        Assert.assertEquals(origin, reconstructed);
+        Assertions.assertEquals(origin, reconstructed);
     }
 
     /**

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/model/NetworkEndpointMaskTest.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/model/NetworkEndpointMaskTest.java
@@ -19,8 +19,8 @@ import org.openkilda.messaging.StringSerializer;
 import org.openkilda.messaging.Utils;
 import org.openkilda.model.SwitchId;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -49,7 +49,7 @@ public class NetworkEndpointMaskTest {
             serializer.serialize(origin);
 
             NetworkEndpointMask reconstructed = (NetworkEndpointMask) serializer.deserialize();
-            Assert.assertEquals(origin, reconstructed);
+            Assertions.assertEquals(origin, reconstructed);
         }
     }
 }

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/model/NetworkEndpointTest.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/model/NetworkEndpointTest.java
@@ -19,8 +19,8 @@ import org.openkilda.messaging.StringSerializer;
 import org.openkilda.messaging.Utils;
 import org.openkilda.model.SwitchId;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -44,6 +44,6 @@ public class NetworkEndpointTest {
         serializer.serialize(origin);
 
         NetworkEndpoint reconstructed = (NetworkEndpoint) serializer.deserialize();
-        Assert.assertEquals(origin, reconstructed);
+        Assertions.assertEquals(origin, reconstructed);
     }
 }

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/model/PingMetersTest.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/model/PingMetersTest.java
@@ -17,18 +17,18 @@ package org.openkilda.messaging.model;
 
 import org.openkilda.messaging.ObjectSerializer;
 
-import java.io.IOException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Assert;
-import org.junit.Test;
+import java.io.IOException;
 
 public class PingMetersTest {
     ObjectSerializer serializer;
-	
-	public PingMetersTest() throws IOException {
-		serializer = new ObjectSerializer();
-	}
-	
+
+    public PingMetersTest() throws IOException {
+        serializer = new ObjectSerializer();
+    }
+
     @Test
     public void serializeLoop() throws Exception {
         PingMeters origin = new PingMeters(1L, 2L, 3L);
@@ -36,9 +36,7 @@ public class PingMetersTest {
         serializer.serialize(origin);
         PingMeters decoded = (PingMeters) serializer.deserialize();
 
-        Assert.assertEquals(
-                String.format("%s object have been mangled in serialisation/deserialization loop",
-                        origin.getClass().getName()),
-                origin, decoded);
+        Assertions.assertEquals(origin, decoded, String.format("%s object have been mangled"
+                + " in serialisation/deserialization loop", origin.getClass().getName()));
     }
 }

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/model/PingReportTest.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/model/PingReportTest.java
@@ -18,28 +18,26 @@ package org.openkilda.messaging.model;
 import org.openkilda.messaging.ObjectSerializer;
 import org.openkilda.messaging.model.PingReport.State;
 
-import java.io.IOException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Assert;
-import org.junit.Test;
+import java.io.IOException;
 
 public class PingReportTest {
     ObjectSerializer serializer;
-	
-	public PingReportTest() throws IOException {
-		serializer = new ObjectSerializer();
-	}	
 
-	@Test
+    public PingReportTest() throws IOException {
+        serializer = new ObjectSerializer();
+    }
+
+    @Test
     public void serializeLoop() throws Exception {
         PingReport origin = new PingReport("flowId-" + getClass().getSimpleName(), State.OPERATIONAL);
 
         serializer.serialize(origin);
         PingReport decoded = (PingReport) serializer.deserialize();
 
-        Assert.assertEquals(
-                String.format("%s object have been mangled in serialisation/deserialization loop",
-                        origin.getClass().getName()),
-                origin, decoded);
+        Assertions.assertEquals(origin, decoded, String.format("%s object have been mangled in"
+                + " serialisation/deserialization loop", origin.getClass().getName()));
     }
 }

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/model/PingTest.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/model/PingTest.java
@@ -20,8 +20,8 @@ import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.FlowTransitEncapsulation;
 import org.openkilda.model.SwitchId;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -41,9 +41,7 @@ public class PingTest {
         serializer.serialize(origin);
         Ping decoded = (Ping) serializer.deserialize();
 
-        Assert.assertEquals(
-                String.format("%s object have been mangled in serialisation/deserialization loop",
-                        origin.getClass().getName()),
-                origin, decoded);
+        Assertions.assertEquals(origin, decoded, String.format("%s object have been mangled in"
+                + " serialisation/deserialization loop", origin.getClass().getName()));
     }
 }

--- a/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/model/SwitchTest.java
+++ b/src-java/base-topology/base-messaging/src/test/java/org/openkilda/messaging/model/SwitchTest.java
@@ -23,8 +23,8 @@ import org.openkilda.model.SwitchFeature;
 import org.openkilda.model.SwitchId;
 import org.openkilda.model.SwitchStatus;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -58,6 +58,6 @@ public class SwitchTest {
         serializer.serialize(origin);
 
         Switch reconstructed = (Switch) serializer.deserialize();
-        Assert.assertEquals(origin, reconstructed);
+        Assertions.assertEquals(origin, reconstructed);
     }
 }

--- a/src-java/base-topology/base-storm-topology/build.gradle
+++ b/src-java/base-topology/base-storm-topology/build.gradle
@@ -89,7 +89,8 @@ dependencies {
     api 'io.micrometer:micrometer-core:1.10.5'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.hamcrest:hamcrest-library'
     testImplementation 'org.apache.curator:curator-test'
@@ -137,4 +138,8 @@ artifacts {
 
 buildAndCopyArtifacts {
     from("${project.buildDir}/resources/releaseResources/topology.properties") { into "${project.name}/resources" }
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/base-topology/base-storm-topology/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/base-topology/base-storm-topology/src/checkstyle/checkstyle-suppressions.xml
@@ -5,6 +5,7 @@
 
 <suppressions>
     <suppress files="src/main/.*Fsm\.java$" checks="JavadocMethod" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="VariableDeclarationUsageDistance" />
     <suppress files="src/main/java/org/openkilda/wfm/ctrl/RouteBolt.java" lines="47" checks="JavadocMethod"/>
     <suppress files="src/main/java/org/openkilda/wfm/ctrl/CtrlAction.java" lines="94" checks="JavadocMethod"/>
@@ -27,4 +28,5 @@
     <suppress files="src/test/java/org/openkilda/wfm/TestUtils.java" lines="83" checks="JavadocMethod"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/TestKafkaConsumer.java" lines="58" checks="JavadocMethod"/>
     <suppress files="src/test/java/org/openkilda/wfm/topology/TestKafkaProducer.java" lines="37" checks="JavadocMethod"/>
+
 </suppressions>

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/config/SecondsToMilisConverterTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/config/SecondsToMilisConverterTest.java
@@ -15,15 +15,14 @@
 
 package org.openkilda.wfm.config;
 
-import static org.junit.Assert.assertEquals;
-
 import com.google.common.collect.ImmutableMap;
 import com.sabre.oss.conf4j.annotation.Configuration;
 import com.sabre.oss.conf4j.annotation.Converter;
 import com.sabre.oss.conf4j.annotation.Key;
 import com.sabre.oss.conf4j.factory.jdkproxy.JdkProxyStaticConfigurationFactory;
 import com.sabre.oss.conf4j.source.MapConfigurationSource;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SecondsToMilisConverterTest {
 
@@ -38,7 +37,7 @@ public class SecondsToMilisConverterTest {
         TestConfig config = factory.createConfiguration(TestConfig.class, source);
 
         // then
-        assertEquals(10000, config.getTestProperty());
+        Assertions.assertEquals(10000, config.getTestProperty());
     }
 
     @Configuration

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/config/provider/MultiPrefixConfigurationProviderTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/config/provider/MultiPrefixConfigurationProviderTest.java
@@ -16,12 +16,11 @@
 package org.openkilda.wfm.config.provider;
 
 import static java.lang.String.format;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 import com.sabre.oss.conf4j.annotation.Configuration;
 import com.sabre.oss.conf4j.annotation.Key;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
@@ -42,7 +41,7 @@ public class MultiPrefixConfigurationProviderTest {
         TestConfig config = provider.getConfiguration(TestConfig.class);
 
         // then
-        assertNull(config.getTestProperty());
+        Assertions.assertNull(config.getTestProperty());
     }
 
     @Test
@@ -56,7 +55,7 @@ public class MultiPrefixConfigurationProviderTest {
         TestConfig config = provider.getConfiguration(TestConfig.class);
 
         // then
-        assertEquals(TEST_VALUE, config.getTestProperty());
+        Assertions.assertEquals(TEST_VALUE, config.getTestProperty());
     }
 
     @Configuration

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/bolt/MonotonicClockTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/bolt/MonotonicClockTest.java
@@ -31,12 +31,12 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.TupleImpl;
 import org.apache.storm.tuple.Values;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -44,7 +44,7 @@ import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.Objects;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class MonotonicClockTest {
     @Mock
     private OutputCollector output;
@@ -52,7 +52,7 @@ public class MonotonicClockTest {
     @Mock
     private TopologyContext topologyContext;
 
-    @BeforeClass
+    @BeforeAll
     public static void initPersistenceManager() {
         InMemoryGraphPersistenceManager.newInstance().install();
     }
@@ -159,7 +159,7 @@ public class MonotonicClockTest {
 
     private Tuple makeSystemTickTuple() {
         return new TupleImpl(topologyContext, Collections.emptyList(),
-                             (int) Constants.SYSTEM_TASK_ID, Constants.SYSTEM_TICK_STREAM_ID);
+                (int) Constants.SYSTEM_TASK_ID, Constants.SYSTEM_TICK_STREAM_ID);
 
     }
 

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/flow/resources/CookiePoolTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/flow/resources/CookiePoolTest.java
@@ -16,17 +16,18 @@
 package org.openkilda.wfm.share.flow.resources;
 
 import static java.lang.String.format;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.FlowCookie;
 import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.FlowCookieRepository;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -40,7 +41,7 @@ public class CookiePoolTest extends InMemoryGraphBasedTest {
     private CookiePool cookiePool;
     private FlowCookieRepository flowCookieRepository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         cookiePool = new CookiePool(persistenceManager, MIN_COOKIE, MAX_COOKIE, 1);
         flowCookieRepository = persistenceManager.getRepositoryFactory().createFlowCookieRepository();
@@ -58,12 +59,14 @@ public class CookiePoolTest extends InMemoryGraphBasedTest {
         });
     }
 
-    @Test(expected = ResourceNotAvailableException.class)
+    @Test
     public void cookiePoolFullTest() {
-        transactionManager.doInTransaction(() -> {
-            for (long i = MIN_COOKIE; i <= MAX_COOKIE + 1; i++) {
-                assertTrue(cookiePool.allocate(format("flow_%d", i)) > 0);
-            }
+        Assertions.assertThrows(ResourceNotAvailableException.class, () -> {
+            transactionManager.doInTransaction(() -> {
+                for (long i = MIN_COOKIE; i <= MAX_COOKIE + 1; i++) {
+                    assertTrue(cookiePool.allocate(format("flow_%d", i)) > 0);
+                }
+            });
         });
     }
 

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/flow/resources/FlowResourcesManagerTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/flow/resources/FlowResourcesManagerTest.java
@@ -16,8 +16,8 @@
 package org.openkilda.wfm.share.flow.resources;
 
 import static java.lang.String.format;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 
 import org.openkilda.config.provider.PropertiesBasedConfigurationProvider;
@@ -37,8 +37,9 @@ import org.openkilda.persistence.repositories.SwitchRepository;
 import org.openkilda.wfm.share.flow.resources.transitvlan.TransitVlanEncapsulation;
 import org.openkilda.wfm.share.mappers.FlowMapper;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Properties;
@@ -121,7 +122,7 @@ public class FlowResourcesManagerTest extends InMemoryGraphBasedTest {
     private Switch switch4 = Switch.builder().switchId(new SwitchId("ff:04")).build();
     private Switch switch5 = Switch.builder().switchId(new SwitchId("ff:05")).build();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         Properties configProps = new Properties();
         configProps.setProperty("flow.meter-id.max", "40");
@@ -149,7 +150,7 @@ public class FlowResourcesManagerTest extends InMemoryGraphBasedTest {
     }
 
     @Test
-    public void shouldNotImmediatelyReuseResources() throws ResourceAllocationException {
+    public void shouldNotImmediatelyReuseResources() {
         transactionManager.doInTransaction(() -> {
             Flow flow = convertFlow(firstFlow);
             FlowResources flowResources = resourcesManager.allocateFlowResources(flow);
@@ -163,7 +164,7 @@ public class FlowResourcesManagerTest extends InMemoryGraphBasedTest {
     }
 
     @Test
-    public void shouldAllocateForNoBandwidthFlow() throws ResourceAllocationException {
+    public void shouldAllocateForNoBandwidthFlow() {
         transactionManager.doInTransaction(() -> {
             Flow flow = convertFlow(fourthFlow);
             verifyMeterLessAllocation(resourcesManager.allocateFlowResources(flow));
@@ -171,7 +172,7 @@ public class FlowResourcesManagerTest extends InMemoryGraphBasedTest {
     }
 
     @Test
-    public void shouldNotConsumeVlansForSingleSwitchFlows() throws ResourceAllocationException {
+    public void shouldNotConsumeVlansForSingleSwitchFlows() {
         transactionManager.doInTransaction(() -> {
             /*
              * This is to validate that single switch flows don't consume transit vlans.
@@ -191,7 +192,7 @@ public class FlowResourcesManagerTest extends InMemoryGraphBasedTest {
     }
 
     @Test
-    public void shouldNotConsumeMetersForUnmeteredFlows() throws ResourceAllocationException {
+    public void shouldNotConsumeMetersForUnmeteredFlows() {
         transactionManager.doInTransaction(() -> {
             // for forward and reverse flows 2 meters are allocated, so just try max / 2 + 1 attempts
             final int attemps = (flowResourcesConfig.getMaxFlowMeterId()
@@ -207,7 +208,7 @@ public class FlowResourcesManagerTest extends InMemoryGraphBasedTest {
     }
 
     @Test
-    public void deallocateFlowResourcesTest() throws Exception {
+    public void deallocateFlowResourcesTest() {
         transactionManager.doInTransaction(() -> {
             Flow flow = convertFlow(firstFlow);
 
@@ -219,7 +220,7 @@ public class FlowResourcesManagerTest extends InMemoryGraphBasedTest {
     }
 
     @Test
-    public void deallocatePathResourcesTest() throws Exception {
+    public void deallocatePathResourcesTest() {
         transactionManager.doInTransaction(() -> {
             Flow flow = convertFlow(firstFlow);
 
@@ -233,15 +234,17 @@ public class FlowResourcesManagerTest extends InMemoryGraphBasedTest {
         });
     }
 
-    @Test(expected = ResourceAllocationException.class)
-    public void shouldThrowExceptionOnAllocationFailed() throws ResourceAllocationException {
-        transactionManager.doInTransaction(() -> {
-            FlowResourcesManager spy = Mockito.spy(resourcesManager);
-            Mockito.doThrow(ConstraintViolationException.class)
-                    .when(spy).allocateResources(any(), any(), any());
+    @Test
+    public void shouldThrowExceptionOnAllocationFailed() {
+        Assertions.assertThrows(ResourceAllocationException.class, () -> {
+            transactionManager.doInTransaction(() -> {
+                FlowResourcesManager spy = Mockito.spy(resourcesManager);
+                Mockito.doThrow(ConstraintViolationException.class)
+                        .when(spy).allocateResources(any(), any(), any());
 
-            Flow flow = convertFlow(firstFlow);
-            spy.allocateFlowResources(flow);
+                Flow flow = convertFlow(firstFlow);
+                spy.allocateFlowResources(flow);
+            });
         });
     }
 

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/flow/resources/transitvlan/TransitVlanPoolTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/flow/resources/transitvlan/TransitVlanPoolTest.java
@@ -16,8 +16,9 @@
 package org.openkilda.wfm.share.flow.resources.transitvlan;
 
 import static java.lang.String.format;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.Flow;
 import org.openkilda.model.PathId;
@@ -28,9 +29,8 @@ import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.TransitVlanRepository;
 import org.openkilda.wfm.share.flow.resources.ResourceNotAvailableException;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -53,7 +53,7 @@ public class TransitVlanPoolTest extends InMemoryGraphBasedTest {
     private TransitVlanPool transitVlanPool;
     private TransitVlanRepository transitVlanRepository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         transitVlanPool = new TransitVlanPool(persistenceManager, MIN_TRANSIT_VLAN, MAX_TRANSIT_VLAN, 1);
         transitVlanRepository = persistenceManager.getRepositoryFactory().createTransitVlanRepository();
@@ -74,16 +74,16 @@ public class TransitVlanPoolTest extends InMemoryGraphBasedTest {
         });
     }
 
-    @Test(expected = ResourceNotAvailableException.class)
+    @Test
     public void vlanPoolFullTest() {
-        transactionManager.doInTransaction(() -> {
+        assertThrows(ResourceNotAvailableException.class, () -> transactionManager.doInTransaction(() -> {
             for (int i = MIN_TRANSIT_VLAN; i <= MAX_TRANSIT_VLAN + 1; i++) {
                 assertTrue(transitVlanPool.allocate(
                         format("flow_%d", i),
                         new PathId(format("path_%d", i)),
                         new PathId(format("opposite_dummy_%d", i))).getTransitVlan().getVlan() > 0);
             }
-        });
+        }));
     }
 
     @Test
@@ -96,7 +96,7 @@ public class TransitVlanPoolTest extends InMemoryGraphBasedTest {
 
             TransitVlan reverse = transitVlanPool.allocate(FLOW_ID_1, reversePathId, forwardPathId)
                     .getTransitVlan();
-            Assert.assertEquals(forward, reverse);
+            assertEquals(forward, reverse);
         });
     }
 

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/flow/resources/vxlan/VxlanPoolTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/flow/resources/vxlan/VxlanPoolTest.java
@@ -16,8 +16,8 @@
 package org.openkilda.wfm.share.flow.resources.vxlan;
 
 import static java.lang.String.format;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.Flow;
 import org.openkilda.model.PathId;
@@ -28,8 +28,9 @@ import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.VxlanRepository;
 import org.openkilda.wfm.share.flow.resources.ResourceNotAvailableException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -50,7 +51,7 @@ public class VxlanPoolTest extends InMemoryGraphBasedTest {
     private VxlanPool vxlanPool;
     private VxlanRepository vxlanRepository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         vxlanPool = new VxlanPool(persistenceManager, MIN_VXLAN, MAX_VXLAN, 1);
         vxlanRepository = persistenceManager.getRepositoryFactory().createVxlanRepository();
@@ -72,14 +73,14 @@ public class VxlanPoolTest extends InMemoryGraphBasedTest {
     }
 
 
-    @Test(expected = ResourceNotAvailableException.class)
+    @Test
     public void vxlanPoolFullTest() {
-        transactionManager.doInTransaction(() -> {
+        Assertions.assertThrows(ResourceNotAvailableException.class, () -> transactionManager.doInTransaction(() -> {
             for (int i = MIN_VXLAN; i <= MAX_VXLAN + 1; i++) {
                 assertTrue(vxlanPool.allocate(format("flow_%d", i), new PathId(format("path_%d", i)),
                         new PathId(format("op_path_%d", i))).getVxlan().getVni() > 0);
             }
-        });
+        }));
     }
 
     @Test

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/hubandspoke/CoordinatorBoltTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/hubandspoke/CoordinatorBoltTest.java
@@ -16,8 +16,6 @@
 package org.openkilda.wfm.share.hubandspoke;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
@@ -26,16 +24,18 @@ import static org.mockito.Mockito.when;
 
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CoordinatorBoltTest {
 
     private CoordinatorBolt target = new CoordinatorBolt();
@@ -46,7 +46,7 @@ public class CoordinatorBoltTest {
     @Mock
     private TopologyContext topologyContext;
 
-    @Before
+    @BeforeEach
     public void setup() {
         when(topologyContext.getThisTaskId()).thenReturn(1);
 
@@ -63,11 +63,11 @@ public class CoordinatorBoltTest {
         final int taskId = 101;
         target.registerCallback(key, context, timeout, taskId);
 
-        assertThat(target.getCallbacks().size(), is(1));
-        assertThat(target.getTimeouts().size(), is(1));
+        MatcherAssert.assertThat(target.getCallbacks().size(), is(1));
+        MatcherAssert.assertThat(target.getTimeouts().size(), is(1));
 
         target.cancelCallback(key);
-        assertTrue(target.getCallbacks().isEmpty());
+        Assertions.assertTrue(target.getCallbacks().isEmpty());
     }
 
     @Test
@@ -79,7 +79,7 @@ public class CoordinatorBoltTest {
         final int secondTask = 102;
         target.registerCallback("request2", "some context", timeout, secondTask);
 
-        assertThat(target.getCallbacks().size(), is(2));
+        MatcherAssert.assertThat(target.getCallbacks().size(), is(2));
 
         // check that we have stored timeouts for out tasks
         Set<String> tasks = target.getTimeouts()
@@ -87,7 +87,7 @@ public class CoordinatorBoltTest {
                 .stream()
                 .flatMap(Set::stream)
                 .collect(Collectors.toSet());
-        assertThat(tasks.size(), is(2));
+        MatcherAssert.assertThat(tasks.size(), is(2));
 
         long afterTimeout = System.currentTimeMillis() + timeout + 1L;
         target.tick(afterTimeout);

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/mappers/FlowMapperTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/mappers/FlowMapperTest.java
@@ -16,8 +16,6 @@
 package org.openkilda.wfm.share.mappers;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import org.openkilda.messaging.info.event.PathInfoData;
 import org.openkilda.messaging.info.event.PathNode;
@@ -38,7 +36,8 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.model.cookie.FlowSegmentCookie;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.List;
@@ -109,15 +108,15 @@ public class FlowMapperTest {
 
         FlowPairDto<FlowDto, FlowDto> pair = new FlowPairDto<>(forwardFlow, reverseFlow);
         Flow p = FlowMapper.INSTANCE.map(pair, () -> KildaConfiguration.DEFAULTS);
-        assertEquals(p.getFlowId(), pair.getLeft().getFlowId());
+        Assertions.assertEquals(p.getFlowId(), pair.getLeft().getFlowId());
         assertDetectConnectedDevices(forwardFlow.getDetectConnectedDevices(), p.getDetectConnectedDevices());
     }
 
     private void assertDetectConnectedDevices(DetectConnectedDevicesDto expected, DetectConnectedDevices actual) {
-        assertEquals(expected.isSrcLldp(), actual.isSrcLldp());
-        assertEquals(expected.isSrcArp(), actual.isSrcArp());
-        assertEquals(expected.isDstLldp(), actual.isDstLldp());
-        assertEquals(expected.isDstArp(), actual.isDstArp());
+        Assertions.assertEquals(expected.isSrcLldp(), actual.isSrcLldp());
+        Assertions.assertEquals(expected.isSrcArp(), actual.isSrcArp());
+        Assertions.assertEquals(expected.isDstLldp(), actual.isDstLldp());
+        Assertions.assertEquals(expected.isDstArp(), actual.isDstArp());
     }
 
     @Test
@@ -126,9 +125,9 @@ public class FlowMapperTest {
 
         FlowDto flowDto = FlowMapper.INSTANCE.map(flow);
 
-        assertNotNull(flowDto.getFlowStatusDetails());
-        assertEquals(FlowPathStatus.ACTIVE, flowDto.getFlowStatusDetails().getMainFlowPathStatus());
-        assertEquals(FlowPathStatus.INACTIVE, flowDto.getFlowStatusDetails().getProtectedFlowPathStatus());
+        Assertions.assertNotNull(flowDto.getFlowStatusDetails());
+        Assertions.assertEquals(FlowPathStatus.ACTIVE, flowDto.getFlowStatusDetails().getMainFlowPathStatus());
+        Assertions.assertEquals(FlowPathStatus.INACTIVE, flowDto.getFlowStatusDetails().getProtectedFlowPathStatus());
         assertDetectConnectedDevices(flowDto.getDetectConnectedDevices(), flow.getDetectConnectedDevices());
     }
 
@@ -139,15 +138,15 @@ public class FlowMapperTest {
         FlowDto flowDto = FlowMapper.INSTANCE.map(
                 flow, new HashSet<>(), new HashSet<>(), new HashSet<>(), buildFlowMirrorPathList());
 
-        assertNotNull(flowDto.getMirrorPointStatuses());
-        assertEquals(2, flowDto.getMirrorPointStatuses().size());
+        Assertions.assertNotNull(flowDto.getMirrorPointStatuses());
+        Assertions.assertEquals(2, flowDto.getMirrorPointStatuses().size());
 
-        assertEquals(MIRROR_PATH_ID_A.getId(), flowDto.getMirrorPointStatuses().get(0).getMirrorPointId());
-        assertEquals(FLOW_PATH_STATUS_A.toString().toLowerCase(),
+        Assertions.assertEquals(MIRROR_PATH_ID_A.getId(), flowDto.getMirrorPointStatuses().get(0).getMirrorPointId());
+        Assertions.assertEquals(FLOW_PATH_STATUS_A.toString().toLowerCase(),
                 flowDto.getMirrorPointStatuses().get(0).getStatus());
 
-        assertEquals(MIRROR_PATH_ID_B.getId(), flowDto.getMirrorPointStatuses().get(1).getMirrorPointId());
-        assertEquals(FLOW_PATH_STATUS_B.toString().toLowerCase(),
+        Assertions.assertEquals(MIRROR_PATH_ID_B.getId(), flowDto.getMirrorPointStatuses().get(1).getMirrorPointId());
+        Assertions.assertEquals(FLOW_PATH_STATUS_B.toString().toLowerCase(),
                 flowDto.getMirrorPointStatuses().get(1).getStatus());
     }
 

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/mappers/HistoryMapperTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/mappers/HistoryMapperTest.java
@@ -31,8 +31,8 @@ import org.openkilda.model.history.FlowEvent;
 import org.openkilda.model.history.FlowEventAction;
 import org.openkilda.model.history.FlowEventDump;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -87,7 +87,7 @@ public class HistoryMapperTest {
 
     public static FlowEventDump flowEventDump;
 
-    @BeforeClass
+    @BeforeAll
     public static void initializeData() {
         action = new FlowEventAction();
         action.setTimestamp(TIMESTAMP);

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/mappers/IslMapperTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/mappers/IslMapperTest.java
@@ -22,8 +22,8 @@ import org.openkilda.model.Isl;
 import org.openkilda.model.IslStatus;
 import org.openkilda.model.SwitchId;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class IslMapperTest {
 
@@ -47,10 +47,10 @@ public class IslMapperTest {
 
         Isl isl = IslMapper.INSTANCE.map(islInfoData);
 
-        Assert.assertEquals(IslStatus.ACTIVE, isl.getStatus());
+        Assertions.assertEquals(IslStatus.ACTIVE, isl.getStatus());
 
         IslInfoData islInfoDataMapping = IslMapper.INSTANCE.map(isl);
 
-        Assert.assertEquals(islInfoData, islInfoDataMapping);
+        Assertions.assertEquals(islInfoData, islInfoDataMapping);
     }
 }

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/mappers/PortMapperTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/mappers/PortMapperTest.java
@@ -20,8 +20,8 @@ import org.openkilda.messaging.info.event.PortInfoData;
 import org.openkilda.model.Port;
 import org.openkilda.model.SwitchId;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 
 public class PortMapperTest {
@@ -36,18 +36,18 @@ public class PortMapperTest {
 
         Port port = portMapper.map(portInfoData);
 
-        Assert.assertNotNull(port.getSwitchObj());
-        Assert.assertEquals(portInfoData.getSwitchId(), port.getSwitchObj().getSwitchId());
-        Assert.assertEquals(portInfoData.getSwitchId(), port.getSwitchId());
-        Assert.assertEquals(portInfoData.getPortNo(), port.getPortNo());
-        Assert.assertEquals(portInfoData.getCurrentSpeed().longValue(), port.getCurrentSpeed());
-        Assert.assertEquals(portInfoData.getMaxSpeed().longValue(), port.getMaxSpeed());
+        Assertions.assertNotNull(port.getSwitchObj());
+        Assertions.assertEquals(portInfoData.getSwitchId(), port.getSwitchObj().getSwitchId());
+        Assertions.assertEquals(portInfoData.getSwitchId(), port.getSwitchId());
+        Assertions.assertEquals(portInfoData.getPortNo(), port.getPortNo());
+        Assertions.assertEquals(portInfoData.getCurrentSpeed().longValue(), port.getCurrentSpeed());
+        Assertions.assertEquals(portInfoData.getMaxSpeed().longValue(), port.getMaxSpeed());
 
         PortInfoData portInfoDataMapping = portMapper.map(port);
 
-        Assert.assertEquals(port.getSwitchId(), portInfoDataMapping.getSwitchId());
-        Assert.assertEquals(port.getPortNo(), portInfoDataMapping.getPortNo());
-        Assert.assertEquals(port.getCurrentSpeed(), portInfoDataMapping.getCurrentSpeed().longValue());
-        Assert.assertEquals(port.getMaxSpeed(), portInfoDataMapping.getMaxSpeed().longValue());
+        Assertions.assertEquals(port.getSwitchId(), portInfoDataMapping.getSwitchId());
+        Assertions.assertEquals(port.getPortNo(), portInfoDataMapping.getPortNo());
+        Assertions.assertEquals(port.getCurrentSpeed(), portInfoDataMapping.getCurrentSpeed().longValue());
+        Assertions.assertEquals(port.getMaxSpeed(), portInfoDataMapping.getMaxSpeed().longValue());
     }
 }

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/service/IntersectionComputerTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/service/IntersectionComputerTest.java
@@ -16,8 +16,7 @@
 package org.openkilda.wfm.share.service;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.messaging.payload.flow.OverlappingSegmentsStats;
 import org.openkilda.model.Flow;
@@ -29,8 +28,9 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.share.flow.TestFlowBuilder;
 
 import com.google.common.collect.Lists;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -56,7 +56,7 @@ public class IntersectionComputerTest {
     private Flow flow;
     private Flow flow2;
 
-    @Before
+    @BeforeEach
     public void setup() {
         flow = new TestFlowBuilder(FLOW_ID)
                 .srcSwitch(Switch.builder().switchId(SWITCH_ID_A).build())
@@ -314,41 +314,42 @@ public class IntersectionComputerTest {
         assertEquals(SWITCH_ID_C, sharedPath.get(1).getDestSwitchId());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void failCalculateSharedPathForOnePathTest() {
-        FlowPath firstPath = FlowPath.builder()
-                .pathId(PATH_ID)
-                .srcSwitch(makeSwitch(SWITCH_ID_A))
-                .destSwitch(makeSwitch(SWITCH_ID_C))
-                .segments(Lists.newArrayList(
-                        buildPathSegment(NEW_PATH_ID, SWITCH_ID_A, SWITCH_ID_B, 1, 1),
-                        buildPathSegment(NEW_PATH_ID, SWITCH_ID_B, SWITCH_ID_C, 2, 2)))
-                .build();
-        IntersectionComputer.calculatePathIntersectionFromSource(Collections.singletonList(firstPath));
-        fail();
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            FlowPath firstPath = FlowPath.builder()
+                    .pathId(PATH_ID)
+                    .srcSwitch(makeSwitch(SWITCH_ID_A))
+                    .destSwitch(makeSwitch(SWITCH_ID_C))
+                    .segments(Lists.newArrayList(
+                            buildPathSegment(NEW_PATH_ID, SWITCH_ID_A, SWITCH_ID_B, 1, 1),
+                            buildPathSegment(NEW_PATH_ID, SWITCH_ID_B, SWITCH_ID_C, 2, 2)))
+                    .build();
+            IntersectionComputer.calculatePathIntersectionFromSource(Collections.singletonList(firstPath));
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void failCalculateSharedPathForDifferentSourcesTest() {
-        FlowPath firstPath = FlowPath.builder()
-                .pathId(PATH_ID)
-                .srcSwitch(makeSwitch(SWITCH_ID_A))
-                .destSwitch(makeSwitch(SWITCH_ID_C))
-                .segments(Lists.newArrayList(
-                        buildPathSegment(NEW_PATH_ID, SWITCH_ID_A, SWITCH_ID_B, 1, 1),
-                        buildPathSegment(NEW_PATH_ID, SWITCH_ID_B, SWITCH_ID_C, 2, 2)))
-                .build();
-        FlowPath secondPath = FlowPath.builder()
-                .pathId(NEW_PATH_ID)
-                .srcSwitch(makeSwitch(SWITCH_ID_B))
-                .destSwitch(makeSwitch(SWITCH_ID_D))
-                .segments(Lists.newArrayList(
-                        buildPathSegment(NEW_PATH_ID, SWITCH_ID_B, SWITCH_ID_C, 1, 1),
-                        buildPathSegment(NEW_PATH_ID, SWITCH_ID_C, SWITCH_ID_D, 3, 3)))
-                .build();
-
-        IntersectionComputer.calculatePathIntersectionFromSource(asList(firstPath, secondPath));
-        fail();
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            FlowPath firstPath = FlowPath.builder()
+                    .pathId(PATH_ID)
+                    .srcSwitch(makeSwitch(SWITCH_ID_A))
+                    .destSwitch(makeSwitch(SWITCH_ID_C))
+                    .segments(Lists.newArrayList(
+                            buildPathSegment(NEW_PATH_ID, SWITCH_ID_A, SWITCH_ID_B, 1, 1),
+                            buildPathSegment(NEW_PATH_ID, SWITCH_ID_B, SWITCH_ID_C, 2, 2)))
+                    .build();
+            FlowPath secondPath = FlowPath.builder()
+                    .pathId(NEW_PATH_ID)
+                    .srcSwitch(makeSwitch(SWITCH_ID_B))
+                    .destSwitch(makeSwitch(SWITCH_ID_D))
+                    .segments(Lists.newArrayList(
+                            buildPathSegment(NEW_PATH_ID, SWITCH_ID_B, SWITCH_ID_C, 1, 1),
+                            buildPathSegment(NEW_PATH_ID, SWITCH_ID_C, SWITCH_ID_D, 3, 3)))
+                    .build();
+            IntersectionComputer.calculatePathIntersectionFromSource(asList(firstPath, secondPath));
+        });
     }
 
     @Test

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/service/SpeakerFlowSegmentRequestBuilderTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/service/SpeakerFlowSegmentRequestBuilderTest.java
@@ -16,10 +16,8 @@
 package org.openkilda.wfm.share.service;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.floodlight.api.request.EgressFlowSegmentRequest;
 import org.openkilda.floodlight.api.request.FlowSegmentRequest;
@@ -52,9 +50,9 @@ import org.openkilda.wfm.share.model.SpeakerRequestBuildContext;
 import com.fasterxml.uuid.Generators;
 import com.fasterxml.uuid.NoArgGenerator;
 import com.google.common.collect.ImmutableList;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 import java.util.List;
@@ -78,7 +76,7 @@ public class SpeakerFlowSegmentRequestBuilderTest extends InMemoryGraphBasedTest
     private SpeakerFlowSegmentRequestBuilder target;
     private TransitVlanRepository vlanRepository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         FlowResourcesManager resourcesManager = new FlowResourcesManager(persistenceManager,
                 configurationProvider.getConfiguration(FlowResourcesConfig.class));
@@ -190,15 +188,15 @@ public class SpeakerFlowSegmentRequestBuilderTest extends InMemoryGraphBasedTest
             // search command for flow source side
             if (SWITCH_1.equals(entry.getSwitchId())) {
                 haveMatch = true;
-                Assert.assertTrue(entry instanceof IngressFlowSegmentRequestFactory);
+                Assertions.assertTrue(entry instanceof IngressFlowSegmentRequestFactory);
 
                 IngressFlowSegmentRequestFactory segment = (IngressFlowSegmentRequestFactory) entry;
                 IngressFlowSegmentRequest request = segment.makeInstallRequest(commandIdGenerator.generate());
-                Assert.assertEquals(goal.getSrcVlan(), request.getEndpoint().getOuterVlanId());
+                assertEquals(goal.getSrcVlan(), request.getEndpoint().getOuterVlanId());
             }
         }
 
-        Assert.assertTrue(haveMatch);
+        Assertions.assertTrue(haveMatch);
     }
 
     private void commonIngressCommandTest(int bandwidth) {
@@ -243,8 +241,7 @@ public class SpeakerFlowSegmentRequestBuilderTest extends InMemoryGraphBasedTest
 
     private IngressFlowSegmentRequest verifyCommonIngressRequest(
             Flow flow, FlowPath path, FlowSegmentRequest rawRequest) {
-        assertThat(
-                "Should be egress segment request", rawRequest, instanceOf(IngressFlowSegmentRequest.class));
+        assertThat("Should be egress segment request", rawRequest, instanceOf(IngressFlowSegmentRequest.class));
         IngressFlowSegmentRequest request = (IngressFlowSegmentRequest) rawRequest;
 
         assertEquals(flow.getFlowId(), request.getFlowId());
@@ -255,7 +252,7 @@ public class SpeakerFlowSegmentRequestBuilderTest extends InMemoryGraphBasedTest
             MeterConfig config = new MeterConfig(path.getMeterId(), flow.getBandwidth());
             assertEquals(config, request.getMeterConfig());
         } else {
-            assertNull(request.getMeterConfig());
+            Assertions.assertNull(request.getMeterConfig());
         }
 
         verifyVlanEncapsulation(flow, path, request.getEncapsulation());
@@ -275,8 +272,7 @@ public class SpeakerFlowSegmentRequestBuilderTest extends InMemoryGraphBasedTest
 
     private TransitFlowSegmentRequest verifyCommonTransitRequest(
             Flow flow, FlowPath path, SwitchId datapath, FlowSegmentRequest rawRequest) {
-        assertThat(
-                "Should be egress segment request", rawRequest, instanceOf(TransitFlowSegmentRequest.class));
+        assertThat("Should be egress segment request", rawRequest, instanceOf(TransitFlowSegmentRequest.class));
         TransitFlowSegmentRequest request = (TransitFlowSegmentRequest) rawRequest;
 
         assertEquals(flow.getFlowId(), request.getFlowId());
@@ -293,8 +289,8 @@ public class SpeakerFlowSegmentRequestBuilderTest extends InMemoryGraphBasedTest
             }
         }
 
-        assertNotNull(ingress);
-        assertNotNull(egress);
+        Assertions.assertNotNull(ingress);
+        Assertions.assertNotNull(egress);
 
         assertEquals(ingress.getDestPort(), (int) request.getIngressIslPort());
         assertEquals(egress.getSrcPort(), (int) request.getEgressIslPort());
@@ -331,8 +327,7 @@ public class SpeakerFlowSegmentRequestBuilderTest extends InMemoryGraphBasedTest
 
     private EgressFlowSegmentRequest verifyCommonEgressRequest(
             Flow flow, FlowPath path, FlowSegmentRequest rawRequest) {
-        assertThat(
-                "Should be egress segment request", rawRequest, instanceOf(EgressFlowSegmentRequest.class));
+        assertThat("Should be egress segment request", rawRequest, instanceOf(EgressFlowSegmentRequest.class));
         EgressFlowSegmentRequest request = (EgressFlowSegmentRequest) rawRequest;
 
         assertEquals(flow.getFlowId(), request.getFlowId());
@@ -349,11 +344,9 @@ public class SpeakerFlowSegmentRequestBuilderTest extends InMemoryGraphBasedTest
         FlowPath path = Objects.requireNonNull(flow.getForwardPath());
         OneSwitchFlowRequest request = verifyCommonOneSwitchRequest(flow, path, rawRequest);
 
-        assertEquals(
-                new FlowEndpoint(flow.getSrcSwitchId(), flow.getSrcPort(), flow.getSrcVlan()),
+        assertEquals(new FlowEndpoint(flow.getSrcSwitchId(), flow.getSrcPort(), flow.getSrcVlan()),
                 request.getEndpoint());
-        assertEquals(
-                new FlowEndpoint(flow.getDestSwitchId(), flow.getDestPort(), flow.getDestVlan()),
+        assertEquals(new FlowEndpoint(flow.getDestSwitchId(), flow.getDestPort(), flow.getDestVlan()),
                 request.getEgressEndpoint());
     }
 
@@ -361,18 +354,15 @@ public class SpeakerFlowSegmentRequestBuilderTest extends InMemoryGraphBasedTest
         FlowPath path = Objects.requireNonNull(flow.getReversePath());
         OneSwitchFlowRequest request = verifyCommonOneSwitchRequest(flow, path, rawRequest);
 
-        assertEquals(
-                new FlowEndpoint(flow.getDestSwitchId(), flow.getDestPort(), flow.getDestVlan()),
+        assertEquals(new FlowEndpoint(flow.getDestSwitchId(), flow.getDestPort(), flow.getDestVlan()),
                 request.getEndpoint());
-        assertEquals(
-                new FlowEndpoint(flow.getSrcSwitchId(), flow.getSrcPort(), flow.getSrcVlan()),
+        assertEquals(new FlowEndpoint(flow.getSrcSwitchId(), flow.getSrcPort(), flow.getSrcVlan()),
                 request.getEgressEndpoint());
     }
 
     private OneSwitchFlowRequest verifyCommonOneSwitchRequest(
             Flow flow, FlowPath path, FlowSegmentRequest rawRequest) {
-        assertThat(
-                "Should be one switch flow request", rawRequest, instanceOf(OneSwitchFlowRequest.class));
+        assertThat("Should be one switch flow request", rawRequest, instanceOf(OneSwitchFlowRequest.class));
         OneSwitchFlowRequest request = (OneSwitchFlowRequest) rawRequest;
 
         assertEquals(flow.getFlowId(), request.getFlowId());

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/utils/AbstractBaseFsmTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/utils/AbstractBaseFsmTest.java
@@ -16,19 +16,19 @@
 package org.openkilda.wfm.share.utils;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.openkilda.wfm.share.utils.AbstractBaseFsmTest.Fsm.Event;
 import org.openkilda.wfm.share.utils.AbstractBaseFsmTest.Fsm.State;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.squirrelframework.foundation.fsm.StateMachineBuilder;
 import org.squirrelframework.foundation.fsm.StateMachineBuilderFactory;
 
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AbstractBaseFsmTest {
 
     @Test

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/utils/PoolManagerTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/utils/PoolManagerTest.java
@@ -15,15 +15,18 @@
 
 package org.openkilda.wfm.share.utils;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.openkilda.wfm.share.flow.resources.ResourceNotAvailableException;
 import org.openkilda.wfm.share.utils.PoolManager.PoolConfig;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PoolManagerTest {
     @Test
     public void testSequentialAllocation() {
@@ -32,12 +35,12 @@ public class PoolManagerTest {
         PoolConfig config = newConfig();
         PoolManager<Long> poolManager = newPoolManager(config, adapter);
 
-        Assert.assertEquals(0L, (long) poolManager.allocate(this::dummyAllocate));
+        assertEquals(0L, (long) poolManager.allocate(this::dummyAllocate));
         for (int idx = 1; idx <= config.getIdMaximum(); idx++) {
-            Assert.assertEquals(idx, (long) poolManager.allocate(this::dummyAllocate));
+            assertEquals(idx, (long) poolManager.allocate(this::dummyAllocate));
         }
 
-        Assert.assertThrows(ResourceNotAvailableException.class, () -> poolManager.allocate(this::dummyAllocate));
+        assertThrows(ResourceNotAvailableException.class, () -> poolManager.allocate(this::dummyAllocate));
     }
 
     @Test
@@ -45,16 +48,16 @@ public class PoolManagerTest {
         PoolConfig config = newConfig();
         InMemorySetPoolEntityAdapter adapter = new InMemorySetPoolEntityAdapter();
         long chunkSize = (config.getIdMaximum() - config.getIdMinimum()) / config.getChunksCount();
-        Assert.assertTrue(1 < config.getChunksCount());
-        Assert.assertTrue(1 < chunkSize);
+        Assertions.assertTrue(1 < config.getChunksCount());
+        Assertions.assertTrue(1 < chunkSize);
 
         for (long idx = config.getIdMinimum() + 1; idx < chunkSize + 1; idx++) {
             adapter.allocateSpecificId(idx);
         }
 
         PoolManager<Long> poolManager = newPoolManager(config, adapter);
-        Assert.assertEquals(config.getIdMinimum(), (long) poolManager.allocate(this::dummyAllocate));
-        Assert.assertEquals(chunkSize + 1, (long) poolManager.allocate(this::dummyAllocate));
+        assertEquals(config.getIdMinimum(), (long) poolManager.allocate(this::dummyAllocate));
+        assertEquals(chunkSize + 1, (long) poolManager.allocate(this::dummyAllocate));
     }
 
     @Test
@@ -62,20 +65,20 @@ public class PoolManagerTest {
         PoolConfig config = newConfig();
         InMemorySetPoolEntityAdapter adapter = new InMemorySetPoolEntityAdapter();
         long chunkSize = (config.getIdMaximum() - config.getIdMinimum()) / config.getChunksCount();
-        Assert.assertTrue(1 < config.getChunksCount());
-        Assert.assertTrue(1 < chunkSize);
+        Assertions.assertTrue(1 < config.getChunksCount());
+        Assertions.assertTrue(1 < chunkSize);
 
         for (long idx = config.getIdMinimum(); idx <= config.getIdMaximum(); idx++) {
             adapter.allocateSpecificId(idx);
         }
 
         PoolManager<Long> poolManager = newPoolManager(config, adapter);
-        Assert.assertThrows(ResourceNotAvailableException.class, () -> poolManager.allocate(this::dummyAllocate));
+        assertThrows(ResourceNotAvailableException.class, () -> poolManager.allocate(this::dummyAllocate));
 
         adapter.release(config.getIdMinimum() + 1);
-        Assert.assertEquals(config.getIdMinimum() + 1, (long) poolManager.allocate(this::dummyAllocate));
+        assertEquals(config.getIdMinimum() + 1, (long) poolManager.allocate(this::dummyAllocate));
 
-        Assert.assertThrows(ResourceNotAvailableException.class, () -> poolManager.allocate(this::dummyAllocate));
+        assertThrows(ResourceNotAvailableException.class, () -> poolManager.allocate(this::dummyAllocate));
     }
 
     @Test
@@ -93,9 +96,9 @@ public class PoolManagerTest {
         PoolManager<Long> poolManager = newPoolManager(config, adapter);
         for (long idx = 0; idx <= config.getChunksCount(); idx++) {
             Long entry = poolManager.allocate(this::dummyAllocate);
-            Assert.assertEquals(idx * chunkSize, (long) entry);
+            assertEquals(idx * chunkSize, (long) entry);
         }
-        Assert.assertThrows(ResourceNotAvailableException.class, () -> poolManager.allocate(this::dummyAllocate));
+        assertThrows(ResourceNotAvailableException.class, () -> poolManager.allocate(this::dummyAllocate));
     }
 
     @Test
@@ -113,10 +116,10 @@ public class PoolManagerTest {
         PoolManager<Long> poolManager = newPoolManager(config, adapter);
         for (long idx = 0; idx < config.getChunksCount() - 1; idx++) {
             Long entry = poolManager.allocate(this::dummyAllocate);
-            Assert.assertEquals((idx + 1) * chunkSize - 1, (long) entry);
+            assertEquals((idx + 1) * chunkSize - 1, (long) entry);
         }
-        Assert.assertEquals(config.getIdMaximum(), (long) poolManager.allocate(this::dummyAllocate));
-        Assert.assertThrows(ResourceNotAvailableException.class, () -> poolManager.allocate(this::dummyAllocate));
+        assertEquals(config.getIdMaximum(), (long) poolManager.allocate(this::dummyAllocate));
+        assertThrows(ResourceNotAvailableException.class, () -> poolManager.allocate(this::dummyAllocate));
     }
 
     @Test
@@ -125,9 +128,9 @@ public class PoolManagerTest {
         InMemorySetPoolEntityAdapter adapter = new InMemorySetPoolEntityAdapter();
         PoolManager<Long> poolManager = newPoolManager(config, adapter);
         for (int idx = 0; idx <= config.getIdMaximum(); idx++) {
-            Assert.assertEquals(idx, (long) poolManager.allocate(this::dummyAllocate));
+            assertEquals(idx, (long) poolManager.allocate(this::dummyAllocate));
         }
-        Assert.assertThrows(ResourceNotAvailableException.class, () -> poolManager.allocate(this::dummyAllocate));
+        assertThrows(ResourceNotAvailableException.class, () -> poolManager.allocate(this::dummyAllocate));
     }
 
     private Long dummyAllocate(Long entityId) {

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/utils/TimestampHelperTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/utils/TimestampHelperTest.java
@@ -15,12 +15,12 @@
 
 package org.openkilda.wfm.share.utils;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openkilda.wfm.share.utils.TimestampHelper.noviflowTimestamp;
 import static org.openkilda.wfm.share.utils.TimestampHelper.noviflowTimestampToInstant;
 import static org.openkilda.wfm.share.utils.TimestampHelper.noviflowTimestampsToDuration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/topology/AbstractTopologyTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/topology/AbstractTopologyTest.java
@@ -15,9 +15,6 @@
 
 package org.openkilda.wfm.topology;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
 import org.openkilda.wfm.AbstractStormTest;
 import org.openkilda.wfm.LaunchEnvironment;
 import org.openkilda.wfm.error.ConfigurationException;
@@ -25,7 +22,8 @@ import org.openkilda.wfm.error.ConfigurationException;
 import com.sabre.oss.conf4j.annotation.Configuration;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.storm.generated.StormTopology;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kohsuke.args4j.CmdLineException;
 
 import java.io.IOException;
@@ -54,72 +52,72 @@ public class AbstractTopologyTest extends AbstractStormTest {
     @Test
     public void getKnownBoltParallelismTest() throws CmdLineException, ConfigurationException, IOException {
         TestTopology topology = new TestTopology(getLaunchEnvironment(), TOPOLOGY_NAME);
-        assertEquals(FIRST_BOLT_PARALLELISM, topology.getBoltParallelism(FIRST_BOLT_NAME));
+        Assertions.assertEquals(FIRST_BOLT_PARALLELISM, topology.getBoltParallelism(FIRST_BOLT_NAME));
     }
 
     @Test
     public void getUnknownBoltParallelismTest() throws CmdLineException, ConfigurationException, IOException {
         TestTopology topology = new TestTopology(getLaunchEnvironment(), TOPOLOGY_NAME);
         // For unknown bolts we should get topology parallelism
-        assertEquals(TOPOLOGY_PARALLELISM, topology.getBoltParallelism(UNKNOWN_BOLT_NAME));
+        Assertions.assertEquals(TOPOLOGY_PARALLELISM, topology.getBoltParallelism(UNKNOWN_BOLT_NAME));
     }
 
     @Test
     public void getBoltParallelismWithoutConfigTest() throws CmdLineException, ConfigurationException, IOException {
         // There is no config in /resources folder for unknown topology. So null parallelism must be returned
         TestTopology topology = new TestTopology(getLaunchEnvironment(), UNKNOWN_TOPOLOGY_NAME);
-        assertNull(topology.getBoltParallelism(FIRST_BOLT_NAME));
+        Assertions.assertNull(topology.getBoltParallelism(FIRST_BOLT_NAME));
     }
 
     @Test
     public void getKnownBoltNumTasksTest() throws CmdLineException, ConfigurationException, IOException {
         TestTopology topology = new TestTopology(getLaunchEnvironment(), TOPOLOGY_NAME);
-        assertEquals(FIRST_BOLT_NUM_TASKS, topology.getBoltNumTasks(FIRST_BOLT_NAME));
+        Assertions.assertEquals(FIRST_BOLT_NUM_TASKS, topology.getBoltNumTasks(FIRST_BOLT_NAME));
     }
 
     @Test
     public void getUnknownBoltNumTasksTest() throws CmdLineException, ConfigurationException, IOException {
         TestTopology topology = new TestTopology(getLaunchEnvironment(), TOPOLOGY_NAME);
         // For unknown bolts we just return null
-        assertNull(topology.getBoltNumTasks(UNKNOWN_BOLT_NAME));
+        Assertions.assertNull(topology.getBoltNumTasks(UNKNOWN_BOLT_NAME));
     }
 
     @Test
     public void getBoltNumTasksWithoutConfigTest() throws CmdLineException, ConfigurationException, IOException {
         // There is no config in /resources folder for unknown topology. So null num tasks must be returned
         TestTopology topology = new TestTopology(getLaunchEnvironment(), UNKNOWN_TOPOLOGY_NAME);
-        assertNull(topology.getBoltParallelism(FIRST_BOLT_NAME));
+        Assertions.assertNull(topology.getBoltParallelism(FIRST_BOLT_NAME));
     }
 
     @Test
     public void getKnownBoltInstancesCountTest() throws CmdLineException, ConfigurationException, IOException {
         TestTopology topology = new TestTopology(getLaunchEnvironment(), TOPOLOGY_NAME);
-        assertEquals(FIRST_BOLT_NUM_TASKS.intValue(), topology.getBoltInstancesCount(FIRST_BOLT_NAME));
+        Assertions.assertEquals(FIRST_BOLT_NUM_TASKS.intValue(), topology.getBoltInstancesCount(FIRST_BOLT_NAME));
     }
 
     @Test
     public void getKnownBoltInstancesCountWithoutCountInConfigTest()
             throws CmdLineException, ConfigurationException, IOException {
         TestTopology topology = new TestTopology(getLaunchEnvironment(), TOPOLOGY_NAME);
-        assertEquals(SECOND_BOLT_PARALLELISM.intValue(), topology.getBoltInstancesCount(SECOND_BOLT_NAME));
+        Assertions.assertEquals(SECOND_BOLT_PARALLELISM.intValue(), topology.getBoltInstancesCount(SECOND_BOLT_NAME));
     }
 
     @Test
     public void getUnknownBoltInstancesCountTest() throws CmdLineException, ConfigurationException, IOException {
         TestTopology topology = new TestTopology(getLaunchEnvironment(), TOPOLOGY_NAME);
-        assertEquals(TOPOLOGY_PARALLELISM.intValue(), topology.getBoltInstancesCount(UNKNOWN_BOLT_NAME));
+        Assertions.assertEquals(TOPOLOGY_PARALLELISM.intValue(), topology.getBoltInstancesCount(UNKNOWN_BOLT_NAME));
     }
 
     @Test
     public void getBoltInstancesCountWithoutConfigTest() throws CmdLineException, ConfigurationException, IOException {
         TestTopology topology = new TestTopology(getLaunchEnvironment(), UNKNOWN_TOPOLOGY_NAME);
-        assertEquals(1, topology.getBoltInstancesCount(FIRST_BOLT_NAME));
+        Assertions.assertEquals(1, topology.getBoltInstancesCount(FIRST_BOLT_NAME));
     }
 
     @Test
     public void getBoltInstancesCountSeveralBoltsTest() throws CmdLineException, ConfigurationException, IOException {
         TestTopology topology = new TestTopology(getLaunchEnvironment(), TOPOLOGY_NAME);
-        assertEquals(FIRST_BOLT_NUM_TASKS + SECOND_BOLT_PARALLELISM + TOPOLOGY_PARALLELISM,
+        Assertions.assertEquals(FIRST_BOLT_NUM_TASKS + SECOND_BOLT_PARALLELISM + TOPOLOGY_PARALLELISM,
                 topology.getBoltInstancesCount(FIRST_BOLT_NAME, SECOND_BOLT_NAME, UNKNOWN_BOLT_NAME));
     }
 
@@ -131,7 +129,7 @@ public class AbstractTopologyTest extends AbstractStormTest {
         int parallelism = 10;
         int numTasks = 5;
         TestTopology topology = new TestTopology(getLaunchEnvironment(parallelism, numTasks), TOPOLOGY_NAME);
-        assertEquals(numTasks, topology.getBoltInstancesCount(FIRST_BOLT_NAME));
+        Assertions.assertEquals(numTasks, topology.getBoltInstancesCount(FIRST_BOLT_NAME));
     }
 
     private LaunchEnvironment getLaunchEnvironment() throws IOException, CmdLineException, ConfigurationException {

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowPathBuilderTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowPathBuilderTest.java
@@ -17,9 +17,6 @@ package org.openkilda.wfm.topology.flowhs.service;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -45,8 +42,9 @@ import org.openkilda.persistence.repositories.SwitchRepository;
 import org.openkilda.wfm.share.flow.resources.FlowResources.PathResources;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -65,7 +63,7 @@ public class FlowPathBuilderTest {
 
     private FlowPathBuilder builder;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         SwitchRepository switchRepository = mock(SwitchRepository.class);
         SwitchPropertiesRepository switchPropertiesRepository = mock(SwitchPropertiesRepository.class);
@@ -97,7 +95,7 @@ public class FlowPathBuilderTest {
                 .pathId(new PathId("test_path_id"))
                 .build();
 
-        assertTrue(builder.isSamePath(path, flowPath));
+        Assertions.assertTrue(builder.isSamePath(path, flowPath));
     }
 
     @Test
@@ -114,7 +112,7 @@ public class FlowPathBuilderTest {
                 .pathId(new PathId("test_path_id"))
                 .build();
 
-        assertFalse(builder.isSamePath(path, flowPath));
+        Assertions.assertFalse(builder.isSamePath(path, flowPath));
     }
 
     @Test
@@ -133,7 +131,7 @@ public class FlowPathBuilderTest {
                 .segments(singletonList(buildPathSegment(flowPathId, SWITCH_1, 1, SWITCH_2, 2)))
                 .build();
 
-        assertTrue(builder.isSamePath(path, flowPath));
+        Assertions.assertTrue(builder.isSamePath(path, flowPath));
     }
 
     @Test
@@ -154,7 +152,7 @@ public class FlowPathBuilderTest {
                         .srcSwitch(SWITCH_1).srcPort(2).destSwitch(SWITCH_2).destPort(3).build()))
                 .build();
 
-        assertFalse(builder.isSamePath(path, flowPath));
+        Assertions.assertFalse(builder.isSamePath(path, flowPath));
     }
 
     @Test
@@ -178,7 +176,7 @@ public class FlowPathBuilderTest {
                                 .srcSwitch(SWITCH_3).srcPort(1).destSwitch(SWITCH_2).destPort(2).build()))
                 .build();
 
-        assertTrue(builder.isSamePath(path, flowPath));
+        Assertions.assertTrue(builder.isSamePath(path, flowPath));
     }
 
     @Test
@@ -200,10 +198,10 @@ public class FlowPathBuilderTest {
 
         FlowPath flowPath = builder.buildFlowPath(flow, pathResources, path, cookie, false, flow.getFlowId());
 
-        assertEquals(pathId, flowPath.getPathId());
-        assertEquals(meterId, flowPath.getMeterId());
-        assertEquals(cookie, flowPath.getCookie());
-        assertEquals(0, flowPath.getSegments().size());
+        Assertions.assertEquals(pathId, flowPath.getPathId());
+        Assertions.assertEquals(meterId, flowPath.getMeterId());
+        Assertions.assertEquals(cookie, flowPath.getCookie());
+        Assertions.assertEquals(0, flowPath.getSegments().size());
     }
 
     @Test
@@ -225,12 +223,12 @@ public class FlowPathBuilderTest {
 
         FlowPath flowPath = builder.buildFlowPath(flow, pathResources, path, cookie, false, flow.getFlowId());
 
-        assertEquals(SWITCH_ID_1, flowPath.getSrcSwitchId());
-        assertEquals(SWITCH_ID_2, flowPath.getDestSwitchId());
-        assertEquals(pathId, flowPath.getPathId());
-        assertEquals(meterId, flowPath.getMeterId());
-        assertEquals(cookie, flowPath.getCookie());
-        assertEquals(1, flowPath.getSegments().size());
+        Assertions.assertEquals(SWITCH_ID_1, flowPath.getSrcSwitchId());
+        Assertions.assertEquals(SWITCH_ID_2, flowPath.getDestSwitchId());
+        Assertions.assertEquals(pathId, flowPath.getPathId());
+        Assertions.assertEquals(meterId, flowPath.getMeterId());
+        Assertions.assertEquals(cookie, flowPath.getCookie());
+        Assertions.assertEquals(1, flowPath.getSegments().size());
     }
 
     @Test
@@ -252,12 +250,12 @@ public class FlowPathBuilderTest {
 
         FlowPath flowPath = builder.buildFlowPath(flow, pathResources, path, cookie, false, flow.getFlowId());
 
-        assertEquals(SWITCH_ID_1, flowPath.getSrcSwitchId());
-        assertEquals(SWITCH_ID_2, flowPath.getDestSwitchId());
-        assertEquals(PATH_ID_1, flowPath.getPathId());
-        assertEquals(meterId, flowPath.getMeterId());
-        assertEquals(cookie, flowPath.getCookie());
-        assertEquals(2, flowPath.getSegments().size());
+        Assertions.assertEquals(SWITCH_ID_1, flowPath.getSrcSwitchId());
+        Assertions.assertEquals(SWITCH_ID_2, flowPath.getDestSwitchId());
+        Assertions.assertEquals(PATH_ID_1, flowPath.getPathId());
+        Assertions.assertEquals(meterId, flowPath.getMeterId());
+        Assertions.assertEquals(cookie, flowPath.getCookie());
+        Assertions.assertEquals(2, flowPath.getSegments().size());
     }
 
     @Test
@@ -276,7 +274,7 @@ public class FlowPathBuilderTest {
                 .segments(ImmutableList.of(buildPathSegment(PATH_ID_1, SWITCH_1, 1, SWITCH_2, 2)))
                 .build();
 
-        assertTrue(builder.arePathsOverlapped(path, flowPath));
+        Assertions.assertTrue(builder.arePathsOverlapped(path, flowPath));
     }
 
     @Test
@@ -295,7 +293,7 @@ public class FlowPathBuilderTest {
                 .segments(ImmutableList.of(buildPathSegment(PATH_ID_1, SWITCH_1, 7, SWITCH_2, 8)))
                 .build();
 
-        assertFalse(builder.arePathsOverlapped(path, flowPath));
+        Assertions.assertFalse(builder.arePathsOverlapped(path, flowPath));
     }
 
     @Test
@@ -320,7 +318,7 @@ public class FlowPathBuilderTest {
 
         HaFlowPath haFlowPath = HaFlowPath.builder().sharedSwitch(SWITCH_1).haPathId(PATH_ID_1).build();
         haFlowPath.setSubPaths(singletonList(subPath));
-        assertTrue(builder.arePathsOverlapped(haPath, haFlowPath));
+        Assertions.assertTrue(builder.arePathsOverlapped(haPath, haFlowPath));
     }
 
     @Test
@@ -346,7 +344,7 @@ public class FlowPathBuilderTest {
         HaFlowPath haFlowPath = HaFlowPath.builder().sharedSwitch(SWITCH_1).haPathId(PATH_ID_1).build();
         haFlowPath.setSubPaths(singletonList(subPath));
 
-        assertFalse(builder.arePathsOverlapped(haPath, haFlowPath));
+        Assertions.assertFalse(builder.arePathsOverlapped(haPath, haFlowPath));
     }
 
     private static Flow buildFlow(Switch srcSwitch, Switch dstSwitch) {

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/topology/utils/TestLoggerContextInitializer.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/topology/utils/TestLoggerContextInitializer.java
@@ -16,9 +16,9 @@
 
 package org.openkilda.wfm.topology.utils;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class TestLoggerContextInitializer {

--- a/src-java/blue-green/build.gradle
+++ b/src-java/blue-green/build.gradle
@@ -26,10 +26,14 @@ dependencies {
     annotationProcessor 'org.mapstruct:mapstruct-processor'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.mockito:mockito-junit-jupiter'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding'
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/blue-green/src/test/java/org/openkilda/bluegreen/ZkClientTest.java
+++ b/src-java/blue-green/src/test/java/org/openkilda/bluegreen/ZkClientTest.java
@@ -15,9 +15,6 @@
 
 package org.openkilda.bluegreen;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -30,7 +27,8 @@ import org.apache.zookeeper.Watcher.Event.KeeperState;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -45,7 +43,7 @@ public class ZkClientTest {
     public void testGetPaths() {
         ZkClient client = Mockito.mock(ZkClient.class, Mockito.CALLS_REAL_METHODS);
         String actual = client.getPaths("path", "to");
-        assertEquals("/path/to", actual);
+        Assertions.assertEquals("/path/to", actual);
     }
 
     @Test
@@ -56,7 +54,7 @@ public class ZkClientTest {
         when(client.isRefreshIntervalPassed()).thenReturn(true);
         when(client.getZk()).thenReturn(zkMock);
         when(client.refreshConnectionIfNeeded(any())).thenCallRealMethod();
-        assertTrue(client.refreshConnectionIfNeeded(KeeperState.Expired));
+        Assertions.assertTrue(client.refreshConnectionIfNeeded(KeeperState.Expired));
         verify(client, Mockito.times(1)).safeRefreshConnection();
     }
 
@@ -68,7 +66,7 @@ public class ZkClientTest {
         when(client.isRefreshIntervalPassed()).thenReturn(true);
         when(client.getZk()).thenReturn(zkMock);
         when(client.refreshConnectionIfNeeded(any())).thenCallRealMethod();
-        assertTrue(client.refreshConnectionIfNeeded(KeeperState.Disconnected));
+        Assertions.assertTrue(client.refreshConnectionIfNeeded(KeeperState.Disconnected));
         verify(client, Mockito.times(1)).safeRefreshConnection();
     }
 
@@ -102,7 +100,7 @@ public class ZkClientTest {
         states.remove(KeeperState.Disconnected);
         states.remove(KeeperState.Expired);
         for (KeeperState state : states) {
-            assertFalse(client.refreshConnectionIfNeeded(state));
+            Assertions.assertFalse(client.refreshConnectionIfNeeded(state));
             verify(client, Mockito.times(0)).getZk();
             verify(client, Mockito.times(0)).init();
         }
@@ -160,7 +158,7 @@ public class ZkClientTest {
         try {
             client.ensureZNode("test");
         } catch (IllegalStateException e) {
-            assertEquals("Zk node /test still does not exists", e.getMessage());
+            Assertions.assertEquals("Zk node /test still does not exists", e.getMessage());
         }
         verify(zkMock, Mockito.times(1))
                 .create(eq("/test"), Mockito.any(), eq(Ids.OPEN_ACL_UNSAFE), eq(CreateMode.PERSISTENT));

--- a/src-java/blue-green/src/test/java/org/openkilda/bluegreen/ZkStateTrackerTest.java
+++ b/src-java/blue-green/src/test/java/org/openkilda/bluegreen/ZkStateTrackerTest.java
@@ -15,11 +15,11 @@
 
 package org.openkilda.bluegreen;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.UUID;
@@ -34,7 +34,7 @@ public class ZkStateTrackerTest {
         LifecycleEvent event = LifecycleEvent.builder().signal(Signal.START).uuid(startUid).build();
         stateTracker.processLifecycleEvent(event);
         verify(writer, Mockito.times(1)).setState(eq(1));
-        assertTrue(stateTracker.shutdownUuid == null);
+        assertNull(stateTracker.shutdownUuid);
     }
 
 
@@ -48,6 +48,6 @@ public class ZkStateTrackerTest {
         LifecycleEvent event = LifecycleEvent.builder().signal(Signal.SHUTDOWN).uuid(shutdownUuid).build();
         stateTracker.processLifecycleEvent(event);
         verify(writer, Mockito.times(1)).setState(eq(0));
-        assertTrue(stateTracker.startUuid == null);
+        assertNull(stateTracker.startUuid);
     }
 }

--- a/src-java/blue-green/src/test/java/org/openkilda/bluegreen/ZkWatchDogTest.java
+++ b/src-java/blue-green/src/test/java/org/openkilda/bluegreen/ZkWatchDogTest.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.bluegreen;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
@@ -29,7 +27,8 @@ import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher.Event.EventType;
 import org.apache.zookeeper.Watcher.Event.KeeperState;
 import org.apache.zookeeper.ZooKeeper;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -89,8 +88,8 @@ public class ZkWatchDogTest {
         doCallRealMethod().when(watchDog).subscribe(any(LifeCycleObserver.class));
         doCallRealMethod().when(watchDog).unsubscribe(any(LifeCycleObserver.class));
         watchDog.subscribe(observer);
-        assertEquals(1, watchDog.observers.size());
-        assertTrue(watchDog.observers.contains(observer));
+        Assertions.assertEquals(1, watchDog.observers.size());
+        Assertions.assertTrue(watchDog.observers.contains(observer));
     }
 
     @Test
@@ -101,8 +100,8 @@ public class ZkWatchDogTest {
         doCallRealMethod().when(watchDog).subscribe(any(BuildVersionObserver.class));
         doCallRealMethod().when(watchDog).unsubscribe(any(BuildVersionObserver.class));
         watchDog.subscribe(observer);
-        assertEquals(1, watchDog.buildVersionObservers.size());
-        assertTrue(watchDog.buildVersionObservers.contains(observer));
+        Assertions.assertEquals(1, watchDog.buildVersionObservers.size());
+        Assertions.assertTrue(watchDog.buildVersionObservers.contains(observer));
     }
 
     @Test

--- a/src-java/blue-green/src/test/java/org/openkilda/bluegreen/ZkWriterTest.java
+++ b/src-java/blue-green/src/test/java/org/openkilda/bluegreen/ZkWriterTest.java
@@ -23,7 +23,7 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher.Event.EventType;
 import org.apache.zookeeper.Watcher.Event.KeeperState;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;

--- a/src-java/blue-green/src/test/java/org/openkilda/bluegreen/kafka/interceptors/VersioningConsumerInterceptorTest.java
+++ b/src-java/blue-green/src/test/java/org/openkilda/bluegreen/kafka/interceptors/VersioningConsumerInterceptorTest.java
@@ -32,8 +32,8 @@ import com.google.common.collect.Lists;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.HashMap;
@@ -63,7 +63,7 @@ public class VersioningConsumerInterceptorTest {
         ConsumerRecords<String, String> result = interceptor.onConsume(records);
 
         // interceptor with unset version skips all records
-        Assert.assertEquals(0, result.count());
+        Assertions.assertEquals(0, result.count());
     }
 
     @Test
@@ -74,10 +74,10 @@ public class VersioningConsumerInterceptorTest {
         ConsumerRecords<String, String> result = interceptor.onConsume(records);
 
         // interceptor will remove record with unset version and record with wrong version
-        Assert.assertEquals(2, result.count());
+        Assertions.assertEquals(2, result.count());
         Set<String> values = getRecordValues(result);
-        Assert.assertTrue(values.contains(VALUE_2));
-        Assert.assertTrue(values.contains(VALUE_3));
+        Assertions.assertTrue(values.contains(VALUE_2));
+        Assertions.assertTrue(values.contains(VALUE_3));
     }
 
     @Test
@@ -97,32 +97,39 @@ public class VersioningConsumerInterceptorTest {
         ConsumerRecords<String, String> result = interceptor.onConsume(records);
 
         // interceptor will skip record because it has 2 headers, but must has one
-        Assert.assertEquals(0, result.count());
+        Assertions.assertEquals(0, result.count());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void missedConnectionStringTest() {
-        VersioningConsumerInterceptor<String, String> interceptor = createInterceptor();
-        interceptor.configure(new HashMap<>());
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            VersioningConsumerInterceptor<String, String> interceptor = createInterceptor();
+            interceptor.configure(new HashMap<>());
+        });
+
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void missedRunIdTest() {
-        Map<String, String> config = new HashMap<>();
-        config.put(CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY, "test");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            Map<String, String> config = new HashMap<>();
+            config.put(CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY, "test");
 
-        VersioningConsumerInterceptor<String, String> interceptor = createInterceptor();
-        interceptor.configure(config);
+            VersioningConsumerInterceptor<String, String> interceptor = createInterceptor();
+            interceptor.configure(config);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void missedComponentNameTest() {
-        Map<String, String> config = new HashMap<>();
-        config.put(CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY, "test");
-        config.put(CONSUMER_RUN_ID_PROPERTY, "run_id");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            Map<String, String> config = new HashMap<>();
+            config.put(CONSUMER_ZOOKEEPER_CONNECTION_STRING_PROPERTY, "test");
+            config.put(CONSUMER_RUN_ID_PROPERTY, "run_id");
 
-        VersioningConsumerInterceptor<String, String> interceptor = createInterceptor();
-        interceptor.configure(config);
+            VersioningConsumerInterceptor<String, String> interceptor = createInterceptor();
+            interceptor.configure(config);
+        });
     }
 
     @Test

--- a/src-java/blue-green/src/test/java/org/openkilda/bluegreen/kafka/interceptors/VersioningInterceptorBaseTest.java
+++ b/src-java/blue-green/src/test/java/org/openkilda/bluegreen/kafka/interceptors/VersioningInterceptorBaseTest.java
@@ -17,8 +17,8 @@ package org.openkilda.bluegreen.kafka.interceptors;
 
 import static org.openkilda.bluegreen.kafka.interceptors.VersioningInterceptorBase.VERSION_IS_NOT_SET_LOG_TIMEOUT;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -29,14 +29,14 @@ public class VersioningInterceptorBaseTest {
     public void timeoutInitializationTest() {
         VersioningInterceptorBase interceptorBase = new TestClass();
         // initial value of timestamp is 0, so timeout is passed
-        Assert.assertTrue(interceptorBase.isVersionTimeoutPassed());
+        Assertions.assertTrue(interceptorBase.isVersionTimeoutPassed());
     }
 
     @Test
     public void timeoutIsNotPassedTest() {
         VersioningInterceptorBase interceptorBase = new TestClass();
         interceptorBase.versionIsNotSetTimestamp = Instant.now();
-        Assert.assertFalse(interceptorBase.isVersionTimeoutPassed());
+        Assertions.assertFalse(interceptorBase.isVersionTimeoutPassed());
     }
 
     @Test
@@ -44,7 +44,7 @@ public class VersioningInterceptorBaseTest {
         VersioningInterceptorBase interceptorBase = new TestClass();
         interceptorBase.versionIsNotSetTimestamp = Instant.now()
                 .minus(VERSION_IS_NOT_SET_LOG_TIMEOUT * 2, ChronoUnit.SECONDS);
-        Assert.assertTrue(interceptorBase.isVersionTimeoutPassed());
+        Assertions.assertTrue(interceptorBase.isVersionTimeoutPassed());
     }
 
     // needed to create an instance of abstract class VersioningInterceptorBase

--- a/src-java/blue-green/src/test/java/org/openkilda/bluegreen/kafka/interceptors/VersioningProducerInterceptorTest.java
+++ b/src-java/blue-green/src/test/java/org/openkilda/bluegreen/kafka/interceptors/VersioningProducerInterceptorTest.java
@@ -15,6 +15,8 @@
 
 package org.openkilda.bluegreen.kafka.interceptors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.times;
@@ -31,8 +33,8 @@ import org.openkilda.bluegreen.ZkWatchDog;
 import com.google.common.collect.Lists;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Header;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.HashMap;
@@ -54,7 +56,7 @@ public class VersioningProducerInterceptorTest {
         ProducerRecord<String, String> result = interceptor.onSend(record);
 
         // version inside interceptor is not set. Interceptor must not add version header and remove old version headers
-        Assert.assertFalse(result.headers().headers(MESSAGE_VERSION_HEADER).iterator().hasNext());
+        Assertions.assertFalse(result.headers().headers(MESSAGE_VERSION_HEADER).iterator().hasNext());
     }
 
     @Test
@@ -66,8 +68,8 @@ public class VersioningProducerInterceptorTest {
         ProducerRecord<String, String> result = interceptor.onSend(record);
 
         List<Header> versionHeaders = Lists.newArrayList(result.headers().headers(MESSAGE_VERSION_HEADER));
-        Assert.assertEquals(1, versionHeaders.size());
-        Assert.assertEquals(VERSION_1, new String(versionHeaders.get(0).value()));
+        assertEquals(1, versionHeaders.size());
+        assertEquals(VERSION_1, new String(versionHeaders.get(0).value()));
     }
 
     @Test
@@ -82,33 +84,40 @@ public class VersioningProducerInterceptorTest {
 
         // record had version1 header, but it was replaced with version2
         List<Header> versionHeaders = Lists.newArrayList(result.headers().headers(MESSAGE_VERSION_HEADER));
-        Assert.assertEquals(1, versionHeaders.size());
-        Assert.assertEquals(VERSION_2, new String(versionHeaders.get(0).value()));
+        assertEquals(1, versionHeaders.size());
+        assertEquals(VERSION_2, new String(versionHeaders.get(0).value()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void missedConnectionStringTest() {
-        VersioningProducerInterceptor<String, String> interceptor = createInterceptor();
-        interceptor.configure(new HashMap<>());
+        assertThrows(IllegalArgumentException.class, () -> {
+            VersioningProducerInterceptor<String, String> interceptor = createInterceptor();
+            interceptor.configure(new HashMap<>());
+        });
+
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void missedRunIdTest() {
-        Map<String, String> config = new HashMap<>();
-        config.put(PRODUCER_ZOOKEEPER_CONNECTION_STRING_PROPERTY, "test");
+        assertThrows(IllegalArgumentException.class, () -> {
+            Map<String, String> config = new HashMap<>();
+            config.put(PRODUCER_ZOOKEEPER_CONNECTION_STRING_PROPERTY, "test");
 
-        VersioningProducerInterceptor<String, String> interceptor = createInterceptor();
-        interceptor.configure(config);
+            VersioningProducerInterceptor<String, String> interceptor = createInterceptor();
+            interceptor.configure(config);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void missedComponentNameTest() {
-        Map<String, String> config = new HashMap<>();
-        config.put(PRODUCER_ZOOKEEPER_CONNECTION_STRING_PROPERTY, "test");
-        config.put(PRODUCER_RUN_ID_PROPERTY, "run_id");
+        assertThrows(IllegalArgumentException.class, () -> {
+            Map<String, String> config = new HashMap<>();
+            config.put(PRODUCER_ZOOKEEPER_CONNECTION_STRING_PROPERTY, "test");
+            config.put(PRODUCER_RUN_ID_PROPERTY, "run_id");
 
-        VersioningProducerInterceptor<String, String> interceptor = createInterceptor();
-        interceptor.configure(config);
+            VersioningProducerInterceptor<String, String> interceptor = createInterceptor();
+            interceptor.configure(config);
+        });
     }
 
     @Test

--- a/src-java/build.gradle
+++ b/src-java/build.gradle
@@ -125,6 +125,7 @@ subprojects {
             implementation 'org.junit.vintage:junit-vintage-engine:5.8.2'
             implementation 'com.nitorcreations:matchers:1.3'
             testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+            testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
             testImplementation 'org.junit.vintage:junit-vintage-engine:5.8.2'
             testImplementation 'org.hamcrest:hamcrest-library:2.2'
             testImplementation 'org.mockito:mockito-junit-jupiter:4.2.0'

--- a/src-java/connecteddevices-topology/connecteddevices-storm-topology/build.gradle
+++ b/src-java/connecteddevices-topology/connecteddevices-storm-topology/build.gradle
@@ -20,9 +20,9 @@ dependencies {
     compileOnly('org.apache.storm:storm-core')
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation 'org.mockito:mockito-junit-jupiter'
-    testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
 
     compileOnly 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'
@@ -47,4 +47,8 @@ shadowJar {
 
 artifacts {
     archives shadowJar
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/connecteddevices-topology/connecteddevices-storm-topology/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/connecteddevices-topology/connecteddevices-storm-topology/src/checkstyle/checkstyle-suppressions.xml
@@ -5,5 +5,6 @@
 
 <suppressions>
     <suppress files="src/main/.*Fsm\.java$" checks="JavadocMethod" />
+    <suppress files="src/test/.*Test\.java$" checks="JavadocMethod" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="VariableDeclarationUsageDistance" />
 </suppressions>

--- a/src-java/flowhs-topology/flowhs-messaging/build.gradle
+++ b/src-java/flowhs-topology/flowhs-messaging/build.gradle
@@ -15,9 +15,13 @@ dependencies {
 
     implementation 'com.google.guava:guava'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding'
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/flowhs-topology/flowhs-messaging/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/flowhs-topology/flowhs-messaging/src/checkstyle/checkstyle-suppressions.xml
@@ -4,4 +4,5 @@
         "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
 
 <suppressions>
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
 </suppressions>

--- a/src-java/flowhs-topology/flowhs-messaging/src/test/java/org/openkilda/messaging/info/flow/FlowStatusResponseTest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/test/java/org/openkilda/messaging/info/flow/FlowStatusResponseTest.java
@@ -22,8 +22,8 @@ import org.openkilda.messaging.info.InfoMessage;
 import org.openkilda.messaging.payload.flow.FlowIdStatusPayload;
 import org.openkilda.messaging.payload.flow.FlowState;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -46,11 +46,11 @@ public class FlowStatusResponseTest {
             + "\"clazz\":\"org.openkilda.messaging.info.InfoMessage\","
             + "\"destination\":\"NORTHBOUND\","
             + "\"payload\":{"
-            +     "\"clazz\":\"org.openkilda.messaging.info.flow.FlowStatusResponse\","
-            +     "\"payload\":{"
-            +         "\"flowid\":\"FLOW\","
-            +         "\"status\":\"UP\"},"
-            +     "\"timestamp\":1520474258050},"
+            + "\"clazz\":\"org.openkilda.messaging.info.flow.FlowStatusResponse\","
+            + "\"payload\":{"
+            + "\"flowid\":\"FLOW\","
+            + "\"status\":\"UP\"},"
+            + "\"timestamp\":1520474258050},"
             + "\"timestamp\":10,"
             + "\"correlation_id\":\"CORRELATION\"}";
 
@@ -67,10 +67,10 @@ public class FlowStatusResponseTest {
         FlowStatusResponse fsrJson = (FlowStatusResponse) fromJson.getData();
         FlowStatusResponse fsrObj = (FlowStatusResponse) msg.getData();
 
-        Assert.assertEquals(fsrJson.getPayload().getId(), fsrObj.getPayload().getId());
-        Assert.assertEquals(fsrJson.getPayload().getStatus(), fsrObj.getPayload().getStatus());
-        Assert.assertEquals(fsrJson.getPayload().getStatus(), FlowState.UP);
-        Assert.assertEquals(fromJson.getCorrelationId(), msg.getCorrelationId());
+        Assertions.assertEquals(fsrJson.getPayload().getId(), fsrObj.getPayload().getId());
+        Assertions.assertEquals(fsrJson.getPayload().getStatus(), fsrObj.getPayload().getStatus());
+        Assertions.assertEquals(fsrJson.getPayload().getStatus(), FlowState.UP);
+        Assertions.assertEquals(fromJson.getCorrelationId(), msg.getCorrelationId());
 
 
         System.out.println("JSON: " + MAPPER.writeValueAsString(msg));

--- a/src-java/flowhs-topology/flowhs-storm-topology/build.gradle
+++ b/src-java/flowhs-topology/flowhs-storm-topology/build.gradle
@@ -33,7 +33,8 @@ dependencies {
     testImplementation('org.apache.storm:storm-core')
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.hamcrest:hamcrest-library'
     testRuntimeOnly 'org.hibernate.validator:hibernate-validator'
@@ -69,4 +70,8 @@ shadowJar {
 
 artifacts {
     archives shadowJar
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/checkstyle/checkstyle-suppressions.xml
@@ -6,4 +6,5 @@
 <suppressions>
     <suppress files="src/main/.*Fsm\.java$" checks="JavadocMethod" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="VariableDeclarationUsageDistance" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
 </suppressions>

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseFlowRuleRemovalActionTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseFlowRuleRemovalActionTest.java
@@ -16,11 +16,12 @@
 package org.openkilda.wfm.topology.flowhs.fsm.common.actions;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -37,17 +38,17 @@ import org.openkilda.wfm.topology.flowhs.fsm.common.FlowProcessingFsm;
 import org.openkilda.wfm.topology.flowhs.model.DetectConnectedDevices;
 import org.openkilda.wfm.topology.flowhs.model.RequestedFlow;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.squirrelframework.foundation.fsm.StateMachine;
 
 import java.util.Optional;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class BaseFlowRuleRemovalActionTest extends InMemoryGraphBasedTest {
 
     public static final String FLOW_ID_1 = "flow1";
@@ -71,14 +72,14 @@ public class BaseFlowRuleRemovalActionTest extends InMemoryGraphBasedTest {
     private SwitchPropertiesRepository switchPropertiesRepository;
     TestClass testClass;
 
-    @Before
+    @BeforeEach
     public void setup() {
         flowRepository = spy(persistenceManager.getRepositoryFactory().createFlowRepository());
         switchPropertiesRepository = spy(persistenceManager.getRepositoryFactory().createSwitchPropertiesRepository());
         when(repositoryFactory.createFlowRepository()).thenReturn(flowRepository);
         when(repositoryFactory.createSwitchPropertiesRepository()).thenReturn(switchPropertiesRepository);
         testClass = new TestClass(persistenceManager, null);
-        when(switchPropertiesRepository.findBySwitchId(any()))
+        lenient().when(switchPropertiesRepository.findBySwitchId(any()))
                 .thenReturn(Optional.of(SwitchProperties.builder().build()));
     }
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseResourceAllocationActionTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/BaseResourceAllocationActionTest.java
@@ -36,13 +36,14 @@ import org.openkilda.wfm.share.flow.resources.ResourceAllocationException;
 import org.openkilda.wfm.share.logger.FlowOperationsDashboardLogger;
 
 import com.google.common.base.Suppliers;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class BaseResourceAllocationActionTest extends InMemoryGraphBasedTest {
     private IslRepository islRepositorySpy;
 
@@ -55,30 +56,33 @@ public class BaseResourceAllocationActionTest extends InMemoryGraphBasedTest {
     @Mock
     FlowOperationsDashboardLogger dashboardLogger;
 
-    @Test(expected = ResourceAllocationException.class)
+    @Test
     public void updateAvailableBandwidthFailsOnOverProvisionTest() throws ResourceAllocationException {
-        islRepositorySpy = spy(persistenceManager.getRepositoryFactory().createIslRepository());
-        when(repositoryFactory.createIslRepository()).thenReturn(islRepositorySpy);
+        Assertions.assertThrows(ResourceAllocationException.class, () -> {
+            islRepositorySpy = spy(persistenceManager.getRepositoryFactory().createIslRepository());
+            when(repositoryFactory.createIslRepository()).thenReturn(islRepositorySpy);
 
-        doReturn(-1L).when(islRepositorySpy).updateAvailableBandwidth(any(), anyInt(), any(), anyInt());
+            doReturn(-1L).when(islRepositorySpy).updateAvailableBandwidth(any(), anyInt(), any(), anyInt());
 
-        BaseResourceAllocationAction action = mock(BaseResourceAllocationAction.class,
-                Mockito.withSettings()
-                        .useConstructor(persistenceManager, 3, 3, 3, pathComputer, resourcesManager, dashboardLogger)
-                        .defaultAnswer(Mockito.CALLS_REAL_METHODS));
+            BaseResourceAllocationAction action = mock(BaseResourceAllocationAction.class,
+                    Mockito.withSettings()
+                            .useConstructor(persistenceManager, 3, 3, 3,
+                                    pathComputer, resourcesManager, dashboardLogger)
+                            .defaultAnswer(Mockito.CALLS_REAL_METHODS));
 
-        PathSegment segment = PathSegment.builder()
-                .pathId(new PathId(""))
-                .srcSwitch(Switch.builder().switchId(new SwitchId(1)).build())
-                .srcPort(1)
-                .destSwitch(Switch.builder().switchId(new SwitchId(2)).build())
-                .destPort(2)
-                .build();
+            PathSegment segment = PathSegment.builder()
+                    .pathId(new PathId(""))
+                    .srcSwitch(Switch.builder().switchId(new SwitchId(1)).build())
+                    .srcPort(1)
+                    .destSwitch(Switch.builder().switchId(new SwitchId(2)).build())
+                    .destPort(2)
+                    .build();
 
-        action.createPathSegments(singletonList(segment), Suppliers.ofInstance(emptyMap()));
+            action.createPathSegments(singletonList(segment), Suppliers.ofInstance(emptyMap()));
+        });
     }
 
-    @Test()
+    @Test
     public void updateAvailableBandwidthNoOverProvisionTest() throws ResourceAllocationException {
         islRepositorySpy = spy(persistenceManager.getRepositoryFactory().createIslRepository());
         when(repositoryFactory.createIslRepository()).thenReturn(islRepositorySpy);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/fsm/common/converters/OfCommandConverterTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/fsm/common/converters/OfCommandConverterTest.java
@@ -29,7 +29,7 @@ import org.openkilda.floodlight.api.request.rulemanager.FlowCommand;
 import org.openkilda.floodlight.api.request.rulemanager.OfCommand;
 import org.openkilda.rulemanager.FlowSpeakerData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/validation/HaFlowValidationServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/validation/HaFlowValidationServiceTest.java
@@ -16,9 +16,9 @@
 package org.openkilda.wfm.topology.flowhs.fsm.haflow.validation;
 
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -41,8 +41,9 @@ import org.openkilda.wfm.error.IllegalFlowStateException;
 import org.openkilda.wfm.error.SwitchNotFoundException;
 
 import com.google.common.collect.Sets;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -63,7 +64,7 @@ public class HaFlowValidationServiceTest extends HaFlowValidationTestBase {
     static HaFlowPath forwardPath = mock(HaFlowPath.class);
     static HaFlowPath reversePath = mock(HaFlowPath.class);
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpOnce() {
         RepositoryFactory repositoryFactory = mock(RepositoryFactory.class);
         PersistenceManager persistenceManager = mock(PersistenceManager.class);
@@ -107,21 +108,20 @@ public class HaFlowValidationServiceTest extends HaFlowValidationTestBase {
                 Collections.singletonList(getGroupDumpResponse(filterGroupSpeakerData(floodLightSpeakerData))),
                 Collections.emptySet());
 
-        assertTrue("Must be true since this must be a valid flow", haFlowValidationResponse.isAsExpected());
-        assertEquals("The number of validation results and the number of sub flows must be equal", 2,
-                haFlowValidationResponse.getSubFlowValidationResults().size());
-        assertEquals("The number of rules for the reverse flow must be equal", 6,
-                haFlowValidationResponse.getSubFlowValidationResults().get(0)
-                        .getFlowRulesTotal().intValue());
-        assertEquals("The number of rules in total must be equal", 15,
-                haFlowValidationResponse.getSubFlowValidationResults().get(0)
-                        .getSwitchRulesTotal().intValue());
+        Assertions.assertTrue(haFlowValidationResponse.isAsExpected(),
+                "Must be true since this must be a valid flow");
+        assertEquals(2, haFlowValidationResponse.getSubFlowValidationResults().size(),
+                "The number of validation results and the number of sub flows must be equal");
+        assertEquals(6, haFlowValidationResponse.getSubFlowValidationResults().get(0)
+                .getFlowRulesTotal().intValue(), "The number of rules for the reverse flow must be equal");
+        assertEquals(15, haFlowValidationResponse.getSubFlowValidationResults().get(0)
+                .getSwitchRulesTotal().intValue(), "The number of rules in total must be equal");
 
-        assertEquals("The number of rules for the reverse flow must be equal", 9,
-                haFlowValidationResponse.getSubFlowValidationResults().get(1)
-                        .getFlowRulesTotal().intValue());
-        assertEquals("The number of rules in total must be equal", 15,
-                haFlowValidationResponse.getSubFlowValidationResults().get(1).getSwitchRulesTotal().intValue());
+        assertEquals(9, haFlowValidationResponse.getSubFlowValidationResults().get(1)
+                .getFlowRulesTotal().intValue(), "The number of rules for the reverse flow must be equal");
+        assertEquals(15,
+                haFlowValidationResponse.getSubFlowValidationResults().get(1).getSwitchRulesTotal().intValue(),
+                "The number of rules in total must be equal");
     }
 
     @Test
@@ -141,51 +141,52 @@ public class HaFlowValidationServiceTest extends HaFlowValidationTestBase {
                 Collections.singletonList(getGroupDumpResponse(filterGroupSpeakerData(floodLightSpeakerData))),
                 Collections.emptySet());
 
-        assertFalse("This must be false since the forward flow is not valid",
-                haFlowValidationResponse.isAsExpected());
-        assertFalse("This must be false since the forward flow is not valid",
-                haFlowValidationResponse.getSubFlowValidationResults().get(1).getAsExpected());
-        assertEquals("The number of rules in total must be equal", 12,
-                haFlowValidationResponse.getSubFlowValidationResults().get(1)
-                        .getSwitchRulesTotal().intValue());
-        assertEquals("The number of rules for the forward flow must be equal", 9,
-                haFlowValidationResponse.getSubFlowValidationResults().get(1)
-                        .getFlowRulesTotal().intValue());
-        assertEquals("The number of meters must be", 1,
-                haFlowValidationResponse.getSubFlowValidationResults().get(1)
-                        .getSwitchMetersTotal().intValue());
-        assertEquals("There must be 'all' keyword for the rule that is exist only in RuleManager and"
-                + " not in FloodLight", "all", haFlowValidationResponse.getSubFlowValidationResults().get(1)
-                .getDiscrepancies().get(0).getField());
-        assertEquals("There must be 'all' keyword for the rule that is exist only in RuleManager and"
-                + " not in FloodLight", "all", haFlowValidationResponse.getSubFlowValidationResults().get(1)
-                .getDiscrepancies().get(1).getField());
-        assertEquals("There must be 'all' keyword for the rule that is exist only in RuleManager and"
-                + " not in FloodLight", "all", haFlowValidationResponse.getSubFlowValidationResults().get(1)
-                .getDiscrepancies().get(2).getField());
-        assertEquals("There must be the 'outPort' discrepancy", "outPort",
-                haFlowValidationResponse.getSubFlowValidationResults().get(1)
-                        .getDiscrepancies().get(3).getField());
-        assertEquals("There must be the 'outVlan' discrepancy", "outVlan",
-                haFlowValidationResponse.getSubFlowValidationResults().get(1)
-                        .getDiscrepancies().get(4).getField());
+        assertFalse(haFlowValidationResponse.isAsExpected(),
+                "This must be false since the forward flow is not valid");
+        assertFalse(haFlowValidationResponse.getSubFlowValidationResults().get(1).getAsExpected(),
+                "This must be false since the forward flow is not valid");
+        assertEquals(12, haFlowValidationResponse.getSubFlowValidationResults().get(1)
+                .getSwitchRulesTotal().intValue(), "The number of rules in total must be equal");
+        assertEquals(9, haFlowValidationResponse.getSubFlowValidationResults().get(1)
+                .getFlowRulesTotal().intValue(), "The number of rules for the forward flow must be equal");
+        assertEquals(1, haFlowValidationResponse.getSubFlowValidationResults().get(1)
+                .getSwitchMetersTotal().intValue(), "The number of meters must be");
+        assertEquals("all", haFlowValidationResponse.getSubFlowValidationResults().get(1)
+                        .getDiscrepancies().get(0).getField(),
+                "There must be 'all' keyword for the rule that is exist only in RuleManager and"
+                        + " not in FloodLight");
+        assertEquals("all", haFlowValidationResponse.getSubFlowValidationResults().get(1)
+                        .getDiscrepancies().get(1).getField(),
+                "There must be 'all' keyword for the rule that is exist only in RuleManager and"
+                        + " not in FloodLight");
+        assertEquals("all", haFlowValidationResponse.getSubFlowValidationResults().get(1)
+                        .getDiscrepancies().get(2).getField(),
+                "There must be 'all' keyword for the rule that is exist only in RuleManager and"
+                        + " not in FloodLight");
+        assertEquals("outPort", haFlowValidationResponse.getSubFlowValidationResults().get(1)
+                .getDiscrepancies().get(3).getField(), "There must be the 'outPort' discrepancy");
+        assertEquals("outVlan", haFlowValidationResponse.getSubFlowValidationResults().get(1)
+                .getDiscrepancies().get(4).getField(), "There must be the 'outVlan' discrepancy");
     }
 
-    @Test(expected = FlowNotFoundException.class)
-    public void validateCheckFlowStatusAndGetFlowUsingNotExistingFlow()
-            throws FlowNotFoundException, IllegalFlowStateException {
-        service.findValidHaFlowById("test");
+    @Test
+    public void validateCheckFlowStatusAndGetFlowUsingNotExistingFlow() {
+        assertThrows(FlowNotFoundException.class, () -> {
+            service.findValidHaFlowById("test");
+        });
     }
 
-    @Test(expected = IllegalFlowStateException.class)
-    public void validateCheckFlowStatusAndGetFlowWithDownStatus()
-            throws FlowNotFoundException, IllegalFlowStateException {
-        when(haFlow.getStatus()).thenReturn(FlowStatus.DOWN);
-        service.findValidHaFlowById(HA_FLOW_ID_1);
+    @Test
+    public void validateCheckFlowStatusAndGetFlowWithDownStatus() {
+        assertThrows(IllegalFlowStateException.class, () -> {
+            when(haFlow.getStatus()).thenReturn(FlowStatus.DOWN);
+            service.findValidHaFlowById(HA_FLOW_ID_1);
+        });
     }
 
-    @Test(expected = FlowNotFoundException.class)
-    public void validateFlowUsingNotExistingFlow() throws FlowNotFoundException, SwitchNotFoundException {
-        service.validateFlow("test", emptyList(), emptyList(), emptyList(), Sets.newHashSet());
+    @Test
+    public void validateFlowUsingNotExistingFlow() {
+        assertThrows(FlowNotFoundException.class, () ->
+                service.validateFlow("test", emptyList(), emptyList(), emptyList(), Sets.newHashSet()));
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/fsm/validation/FlowValidationServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/fsm/validation/FlowValidationServiceTest.java
@@ -16,8 +16,8 @@
 package org.openkilda.wfm.topology.flowhs.fsm.validation;
 
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.openkilda.messaging.info.flow.FlowDumpResponse;
 import org.openkilda.messaging.info.flow.FlowValidationResponse;
@@ -30,8 +30,9 @@ import org.openkilda.wfm.error.FlowNotFoundException;
 import org.openkilda.wfm.error.SwitchNotFoundException;
 
 import com.google.common.collect.Sets;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
@@ -41,7 +42,7 @@ public class FlowValidationServiceTest extends FlowValidationTestBase {
     private static FlowValidationService service;
 
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpOnce() {
         FlowValidationTestBase.setUpOnce();
         RuleManagerConfig ruleManagerConfig = configurationProvider.getConfiguration(RuleManagerConfig.class);
@@ -109,28 +110,28 @@ public class FlowValidationServiceTest extends FlowValidationTestBase {
         List<String> forwardDiscrepancies = result.get(0).getDiscrepancies().stream()
                 .map(PathDiscrepancyEntity::getField)
                 .collect(Collectors.toList());
-        assertTrue(forwardDiscrepancies.contains("all"));
-        assertTrue(forwardDiscrepancies.contains(isTransitVlan ? "inVlan" : "tunnelId"));
-        assertTrue(forwardDiscrepancies.contains("outVlan"));
+        Assertions.assertTrue(forwardDiscrepancies.contains("all"));
+        Assertions.assertTrue(forwardDiscrepancies.contains(isTransitVlan ? "inVlan" : "tunnelId"));
+        Assertions.assertTrue(forwardDiscrepancies.contains("outVlan"));
 
         List<String> reverseDiscrepancies = result.get(1).getDiscrepancies().stream()
                 .map(PathDiscrepancyEntity::getField)
                 .collect(Collectors.toList());
-        assertTrue(reverseDiscrepancies.contains("inPort"));
-        assertTrue(reverseDiscrepancies.contains("outPort"));
-        assertTrue(reverseDiscrepancies.contains("meterId"));
+        Assertions.assertTrue(reverseDiscrepancies.contains("inPort"));
+        Assertions.assertTrue(reverseDiscrepancies.contains("outPort"));
+        Assertions.assertTrue(reverseDiscrepancies.contains("meterId"));
 
         List<String> protectedForwardDiscrepancies = result.get(2).getDiscrepancies().stream()
                 .map(PathDiscrepancyEntity::getField)
                 .collect(Collectors.toList());
-        assertTrue(protectedForwardDiscrepancies.contains(isTransitVlan ? "inVlan" : "tunnelId"));
-        assertTrue(protectedForwardDiscrepancies.contains("outVlan"));
+        Assertions.assertTrue(protectedForwardDiscrepancies.contains(isTransitVlan ? "inVlan" : "tunnelId"));
+        Assertions.assertTrue(protectedForwardDiscrepancies.contains("outVlan"));
 
         List<String> protectedReverseDiscrepancies = result.get(3).getDiscrepancies().stream()
                 .map(PathDiscrepancyEntity::getField)
                 .collect(Collectors.toList());
-        assertTrue(protectedReverseDiscrepancies.contains("outPort"));
-        assertTrue(protectedReverseDiscrepancies.contains("inPort"));
+        Assertions.assertTrue(protectedReverseDiscrepancies.contains("outPort"));
+        Assertions.assertTrue(protectedReverseDiscrepancies.contains("inPort"));
     }
 
     @Test
@@ -148,9 +149,10 @@ public class FlowValidationServiceTest extends FlowValidationTestBase {
         assertEquals(0, result.get(1).getDiscrepancies().size());
     }
 
-    @Test(expected = FlowNotFoundException.class)
-    public void validateFlowUsingNotExistingFlow() throws FlowNotFoundException, SwitchNotFoundException {
-        service.validateFlow("test", emptyList(), emptyList(), emptyList(), Sets.newHashSet());
+    @Test
+    public void validateFlowUsingNotExistingFlow() {
+        assertThrows(FlowNotFoundException.class, () ->
+                service.validateFlow("test", emptyList(), emptyList(), emptyList(), Sets.newHashSet()));
     }
 
     @Test

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/fsm/validation/SimpleSwitchRuleConverterTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/fsm/validation/SimpleSwitchRuleConverterTest.java
@@ -16,9 +16,6 @@
 package org.openkilda.wfm.topology.flowhs.fsm.validation;
 
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.openkilda.rulemanager.action.ActionType.PUSH_VXLAN_NOVIFLOW;
 
 import org.openkilda.messaging.info.flow.FlowDumpResponse;
@@ -57,7 +54,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -123,8 +122,8 @@ public class SimpleSwitchRuleConverterTest {
                                     flowDumpList.get(i).getFlowSpeakerData(),
                                     meterDumpList.get(i).getMeterSpeakerData(),
                                     Collections.singletonList(GroupSpeakerData.builder().build()));
-            assertThat(actualSimpleSwitchRules, hasSize(1));
-            assertEquals(expectedSwitchRules.get(i), actualSimpleSwitchRules.get(0));
+            MatcherAssert.assertThat(actualSimpleSwitchRules, hasSize(1));
+            Assertions.assertEquals(expectedSwitchRules.get(i), actualSimpleSwitchRules.get(0));
         }
     }
 
@@ -141,8 +140,8 @@ public class SimpleSwitchRuleConverterTest {
                             switchFlowEntries.get(i).getFlowSpeakerData(),
                             switchMeterEntries.get(i).getMeterSpeakerData(),
                             Collections.singletonList(GroupSpeakerData.builder().build()));
-            assertThat(switchRules, hasSize(1));
-            assertEquals(expectedSwitchRules.get(i), switchRules.get(0));
+            MatcherAssert.assertThat(switchRules, hasSize(1));
+            Assertions.assertEquals(expectedSwitchRules.get(i), switchRules.get(0));
         }
     }
 
@@ -158,7 +157,7 @@ public class SimpleSwitchRuleConverterTest {
                         getMeterDumpResponseOneSwitchFlow().getMeterSpeakerData(),
                         Collections.singletonList(GroupSpeakerData.builder().build()));
 
-        assertEquals(expectedSwitchRules, switchRules);
+        Assertions.assertEquals(expectedSwitchRules, switchRules);
     }
 
     @Test
@@ -176,8 +175,8 @@ public class SimpleSwitchRuleConverterTest {
                             flowDumpResponses.get(i).getFlowSpeakerData(),
                             meterDumpResponses.get(0).getMeterSpeakerData(),
                             groupDumpResponses.get(0).getGroupSpeakerData());
-            assertThat(actualList, hasSize(1));
-            assertEquals(expectedSwitchRules.get(i), actualList.get(0));
+            MatcherAssert.assertThat(actualList, hasSize(1));
+            Assertions.assertEquals(expectedSwitchRules.get(i), actualList.get(0));
         }
     }
 
@@ -196,8 +195,8 @@ public class SimpleSwitchRuleConverterTest {
                             flowDumpResponses.get(i).getFlowSpeakerData(),
                             meterDumpResponses.get(0).getMeterSpeakerData(),
                             groupDumpResponses.get(0).getGroupSpeakerData());
-            assertThat(switchRules, hasSize(1));
-            assertEquals(expectedSwitchRules.get(i), switchRules.get(0));
+            MatcherAssert.assertThat(switchRules, hasSize(1));
+            Assertions.assertEquals(expectedSwitchRules.get(i), switchRules.get(0));
         }
     }
 
@@ -215,7 +214,7 @@ public class SimpleSwitchRuleConverterTest {
                             getMeterDumpResponseOneSwitchFlow().getMeterSpeakerData(),
                             groupDumpResponses.get(0).getGroupSpeakerData());
 
-            assertEquals(expectedSwitchRules.get(i), switchRules.get(0));
+            Assertions.assertEquals(expectedSwitchRules.get(i), switchRules.get(0));
         }
     }
 
@@ -262,14 +261,14 @@ public class SimpleSwitchRuleConverterTest {
             int base = (int) cookie.getFlowEffectiveId();
 
             if (cookie.isMirror()) {
-                assertEquals(base + 8, switchRule.getMeterId().intValue());
-                assertEquals(base + 9, switchRule.getGroupId());
+                Assertions.assertEquals(base + 8, switchRule.getMeterId().intValue());
+                Assertions.assertEquals(base + 9, switchRule.getGroupId());
             } else if (cookie.getDirection() == FlowPathDirection.FORWARD) {
-                assertEquals(base + 8, switchRule.getMeterId().intValue());
-                assertEquals(0, switchRule.getGroupId());
+                Assertions.assertEquals(base + 8, switchRule.getMeterId().intValue());
+                Assertions.assertEquals(0, switchRule.getGroupId());
             } else if (cookie.getDirection() == FlowPathDirection.REVERSE) {
-                assertNull(switchRule.getMeterId());
-                assertEquals(0, switchRule.getGroupId());
+                Assertions.assertNull(switchRule.getMeterId());
+                Assertions.assertEquals(0, switchRule.getGroupId());
             } else {
                 throw new AssertionError(String.format("Unknown rule %s", switchRule));
             }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/mapper/HaFlowMapperTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/mapper/HaFlowMapperTest.java
@@ -15,9 +15,7 @@
 
 package org.openkilda.wfm.topology.flowhs.mapper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -42,8 +40,9 @@ import org.openkilda.wfm.topology.flowhs.model.RequestedFlow;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import java.time.Instant;
@@ -106,7 +105,7 @@ public class HaFlowMapperTest {
     @Mock
     HaFlowRepository haFlowRepository;
 
-    @Before
+    @BeforeEach
     public void init() {
         flowRepository = mock(FlowRepository.class);
         haFlowRepository = mock(HaFlowRepository.class);
@@ -136,7 +135,7 @@ public class HaFlowMapperTest {
         assertEquals(request.getSharedEndpoint().getPortNumber().intValue(), result.getSharedPort());
         assertEquals(request.getSharedEndpoint().getOuterVlanId(), result.getSharedOuterVlan());
         assertEquals(request.getSharedEndpoint().getInnerVlanId(), result.getSharedInnerVlan());
-        assertEquals("Subflows must be mapped separately", 0, result.getHaSubFlows().size());
+        assertEquals(0, result.getHaSubFlows().size(), "Subflows must be mapped separately");
     }
 
     @Test
@@ -193,9 +192,9 @@ public class HaFlowMapperTest {
         assertEquals(haFlow.getSharedPort(), result.getSharedEndpoint().getPortNumber().intValue());
         assertEquals(haFlow.getSharedOuterVlan(), result.getSharedEndpoint().getOuterVlanId());
         assertEquals(haFlow.getSharedInnerVlan(), result.getSharedEndpoint().getInnerVlanId());
-        assertTrue(result.getDiverseWithFlows().isEmpty());
-        assertTrue(result.getDiverseWithYFlows().isEmpty());
-        assertTrue(result.getDiverseWithHaFlows().isEmpty());
+        Assertions.assertTrue(result.getDiverseWithFlows().isEmpty());
+        Assertions.assertTrue(result.getDiverseWithYFlows().isEmpty());
+        Assertions.assertTrue(result.getDiverseWithHaFlows().isEmpty());
         assertSubFlows(haFlow.getHaSubFlows(), result.getSubFlows());
     }
 
@@ -344,7 +343,7 @@ public class HaFlowMapperTest {
         assertEquals(maxLatency, actual.getMaxLatency());
         assertEquals(maxLatencyTier2, actual.getMaxLatencyTier2());
         assertEquals(strategy, actual.getPathComputationStrategy());
-        assertNull(actual.getYFlowId());
+        Assertions.assertNull(actual.getYFlowId());
     }
 
     private static Flow buildFlow(String flowId) {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/mapper/RequestedFlowMapperTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/mapper/RequestedFlowMapperTest.java
@@ -15,9 +15,9 @@
 
 package org.openkilda.wfm.topology.flowhs.mapper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.messaging.command.flow.FlowRequest;
 import org.openkilda.messaging.model.DetectConnectedDevicesDto;
@@ -31,7 +31,7 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.topology.flowhs.model.DetectConnectedDevices;
 import org.openkilda.wfm.topology.flowhs.model.RequestedFlow;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RequestedFlowMapperTest {
 
@@ -123,8 +123,8 @@ public class RequestedFlowMapperTest {
         assertTrue(requestedFlow.isAllocateProtectedPath());
         assertTrue(requestedFlow.isIgnoreBandwidth());
         assertTrue(requestedFlow.isPeriodicPings());
-        assertEquals(new DetectConnectedDevices(true, true, true, true, true, true, true, true),
-                requestedFlow.getDetectConnectedDevices());
+        assertEquals(new DetectConnectedDevices(true, true, true, true, true, true,
+                true, true), requestedFlow.getDetectConnectedDevices());
     }
 
     @Test
@@ -148,8 +148,8 @@ public class RequestedFlowMapperTest {
         assertTrue(requestedFlow.isAllocateProtectedPath());
         assertTrue(requestedFlow.isIgnoreBandwidth());
         assertTrue(requestedFlow.isPeriodicPings());
-        assertEquals(new DetectConnectedDevices(true, true, true, true, true, true, true, true),
-                requestedFlow.getDetectConnectedDevices());
+        assertEquals(new DetectConnectedDevices(true, true, true, true, true, true,
+                true, true), requestedFlow.getDetectConnectedDevices());
 
         Flow mappedFlow = RequestedFlowMapper.INSTANCE.toFlow(requestedFlow);
         assertEquals(flow, mappedFlow);
@@ -203,9 +203,8 @@ public class RequestedFlowMapperTest {
 
         assertTrue(result.isPinned());
 
-        assertEquals(
-                new org.openkilda.model.DetectConnectedDevices(true, true, true, true, true, true, true, true),
-                result.getDetectConnectedDevices());
+        assertEquals(new org.openkilda.model.DetectConnectedDevices(true, true, true, true, true,
+                true, true, true), result.getDetectConnectedDevices());
 
         assertEquals(PATH_COMPUTATION_STRATEGY, result.getPathComputationStrategy());
         assertNull(result.getTargetPathComputationStrategy());
@@ -243,9 +242,8 @@ public class RequestedFlowMapperTest {
 
         assertEquals(ENCAPSULATION_TYPE, result.getFlowEncapsulationType());
         assertEquals(PATH_COMPUTATION_STRATEGY, result.getPathComputationStrategy());
-        assertEquals(
-                new DetectConnectedDevices(true, true, true, true, true, true, true, true),
-                result.getDetectConnectedDevices());
+        assertEquals(new DetectConnectedDevices(true, true, true, true, true, true,
+                true, true), result.getDetectConnectedDevices());
     }
 
     @Test
@@ -269,8 +267,8 @@ public class RequestedFlowMapperTest {
         assertTrue(flowRequest.isAllocateProtectedPath());
         assertTrue(flowRequest.isIgnoreBandwidth());
         assertTrue(flowRequest.isPeriodicPings());
-        assertEquals(new DetectConnectedDevicesDto(true, true, true, true, true, true, true, true),
-                flowRequest.getDetectConnectedDevices());
+        assertEquals(new DetectConnectedDevicesDto(true, true, true, true, true, true,
+                true, true), flowRequest.getDetectConnectedDevices());
     }
 
     @Test

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/mapper/RequestedFlowMirrorPointMapperTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/mapper/RequestedFlowMirrorPointMapperTest.java
@@ -15,15 +15,14 @@
 
 package org.openkilda.wfm.topology.flowhs.mapper;
 
-import static org.junit.Assert.assertEquals;
-
 import org.openkilda.messaging.command.flow.FlowMirrorPointCreateRequest;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowPathDirection;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.topology.flowhs.model.RequestedFlowMirrorPoint;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RequestedFlowMirrorPointMapperTest {
 
@@ -53,10 +52,10 @@ public class RequestedFlowMirrorPointMapperTest {
 
         RequestedFlowMirrorPoint flowMirrorPoint = RequestedFlowMirrorPointMapper.INSTANCE.map(request);
 
-        assertEquals(request.getFlowId(), flowMirrorPoint.getFlowId());
-        assertEquals(request.getMirrorPointId(), flowMirrorPoint.getMirrorPointId());
-        assertEquals(MIRROR_POINT_DIRECTION, flowMirrorPoint.getMirrorPointDirection());
-        assertEquals(request.getMirrorPointSwitchId(), flowMirrorPoint.getMirrorPointSwitchId());
-        assertEquals(request.getSinkEndpoint(), flowMirrorPoint.getSinkEndpoint());
+        Assertions.assertEquals(request.getFlowId(), flowMirrorPoint.getFlowId());
+        Assertions.assertEquals(request.getMirrorPointId(), flowMirrorPoint.getMirrorPointId());
+        Assertions.assertEquals(MIRROR_POINT_DIRECTION, flowMirrorPoint.getMirrorPointDirection());
+        Assertions.assertEquals(request.getMirrorPointSwitchId(), flowMirrorPoint.getMirrorPointSwitchId());
+        Assertions.assertEquals(request.getSinkEndpoint(), flowMirrorPoint.getSinkEndpoint());
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/mapper/YFlowMapperTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/mapper/YFlowMapperTest.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.wfm.topology.flowhs.mapper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -33,8 +31,9 @@ import org.openkilda.persistence.repositories.HaFlowRepository;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 public class YFlowMapperTest {
@@ -58,7 +57,7 @@ public class YFlowMapperTest {
     @Mock
     HaFlowRepository haFlowRepository;
 
-    @Before
+    @BeforeEach
     public void init() {
         flowRepository = mock(FlowRepository.class);
         haFlowRepository = mock(HaFlowRepository.class);
@@ -82,10 +81,10 @@ public class YFlowMapperTest {
                 .thenReturn(Lists.newArrayList(HA_FLOW_ID_1, HA_FLOW_ID_2));
 
         YFlowDto result = mapper.toYFlowDto(yFlow, flowRepository, haFlowRepository);
-        assertEquals(Y_FLOW_ID_1, result.getYFlowId());
-        assertEquals(Sets.newHashSet(FLOW_ID_1, FLOW_ID_2), result.getDiverseWithFlows());
-        assertEquals(Sets.newHashSet(Y_FLOW_ID_2), result.getDiverseWithYFlows());
-        assertEquals(Sets.newHashSet(HA_FLOW_ID_1, HA_FLOW_ID_2), result.getDiverseWithHaFlows());
+        Assertions.assertEquals(Y_FLOW_ID_1, result.getYFlowId());
+        Assertions.assertEquals(Sets.newHashSet(FLOW_ID_1, FLOW_ID_2), result.getDiverseWithFlows());
+        Assertions.assertEquals(Sets.newHashSet(Y_FLOW_ID_2), result.getDiverseWithYFlows());
+        Assertions.assertEquals(Sets.newHashSet(HA_FLOW_ID_1, HA_FLOW_ID_2), result.getDiverseWithHaFlows());
     }
 
     @Test
@@ -96,10 +95,10 @@ public class YFlowMapperTest {
                 .build();
 
         YFlowDto result = mapper.toYFlowDto(yFlow, flowRepository, haFlowRepository);
-        assertEquals(Y_FLOW_ID_1, result.getYFlowId());
-        assertTrue(result.getDiverseWithFlows().isEmpty());
-        assertTrue(result.getDiverseWithYFlows().isEmpty());
-        assertTrue(result.getDiverseWithHaFlows().isEmpty());
+        Assertions.assertEquals(Y_FLOW_ID_1, result.getYFlowId());
+        Assertions.assertTrue(result.getDiverseWithFlows().isEmpty());
+        Assertions.assertTrue(result.getDiverseWithYFlows().isEmpty());
+        Assertions.assertTrue(result.getDiverseWithHaFlows().isEmpty());
     }
 
     private static Flow buildFlow(String flowId) {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/mapper/YFlowRequestMapperTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/mapper/YFlowRequestMapperTest.java
@@ -15,9 +15,9 @@
 
 package org.openkilda.wfm.topology.flowhs.mapper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.openkilda.messaging.command.yflow.SubFlowDto;
 import org.openkilda.messaging.command.yflow.SubFlowSharedEndpointEncapsulation;
@@ -29,7 +29,7 @@ import org.openkilda.model.PathComputationStrategy;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.topology.flowhs.model.RequestedFlow;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -95,8 +95,8 @@ public class YFlowRequestMapperTest {
         assertEquals(REQUEST_PERIODIC_PINGS, actualRequestedFlow.isPeriodicPings());
         assertEquals(REQUEST_COMPUTATION_STRATEGY, actualRequestedFlow.getPathComputationStrategy());
         assertEquals(REQUEST_ALLOCATE_PROTECTED_PATH, actualRequestedFlow.isAllocateProtectedPath());
-        assertNotEquals("A diverse flow id from the request is ignored",
-                REQUEST_DIVERSE_FLOW_ID, actualRequestedFlow.getDiverseFlowId());
+        assertNotEquals(REQUEST_DIVERSE_FLOW_ID, actualRequestedFlow.getDiverseFlowId(),
+                "A diverse flow id from the request is ignored");
         assertNull(actualRequestedFlow.getDiverseFlowId());
 
         // taken from subflows

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/AbstractFlowTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/AbstractFlowTest.java
@@ -17,7 +17,6 @@ package org.openkilda.wfm.topology.flowhs.service;
 
 import static java.util.Collections.singleton;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -71,9 +70,9 @@ import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
 
 import com.google.common.collect.ImmutableList;
 import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.hamcrest.MockitoHamcrest;
@@ -130,7 +129,7 @@ public abstract class AbstractFlowTest<T> extends InMemoryGraphBasedTest {
     protected final Queue<T> requests = new ArrayDeque<>();
     final Map<SwitchId, Map<Cookie, FlowSegmentRequest>> installedSegments = new HashMap<>();
 
-    @Before
+    @BeforeEach
     public void before() {
         dummyFactory = new PersistenceDummyEntityFactory(persistenceManager);
 
@@ -149,7 +148,7 @@ public abstract class AbstractFlowTest<T> extends InMemoryGraphBasedTest {
         }
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (flowRepositorySpy != null) {
             reset(flowRepositorySpy);
@@ -260,15 +259,13 @@ public abstract class AbstractFlowTest<T> extends InMemoryGraphBasedTest {
 
     protected Flow verifyFlowStatus(String flowId, FlowStatus expectedStatus) {
         Flow flow = fetchFlow(flowId);
-        assertEquals(expectedStatus, flow.getStatus());
+        Assertions.assertEquals(expectedStatus, flow.getStatus());
         return flow;
     }
 
     protected void verifyFlowPathStatus(FlowPath path, FlowPathStatus expectedStatus, String name) {
-        Assert.assertNotNull(String.format("%s flow path not defined (is null)", name), path);
-        Assert.assertSame(
-                String.format("%s flow path status is invalid", name),
-                expectedStatus, path.getStatus());
+        Assertions.assertNotNull(path, String.format("%s flow path not defined (is null)", name));
+        Assertions.assertSame(expectedStatus, path.getStatus(), String.format("%s flow path status is invalid", name));
     }
 
     protected void verifyNorthboundSuccessResponse(FlowGenericCarrier carrierMock) {
@@ -280,11 +277,11 @@ public abstract class AbstractFlowTest<T> extends InMemoryGraphBasedTest {
         verify(carrierMock).sendNorthboundResponse(responseCaptor.capture());
 
         Message rawResponse = responseCaptor.getValue();
-        Assert.assertNotNull(rawResponse);
-        Assert.assertTrue(rawResponse instanceof InfoMessage);
+        Assertions.assertNotNull(rawResponse);
+        Assertions.assertTrue(rawResponse instanceof InfoMessage);
 
         InfoData rawPayload = ((InfoMessage) rawResponse).getData();
-        Assert.assertTrue(expectedPayloadType.isInstance(rawPayload));
+        Assertions.assertTrue(expectedPayloadType.isInstance(rawPayload));
     }
 
     protected void verifyNorthboundErrorResponse(FlowGenericCarrier carrier, ErrorType expectedErrorType) {
@@ -292,11 +289,11 @@ public abstract class AbstractFlowTest<T> extends InMemoryGraphBasedTest {
         verify(carrier).sendNorthboundResponse(responseCaptor.capture());
 
         Message rawResponse = responseCaptor.getValue();
-        Assert.assertNotNull(rawResponse);
-        Assert.assertTrue(rawResponse instanceof ErrorMessage);
+        Assertions.assertNotNull(rawResponse);
+        Assertions.assertTrue(rawResponse instanceof ErrorMessage);
         ErrorMessage response = (ErrorMessage) rawResponse;
 
-        Assert.assertSame(expectedErrorType, response.getData().getErrorType());
+        Assertions.assertSame(expectedErrorType, response.getData().getErrorType());
     }
 
     protected void verifyNoSpeakerInteraction(FlowGenericCarrier carrier) {
@@ -304,13 +301,13 @@ public abstract class AbstractFlowTest<T> extends InMemoryGraphBasedTest {
     }
 
     protected void verifyNoPathReplace(Flow origin, Flow result) {
-        Assert.assertEquals(origin.getForwardPathId(), result.getForwardPathId());
-        Assert.assertEquals(origin.getReversePathId(), result.getReversePathId());
+        Assertions.assertEquals(origin.getForwardPathId(), result.getForwardPathId());
+        Assertions.assertEquals(origin.getReversePathId(), result.getReversePathId());
     }
 
     protected void verifyPathReplace(Flow origin, Flow result) {
-        Assert.assertNotEquals(origin.getForwardPathId(), result.getForwardPathId());
-        Assert.assertNotEquals(origin.getReversePathId(), result.getReversePathId());
+        Assertions.assertNotEquals(origin.getForwardPathId(), result.getForwardPathId());
+        Assertions.assertNotEquals(origin.getReversePathId(), result.getReversePathId());
     }
 
     protected void alterFeatureToggles(Boolean isCreateAllowed, Boolean isUpdateAllowed, Boolean isDeleteAllowed) {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/AbstractHaFlowTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/AbstractHaFlowTest.java
@@ -22,7 +22,7 @@ import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.rulemanager.RuleManager;
 import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mock;
 
 public abstract class AbstractHaFlowTest<T> extends InMemoryGraphBasedTest {
@@ -33,7 +33,7 @@ public abstract class AbstractHaFlowTest<T> extends InMemoryGraphBasedTest {
     @Mock
     protected PathComputer pathComputer;
 
-    @Before
+    @BeforeEach
     public void before() {
         ruleManager = mock(RuleManager.class);
         pathComputer = mock(PathComputer.class);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/AbstractYFlowTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/AbstractYFlowTest.java
@@ -18,9 +18,6 @@ package org.openkilda.wfm.topology.flowhs.service;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -77,9 +74,9 @@ import com.google.common.collect.ImmutableList;
 import lombok.SneakyThrows;
 import net.jodah.failsafe.function.CheckedConsumer;
 import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.hamcrest.MockitoHamcrest;
@@ -174,7 +171,7 @@ public abstract class AbstractYFlowTest<T> extends InMemoryGraphBasedTest {
 
     protected final Queue<T> requests = new ArrayDeque<>();
 
-    @Before
+    @BeforeEach
     public void before() {
         dummyFactory = new PersistenceDummyEntityFactory(persistenceManager);
 
@@ -204,7 +201,7 @@ public abstract class AbstractYFlowTest<T> extends InMemoryGraphBasedTest {
         }
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (yFlowRepositorySpy != null) {
             reset(yFlowRepositorySpy);
@@ -287,15 +284,15 @@ public abstract class AbstractYFlowTest<T> extends InMemoryGraphBasedTest {
 
     protected YFlow verifyYFlowStatus(String yFlowId, FlowStatus expectedStatus) {
         YFlow flow = getYFlow(yFlowId);
-        assertEquals(expectedStatus, flow.getStatus());
+        Assertions.assertEquals(expectedStatus, flow.getStatus());
         return flow;
     }
 
     protected void verifyYFlowAndSubFlowStatus(String yFlowId, FlowStatus expectedStatus) {
         YFlow flow = getYFlow(yFlowId);
-        assertEquals(expectedStatus, flow.getStatus());
+        Assertions.assertEquals(expectedStatus, flow.getStatus());
         flow.getSubFlows().forEach(subFlow -> {
-            assertEquals(expectedStatus, subFlow.getFlow().getStatus());
+            Assertions.assertEquals(expectedStatus, subFlow.getFlow().getStatus());
         });
     }
 
@@ -305,18 +302,18 @@ public abstract class AbstractYFlowTest<T> extends InMemoryGraphBasedTest {
                 .map(YSubFlow::getFlow)
                 .map(Flow::getAffinityGroupId)
                 .collect(Collectors.toSet());
-        assertEquals(1, affinityGroups.size());
+        Assertions.assertEquals(1, affinityGroups.size());
 
         String affinityGroupId = affinityGroups.iterator().next();
         Set<String> subFlowIds = flow.getSubFlows().stream()
                 .map(YSubFlow::getSubFlowId)
                 .collect(Collectors.toSet());
-        assertTrue(subFlowIds.contains(affinityGroupId));
+        Assertions.assertTrue(subFlowIds.contains(affinityGroupId));
     }
 
     protected void verifyYFlowIsAbsent(String yFlowId) {
         YFlowRepository repository = persistenceManager.getRepositoryFactory().createYFlowRepository();
-        assertFalse(repository.findById(yFlowId).isPresent());
+        Assertions.assertFalse(repository.findById(yFlowId).isPresent());
     }
 
     protected YFlow getYFlow(String yFlowId) {
@@ -337,11 +334,11 @@ public abstract class AbstractYFlowTest<T> extends InMemoryGraphBasedTest {
         verify(carrierMock, times(times)).sendNorthboundResponse(responseCaptor.capture());
 
         Message rawResponse = responseCaptor.getValue();
-        Assert.assertNotNull(rawResponse);
-        Assert.assertTrue(rawResponse instanceof InfoMessage);
+        Assertions.assertNotNull(rawResponse);
+        Assertions.assertTrue(rawResponse instanceof InfoMessage);
 
         InfoData rawPayload = ((InfoMessage) rawResponse).getData();
-        Assert.assertTrue(expectedPayloadType.isInstance(rawPayload));
+        Assertions.assertTrue(expectedPayloadType.isInstance(rawPayload));
     }
 
     protected void verifyNorthboundErrorResponse(NorthboundResponseCarrier carrier, ErrorType expectedErrorType) {
@@ -349,11 +346,11 @@ public abstract class AbstractYFlowTest<T> extends InMemoryGraphBasedTest {
         verify(carrier).sendNorthboundResponse(responseCaptor.capture());
 
         Message rawResponse = responseCaptor.getValue();
-        Assert.assertNotNull(rawResponse);
-        Assert.assertTrue(rawResponse instanceof ErrorMessage);
+        Assertions.assertNotNull(rawResponse);
+        Assertions.assertTrue(rawResponse instanceof ErrorMessage);
         ErrorMessage response = (ErrorMessage) rawResponse;
 
-        Assert.assertSame(expectedErrorType, response.getData().getErrorType());
+        Assertions.assertSame(expectedErrorType, response.getData().getErrorType());
     }
 
     protected void verifyNoNorthboundResponse(NorthboundResponseCarrier carrier) {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowCreateServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowCreateServiceTest.java
@@ -18,7 +18,6 @@ package org.openkilda.wfm.topology.flowhs.service;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
@@ -45,12 +44,12 @@ import org.openkilda.wfm.CommandContext;
 import org.openkilda.wfm.topology.flowhs.exception.DuplicateKeyException;
 import org.openkilda.wfm.topology.flowhs.exception.UnknownKeyException;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -58,12 +57,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FlowCreateServiceTest extends AbstractFlowTest<FlowSegmentRequest> {
     @Mock
     private FlowGenericCarrier carrier;
 
-    @Before
+    @BeforeEach
     public void init() {
         doAnswer(buildSpeakerRequestAnswer()).when(carrier).sendSpeakerRequest(any(FlowSegmentRequest.class));
     }
@@ -112,7 +111,7 @@ public class FlowCreateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
                 .build();
         preparePathComputation(request.getFlowId(), make3SwitchesPathPair());
         Flow result = testHappyPath(request, "successful_flow_create");
-        Assert.assertTrue(result.isPinned());
+        Assertions.assertTrue(result.isPinned());
     }
 
     @Test
@@ -129,7 +128,7 @@ public class FlowCreateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
                 .thenReturn(make3SwitchesPathPair());
 
         Flow result = testHappyPath(request, "successful_flow_create");
-        Assert.assertTrue(result.isAllocateProtectedPath());
+        Assertions.assertTrue(result.isAllocateProtectedPath());
         verifyFlowPathStatus(result.getProtectedForwardPath(), FlowPathStatus.ACTIVE, "protected-forward");
         verifyFlowPathStatus(result.getProtectedReversePath(), FlowPathStatus.ACTIVE, "protected-reverse");
     }
@@ -205,12 +204,12 @@ public class FlowCreateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
             }
         }
 
-        assertEquals("All installed rules should be deleted", installCommands, deleteCommands);
+        Assertions.assertEquals(installCommands, deleteCommands, "All installed rules should be deleted");
 
         Flow result = verifyFlowStatus(flowRequest.getFlowId(), FlowStatus.DOWN);
         // TODO(surabujin): do we really want to create flow without paths?
-        Assert.assertNull(result.getForwardPath());
-        Assert.assertNull(result.getReversePath());
+        Assertions.assertNull(result.getForwardPath());
+        Assertions.assertNull(result.getReversePath());
     }
 
     @Test
@@ -254,10 +253,10 @@ public class FlowCreateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
             }
         }
 
-        assertEquals("All installed rules should be deleted", installCommands, deleteCommands);
+        Assertions.assertEquals(installCommands, deleteCommands, "All installed rules should be deleted");
         Flow result = verifyFlowStatus(flowRequest.getFlowId(), FlowStatus.DOWN);
-        Assert.assertNull(result.getForwardPath());
-        Assert.assertNull(result.getReversePath());
+        Assertions.assertNull(result.getForwardPath());
+        Assertions.assertNull(result.getReversePath());
     }
 
     @Test
@@ -338,7 +337,7 @@ public class FlowCreateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
             }
         }
 
-        Assert.assertFalse(producedErrors.isEmpty());
+        Assertions.assertFalse(producedErrors.isEmpty());
         for (Map.Entry<UUID, Integer> entry : seenCounter.entrySet()) {
             if (!producedErrors.contains(entry.getKey())) {
                 continue;
@@ -346,9 +345,9 @@ public class FlowCreateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
 
             Integer counter = entry.getValue();
             if (mustRetry) {
-                Assert.assertEquals(retriesLimit + 1, (int) counter);
+                Assertions.assertEquals(retriesLimit + 1, (int) counter);
             } else {
-                Assert.assertEquals(1, (int) counter);
+                Assertions.assertEquals(1, (int) counter);
             }
         }
 
@@ -386,7 +385,7 @@ public class FlowCreateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
         while ((request = requests.poll()) != null) {
             UUID commandId = request.getCommandId();
             Integer remaining = remainingRetries.getOrDefault(commandId, retriesLimit + 1);
-            Assert.assertTrue(0 < remaining);
+            Assertions.assertTrue(0 < remaining);
             try {
                 if (request instanceof EgressFlowSegmentInstallRequest) {
                     remainingRetries.put(commandId, remaining - 1);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowDeleteServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowDeleteServiceTest.java
@@ -16,10 +16,11 @@
 package org.openkilda.wfm.topology.flowhs.service;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -39,24 +40,24 @@ import org.openkilda.wfm.topology.flowhs.exception.DuplicateKeyException;
 import org.openkilda.wfm.topology.flowhs.exception.UnknownKeyException;
 
 import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.hamcrest.MockitoHamcrest;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FlowDeleteServiceTest extends AbstractFlowTest<FlowSegmentRequest> {
     private static final int SPEAKER_COMMAND_RETRIES_LIMIT = 3;
 
     @Mock
     private FlowGenericCarrier carrier;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        doAnswer(buildSpeakerRequestAnswer()).when(carrier).sendSpeakerRequest(any(FlowSegmentRequest.class));
+        lenient().doAnswer(buildSpeakerRequestAnswer()).when(carrier).sendSpeakerRequest(any(FlowSegmentRequest.class));
 
         // must be done before first service create attempt, because repository objects are cached inside FSM actions
         setupFlowRepositorySpy();
@@ -69,7 +70,7 @@ public class FlowDeleteServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
 
         // make sure flow is missing
         FlowRepository repository = persistenceManager.getRepositoryFactory().createFlowRepository();
-        Assert.assertFalse(repository.findById(flowId).isPresent());
+        assertFalse(repository.findById(flowId).isPresent());
 
         makeService().handleRequest(dummyRequestKey, commandContext, flowId);
 
@@ -183,7 +184,7 @@ public class FlowDeleteServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
             throws DuplicateKeyException, UnknownKeyException {
         Flow target = makeFlow();
         FlowPath forwardPath = target.getForwardPath();
-        Assert.assertNotNull(forwardPath);
+        Assertions.assertNotNull(forwardPath);
 
         FlowPathRepository repository = setupFlowPathRepositorySpy();
         doThrow(new RuntimeException(injectedErrorMessage))
@@ -208,7 +209,7 @@ public class FlowDeleteServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
             throws DuplicateKeyException, UnknownKeyException {
         Flow target = makeFlow();
         FlowPath forwardPath = target.getForwardPath();
-        Assert.assertNotNull(forwardPath);
+        Assertions.assertNotNull(forwardPath);
 
         doThrow(new RuntimeException(injectedErrorMessage))
                 .when(flowResourcesManager)
@@ -287,12 +288,11 @@ public class FlowDeleteServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
         FlowRepository flowRepository = repositoryFactory.createFlowRepository();
         FlowPathRepository flowPathRepository = repositoryFactory.createFlowPathRepository();
 
-        Assert.assertFalse(flowRepository.findById(flow.getFlowId()).isPresent());
+        assertFalse(flowRepository.findById(flow.getFlowId()).isPresent());
 
         for (FlowPath path : flow.getPaths()) {
-            Assert.assertFalse(
-                    String.format("Flow path %s still exists", path.getPathId()),
-                    flowPathRepository.findById(path.getPathId()).isPresent());
+            assertFalse(flowPathRepository.findById(path.getPathId()).isPresent(),
+                    String.format("Flow path %s still exists", path.getPathId()));
         }
 
         // TODO(surabujin): maybe we should make more deep scanning for flow related resources and nested objects

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowPathSwapServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowPathSwapServiceTest.java
@@ -16,8 +16,6 @@
 package org.openkilda.wfm.topology.flowhs.service;
 
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
@@ -35,13 +33,14 @@ import org.openkilda.rulemanager.RuleManager;
 import org.openkilda.rulemanager.RuleManagerConfig;
 import org.openkilda.rulemanager.RuleManagerImpl;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FlowPathSwapServiceTest extends AbstractFlowTest<SpeakerRequest> {
     private static final int SPEAKER_COMMAND_RETRIES_LIMIT = 0;
 
@@ -49,7 +48,7 @@ public class FlowPathSwapServiceTest extends AbstractFlowTest<SpeakerRequest> {
     private FlowPathSwapHubCarrier carrier;
     private RuleManager ruleManager;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         doAnswer(buildSpeakerRequestAnswer()).when(carrier).sendSpeakerRequest(any(SpeakerRequest.class));
 
@@ -114,7 +113,7 @@ public class FlowPathSwapServiceTest extends AbstractFlowTest<SpeakerRequest> {
                     service.handleAsyncResponse(dummyRequestKey, buildSpeakerResponse(flowSegmentRequest));
                 }
             } else {
-                fail();
+                Assertions.fail();
             }
         }
 
@@ -162,17 +161,17 @@ public class FlowPathSwapServiceTest extends AbstractFlowTest<SpeakerRequest> {
     }
 
     private void verifyPathSwapped(Flow origin, Flow result) {
-        assertEquals(origin.getProtectedForwardPathId(), result.getForwardPathId());
-        assertEquals(origin.getForwardPathId(), result.getProtectedForwardPathId());
-        assertEquals(origin.getProtectedReversePathId(), result.getReversePathId());
-        assertEquals(origin.getReversePathId(), result.getProtectedReversePathId());
+        Assertions.assertEquals(origin.getProtectedForwardPathId(), result.getForwardPathId());
+        Assertions.assertEquals(origin.getForwardPathId(), result.getProtectedForwardPathId());
+        Assertions.assertEquals(origin.getProtectedReversePathId(), result.getReversePathId());
+        Assertions.assertEquals(origin.getReversePathId(), result.getProtectedReversePathId());
     }
 
     private void verifyPathNotSwapped(Flow origin, Flow result) {
-        assertEquals(origin.getForwardPathId(), result.getForwardPathId());
-        assertEquals(origin.getProtectedForwardPathId(), result.getProtectedForwardPathId());
-        assertEquals(origin.getReversePathId(), result.getReversePathId());
-        assertEquals(origin.getProtectedReversePathId(), result.getProtectedReversePathId());
+        Assertions.assertEquals(origin.getForwardPathId(), result.getForwardPathId());
+        Assertions.assertEquals(origin.getProtectedForwardPathId(), result.getProtectedForwardPathId());
+        Assertions.assertEquals(origin.getReversePathId(), result.getReversePathId());
+        Assertions.assertEquals(origin.getProtectedReversePathId(), result.getProtectedReversePathId());
     }
 
     @Override

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowRerouteServiceTest.java
@@ -18,18 +18,14 @@ package org.openkilda.wfm.topology.flowhs.service;
 import static java.util.stream.Collectors.toSet;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -59,21 +55,21 @@ import org.openkilda.wfm.CommandContext;
 import org.openkilda.wfm.share.flow.resources.ResourceAllocationException;
 import org.openkilda.wfm.topology.flowhs.exception.UnknownKeyException;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FlowRerouteServiceTest extends AbstractFlowTest<FlowSegmentRequest> {
     private static final int PATH_ALLOCATION_RETRIES_LIMIT = 10;
     private static final int PATH_ALLOCATION_RETRY_DELAY = 0;
@@ -84,9 +80,9 @@ public class FlowRerouteServiceTest extends AbstractFlowTest<FlowSegmentRequest>
 
     private String currentRequestKey = dummyRequestKey;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        doAnswer(buildSpeakerRequestAnswer()).when(carrier).sendSpeakerRequest(any(FlowSegmentRequest.class));
+        lenient().doAnswer(buildSpeakerRequestAnswer()).when(carrier).sendSpeakerRequest(any(FlowSegmentRequest.class));
 
         // must be done before first service create attempt, because repository objects are cached inside FSM actions
         setupFlowRepositorySpy();
@@ -145,7 +141,7 @@ public class FlowRerouteServiceTest extends AbstractFlowTest<FlowSegmentRequest>
 
         doThrow(new ResourceAllocationException(injectedErrorMessage))
                 .when(flowResourcesManager).allocateFlowResources(makeFlowArgumentMatch(origin.getFlowId()),
-                any(), any());
+                        any(), any());
 
         FlowRerouteRequest request = new FlowRerouteRequest(origin.getFlowId(), false,
                 false, Collections.emptySet(), null, false);
@@ -336,7 +332,7 @@ public class FlowRerouteServiceTest extends AbstractFlowTest<FlowSegmentRequest>
                 any(String.class));
     }
 
-    @Ignore("FIXME: need to replace mocking of updateStatus with another approach")
+    @Disabled("FIXME: need to replace mocking of updateStatus with another approach")
     @Test
     public void shouldFailRerouteOnSwapPathsError()
             throws RecoverableException, UnroutableFlowException, UnknownKeyException {
@@ -346,7 +342,7 @@ public class FlowRerouteServiceTest extends AbstractFlowTest<FlowSegmentRequest>
         FlowPathRepository flowPathRepository = setupFlowPathRepositorySpy();
         doThrow(new RuntimeException(injectedErrorMessage))
                 .when(flowPathRepository).updateStatus(eq(origin.getForwardPathId()),
-                eq(FlowPathStatus.IN_PROGRESS));
+                        eq(FlowPathStatus.IN_PROGRESS));
 
         FlowRerouteService service = makeService();
         FlowRerouteRequest request = new FlowRerouteRequest(origin.getFlowId(), false,
@@ -451,8 +447,8 @@ public class FlowRerouteServiceTest extends AbstractFlowTest<FlowSegmentRequest>
 
         doThrow(new RuntimeException(injectedErrorMessage))
                 .when(flowResourcesManager).deallocatePathResources(argThat(
-                hasProperty("forward",
-                        hasProperty("pathId", equalTo(origin.getForwardPathId())))));
+                        hasProperty("forward",
+                                hasProperty("pathId", equalTo(origin.getForwardPathId())))));
 
         FlowSegmentRequest speakerRequest;
         while ((speakerRequest = requests.poll()) != null) {
@@ -529,8 +525,8 @@ public class FlowRerouteServiceTest extends AbstractFlowTest<FlowSegmentRequest>
         verifyPathReplace(origin, result);
 
         FlowPath forwardPath = result.getForwardPath();
-        Assert.assertNotNull(forwardPath);
-        Assert.assertEquals(1, forwardPath.getSegments().size());  // second request is dropped
+        Assertions.assertNotNull(forwardPath);
+        Assertions.assertEquals(1, forwardPath.getSegments().size());  // second request is dropped
 
         verify(carrier).sendRerouteResultStatus(eq(origin.getFlowId()),
                 argThat(hasProperty("message", equalTo("Reroute is in progress"))),
@@ -607,8 +603,8 @@ public class FlowRerouteServiceTest extends AbstractFlowTest<FlowSegmentRequest>
 
         Flow result = verifyFlowStatus(origin.getFlowId(), FlowStatus.UP);
         verifyPathReplace(origin, result);
-        assertEquals(LATENCY, result.getPathComputationStrategy());
-        assertNull(result.getTargetPathComputationStrategy());
+        Assertions.assertEquals(LATENCY, result.getPathComputationStrategy());
+        Assertions.assertNull(result.getTargetPathComputationStrategy());
     }
 
     @Test
@@ -650,8 +646,8 @@ public class FlowRerouteServiceTest extends AbstractFlowTest<FlowSegmentRequest>
 
         Flow result = verifyFlowStatus(origin.getFlowId(), FlowStatus.DEGRADED);
         verifyPathReplace(origin, result);
-        assertEquals(MAX_LATENCY, result.getPathComputationStrategy());
-        assertNull(result.getTargetPathComputationStrategy());
+        Assertions.assertEquals(MAX_LATENCY, result.getPathComputationStrategy());
+        Assertions.assertNull(result.getTargetPathComputationStrategy());
     }
 
     @Test
@@ -677,9 +673,9 @@ public class FlowRerouteServiceTest extends AbstractFlowTest<FlowSegmentRequest>
 
     private IslEndpoint extractIslEndpoint(Flow flow) {
         FlowPath forwardPath = flow.getForwardPath();
-        assertNotNull(forwardPath);
+        Assertions.assertNotNull(forwardPath);
         List<PathSegment> forwardSegments = forwardPath.getSegments();
-        assertFalse(forwardSegments.isEmpty());
+        Assertions.assertFalse(forwardSegments.isEmpty());
         PathSegment firstSegment = forwardSegments.get(0);
 
         return new IslEndpoint(firstSegment.getSrcSwitchId(), firstSegment.getSrcPort());
@@ -693,7 +689,7 @@ public class FlowRerouteServiceTest extends AbstractFlowTest<FlowSegmentRequest>
 
     private void preparePathComputation(String flowId, GetPathsResult pathPair)
             throws RecoverableException, UnroutableFlowException {
-        when(pathComputer.getPath(makeFlowArgumentMatch(flowId), any(), anyBoolean())).thenReturn(pathPair);
+        lenient().when(pathComputer.getPath(makeFlowArgumentMatch(flowId), any(), anyBoolean())).thenReturn(pathPair);
     }
 
     @Override

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowSyncServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowSyncServiceTest.java
@@ -36,12 +36,12 @@ import org.openkilda.wfm.topology.flowhs.model.path.FlowPathResultCode;
 import com.google.common.collect.Sets;
 import lombok.Value;
 import org.apache.commons.lang3.function.FailableConsumer;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -51,7 +51,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FlowSyncServiceTest extends AbstractFlowTest<FlowSegmentRequest> {
     private static final int SPEAKER_RETRY_LIMIT = 3;
     private static final FlowPathOperationConfig PATH_OPERATION_CONFIG = new FlowPathOperationConfig(
@@ -62,7 +62,7 @@ public class FlowSyncServiceTest extends AbstractFlowTest<FlowSegmentRequest> {
 
     private final Queue<CarrierLaunchPathOperation> pathRequests = new ArrayDeque<>();
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         doAnswer(invocation -> {
             CarrierLaunchPathOperation pathOperation = new CarrierLaunchPathOperation(
@@ -97,14 +97,14 @@ public class FlowSyncServiceTest extends AbstractFlowTest<FlowSegmentRequest> {
             }
         });
 
-        Assert.assertTrue(expected.isEmpty());
-        Assert.assertTrue(unexpected.isEmpty());
+        Assertions.assertTrue(expected.isEmpty());
+        Assertions.assertTrue(unexpected.isEmpty());
 
         Flow flow = verifyFlowStatus(origin.getFlowId(), FlowStatus.UP);
         verifyFlowPathStatus(flow.getForwardPath(), FlowPathStatus.ACTIVE, "forward");
         verifyFlowPathStatus(flow.getReversePath(), FlowPathStatus.ACTIVE, "reversed");
 
-        Assert.assertTrue(service.deactivate());
+        Assertions.assertTrue(service.deactivate());
     }
 
     @Test
@@ -130,19 +130,19 @@ public class FlowSyncServiceTest extends AbstractFlowTest<FlowSegmentRequest> {
             FlowPathRequest pathRequest = entry.getRequest();
             FlowPathReference reference = pathRequest.getReference();
             if (expected.remove(reference.getPathId())) {
-                Assert.assertEquals(2, pathRequest.getPathChunks().size());
+                Assertions.assertEquals(2, pathRequest.getPathChunks().size());
                 service.handlePathSyncResponse(reference, FlowPathResultCode.SUCCESS);
             } else if (expectedProtected.remove(reference.getPathId())) {
-                Assert.assertEquals(1, pathRequest.getPathChunks().size());
+                Assertions.assertEquals(1, pathRequest.getPathChunks().size());
                 service.handlePathSyncResponse(reference, FlowPathResultCode.SUCCESS);
             } else {
                 unexpected.add(entry);
             }
         });
 
-        Assert.assertTrue(expected.isEmpty());
-        Assert.assertTrue(expectedProtected.isEmpty());
-        Assert.assertTrue(unexpected.isEmpty());
+        Assertions.assertTrue(expected.isEmpty());
+        Assertions.assertTrue(expectedProtected.isEmpty());
+        Assertions.assertTrue(unexpected.isEmpty());
 
         Flow flow = verifyFlowStatus(origin.getFlowId(), FlowStatus.UP);
         verifyFlowPathStatus(flow.getForwardPath(), FlowPathStatus.ACTIVE, "forward");
@@ -150,7 +150,7 @@ public class FlowSyncServiceTest extends AbstractFlowTest<FlowSegmentRequest> {
         verifyFlowPathStatus(flow.getProtectedForwardPath(), FlowPathStatus.ACTIVE, "forward-protected");
         verifyFlowPathStatus(flow.getProtectedReversePath(), FlowPathStatus.ACTIVE, "reversed-protected");
 
-        Assert.assertTrue(service.deactivate());
+        Assertions.assertTrue(service.deactivate());
     }
 
     @Test
@@ -173,7 +173,7 @@ public class FlowSyncServiceTest extends AbstractFlowTest<FlowSegmentRequest> {
             }
         });
 
-        Assert.assertTrue(unexpected.isEmpty());
+        Assertions.assertTrue(unexpected.isEmpty());
 
         // All flow's path are in ACTIVE state (same as they were before sync), but due to error during sync
         // final flow state will be DEGRADED (so system will try to fix later).
@@ -181,7 +181,7 @@ public class FlowSyncServiceTest extends AbstractFlowTest<FlowSegmentRequest> {
         verifyFlowPathStatus(flow.getForwardPath(), FlowPathStatus.ACTIVE, "forward");
         verifyFlowPathStatus(flow.getReversePath(), FlowPathStatus.ACTIVE, "reversed");
 
-        Assert.assertTrue(service.deactivate());
+        Assertions.assertTrue(service.deactivate());
     }
 
     @Test
@@ -209,7 +209,7 @@ public class FlowSyncServiceTest extends AbstractFlowTest<FlowSegmentRequest> {
         verifyFlowPathStatus(flow.getForwardPath(), FlowPathStatus.INACTIVE, "forward");
         verifyFlowPathStatus(flow.getReversePath(), FlowPathStatus.ACTIVE, "reversed");
 
-        Assert.assertTrue(service.deactivate());
+        Assertions.assertTrue(service.deactivate());
     }
 
     // utility/service

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowUpdateServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowUpdateServiceTest.java
@@ -17,18 +17,14 @@ package org.openkilda.wfm.topology.flowhs.service;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -63,19 +59,19 @@ import org.openkilda.wfm.topology.flowhs.exception.DuplicateKeyException;
 import org.openkilda.wfm.topology.flowhs.exception.UnknownKeyException;
 
 import com.google.common.collect.Sets;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FlowUpdateServiceTest extends AbstractFlowTest<FlowSegmentRequest> {
     private static final int PATH_ALLOCATION_RETRIES_LIMIT = 10;
     private static final int PATH_ALLOCATION_RETRY_DELAY = 0;
@@ -84,9 +80,9 @@ public class FlowUpdateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
     @Mock
     private FlowUpdateHubCarrier carrier;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        doAnswer(buildSpeakerRequestAnswer()).when(carrier).sendSpeakerRequest(any(FlowSegmentRequest.class));
+        lenient().doAnswer(buildSpeakerRequestAnswer()).when(carrier).sendSpeakerRequest(any(FlowSegmentRequest.class));
 
         // must be done before first service create attempt, because repository objects are cached inside FSM actions
         setupFlowRepositorySpy();
@@ -107,7 +103,7 @@ public class FlowUpdateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
                 .build();
 
         Flow result = testExpectedFailure(request, origin, ErrorType.NOT_FOUND);
-        Assert.assertEquals(origin.getBandwidth(), result.getBandwidth());
+        Assertions.assertEquals(origin.getBandwidth(), result.getBandwidth());
 
         verify(pathComputer, times(11))
                 .getPath(makeFlowArgumentMatch(origin.getFlowId()), any(), anyBoolean());
@@ -157,7 +153,7 @@ public class FlowUpdateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
 
         doThrow(new ResourceAllocationException(injectedErrorMessage))
                 .when(flowResourcesManager).allocateFlowResources(makeFlowArgumentMatch(origin.getFlowId()),
-                any(), any());
+                        any(), any());
 
         FlowRequest request = makeRequest()
                 .flowId(origin.getFlowId())
@@ -352,7 +348,7 @@ public class FlowUpdateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
         verifyNoPathReplace(origin, result);
     }
 
-    @Ignore("FIXME: need to replace mocking of updateStatus with another approach")
+    @Disabled("FIXME: need to replace mocking of updateStatus with another approach")
     @Test
     public void shouldFailUpdateOnSwapPathsError()
             throws RecoverableException, UnroutableFlowException, DuplicateKeyException, UnknownKeyException {
@@ -366,7 +362,7 @@ public class FlowUpdateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
         FlowPathRepository flowPathRepository = setupFlowPathRepositorySpy();
         doThrow(new RuntimeException(injectedErrorMessage))
                 .when(flowPathRepository).updateStatus(eq(origin.getForwardPathId()),
-                eq(FlowPathStatus.IN_PROGRESS));
+                        eq(FlowPathStatus.IN_PROGRESS));
 
         FlowUpdateService service = makeService();
         service.handleUpdateRequest(dummyRequestKey, commandContext, request);
@@ -587,8 +583,8 @@ public class FlowUpdateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
         }
 
         Flow result = verifyFlowStatus(origin.getFlowId(), FlowStatus.UP);
-        assertTrue(result.isLooped());
-        assertEquals(request.getSwitchId(), result.getLoopSwitchId());
+        Assertions.assertTrue(result.isLooped());
+        Assertions.assertEquals(request.getSwitchId(), result.getLoopSwitchId());
     }
 
     @Test
@@ -642,8 +638,8 @@ public class FlowUpdateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
         }
 
         Flow result = verifyFlowStatus(origin.getFlowId(), FlowStatus.UP);
-        assertFalse(result.isLooped());
-        assertNull(result.getLoopSwitchId());
+        Assertions.assertFalse(result.isLooped());
+        Assertions.assertNull(result.getLoopSwitchId());
     }
 
     @Test
@@ -714,7 +710,7 @@ public class FlowUpdateServiceTest extends AbstractFlowTest<FlowSegmentRequest> 
 
     private void preparePathComputation(String flowId, GetPathsResult pathPair)
             throws RecoverableException, UnroutableFlowException {
-        when(pathComputer.getPath(makeFlowArgumentMatch(flowId), any(), anyBoolean())).thenReturn(pathPair);
+        lenient().when(pathComputer.getPath(makeFlowArgumentMatch(flowId), any(), anyBoolean())).thenReturn(pathPair);
     }
 
     private FlowUpdateService makeService() {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowValidationHubServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/FlowValidationHubServiceTest.java
@@ -15,9 +15,7 @@
 
 package org.openkilda.wfm.topology.flowhs.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.messaging.Message;
 import org.openkilda.messaging.MessageData;
@@ -45,8 +43,9 @@ import org.openkilda.wfm.topology.flowhs.fsm.validation.FlowValidationTestBase;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
@@ -58,7 +57,7 @@ public class FlowValidationHubServiceTest extends FlowValidationTestBase {
     private static RuleManagerConfig ruleManagerConfig;
     private FlowValidationHubService flowValidationHubService;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpOnce() {
         FlowValidationTestBase.setUpOnce();
         ruleManagerConfig = configurationProvider.getConfiguration(RuleManagerConfig.class);
@@ -70,18 +69,18 @@ public class FlowValidationHubServiceTest extends FlowValidationTestBase {
         FlowValidationHubCarrier carrier = new FlowValidationHubCarrier() {
             @Override
             public void sendSpeakerRequest(String flowId, CommandData commandData) {
-                assertTrue(commandData instanceof DumpRulesForFlowHsRequest
+                Assertions.assertTrue(commandData instanceof DumpRulesForFlowHsRequest
                         || commandData instanceof DumpMetersForFlowHsRequest
                         || commandData instanceof DumpGroupsForFlowHsRequest);
 
                 List<SwitchId> switchIds =
                         Lists.newArrayList(TEST_SWITCH_ID_A, TEST_SWITCH_ID_B, TEST_SWITCH_ID_C, TEST_SWITCH_ID_E);
                 if (commandData instanceof DumpRulesForFlowHsRequest) {
-                    assertTrue(switchIds.contains(((DumpRulesForFlowHsRequest) commandData).getSwitchId()));
+                    Assertions.assertTrue(switchIds.contains(((DumpRulesForFlowHsRequest) commandData).getSwitchId()));
                 } else if (commandData instanceof DumpMetersForFlowHsRequest) {
-                    assertTrue(switchIds.contains(((DumpMetersForFlowHsRequest) commandData).getSwitchId()));
+                    Assertions.assertTrue(switchIds.contains(((DumpMetersForFlowHsRequest) commandData).getSwitchId()));
                 } else {
-                    assertTrue(switchIds.contains(((DumpGroupsForFlowHsRequest) commandData).getSwitchId()));
+                    Assertions.assertTrue(switchIds.contains(((DumpGroupsForFlowHsRequest) commandData).getSwitchId()));
                 }
             }
 
@@ -101,7 +100,7 @@ public class FlowValidationHubServiceTest extends FlowValidationTestBase {
 
             @Override
             public void sendNorthboundResponse(Message message) {
-                fail();
+                Assertions.fail();
             }
 
             @Override
@@ -136,24 +135,24 @@ public class FlowValidationHubServiceTest extends FlowValidationTestBase {
         FlowValidationHubCarrier carrier = new FlowValidationHubCarrier() {
             @Override
             public void sendSpeakerRequest(String flowId, CommandData commandData) {
-                assertTrue(commandData instanceof DumpRulesForFlowHsRequest
+                Assertions.assertTrue(commandData instanceof DumpRulesForFlowHsRequest
                         || commandData instanceof DumpMetersForFlowHsRequest
                         || commandData instanceof DumpGroupsForFlowHsRequest);
 
                 List<SwitchId> switchIds =
                         Lists.newArrayList(TEST_SWITCH_ID_A, TEST_SWITCH_ID_B, TEST_SWITCH_ID_C, TEST_SWITCH_ID_E);
                 if (commandData instanceof DumpRulesForFlowHsRequest) {
-                    assertTrue(switchIds.contains(((DumpRulesForFlowHsRequest) commandData).getSwitchId()));
+                    Assertions.assertTrue(switchIds.contains(((DumpRulesForFlowHsRequest) commandData).getSwitchId()));
                 } else if (commandData instanceof DumpMetersForFlowHsRequest) {
-                    assertTrue(switchIds.contains(((DumpMetersForFlowHsRequest) commandData).getSwitchId()));
+                    Assertions.assertTrue(switchIds.contains(((DumpMetersForFlowHsRequest) commandData).getSwitchId()));
                 } else {
-                    assertTrue(switchIds.contains(((DumpGroupsForFlowHsRequest) commandData).getSwitchId()));
+                    Assertions.assertTrue(switchIds.contains(((DumpGroupsForFlowHsRequest) commandData).getSwitchId()));
                 }
             }
 
             @Override
             public void sendNorthboundResponse(List<? extends InfoData> message) {
-                fail();
+                Assertions.fail();
             }
 
             @Override
@@ -185,24 +184,24 @@ public class FlowValidationHubServiceTest extends FlowValidationTestBase {
         FlowValidationHubCarrier carrier = new FlowValidationHubCarrier() {
             @Override
             public void sendSpeakerRequest(String flowId, CommandData commandData) {
-                assertTrue(commandData instanceof DumpRulesForFlowHsRequest
+                Assertions.assertTrue(commandData instanceof DumpRulesForFlowHsRequest
                         || commandData instanceof DumpMetersForFlowHsRequest
                         || commandData instanceof DumpGroupsForFlowHsRequest);
 
                 List<SwitchId> switchIds =
                         Lists.newArrayList(TEST_SWITCH_ID_A, TEST_SWITCH_ID_B, TEST_SWITCH_ID_C, TEST_SWITCH_ID_E);
                 if (commandData instanceof DumpRulesForFlowHsRequest) {
-                    assertTrue(switchIds.contains(((DumpRulesForFlowHsRequest) commandData).getSwitchId()));
+                    Assertions.assertTrue(switchIds.contains(((DumpRulesForFlowHsRequest) commandData).getSwitchId()));
                 } else if (commandData instanceof DumpMetersForFlowHsRequest) {
-                    assertTrue(switchIds.contains(((DumpMetersForFlowHsRequest) commandData).getSwitchId()));
+                    Assertions.assertTrue(switchIds.contains(((DumpMetersForFlowHsRequest) commandData).getSwitchId()));
                 } else {
-                    assertTrue(switchIds.contains(((DumpGroupsForFlowHsRequest) commandData).getSwitchId()));
+                    Assertions.assertTrue(switchIds.contains(((DumpGroupsForFlowHsRequest) commandData).getSwitchId()));
                 }
             }
 
             @Override
             public void sendNorthboundResponse(List<? extends InfoData> message) {
-                fail();
+                Assertions.fail();
             }
 
             @Override

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/haflow/HaFlowReadServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/haflow/HaFlowReadServiceTest.java
@@ -15,16 +15,16 @@
 
 package org.openkilda.wfm.topology.flowhs.service.haflow;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.openkilda.floodlight.api.request.FlowSegmentRequest;
 import org.openkilda.messaging.command.haflow.HaFlowResponse;
 import org.openkilda.wfm.error.FlowNotFoundException;
 import org.openkilda.wfm.topology.flowhs.service.AbstractHaFlowTest;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.List;
@@ -32,7 +32,7 @@ import java.util.List;
 public class HaFlowReadServiceTest extends AbstractHaFlowTest<FlowSegmentRequest> {
     private static HaFlowReadService haFlowReadService;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpOnce() {
         haFlowReadService = new HaFlowReadService(persistenceManager, 0, Duration.ofMillis(1));
     }
@@ -40,22 +40,24 @@ public class HaFlowReadServiceTest extends AbstractHaFlowTest<FlowSegmentRequest
     @Test
     public void dumpReturnsEmptyListTest() {
         List<HaFlowResponse> haFlows = haFlowReadService.getAllHaFlows();
-        assertEquals(0, haFlows.size());
+        Assertions.assertEquals(0, haFlows.size());
     }
 
-    @Test(expected = FlowNotFoundException.class)
-    public void failingFetchingForUnknownHaFlowIdTest() throws FlowNotFoundException {
-        String haFlowId = "unknown_ha_flow";
+    @Test
+    public void failingFetchingForUnknownHaFlowIdTest() {
+        assertThrows(FlowNotFoundException.class, () -> {
+            String haFlowId = "unknown_ha_flow";
 
-        haFlowReadService.getHaFlow(haFlowId);
-        fail();
+            haFlowReadService.getHaFlow(haFlowId);
+        });
     }
 
-    @Test(expected = FlowNotFoundException.class)
-    public void failingFetchingPathsForUnknownHaFlowIdTest() throws FlowNotFoundException {
-        String haFlowId = "unknown_ha_flow";
+    @Test
+    public void failingFetchingPathsForUnknownHaFlowIdTest() {
+        assertThrows(FlowNotFoundException.class, () -> {
+            String haFlowId = "unknown_ha_flow";
 
-        haFlowReadService.getHaFlowPaths(haFlowId);
-        fail();
+            haFlowReadService.getHaFlowPaths(haFlowId);
+        });
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/haflow/HaFlowUpdateServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/haflow/HaFlowUpdateServiceTest.java
@@ -16,10 +16,10 @@
 package org.openkilda.wfm.topology.flowhs.service.haflow;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.openkilda.model.FlowEncapsulationType.TRANSIT_VLAN;
 import static org.openkilda.model.FlowEncapsulationType.VXLAN;
@@ -47,8 +47,8 @@ import org.openkilda.wfm.topology.flowhs.service.AbstractHaFlowTest;
 import org.openkilda.wfm.topology.flowhs.service.FlowGenericCarrier;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import java.time.Instant;
@@ -94,7 +94,7 @@ public class HaFlowUpdateServiceTest extends AbstractHaFlowTest<FlowSegmentReque
     private FlowGenericCarrier carrier;
     HaFlowUpdateService service;
 
-    @Before
+    @BeforeEach
     public void init() {
         carrier = mock(FlowGenericCarrier.class);
         service = new HaFlowUpdateService(carrier, persistenceManager, pathComputer, flowResourcesManager,
@@ -163,8 +163,10 @@ public class HaFlowUpdateServiceTest extends AbstractHaFlowTest<FlowSegmentReque
 
         assertFalse(service.isFullUpdateRequired(buildPatch(MAX_LATENCY, MAX_LATENCY_1, null), haFlow));
         assertTrue(service.isFullUpdateRequired(buildPatch(MAX_LATENCY, MAX_LATENCY_2, null), haFlow));
-        assertFalse(service.isFullUpdateRequired(buildPatch(MAX_LATENCY, null, MAX_LATENCY_TIER_2_1), haFlow));
-        assertTrue(service.isFullUpdateRequired(buildPatch(MAX_LATENCY, null, MAX_LATENCY_TIER_2_2), haFlow));
+        assertFalse(service.isFullUpdateRequired(
+                buildPatch(MAX_LATENCY, null, MAX_LATENCY_TIER_2_1), haFlow));
+        assertTrue(service.isFullUpdateRequired(
+                buildPatch(MAX_LATENCY, null, MAX_LATENCY_TIER_2_2), haFlow));
         assertFalse(service.isFullUpdateRequired(buildPatch(MAX_LATENCY, MAX_LATENCY_1, MAX_LATENCY_TIER_2_1), haFlow));
         assertTrue(service.isFullUpdateRequired(buildPatch(MAX_LATENCY, MAX_LATENCY_2, MAX_LATENCY_TIER_2_2), haFlow));
     }
@@ -364,8 +366,7 @@ public class HaFlowUpdateServiceTest extends AbstractHaFlowTest<FlowSegmentReque
         assertEquals(PATCH_REQUEST.getPriority(), haFlowRequest.getPriority());
         assertEquals(PATCH_REQUEST.getStrictBandwidth(), haFlowRequest.isStrictBandwidth());
         assertEquals(PATCH_REQUEST.getDescription(), haFlowRequest.getDescription());
-        assertEquals(PATCH_REQUEST.getSharedEndpoint().getSwitchId(),
-                haFlowRequest.getSharedEndpoint().getSwitchId());
+        assertEquals(PATCH_REQUEST.getSharedEndpoint().getSwitchId(), haFlowRequest.getSharedEndpoint().getSwitchId());
         assertEquals(PATCH_REQUEST.getSharedEndpoint().getPortNumber(),
                 haFlowRequest.getSharedEndpoint().getPortNumber());
         assertEquals(PATCH_REQUEST.getSharedEndpoint().getVlanId().intValue(),

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/path/FlowPathServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/path/FlowPathServiceTest.java
@@ -58,12 +58,12 @@ import com.google.common.base.Objects;
 import lombok.Value;
 import org.apache.commons.lang3.function.FailableConsumer;
 import org.apache.storm.shade.com.google.common.collect.Lists;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -73,7 +73,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Queue;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FlowPathServiceTest {
     private final FlowPathOperationConfig config = new FlowPathOperationConfig(3);
 
@@ -90,7 +90,7 @@ public class FlowPathServiceTest {
 
     private final Queue<SpeakerRequest> speakerRequests = new ArrayDeque<>();
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         flowSegmentRequestMetaFactory = newFlowSegmentRequestMetaFactory();
 
@@ -131,7 +131,7 @@ public class FlowPathServiceTest {
 
         verifyRequestIsOver(pathRequest.getReference(), FlowPathResultCode.SUCCESS);
 
-        Assert.assertTrue(service.deactivate());
+        Assertions.assertTrue(service.deactivate());
     }
 
     @Test
@@ -156,7 +156,7 @@ public class FlowPathServiceTest {
 
         verifyRequestIsOver(pathRequest.getReference(), FlowPathResultCode.SUCCESS);
 
-        Assert.assertTrue(service.deactivate());
+        Assertions.assertTrue(service.deactivate());
     }
 
     @Test
@@ -183,7 +183,7 @@ public class FlowPathServiceTest {
 
         verifyRequestIsOver(pathRequest.getReference(), FlowPathResultCode.SPEAKER_ERROR);
 
-        Assert.assertTrue(service.deactivate());
+        Assertions.assertTrue(service.deactivate());
     }
 
     @Test
@@ -217,7 +217,7 @@ public class FlowPathServiceTest {
 
         verifyRequestIsOver(pathRequest.getReference(), FlowPathResultCode.SPEAKER_ERROR);
 
-        Assert.assertTrue(service.deactivate());
+        Assertions.assertTrue(service.deactivate());
     }
 
     @Test
@@ -246,7 +246,7 @@ public class FlowPathServiceTest {
 
         verifyRequestIsOver(pathRequest.getReference(), FlowPathResultCode.SPEAKER_ERROR);
 
-        Assert.assertTrue(service.deactivate());
+        Assertions.assertTrue(service.deactivate());
     }
 
     @Test
@@ -274,7 +274,7 @@ public class FlowPathServiceTest {
 
         verifyRequestIsOver(pathRequest.getReference(), FlowPathResultCode.SPEAKER_ERROR);
 
-        Assert.assertTrue(service.deactivate());
+        Assertions.assertTrue(service.deactivate());
     }
 
     // remove
@@ -283,7 +283,7 @@ public class FlowPathServiceTest {
     // utility/service
 
     private void verifyRequestIsOver(FlowPathReference reference, FlowPathResultCode resultCode) {
-        Assert.assertTrue(speakerRequests.isEmpty());
+        Assertions.assertTrue(speakerRequests.isEmpty());
 
         FlowPathResult result = new FlowPathResult(reference, resultCode);
         verify(carrier).processFlowPathOperationResults(eq(result));
@@ -329,8 +329,8 @@ public class FlowPathServiceTest {
             }
         });
 
-        Assert.assertTrue(expected.isEmpty());
-        Assert.assertTrue(unexpected.isEmpty());
+        Assertions.assertTrue(expected.isEmpty());
+        Assertions.assertTrue(unexpected.isEmpty());
     }
 
     private void proceedSpeakerRequests(FailableConsumer<SpeakerRequest, Exception> handler) throws Exception {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowCreateServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowCreateServiceTest.java
@@ -18,8 +18,8 @@ package org.openkilda.wfm.topology.flowhs.service.yflow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -48,16 +48,16 @@ import org.openkilda.wfm.topology.flowhs.service.FlowCreateService;
 import org.openkilda.wfm.topology.flowhs.service.FlowDeleteService;
 import org.openkilda.wfm.topology.flowhs.service.FlowGenericCarrier;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatcher;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class YFlowCreateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
     private static final int METER_ALLOCATION_RETRIES_LIMIT = 3;
 
@@ -68,13 +68,13 @@ public class YFlowCreateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
     @Mock
     private FlowGenericCarrier yFlowCreateHubCarrier;
 
-    @Before
+    @BeforeEach
     public void init() {
-        doAnswer(buildSpeakerRequestAnswer())
+        lenient().doAnswer(buildSpeakerRequestAnswer())
                 .when(flowCreateHubCarrier).sendSpeakerRequest(any(SpeakerRequest.class));
-        doAnswer(buildSpeakerRequestAnswer())
+        lenient().doAnswer(buildSpeakerRequestAnswer())
                 .when(flowDeleteHubCarrier).sendSpeakerRequest(any(SpeakerRequest.class));
-        doAnswer(buildSpeakerRequestAnswer())
+        lenient().doAnswer(buildSpeakerRequestAnswer())
                 .when(yFlowCreateHubCarrier).sendSpeakerRequest(any(SpeakerRequest.class));
     }
 
@@ -230,7 +230,7 @@ public class YFlowCreateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         preparePathComputation("test_flow_1", buildFirstSubFlowPathPair());
         preparePathComputation("test_flow_2", buildSecondSubFlowPathPair());
         prepareYPointComputation(SWITCH_SHARED, SWITCH_FIRST_EP, SWITCH_SECOND_EP, SWITCH_TRANSIT);
-        doThrow(new ResourceAllocationException(injectedErrorMessage))
+        lenient().doThrow(new ResourceAllocationException(injectedErrorMessage))
                 .when(flowResourcesManager).allocateMeter(eq(request.getYFlowId()), eq(SWITCH_TRANSIT));
 
         // when
@@ -286,7 +286,7 @@ public class YFlowCreateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         verifyYFlowIsAbsent(request.getYFlowId());
     }
 
-    @Ignore("TODO: implement meter validation")
+    @Disabled("TODO: implement meter validation")
     @Test
     public void shouldFailOnUnsuccessfulValidation()
             throws RecoverableException, UnroutableFlowException, DuplicateKeyException {
@@ -310,7 +310,7 @@ public class YFlowCreateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         verifyYFlowIsAbsent(request.getYFlowId());
     }
 
-    @Ignore("TODO: implement meter validation")
+    @Disabled("TODO: implement meter validation")
     @Test
     public void shouldFailOnTimeoutDuringMeterValidation()
             throws RecoverableException, UnroutableFlowException, DuplicateKeyException {
@@ -451,7 +451,7 @@ public class YFlowCreateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
 
     private void preparePathComputation(String flowId, GetPathsResult pathPair)
             throws RecoverableException, UnroutableFlowException {
-        when(pathComputer.getPath(buildFlowIdArgumentMatch(flowId))).thenReturn(pathPair);
+        lenient().when(pathComputer.getPath(buildFlowIdArgumentMatch(flowId))).thenReturn(pathPair);
     }
 
     private void preparePathComputation(String flowId, GetPathsResult pathPair, GetPathsResult pathPair2)
@@ -483,9 +483,9 @@ public class YFlowCreateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
                         .anyMatch(pathSegment -> transit == null
                                 || pathSegment.getSrcSwitchId().equals(transit)
                                 || pathSegment.getDestSwitchId().equals(transit));
-        when(pathComputer.getIntersectionPoint(any(),
-                ArgumentMatchers.argThat(pathArgumentMatcher),
-                ArgumentMatchers.argThat(pathArgumentMatcher)))
+        lenient().when(pathComputer.getIntersectionPoint(any(),
+                        ArgumentMatchers.argThat(pathArgumentMatcher),
+                        ArgumentMatchers.argThat(pathArgumentMatcher)))
                 .thenReturn(yPoint);
     }
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowDeleteServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowDeleteServiceTest.java
@@ -16,7 +16,7 @@
 package org.openkilda.wfm.topology.flowhs.service.yflow;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 
 import org.openkilda.floodlight.api.request.FlowSegmentRequest;
 import org.openkilda.floodlight.api.request.SpeakerRequest;
@@ -34,24 +34,24 @@ import org.openkilda.wfm.topology.flowhs.service.AbstractYFlowTest;
 import org.openkilda.wfm.topology.flowhs.service.FlowDeleteService;
 import org.openkilda.wfm.topology.flowhs.service.FlowGenericCarrier;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class YFlowDeleteServiceTest extends AbstractYFlowTest<SpeakerRequest> {
     @Mock
     private FlowGenericCarrier flowDeleteHubCarrier;
     @Mock
     private FlowGenericCarrier yFlowDeleteHubCarrier;
 
-    @Before
+    @BeforeEach
     public void init() {
-        doAnswer(buildSpeakerRequestAnswer())
+        lenient().doAnswer(buildSpeakerRequestAnswer())
                 .when(flowDeleteHubCarrier).sendSpeakerRequest(any(SpeakerRequest.class));
-        doAnswer(buildSpeakerRequestAnswer())
+        lenient().doAnswer(buildSpeakerRequestAnswer())
                 .when(yFlowDeleteHubCarrier).sendSpeakerRequest(any(SpeakerRequest.class));
     }
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowPathSwapServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowPathSwapServiceTest.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.wfm.topology.flowhs.service.yflow;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 
@@ -40,17 +40,17 @@ import org.openkilda.wfm.topology.flowhs.service.FlowGenericCarrier;
 import org.openkilda.wfm.topology.flowhs.service.FlowPathSwapHubCarrier;
 import org.openkilda.wfm.topology.flowhs.service.FlowPathSwapService;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class YFlowPathSwapServiceTest extends AbstractYFlowTest<SpeakerRequest> {
 
     @Mock
@@ -58,7 +58,7 @@ public class YFlowPathSwapServiceTest extends AbstractYFlowTest<SpeakerRequest> 
     @Mock
     private FlowGenericCarrier yFlowPathSwapHubCarrier;
 
-    @Before
+    @BeforeEach
     public void init() {
         doAnswer(buildSpeakerRequestAnswer())
                 .when(flowPathSwapHubCarrier).sendSpeakerRequest(any(SpeakerRequest.class));

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowReadServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowReadServiceTest.java
@@ -15,10 +15,7 @@
 
 package org.openkilda.wfm.topology.flowhs.service.yflow;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.floodlight.api.request.FlowSegmentRequest;
 import org.openkilda.messaging.command.yflow.SubFlowsResponse;
@@ -28,8 +25,9 @@ import org.openkilda.messaging.command.yflow.YFlowResponse;
 import org.openkilda.wfm.error.FlowNotFoundException;
 import org.openkilda.wfm.topology.flowhs.service.AbstractYFlowTest;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.List;
@@ -37,7 +35,7 @@ import java.util.List;
 public class YFlowReadServiceTest extends AbstractYFlowTest<FlowSegmentRequest> {
     private static YFlowReadService yFlowReadService;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpOnce() {
         yFlowReadService = new YFlowReadService(persistenceManager, 0, Duration.ofMillis(1));
     }
@@ -52,7 +50,7 @@ public class YFlowReadServiceTest extends AbstractYFlowTest<FlowSegmentRequest> 
         // then
         assertEquals(1, yFlows.size());
         YFlowDto yFlow = yFlows.get(0).getYFlow();
-        assertNotNull(yFlow);
+        Assertions.assertNotNull(yFlow);
         assertEquals(yFlowId, yFlow.getYFlowId());
         assertEquals(2, yFlow.getSubFlows().size());
     }
@@ -72,16 +70,17 @@ public class YFlowReadServiceTest extends AbstractYFlowTest<FlowSegmentRequest> 
         YFlowResponse yFlowResponse = yFlowReadService.getYFlow(yFlowId);
         // then
         YFlowDto yFlow = yFlowResponse.getYFlow();
-        assertNotNull(yFlow);
+        Assertions.assertNotNull(yFlow);
         assertEquals(2, yFlow.getSubFlows().size());
     }
 
-    @Test(expected = FlowNotFoundException.class)
-    public void failFetchingForUnknownYFlowId() throws FlowNotFoundException {
-        String yFlowId = "unknown_y_flow";
+    @Test
+    public void failFetchingForUnknownYFlowId() {
+        Assertions.assertThrows(FlowNotFoundException.class, () -> {
+            String yFlowId = "unknown_y_flow";
 
-        yFlowReadService.getYFlow(yFlowId);
-        fail();
+            yFlowReadService.getYFlow(yFlowId);
+        });
     }
 
     @Test
@@ -95,12 +94,14 @@ public class YFlowReadServiceTest extends AbstractYFlowTest<FlowSegmentRequest> 
         assertEquals(2, yFlowResponse.getFlows().size());
     }
 
-    @Test(expected = FlowNotFoundException.class)
-    public void failFetchingSubFlowsForUnknownYFlowId() throws FlowNotFoundException {
-        String yFlowId = "unknown_y_flow";
+    @Test
+    public void failFetchingSubFlowsForUnknownYFlowId() {
+        Assertions.assertThrows(FlowNotFoundException.class, () -> {
+            String yFlowId = "unknown_y_flow";
 
-        yFlowReadService.getYFlowSubFlows(yFlowId);
-        fail();
+            yFlowReadService.getYFlowSubFlows(yFlowId);
+        });
+
     }
 
     @Test
@@ -116,15 +117,17 @@ public class YFlowReadServiceTest extends AbstractYFlowTest<FlowSegmentRequest> 
         assertEquals(SWITCH_SHARED, yFlowResponse.getSharedPath().getForwardPath().get(0).getSwitchId());
         assertEquals(2, yFlowResponse.getSubFlowPaths().size());
         // No protected paths
-        assertNull(yFlowResponse.getSharedPath().getProtectedPath());
+        Assertions.assertNull(yFlowResponse.getSharedPath().getProtectedPath());
     }
 
-    @Test(expected = FlowNotFoundException.class)
-    public void failFetchingPathsForUnknownYFlowId() throws FlowNotFoundException {
-        String yFlowId = "unknown_y_flow";
+    @Test
+    public void failFetchingPathsForUnknownYFlowId() {
+        Assertions.assertThrows(FlowNotFoundException.class, () -> {
+            String yFlowId = "unknown_y_flow";
 
-        yFlowReadService.getYFlowPaths(yFlowId);
-        fail();
+            yFlowReadService.getYFlowPaths(yFlowId);
+        });
+
     }
 
     @Test
@@ -136,7 +139,7 @@ public class YFlowReadServiceTest extends AbstractYFlowTest<FlowSegmentRequest> 
         YFlowResponse yFlowResponse = yFlowReadService.getYFlow(yFlowId);
         // then
         YFlowDto yFlow = yFlowResponse.getYFlow();
-        assertNotNull(yFlow);
+        Assertions.assertNotNull(yFlow);
         assertEquals(2, yFlow.getSubFlows().size());
 
         // and when
@@ -150,7 +153,7 @@ public class YFlowReadServiceTest extends AbstractYFlowTest<FlowSegmentRequest> 
         // The protected paths
         assertEquals(2, yFlowPathsResponse.getSharedPath().getProtectedPath().getForwardPath().size());
         assertEquals(2, yFlowPathsResponse.getSharedPath().getProtectedPath().getReversePath().size());
-        assertEquals(SWITCH_SHARED,
-                yFlowPathsResponse.getSharedPath().getProtectedPath().getForwardPath().get(0).getSwitchId());
+        assertEquals(SWITCH_SHARED, yFlowPathsResponse.getSharedPath().getProtectedPath().getForwardPath()
+                .get(0).getSwitchId());
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowRerouteServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowRerouteServiceTest.java
@@ -15,14 +15,13 @@
 
 package org.openkilda.wfm.topology.flowhs.service.yflow;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -59,20 +58,21 @@ import org.openkilda.wfm.topology.flowhs.service.FlowGenericCarrier;
 import org.openkilda.wfm.topology.flowhs.service.FlowRerouteHubCarrier;
 import org.openkilda.wfm.topology.flowhs.service.FlowRerouteService;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatcher;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class YFlowRerouteServiceTest extends AbstractYFlowTest<SpeakerRequest> {
     private static final int METER_ALLOCATION_RETRIES_LIMIT = 3;
 
@@ -87,11 +87,11 @@ public class YFlowRerouteServiceTest extends AbstractYFlowTest<SpeakerRequest> {
     @Mock
     private YFlowRerouteHubCarrier yFlowRerouteHubCarrier;
 
-    @Before
+    @BeforeEach
     public void init() {
         doAnswer(buildSpeakerRequestAnswer())
                 .when(flowCreateHubCarrier).sendSpeakerRequest(any(SpeakerRequest.class));
-        doAnswer(buildSpeakerRequestAnswer())
+        lenient().doAnswer(buildSpeakerRequestAnswer())
                 .when(flowRerouteHubCarrier).sendSpeakerRequest(any(SpeakerRequest.class));
         doAnswer(buildSpeakerRequestAnswer())
                 .when(yFlowCreateHubCarrier).sendSpeakerRequest(any(SpeakerRequest.class));
@@ -201,7 +201,7 @@ public class YFlowRerouteServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         preparePathComputationForReroute("test_flow_1", buildFirstSubFlowPathPairWithNewTransit());
         preparePathComputationForReroute("test_flow_2", buildSecondSubFlowPathPairWithNewTransit());
         prepareYPointComputation(SWITCH_SHARED, SWITCH_FIRST_EP, SWITCH_SECOND_EP, SWITCH_NEW_TRANSIT);
-        doThrow(new ResourceAllocationException(injectedErrorMessage))
+        lenient().doThrow(new ResourceAllocationException(injectedErrorMessage))
                 .when(flowResourcesManager).allocateMeter(eq("test_successful_yflow"), eq(SWITCH_NEW_TRANSIT));
 
         // when
@@ -461,7 +461,7 @@ public class YFlowRerouteServiceTest extends AbstractYFlowTest<SpeakerRequest> {
     protected YFlow verifyYFlowStatus(String yFlowId, FlowStatus expectedStatus,
                                       FlowStatus expectedFirstSubFlowStatus, FlowStatus expectedSecondSubFlowStatus) {
         YFlow flow = getYFlow(yFlowId);
-        assertEquals(expectedStatus, flow.getStatus());
+        Assertions.assertEquals(expectedStatus, flow.getStatus());
 
         Set<FlowStatus> expectedSubFlowStatuses = Stream.of(expectedFirstSubFlowStatus, expectedSecondSubFlowStatus)
                 .collect(Collectors.toSet());
@@ -470,7 +470,7 @@ public class YFlowRerouteServiceTest extends AbstractYFlowTest<SpeakerRequest> {
                 .map(Flow::getStatus)
                 .collect(Collectors.toSet());
 
-        assertEquals(expectedSubFlowStatuses, actualSubFlowStatuses);
+        Assertions.assertEquals(expectedSubFlowStatuses, actualSubFlowStatuses);
 
         return flow;
     }
@@ -532,7 +532,8 @@ public class YFlowRerouteServiceTest extends AbstractYFlowTest<SpeakerRequest> {
 
     private void preparePathComputationForReroute(String flowId, GetPathsResult pathPair)
             throws RecoverableException, UnroutableFlowException {
-        when(pathComputer.getPath(buildFlowIdArgumentMatch(flowId), any(), anyBoolean())).thenReturn(pathPair);
+        lenient().when(pathComputer.getPath(buildFlowIdArgumentMatch(flowId), any(), anyBoolean()))
+                .thenReturn(pathPair);
     }
 
     private void preparePathComputationForReroute(String flowId, GetPathsResult pathPair, GetPathsResult pathPair2)

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowUpdateServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowUpdateServiceTest.java
@@ -15,13 +15,11 @@
 
 package org.openkilda.wfm.topology.flowhs.service.yflow;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,13 +55,14 @@ import org.openkilda.wfm.topology.flowhs.service.FlowGenericCarrier;
 import org.openkilda.wfm.topology.flowhs.service.FlowUpdateHubCarrier;
 import org.openkilda.wfm.topology.flowhs.service.FlowUpdateService;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatcher;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -71,7 +70,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
     private static final int METER_ALLOCATION_RETRIES_LIMIT = 3;
     private static final String SUB_FLOW_ID_1 = "test_sub_flow_id_1";
@@ -89,15 +88,15 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
     @Mock
     private FlowGenericCarrier yFlowUpdateHubCarrier;
 
-    @Before
+    @BeforeEach
     public void init() {
-        doAnswer(buildSpeakerRequestAnswer())
+        lenient().doAnswer(buildSpeakerRequestAnswer())
                 .when(flowCreateHubCarrier).sendSpeakerRequest(any(SpeakerRequest.class));
-        doAnswer(buildSpeakerRequestAnswer())
+        lenient().doAnswer(buildSpeakerRequestAnswer())
                 .when(flowUpdateHubCarrier).sendSpeakerRequest(any(SpeakerRequest.class));
-        doAnswer(buildSpeakerRequestAnswer())
+        lenient().doAnswer(buildSpeakerRequestAnswer())
                 .when(yFlowCreateHubCarrier).sendSpeakerRequest(any(SpeakerRequest.class));
-        doAnswer(buildSpeakerRequestAnswer())
+        lenient().doAnswer(buildSpeakerRequestAnswer())
                 .when(yFlowUpdateHubCarrier).sendSpeakerRequest(any(SpeakerRequest.class));
     }
 
@@ -120,13 +119,13 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         verifyYFlowStatus(request.getYFlowId(), FlowStatus.UP);
         verifyAffinity(request.getYFlowId());
         YFlow flow = getYFlow(request.getYFlowId());
-        assertEquals(2000L, flow.getMaximumBandwidth());
+        Assertions.assertEquals(2000L, flow.getMaximumBandwidth());
         Set<SwitchId> expectedEndpointSwitchIds = Stream.of(SWITCH_NEW_FIRST_EP, SWITCH_NEW_SECOND_EP)
                 .collect(Collectors.toSet());
         Set<SwitchId> actualEndpointSwitchIds = flow.getSubFlows().stream()
                 .map(YSubFlow::getEndpointSwitchId)
                 .collect(Collectors.toSet());
-        assertEquals(expectedEndpointSwitchIds, actualEndpointSwitchIds);
+        Assertions.assertEquals(expectedEndpointSwitchIds, actualEndpointSwitchIds);
     }
 
     @Test
@@ -154,13 +153,13 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         verifyYFlowStatus(request.getYFlowId(), FlowStatus.UP);
         verifyAffinity(request.getYFlowId());
         YFlow flow = getYFlow(request.getYFlowId());
-        assertEquals(2000L, flow.getMaximumBandwidth());
+        Assertions.assertEquals(2000L, flow.getMaximumBandwidth());
         Set<SwitchId> expectedEndpointSwitchIds = Stream.of(SWITCH_NEW_FIRST_EP, SWITCH_NEW_SECOND_EP)
                 .collect(Collectors.toSet());
         Set<SwitchId> actualEndpointSwitchIds = flow.getSubFlows().stream()
                 .map(YSubFlow::getEndpointSwitchId)
                 .collect(Collectors.toSet());
-        assertEquals(expectedEndpointSwitchIds, actualEndpointSwitchIds);
+        Assertions.assertEquals(expectedEndpointSwitchIds, actualEndpointSwitchIds);
     }
 
     @Test
@@ -184,13 +183,13 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         verifyYFlowStatus(request.getYFlowId(), FlowStatus.UP);
 
         YFlow flow = getYFlow(request.getYFlowId());
-        assertEquals(1000L, flow.getMaximumBandwidth());
+        Assertions.assertEquals(1000L, flow.getMaximumBandwidth());
         Set<SwitchId> expectedEndpointSwitchIds = Stream.of(SWITCH_FIRST_EP, SWITCH_SECOND_EP)
                 .collect(Collectors.toSet());
         Set<SwitchId> actualEndpointSwitchIds = flow.getSubFlows().stream()
                 .map(YSubFlow::getEndpointSwitchId)
                 .collect(Collectors.toSet());
-        assertEquals(expectedEndpointSwitchIds, actualEndpointSwitchIds);
+        Assertions.assertEquals(expectedEndpointSwitchIds, actualEndpointSwitchIds);
     }
 
     @Test
@@ -214,13 +213,13 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         verifyYFlowStatus(request.getYFlowId(), FlowStatus.UP);
 
         YFlow flow = getYFlow(request.getYFlowId());
-        assertEquals(1000L, flow.getMaximumBandwidth());
+        Assertions.assertEquals(1000L, flow.getMaximumBandwidth());
         Set<SwitchId> expectedEndpointSwitchIds = Stream.of(SWITCH_FIRST_EP, SWITCH_SECOND_EP)
                 .collect(Collectors.toSet());
         Set<SwitchId> actualEndpointSwitchIds = flow.getSubFlows().stream()
                 .map(YSubFlow::getEndpointSwitchId)
                 .collect(Collectors.toSet());
-        assertEquals(expectedEndpointSwitchIds, actualEndpointSwitchIds);
+        Assertions.assertEquals(expectedEndpointSwitchIds, actualEndpointSwitchIds);
     }
 
     @Test
@@ -235,7 +234,7 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         preparePathComputationForUpdate(SUB_FLOW_ID_1, buildNewFirstSubFlowPathPair(), buildFirstSubFlowPathPair());
         preparePathComputationForUpdate(SUB_FLOW_ID_2, buildNewSecondSubFlowPathPair(), buildSecondSubFlowPathPair());
         prepareYPointComputation(SWITCH_SHARED, SWITCH_NEW_FIRST_EP, SWITCH_NEW_SECOND_EP, SWITCH_TRANSIT);
-        doThrow(new ResourceAllocationException(injectedErrorMessage))
+        lenient().doThrow(new ResourceAllocationException(injectedErrorMessage))
                 .when(flowResourcesManager).allocateMeter(eq(Y_FLOW_ID), eq(SWITCH_TRANSIT));
 
         // when
@@ -246,13 +245,13 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
                 .allocateMeter(eq(Y_FLOW_ID), eq(SWITCH_TRANSIT));
 
         YFlow flow = getYFlow(request.getYFlowId());
-        assertEquals(1000L, flow.getMaximumBandwidth());
+        Assertions.assertEquals(1000L, flow.getMaximumBandwidth());
         Set<SwitchId> expectedEndpointSwitchIds = Stream.of(SWITCH_FIRST_EP, SWITCH_SECOND_EP)
                 .collect(Collectors.toSet());
         Set<SwitchId> actualEndpointSwitchIds = flow.getSubFlows().stream()
                 .map(YSubFlow::getEndpointSwitchId)
                 .collect(Collectors.toSet());
-        assertEquals(expectedEndpointSwitchIds, actualEndpointSwitchIds);
+        Assertions.assertEquals(expectedEndpointSwitchIds, actualEndpointSwitchIds);
     }
 
     @Test
@@ -279,13 +278,13 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         // then
         verifyYFlowStatus(request.getYFlowId(), FlowStatus.UP);
         YFlow flow = getYFlow(request.getYFlowId());
-        assertEquals(1000L, flow.getMaximumBandwidth());
+        Assertions.assertEquals(1000L, flow.getMaximumBandwidth());
         Set<SwitchId> expectedEndpointSwitchIds = Stream.of(SWITCH_FIRST_EP, SWITCH_SECOND_EP)
                 .collect(Collectors.toSet());
         Set<SwitchId> actualEndpointSwitchIds = flow.getSubFlows().stream()
                 .map(YSubFlow::getEndpointSwitchId)
                 .collect(Collectors.toSet());
-        assertEquals(expectedEndpointSwitchIds, actualEndpointSwitchIds);
+        Assertions.assertEquals(expectedEndpointSwitchIds, actualEndpointSwitchIds);
     }
 
     @Test
@@ -312,13 +311,13 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         // then
         verifyYFlowStatus(request.getYFlowId(), FlowStatus.UP);
         YFlow flow = getYFlow(request.getYFlowId());
-        assertEquals(1000L, flow.getMaximumBandwidth());
+        Assertions.assertEquals(1000L, flow.getMaximumBandwidth());
         Set<SwitchId> expectedEndpointSwitchIds = Stream.of(SWITCH_FIRST_EP, SWITCH_SECOND_EP)
                 .collect(Collectors.toSet());
         Set<SwitchId> actualEndpointSwitchIds = flow.getSubFlows().stream()
                 .map(YSubFlow::getEndpointSwitchId)
                 .collect(Collectors.toSet());
-        assertEquals(expectedEndpointSwitchIds, actualEndpointSwitchIds);
+        Assertions.assertEquals(expectedEndpointSwitchIds, actualEndpointSwitchIds);
     }
 
     @Test
@@ -354,13 +353,13 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
         verifyNorthboundSuccessResponse(yFlowUpdateHubCarrier, YFlowResponse.class);
         verifyYFlowStatus(request.getYFlowId(), FlowStatus.UP);
         YFlow flow = getYFlow(request.getYFlowId());
-        assertEquals(2000L, flow.getMaximumBandwidth());
+        Assertions.assertEquals(2000L, flow.getMaximumBandwidth());
         Set<SwitchId> expectedEndpointSwitchIds = Stream.of(SWITCH_NEW_FIRST_EP, SWITCH_NEW_SECOND_EP)
                 .collect(Collectors.toSet());
         Set<SwitchId> actualEndpointSwitchIds = flow.getSubFlows().stream()
                 .map(YSubFlow::getEndpointSwitchId)
                 .collect(Collectors.toSet());
-        assertEquals(expectedEndpointSwitchIds, actualEndpointSwitchIds);
+        Assertions.assertEquals(expectedEndpointSwitchIds, actualEndpointSwitchIds);
     }
 
     private YFlowRequest createYFlow() throws UnroutableFlowException, RecoverableException, DuplicateKeyException {
@@ -503,7 +502,7 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
     protected YFlow verifyYFlowStatus(String yFlowId, FlowStatus expectedStatus,
                                       FlowStatus expectedFirstSubFlowStatus, FlowStatus expectedSecondSubFlowStatus) {
         YFlow flow = getYFlow(yFlowId);
-        assertEquals(expectedStatus, flow.getStatus());
+        Assertions.assertEquals(expectedStatus, flow.getStatus());
 
         Set<FlowStatus> expectedSubFlowStatuses = Stream.of(expectedFirstSubFlowStatus, expectedSecondSubFlowStatus)
                 .collect(Collectors.toSet());
@@ -512,7 +511,7 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
                 .map(Flow::getStatus)
                 .collect(Collectors.toSet());
 
-        assertEquals(expectedSubFlowStatuses, actualSubFlowStatuses);
+        Assertions.assertEquals(expectedSubFlowStatuses, actualSubFlowStatuses);
 
         return flow;
     }
@@ -583,7 +582,7 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
 
     private void preparePathComputationForUpdate(String flowId, GetPathsResult pathPair, GetPathsResult pathPair2)
             throws RecoverableException, UnroutableFlowException {
-        when(pathComputer.getPath(buildFlowIdArgumentMatch(flowId), any(), anyBoolean()))
+        lenient().when(pathComputer.getPath(buildFlowIdArgumentMatch(flowId), any(), anyBoolean()))
                 .thenReturn(pathPair).thenReturn(pathPair2);
     }
 
@@ -609,9 +608,9 @@ public class YFlowUpdateServiceTest extends AbstractYFlowTest<SpeakerRequest> {
                         .anyMatch(pathSegment -> transit == null
                                 || pathSegment.getSrcSwitchId().equals(transit)
                                 || pathSegment.getDestSwitchId().equals(transit));
-        when(pathComputer.getIntersectionPoint(any(),
-                ArgumentMatchers.argThat(pathArgumentMatcher),
-                ArgumentMatchers.argThat(pathArgumentMatcher)))
+        lenient().when(pathComputer.getIntersectionPoint(any(),
+                        ArgumentMatchers.argThat(pathArgumentMatcher),
+                        ArgumentMatchers.argThat(pathArgumentMatcher)))
                 .thenReturn(yPoint);
     }
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowValidationHubServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/yflow/YFlowValidationHubServiceTest.java
@@ -17,13 +17,11 @@ package org.openkilda.wfm.topology.flowhs.service.yflow;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.openkilda.wfm.topology.flowhs.fsm.validation.SwitchFlowEntriesBuilder.BURST_COEFFICIENT;
@@ -59,19 +57,20 @@ import org.openkilda.wfm.topology.flowhs.service.FlowValidationHubCarrier;
 import org.openkilda.wfm.topology.flowhs.service.FlowValidationHubService;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class YFlowValidationHubServiceTest extends AbstractYFlowTest<Pair<String, CommandData>> {
     @Mock
     private FlowValidationHubCarrier flowValidationHubCarrier;
@@ -79,18 +78,18 @@ public class YFlowValidationHubServiceTest extends AbstractYFlowTest<Pair<String
     private YFlowValidationHubCarrier yFlowValidationHubCarrier;
     private static RuleManagerConfig ruleManagerConfig;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpOnce() {
         ruleManagerConfig = configurationProvider.getConfiguration(RuleManagerConfig.class);
     }
 
-    @Before
+    @BeforeEach
     public void init() {
-        doAnswer(invocation ->
-                requests.offer(Pair.of(invocation.getArgument(0), invocation.getArgument(1))))
+        lenient().doAnswer(invocation ->
+                        requests.offer(Pair.of(invocation.getArgument(0), invocation.getArgument(1))))
                 .when(flowValidationHubCarrier).sendSpeakerRequest(any(String.class), any(CommandData.class));
-        doAnswer(invocation ->
-                requests.offer(Pair.of(invocation.getArgument(0), invocation.getArgument(1))))
+        lenient().doAnswer(invocation ->
+                        requests.offer(Pair.of(invocation.getArgument(0), invocation.getArgument(1))))
                 .when(yFlowValidationHubCarrier).sendSpeakerRequest(any(String.class), any(CommandData.class));
     }
 
@@ -161,8 +160,10 @@ public class YFlowValidationHubServiceTest extends AbstractYFlowTest<Pair<String
         assertTrue(response.getYFlowValidationResult().isAsExpected());
         response.getSubFlowValidationResults()
                 .forEach(result ->
-                        assertTrue(result.getFlowId().equals(failedFlow.getFlowId()) || result.getAsExpected()));
-        assertEquals(1, response.getSubFlowValidationResults().stream().filter(r -> !r.getAsExpected()).count());
+                        assertTrue(result.getFlowId().equals(failedFlow.getFlowId())
+                                || result.getAsExpected()));
+        assertEquals(1, response.getSubFlowValidationResults().stream()
+                .filter(r -> !r.getAsExpected()).count());
     }
 
     private void handleSpeakerRequests(YFlowValidationHubService service, String yFlowFsmKey,
@@ -193,7 +194,7 @@ public class YFlowValidationHubServiceTest extends AbstractYFlowTest<Pair<String
                         .groupSpeakerData(foundGroupEntries != null ? new ArrayList<>(foundGroupEntries) : emptyList())
                         .build();
             } else {
-                fail();
+                Assertions.fail();
             }
 
             String flowId = pair.getKey();
@@ -223,7 +224,7 @@ public class YFlowValidationHubServiceTest extends AbstractYFlowTest<Pair<String
         verify(carrierMock, times(1)).sendNorthboundResponse(responseCaptor.capture());
 
         Message rawResponse = responseCaptor.getValue();
-        assertNotNull(rawResponse);
+        Assertions.assertNotNull(rawResponse);
         assertTrue(rawResponse instanceof InfoMessage);
 
         InfoData rawPayload = ((InfoMessage) rawResponse).getData();

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/validation/FlowValidatorTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/validation/FlowValidatorTest.java
@@ -38,17 +38,18 @@ import org.openkilda.wfm.topology.flowhs.model.DetectConnectedDevices;
 import org.openkilda.wfm.topology.flowhs.model.RequestedFlow;
 import org.openkilda.wfm.topology.flowhs.validation.FlowValidator.EndpointDescriptor;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FlowValidatorTest {
     public static final SwitchId SWITCH_ID_1 = new SwitchId(1);
     public static final SwitchId SWITCH_ID_2 = new SwitchId(2);
@@ -67,7 +68,7 @@ public class FlowValidatorTest {
     private FlowRepository flowRepository;
     private FlowValidator flowValidator;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RepositoryFactory repositoryFactory = mock(RepositoryFactory.class);
         when(repositoryFactory.createFlowRepository()).thenReturn(flowRepository);
@@ -80,80 +81,86 @@ public class FlowValidatorTest {
         flowValidator = new FlowValidator(persistenceManager);
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failOnSwapWhenEqualsEndpointsOnFirstFlowTest() throws InvalidFlowException {
-        RequestedFlow firstFlow = RequestedFlow.builder()
-                .flowId(FLOW_1)
-                .srcSwitch(SWITCH_ID_1)
-                .srcPort(10)
-                .srcVlan(11)
-                .destSwitch(SWITCH_ID_2)
-                .destPort(10)
-                .destVlan(11)
-                .detectConnectedDevices(new DetectConnectedDevices())
-                .build();
+    @Test
+    public void failOnSwapWhenEqualsEndpointsOnFirstFlowTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            RequestedFlow firstFlow = RequestedFlow.builder()
+                    .flowId(FLOW_1)
+                    .srcSwitch(SWITCH_ID_1)
+                    .srcPort(10)
+                    .srcVlan(11)
+                    .destSwitch(SWITCH_ID_2)
+                    .destPort(10)
+                    .destVlan(11)
+                    .detectConnectedDevices(new DetectConnectedDevices())
+                    .build();
 
-        RequestedFlow secondFlow = RequestedFlow.builder()
-                .flowId(FLOW_2)
-                .srcSwitch(SWITCH_ID_2)
-                .destSwitch(SWITCH_ID_2)
-                .detectConnectedDevices(new DetectConnectedDevices())
-                .build();
+            RequestedFlow secondFlow = RequestedFlow.builder()
+                    .flowId(FLOW_2)
+                    .srcSwitch(SWITCH_ID_2)
+                    .destSwitch(SWITCH_ID_2)
+                    .detectConnectedDevices(new DetectConnectedDevices())
+                    .build();
 
-        flowValidator.checkForEqualsEndpoints(firstFlow, secondFlow);
+            flowValidator.checkForEqualsEndpoints(firstFlow, secondFlow);
+        });
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failOnSwapWhenEqualsEndpointsOnSecondFlowTest() throws InvalidFlowException {
-        RequestedFlow firstFlow = RequestedFlow.builder()
-                .flowId(FLOW_1)
-                .srcSwitch(SWITCH_ID_2)
-                .srcPort(10)
-                .srcVlan(11)
-                .destSwitch(SWITCH_ID_2)
-                .destPort(12)
-                .detectConnectedDevices(new DetectConnectedDevices())
-                .build();
+    @Test
+    public void failOnSwapWhenEqualsEndpointsOnSecondFlowTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            RequestedFlow firstFlow = RequestedFlow.builder()
+                    .flowId(FLOW_1)
+                    .srcSwitch(SWITCH_ID_2)
+                    .srcPort(10)
+                    .srcVlan(11)
+                    .destSwitch(SWITCH_ID_2)
+                    .destPort(12)
+                    .detectConnectedDevices(new DetectConnectedDevices())
+                    .build();
 
-        RequestedFlow secondFlow = RequestedFlow.builder()
-                .flowId(FLOW_2)
-                .srcSwitch(SWITCH_ID_1)
-                .srcPort(10)
-                .srcVlan(11)
-                .destSwitch(SWITCH_ID_1)
-                .destPort(10)
-                .destVlan(11)
-                .detectConnectedDevices(new DetectConnectedDevices())
-                .build();
+            RequestedFlow secondFlow = RequestedFlow.builder()
+                    .flowId(FLOW_2)
+                    .srcSwitch(SWITCH_ID_1)
+                    .srcPort(10)
+                    .srcVlan(11)
+                    .destSwitch(SWITCH_ID_1)
+                    .destPort(10)
+                    .destVlan(11)
+                    .detectConnectedDevices(new DetectConnectedDevices())
+                    .build();
 
-        flowValidator.checkForEqualsEndpoints(firstFlow, secondFlow);
+            flowValidator.checkForEqualsEndpoints(firstFlow, secondFlow);
+        });
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failOnSwapWhenEqualsEndpointsOnFirstAndSecondFlowTest() throws InvalidFlowException {
-        RequestedFlow firstFlow = RequestedFlow.builder()
-                .flowId(FLOW_1)
-                .srcSwitch(SWITCH_ID_1)
-                .srcPort(10)
-                .srcVlan(11)
-                .destSwitch(SWITCH_ID_2)
-                .destPort(12)
-                .destVlan(13)
-                .detectConnectedDevices(new DetectConnectedDevices())
-                .build();
+    @Test
+    public void failOnSwapWhenEqualsEndpointsOnFirstAndSecondFlowTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            RequestedFlow firstFlow = RequestedFlow.builder()
+                    .flowId(FLOW_1)
+                    .srcSwitch(SWITCH_ID_1)
+                    .srcPort(10)
+                    .srcVlan(11)
+                    .destSwitch(SWITCH_ID_2)
+                    .destPort(12)
+                    .destVlan(13)
+                    .detectConnectedDevices(new DetectConnectedDevices())
+                    .build();
 
-        RequestedFlow secondFlow = RequestedFlow.builder()
-                .flowId(FLOW_2)
-                .srcSwitch(SWITCH_ID_1)
-                .srcPort(10)
-                .srcVlan(11)
-                .destSwitch(SWITCH_ID_2)
-                .destPort(12)
-                .destVlan(13)
-                .detectConnectedDevices(new DetectConnectedDevices())
-                .build();
+            RequestedFlow secondFlow = RequestedFlow.builder()
+                    .flowId(FLOW_2)
+                    .srcSwitch(SWITCH_ID_1)
+                    .srcPort(10)
+                    .srcVlan(11)
+                    .destSwitch(SWITCH_ID_2)
+                    .destPort(12)
+                    .destVlan(13)
+                    .detectConnectedDevices(new DetectConnectedDevices())
+                    .build();
 
-        flowValidator.checkForEqualsEndpoints(firstFlow, secondFlow);
+            flowValidator.checkForEqualsEndpoints(firstFlow, secondFlow);
+        });
     }
 
     @Test
@@ -207,22 +214,28 @@ public class FlowValidatorTest {
         flowValidator.checkFlowForCorrectOuterVlansWithVlanStatistics(flow);
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failOnSpecifiedBothOuterVlansAndVlanStatisticsTest() throws InvalidFlowException {
-        RequestedFlow flow = buildFlow(VLAN_1, VLAN_2, newHashSet(235));
-        flowValidator.checkFlowForCorrectOuterVlansWithVlanStatistics(flow);
+    @Test
+    public void failOnSpecifiedBothOuterVlansAndVlanStatisticsTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            RequestedFlow flow = buildFlow(VLAN_1, VLAN_2, newHashSet(235));
+            flowValidator.checkFlowForCorrectOuterVlansWithVlanStatistics(flow);
+        });
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failOnTooLowVlanStatisticsTest() throws InvalidFlowException {
-        RequestedFlow flow = buildFlow(VLAN_1, VLAN_2, newHashSet(STATS_VLAN_TOO_LOW));
-        flowValidator.checkFlowForVlanStatisticsInCorrectRange(flow);
+    @Test
+    public void failOnTooLowVlanStatisticsTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            RequestedFlow flow = buildFlow(VLAN_1, VLAN_2, newHashSet(STATS_VLAN_TOO_LOW));
+            flowValidator.checkFlowForVlanStatisticsInCorrectRange(flow);
+        });
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failOnTooHighVlanStatisticsTest() throws InvalidFlowException {
-        RequestedFlow flow = buildFlow(VLAN_1, VLAN_2, newHashSet(STATS_VLAN_TOO_HIGH));
-        flowValidator.checkFlowForVlanStatisticsInCorrectRange(flow);
+    @Test
+    public void failOnTooHighVlanStatisticsTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            RequestedFlow flow = buildFlow(VLAN_1, VLAN_2, newHashSet(STATS_VLAN_TOO_HIGH));
+            flowValidator.checkFlowForVlanStatisticsInCorrectRange(flow);
+        });
     }
 
     @Test
@@ -237,28 +250,34 @@ public class FlowValidatorTest {
         flowValidator.checkFlowForVlanStatisticsInCorrectRange(flow);
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void checkForEncapsulationTypeRequirementNullTypesTest() throws InvalidFlowException {
-        SwitchProperties properties = SwitchProperties.builder()
-                .supportedTransitEncapsulation(null)
-                .build();
-        flowValidator.checkForEncapsulationTypeRequirement(SRC_ENDPOINT, properties, TRANSIT_VLAN);
+    @Test
+    public void checkForEncapsulationTypeRequirementNullTypesTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            SwitchProperties properties = SwitchProperties.builder()
+                    .supportedTransitEncapsulation(null)
+                    .build();
+            flowValidator.checkForEncapsulationTypeRequirement(SRC_ENDPOINT, properties, TRANSIT_VLAN);
+        });
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void checkForEncapsulationTypeRequirementEmptyTypesTest() throws InvalidFlowException {
-        SwitchProperties properties = SwitchProperties.builder()
-                .supportedTransitEncapsulation(new HashSet<>())
-                .build();
-        flowValidator.checkForEncapsulationTypeRequirement(SRC_ENDPOINT, properties, TRANSIT_VLAN);
+    @Test
+    public void checkForEncapsulationTypeRequirementEmptyTypesTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            SwitchProperties properties = SwitchProperties.builder()
+                    .supportedTransitEncapsulation(new HashSet<>())
+                    .build();
+            flowValidator.checkForEncapsulationTypeRequirement(SRC_ENDPOINT, properties, TRANSIT_VLAN);
+        });
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void checkForEncapsulationTypeRequirementDifferentTypeTest() throws InvalidFlowException {
-        SwitchProperties properties = SwitchProperties.builder()
-                .supportedTransitEncapsulation(newHashSet(VXLAN))
-                .build();
-        flowValidator.checkForEncapsulationTypeRequirement(SRC_ENDPOINT, properties, TRANSIT_VLAN);
+    @Test
+    public void checkForEncapsulationTypeRequirementDifferentTypeTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            SwitchProperties properties = SwitchProperties.builder()
+                    .supportedTransitEncapsulation(newHashSet(VXLAN))
+                    .build();
+            flowValidator.checkForEncapsulationTypeRequirement(SRC_ENDPOINT, properties, TRANSIT_VLAN);
+        });
     }
 
     @Test
@@ -269,16 +288,20 @@ public class FlowValidatorTest {
         flowValidator.checkForEncapsulationTypeRequirement(SRC_ENDPOINT, properties, TRANSIT_VLAN);
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failIfMaxLatencyTier2HigherThanMaxLatencyTest() throws InvalidFlowException {
-        RequestedFlow flow = getTestRequestWithMaxLatencyAndMaxLatencyTier2(1000L, 500L);
-        flowValidator.checkMaxLatencyTier(flow);
+    @Test
+    public void failIfMaxLatencyTier2HigherThanMaxLatencyTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            RequestedFlow flow = getTestRequestWithMaxLatencyAndMaxLatencyTier2(1000L, 500L);
+            flowValidator.checkMaxLatencyTier(flow);
+        });
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failIfMaxLatencyTier2butMaxLatencyIsNullTest() throws InvalidFlowException {
-        RequestedFlow flow = getTestRequestWithMaxLatencyAndMaxLatencyTier2(null, 500L);
-        flowValidator.checkMaxLatencyTier(flow);
+    @Test
+    public void failIfMaxLatencyTier2butMaxLatencyIsNullTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            RequestedFlow flow = getTestRequestWithMaxLatencyAndMaxLatencyTier2(null, 500L);
+            flowValidator.checkMaxLatencyTier(flow);
+        });
     }
 
     @Test
@@ -321,16 +344,20 @@ public class FlowValidatorTest {
         flowValidator.checkDiverseFlow(flow);
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failIfMaxLatencyTier2HigherThanMaxLatency() throws InvalidFlowException {
-        RequestedFlow flow = getTestRequestWithMaxLatencyAndMaxLatencyTier2(1000L, 500L);
-        flowValidator.checkMaxLatencyTier(flow);
+    @Test
+    public void failIfMaxLatencyTier2HigherThanMaxLatency() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            RequestedFlow flow = getTestRequestWithMaxLatencyAndMaxLatencyTier2(1000L, 500L);
+            flowValidator.checkMaxLatencyTier(flow);
+        });
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failIfMaxLatencyTier2butMaxLatencyIsNull() throws InvalidFlowException {
-        RequestedFlow flow = getTestRequestWithMaxLatencyAndMaxLatencyTier2(null, 500L);
-        flowValidator.checkMaxLatencyTier(flow);
+    @Test
+    public void failIfMaxLatencyTier2butMaxLatencyIsNull() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            RequestedFlow flow = getTestRequestWithMaxLatencyAndMaxLatencyTier2(null, 500L);
+            flowValidator.checkMaxLatencyTier(flow);
+        });
     }
 
     @Test

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/validation/HaFlowValidatorTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/validation/HaFlowValidatorTest.java
@@ -39,8 +39,9 @@ import org.openkilda.persistence.repositories.RepositoryFactory;
 import org.openkilda.persistence.repositories.SwitchPropertiesRepository;
 import org.openkilda.persistence.repositories.SwitchRepository;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Optional;
@@ -64,7 +65,7 @@ public class HaFlowValidatorTest {
 
     public static HaFlowValidator haFlowValidator;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         RepositoryFactory repositoryFactory = mock(RepositoryFactory.class);
         when(repositoryFactory.createFlowRepository()).thenReturn(mock(FlowRepository.class));
@@ -100,15 +101,16 @@ public class HaFlowValidatorTest {
         when(physicalPortRepository.findBySwitchIdAndPortNumber(any(), anyInt())).thenReturn(Optional.empty());
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failIfNoSubFlowsProvidedTest()
-            throws InvalidFlowException, UnavailableFlowEndpointException {
-        HaFlowRequest request = HaFlowRequest.builder()
-                .haFlowId(HA_FLOW_ID)
-                .sharedEndpoint(new FlowEndpoint(SWITCH_ID_1, PORT_1))
-                .subFlows(emptyList())
-                .build();
-        haFlowValidator.validate(request);
+    @Test
+    public void failIfNoSubFlowsProvidedTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            HaFlowRequest request = HaFlowRequest.builder()
+                    .haFlowId(HA_FLOW_ID)
+                    .sharedEndpoint(new FlowEndpoint(SWITCH_ID_1, PORT_1))
+                    .subFlows(emptyList())
+                    .build();
+            haFlowValidator.validate(request);
+        });
     }
 
     @Test
@@ -137,46 +139,50 @@ public class HaFlowValidatorTest {
         haFlowValidator.validate(request);
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void faitIfBothSubFlowIsOneSwitchFlowTest()
-            throws InvalidFlowException, UnavailableFlowEndpointException {
-        HaFlowRequest request = HaFlowRequest.builder()
-                .haFlowId(HA_FLOW_ID)
-                .sharedEndpoint(new FlowEndpoint(SWITCH_ID_1, PORT_3))
-                .subFlows(Arrays.asList(
-                        buildSubFlow(SUB_FLOW_ID_1, SWITCH_ID_1, PORT_1, VLAN_1, INNER_VLAN_1),
-                        buildSubFlow(SUB_FLOW_ID_2, SWITCH_ID_1, PORT_2, VLAN_2, INNER_VLAN_2)))
-                .build();
-        haFlowValidator.validate(request);
+    @Test
+    public void faitIfBothSubFlowIsOneSwitchFlowTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            HaFlowRequest request = HaFlowRequest.builder()
+                    .haFlowId(HA_FLOW_ID)
+                    .sharedEndpoint(new FlowEndpoint(SWITCH_ID_1, PORT_3))
+                    .subFlows(Arrays.asList(
+                            buildSubFlow(SUB_FLOW_ID_1, SWITCH_ID_1, PORT_1, VLAN_1, INNER_VLAN_1),
+                            buildSubFlow(SUB_FLOW_ID_2, SWITCH_ID_1, PORT_2, VLAN_2, INNER_VLAN_2)))
+                    .build();
+            haFlowValidator.validate(request);
+        });
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failIfNegativeBandwidthProvidedTest()
-            throws InvalidFlowException, UnavailableFlowEndpointException {
-        HaFlowRequest request = HaFlowRequest.builder()
-                .haFlowId(HA_FLOW_ID)
-                .maximumBandwidth(-1)
-                .sharedEndpoint(new FlowEndpoint(SWITCH_ID_1, PORT_1))
-                .subFlows(Arrays.asList(
-                        buildSubFlow(SUB_FLOW_ID_1, SWITCH_ID_2, PORT_2, VLAN_2, INNER_VLAN_2),
-                        buildSubFlow(SUB_FLOW_ID_2, SWITCH_ID_3, PORT_3, VLAN_3, INNER_VLAN_3)))
-                .build();
-        haFlowValidator.validate(request);
+    @Test
+    public void failIfNegativeBandwidthProvidedTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            HaFlowRequest request = HaFlowRequest.builder()
+                    .haFlowId(HA_FLOW_ID)
+                    .maximumBandwidth(-1)
+                    .sharedEndpoint(new FlowEndpoint(SWITCH_ID_1, PORT_1))
+                    .subFlows(Arrays.asList(
+                            buildSubFlow(SUB_FLOW_ID_1, SWITCH_ID_2, PORT_2, VLAN_2, INNER_VLAN_2),
+                            buildSubFlow(SUB_FLOW_ID_2, SWITCH_ID_3, PORT_3, VLAN_3, INNER_VLAN_3)))
+                    .build();
+            haFlowValidator.validate(request);
+        });
     }
 
 
-    @Test(expected = InvalidFlowException.class)
-    public void failIfMaxLatencyTier2HigherThanMaxLatencyTest()
-            throws InvalidFlowException, UnavailableFlowEndpointException {
-        HaFlowRequest request = buildHaFlowRequestWithMaxLatency(1000L, 500L);
-        haFlowValidator.validate(request);
+    @Test
+    public void failIfMaxLatencyTier2HigherThanMaxLatencyTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            HaFlowRequest request = buildHaFlowRequestWithMaxLatency(1000L, 500L);
+            haFlowValidator.validate(request);
+        });
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failIfMaxLatencyTier2butMaxLatencyIsNullTest()
-            throws InvalidFlowException, UnavailableFlowEndpointException {
-        HaFlowRequest request = buildHaFlowRequestWithMaxLatency(null, 500L);
-        haFlowValidator.validate(request);
+    @Test
+    public void failIfMaxLatencyTier2butMaxLatencyIsNullTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            HaFlowRequest request = buildHaFlowRequestWithMaxLatency(null, 500L);
+            haFlowValidator.validate(request);
+        });
     }
 
     @Test
@@ -193,45 +199,48 @@ public class HaFlowValidatorTest {
         haFlowValidator.validate(request);
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failIfNoSharedEndpointProvidedTest()
-            throws InvalidFlowException, UnavailableFlowEndpointException {
-        HaFlowRequest request = HaFlowRequest.builder()
-                .haFlowId(HA_FLOW_ID)
-                .subFlows(Arrays.asList(
-                        buildSubFlow(SUB_FLOW_ID_1, SWITCH_ID_2, PORT_2, VLAN_2, INNER_VLAN_2),
-                        buildSubFlow(SUB_FLOW_ID_2, SWITCH_ID_3, PORT_3, VLAN_3, INNER_VLAN_3)))
-                .build();
-        haFlowValidator.validate(request);
+    @Test
+    public void failIfNoSharedEndpointProvidedTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            HaFlowRequest request = HaFlowRequest.builder()
+                    .haFlowId(HA_FLOW_ID)
+                    .subFlows(Arrays.asList(
+                            buildSubFlow(SUB_FLOW_ID_1, SWITCH_ID_2, PORT_2, VLAN_2, INNER_VLAN_2),
+                            buildSubFlow(SUB_FLOW_ID_2, SWITCH_ID_3, PORT_3, VLAN_3, INNER_VLAN_3)))
+                    .build();
+            haFlowValidator.validate(request);
+        });
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failIfSubFlowHasNoEndpointProvidedTest()
-            throws InvalidFlowException, UnavailableFlowEndpointException {
-        HaFlowRequest request = HaFlowRequest.builder()
-                .haFlowId(HA_FLOW_ID)
-                .sharedEndpoint(new FlowEndpoint(SWITCH_ID_1, PORT_1))
-                .subFlows(Arrays.asList(
-                        HaSubFlowDto.builder().flowId(SUB_FLOW_ID_1).build(),
-                        HaSubFlowDto.builder().flowId(SUB_FLOW_ID_2).build()))
-                .build();
-        haFlowValidator.validate(request);
+    @Test
+    public void failIfSubFlowHasNoEndpointProvidedTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            HaFlowRequest request = HaFlowRequest.builder()
+                    .haFlowId(HA_FLOW_ID)
+                    .sharedEndpoint(new FlowEndpoint(SWITCH_ID_1, PORT_1))
+                    .subFlows(Arrays.asList(
+                            HaSubFlowDto.builder().flowId(SUB_FLOW_ID_1).build(),
+                            HaSubFlowDto.builder().flowId(SUB_FLOW_ID_2).build()))
+                    .build();
+            haFlowValidator.validate(request);
+        });
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failIfSubFlowHasNoIdTest()
-            throws InvalidFlowException, UnavailableFlowEndpointException {
-        HaFlowRequest request = HaFlowRequest.builder()
-                .haFlowId(HA_FLOW_ID)
-                .sharedEndpoint(new FlowEndpoint(SWITCH_ID_1, PORT_1))
-                .subFlows(Arrays.asList(HaSubFlowDto.builder()
-                                .endpoint(new FlowEndpoint(SWITCH_ID_2, PORT_2, VLAN_2))
-                                .build(),
-                        HaSubFlowDto.builder()
-                                .endpoint(new FlowEndpoint(SWITCH_ID_3, PORT_3, VLAN_3))
-                                .build()))
-                .build();
-        haFlowValidator.validate(request);
+    @Test
+    public void failIfSubFlowHasNoIdTest() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            HaFlowRequest request = HaFlowRequest.builder()
+                    .haFlowId(HA_FLOW_ID)
+                    .sharedEndpoint(new FlowEndpoint(SWITCH_ID_1, PORT_1))
+                    .subFlows(Arrays.asList(HaSubFlowDto.builder()
+                                    .endpoint(new FlowEndpoint(SWITCH_ID_2, PORT_2, VLAN_2))
+                                    .build(),
+                            HaSubFlowDto.builder()
+                                    .endpoint(new FlowEndpoint(SWITCH_ID_3, PORT_3, VLAN_3))
+                                    .build()))
+                    .build();
+            haFlowValidator.validate(request);
+        });
     }
 
     private static HaSubFlowDto buildSubFlow(String flowId, SwitchId switchId, int port, int vlan, int innerVlan) {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/validation/ValidatorUtilsTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/validation/ValidatorUtilsTest.java
@@ -21,11 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.openkilda.messaging.error.InvalidFlowException;
 import org.openkilda.messaging.validation.ValidatorUtils;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class ValidatorUtilsTest {
 
     /**
@@ -35,7 +33,7 @@ public class ValidatorUtilsTest {
      * Both parameters can be 0 or null to enable "erasing".
      * @return parameters for test in the format: {{must fail?} {maxLatency value} {maxLatencyTier2 value}}
      */
-    @Parameterized.Parameters()
+
     public static Object[] data() {
         return new Object[][]{
                 {false, null, null},
@@ -56,18 +54,9 @@ public class ValidatorUtilsTest {
         };
     }
 
-    private final boolean mustFail;
-    private final Long maxLatency;
-    private final Long maxLatencyTier2;
-
-    public ValidatorUtilsTest(boolean mustFail, Long maxLatency, Long maxLatencyTier2) {
-        this.mustFail = mustFail;
-        this.maxLatency = maxLatency;
-        this.maxLatencyTier2 = maxLatencyTier2;
-    }
-
-    @Test
-    public void verifyFlowValidatorForMaxLatencyParameters() {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void verifyFlowValidatorForMaxLatencyParameters(boolean mustFail, Long maxLatency, Long maxLatencyTier2) {
         if (mustFail) {
             assertThatValidationThrows(maxLatency, maxLatencyTier2);
         } else {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/validation/YFlowValidatorTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/validation/YFlowValidatorTest.java
@@ -41,8 +41,9 @@ import org.openkilda.persistence.repositories.SwitchPropertiesRepository;
 import org.openkilda.persistence.repositories.SwitchRepository;
 import org.openkilda.persistence.repositories.YFlowRepository;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Optional;
@@ -57,7 +58,7 @@ public class YFlowValidatorTest {
 
     public static YFlowValidator yFlowValidator;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         RepositoryFactory repositoryFactory = mock(RepositoryFactory.class);
         when(repositoryFactory.createFlowRepository()).thenReturn(mock(FlowRepository.class));
@@ -94,18 +95,19 @@ public class YFlowValidatorTest {
         when(physicalPortRepository.findBySwitchIdAndPortNumber(any(), anyInt())).thenReturn(Optional.empty());
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failIfNoSubFlowsProvided()
-            throws InvalidFlowException, UnavailableFlowEndpointException {
-        YFlowRequest request = YFlowRequest.builder()
-                .yFlowId("test")
-                .sharedEndpoint(FlowEndpoint.builder()
-                        .switchId(SWITCH_ID_1)
-                        .portNumber(PORT_1)
-                        .build())
-                .subFlows(emptyList())
-                .build();
-        yFlowValidator.validate(request);
+    @Test
+    public void failIfNoSubFlowsProvided() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            YFlowRequest request = YFlowRequest.builder()
+                    .yFlowId("test")
+                    .sharedEndpoint(FlowEndpoint.builder()
+                            .switchId(SWITCH_ID_1)
+                            .portNumber(PORT_1)
+                            .build())
+                    .subFlows(emptyList())
+                    .build();
+            yFlowValidator.validate(request);
+        });
     }
 
     @Test
@@ -195,34 +197,35 @@ public class YFlowValidatorTest {
         yFlowValidator.validate(request);
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failIfNegativeBandwidthProvided()
-            throws InvalidFlowException, UnavailableFlowEndpointException {
-        YFlowRequest request = YFlowRequest.builder()
-                .yFlowId("test")
-                .maximumBandwidth(-1)
-                .sharedEndpoint(FlowEndpoint.builder()
-                        .switchId(SWITCH_ID_1)
-                        .portNumber(PORT_1)
-                        .build())
-                .subFlows(Arrays.asList(SubFlowDto.builder()
-                                .flowId("test_1")
-                                .sharedEndpoint(new SubFlowSharedEndpointEncapsulation(1, 0))
-                                .endpoint(FlowEndpoint.builder()
-                                        .switchId(SWITCH_ID_2)
-                                        .portNumber(PORT_2)
-                                        .build())
-                                .build(),
-                        SubFlowDto.builder()
-                                .flowId("test_2")
-                                .sharedEndpoint(new SubFlowSharedEndpointEncapsulation(2, 0))
-                                .endpoint(FlowEndpoint.builder()
-                                        .switchId(SWITCH_ID_3)
-                                        .portNumber(PORT_3)
-                                        .build())
-                                .build()))
-                .build();
-        yFlowValidator.validate(request);
+    @Test
+    public void failIfNegativeBandwidthProvided() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            YFlowRequest request = YFlowRequest.builder()
+                    .yFlowId("test")
+                    .maximumBandwidth(-1)
+                    .sharedEndpoint(FlowEndpoint.builder()
+                            .switchId(SWITCH_ID_1)
+                            .portNumber(PORT_1)
+                            .build())
+                    .subFlows(Arrays.asList(SubFlowDto.builder()
+                                    .flowId("test_1")
+                                    .sharedEndpoint(new SubFlowSharedEndpointEncapsulation(1, 0))
+                                    .endpoint(FlowEndpoint.builder()
+                                            .switchId(SWITCH_ID_2)
+                                            .portNumber(PORT_2)
+                                            .build())
+                                    .build(),
+                            SubFlowDto.builder()
+                                    .flowId("test_2")
+                                    .sharedEndpoint(new SubFlowSharedEndpointEncapsulation(2, 0))
+                                    .endpoint(FlowEndpoint.builder()
+                                            .switchId(SWITCH_ID_3)
+                                            .portNumber(PORT_3)
+                                            .build())
+                                    .build()))
+                    .build();
+            yFlowValidator.validate(request);
+        });
     }
 
     private YFlowRequest getTestRequestWithMaxLatencyAndMaxLatencyTier2(Long maxLatency, Long maxLatencyTier2) {
@@ -253,18 +256,20 @@ public class YFlowValidatorTest {
                 .build();
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failIfMaxLatencyTier2HigherThanMaxLatency()
-            throws InvalidFlowException, UnavailableFlowEndpointException {
-        YFlowRequest request = getTestRequestWithMaxLatencyAndMaxLatencyTier2((long) 1000, (long) 500);
-        yFlowValidator.validate(request);
+    @Test
+    public void failIfMaxLatencyTier2HigherThanMaxLatency() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            YFlowRequest request = getTestRequestWithMaxLatencyAndMaxLatencyTier2((long) 1000, (long) 500);
+            yFlowValidator.validate(request);
+        });
     }
 
-    @Test (expected = InvalidFlowException.class)
-    public void failIfMaxLatencyTier2butMaxLatencyIsNull()
-            throws InvalidFlowException, UnavailableFlowEndpointException {
-        YFlowRequest request = getTestRequestWithMaxLatencyAndMaxLatencyTier2(null, (long) 500);
-        yFlowValidator.validate(request);
+    @Test
+    public void failIfMaxLatencyTier2butMaxLatencyIsNull() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            YFlowRequest request = getTestRequestWithMaxLatencyAndMaxLatencyTier2(null, (long) 500);
+            yFlowValidator.validate(request);
+        });
     }
 
     @Test
@@ -281,109 +286,113 @@ public class YFlowValidatorTest {
         yFlowValidator.validate(request);
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failIfNoSharedEndpointProvided()
-            throws InvalidFlowException, UnavailableFlowEndpointException {
-        YFlowRequest request = YFlowRequest.builder()
-                .yFlowId("test")
-                .subFlows(Arrays.asList(SubFlowDto.builder()
-                                .flowId("test_1")
-                                .sharedEndpoint(new SubFlowSharedEndpointEncapsulation(1, 0))
-                                .endpoint(FlowEndpoint.builder()
-                                        .switchId(SWITCH_ID_2)
-                                        .portNumber(PORT_2)
-                                        .build())
-                                .build(),
-                        SubFlowDto.builder()
-                                .flowId("test_2")
-                                .sharedEndpoint(new SubFlowSharedEndpointEncapsulation(2, 0))
-                                .endpoint(FlowEndpoint.builder()
-                                        .switchId(SWITCH_ID_3)
-                                        .portNumber(PORT_3)
-                                        .build())
-                                .build()))
-                .build();
-        yFlowValidator.validate(request);
+    @Test
+    public void failIfNoSharedEndpointProvided() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            YFlowRequest request = YFlowRequest.builder()
+                    .yFlowId("test")
+                    .subFlows(Arrays.asList(SubFlowDto.builder()
+                                    .flowId("test_1")
+                                    .sharedEndpoint(new SubFlowSharedEndpointEncapsulation(1, 0))
+                                    .endpoint(FlowEndpoint.builder()
+                                            .switchId(SWITCH_ID_2)
+                                            .portNumber(PORT_2)
+                                            .build())
+                                    .build(),
+                            SubFlowDto.builder()
+                                    .flowId("test_2")
+                                    .sharedEndpoint(new SubFlowSharedEndpointEncapsulation(2, 0))
+                                    .endpoint(FlowEndpoint.builder()
+                                            .switchId(SWITCH_ID_3)
+                                            .portNumber(PORT_3)
+                                            .build())
+                                    .build()))
+                    .build();
+            yFlowValidator.validate(request);
+        });
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failIfSubFlowHasNoSharedEndpointProvided()
-            throws InvalidFlowException, UnavailableFlowEndpointException {
-        YFlowRequest request = YFlowRequest.builder()
-                .yFlowId("test")
-                .sharedEndpoint(FlowEndpoint.builder()
-                        .switchId(SWITCH_ID_1)
-                        .portNumber(PORT_1)
-                        .build())
-                .subFlows(Arrays.asList(SubFlowDto.builder()
-                                .flowId("test_1")
-                                .endpoint(FlowEndpoint.builder()
-                                        .switchId(SWITCH_ID_2)
-                                        .portNumber(PORT_2)
-                                        .build())
-                                .build(),
-                        SubFlowDto.builder()
-                                .flowId("test_2")
-                                .sharedEndpoint(new SubFlowSharedEndpointEncapsulation(2, 0))
-                                .endpoint(FlowEndpoint.builder()
-                                        .switchId(SWITCH_ID_3)
-                                        .portNumber(PORT_3)
-                                        .build())
-                                .build()))
-                .build();
-        yFlowValidator.validate(request);
+    @Test
+    public void failIfSubFlowHasNoSharedEndpointProvided() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            YFlowRequest request = YFlowRequest.builder()
+                    .yFlowId("test")
+                    .sharedEndpoint(FlowEndpoint.builder()
+                            .switchId(SWITCH_ID_1)
+                            .portNumber(PORT_1)
+                            .build())
+                    .subFlows(Arrays.asList(SubFlowDto.builder()
+                                    .flowId("test_1")
+                                    .endpoint(FlowEndpoint.builder()
+                                            .switchId(SWITCH_ID_2)
+                                            .portNumber(PORT_2)
+                                            .build())
+                                    .build(),
+                            SubFlowDto.builder()
+                                    .flowId("test_2")
+                                    .sharedEndpoint(new SubFlowSharedEndpointEncapsulation(2, 0))
+                                    .endpoint(FlowEndpoint.builder()
+                                            .switchId(SWITCH_ID_3)
+                                            .portNumber(PORT_3)
+                                            .build())
+                                    .build()))
+                    .build();
+            yFlowValidator.validate(request);
+        });
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failIfSubFlowHasNoEndpointProvided()
-            throws InvalidFlowException, UnavailableFlowEndpointException {
-        YFlowRequest request = YFlowRequest.builder()
-                .yFlowId("test")
-                .sharedEndpoint(FlowEndpoint.builder()
-                        .switchId(SWITCH_ID_1)
-                        .portNumber(PORT_1)
-                        .build())
-                .subFlows(Arrays.asList(SubFlowDto.builder()
-                                .flowId("test_1")
-                                .sharedEndpoint(new SubFlowSharedEndpointEncapsulation(1, 0))
-                                .build(),
-                        SubFlowDto.builder()
-                                .flowId("test_2")
-                                .sharedEndpoint(new SubFlowSharedEndpointEncapsulation(2, 0))
-                                .endpoint(FlowEndpoint.builder()
-                                        .switchId(SWITCH_ID_3)
-                                        .portNumber(PORT_3)
-                                        .build())
-                                .build()))
-                .build();
-        yFlowValidator.validate(request);
+    @Test
+    public void failIfSubFlowHasNoEndpointProvided() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            YFlowRequest request = YFlowRequest.builder()
+                    .yFlowId("test")
+                    .sharedEndpoint(FlowEndpoint.builder()
+                            .switchId(SWITCH_ID_1)
+                            .portNumber(PORT_1)
+                            .build())
+                    .subFlows(Arrays.asList(SubFlowDto.builder()
+                                    .flowId("test_1")
+                                    .sharedEndpoint(new SubFlowSharedEndpointEncapsulation(1, 0))
+                                    .build(),
+                            SubFlowDto.builder()
+                                    .flowId("test_2")
+                                    .sharedEndpoint(new SubFlowSharedEndpointEncapsulation(2, 0))
+                                    .endpoint(FlowEndpoint.builder()
+                                            .switchId(SWITCH_ID_3)
+                                            .portNumber(PORT_3)
+                                            .build())
+                                    .build()))
+                    .build();
+            yFlowValidator.validate(request);
+        });
     }
 
-    @Test(expected = InvalidFlowException.class)
-    public void failIfSubFlowHasNoId()
-            throws InvalidFlowException, UnavailableFlowEndpointException {
-        YFlowRequest request = YFlowRequest.builder()
-                .yFlowId("test")
-                .sharedEndpoint(FlowEndpoint.builder()
-                        .switchId(SWITCH_ID_1)
-                        .portNumber(PORT_1)
-                        .build())
-                .subFlows(Arrays.asList(SubFlowDto.builder()
-                                .sharedEndpoint(new SubFlowSharedEndpointEncapsulation(1, 0))
-                                .endpoint(FlowEndpoint.builder()
-                                        .switchId(SWITCH_ID_2)
-                                        .portNumber(PORT_2)
-                                        .build())
-                                .build(),
-                        SubFlowDto.builder()
-                                .flowId("test_2")
-                                .sharedEndpoint(new SubFlowSharedEndpointEncapsulation(2, 0))
-                                .endpoint(FlowEndpoint.builder()
-                                        .switchId(SWITCH_ID_3)
-                                        .portNumber(PORT_3)
-                                        .build())
-                                .build()))
-                .build();
-        yFlowValidator.validate(request);
+    @Test
+    public void failIfSubFlowHasNoId() {
+        Assertions.assertThrows(InvalidFlowException.class, () -> {
+            YFlowRequest request = YFlowRequest.builder()
+                    .yFlowId("test")
+                    .sharedEndpoint(FlowEndpoint.builder()
+                            .switchId(SWITCH_ID_1)
+                            .portNumber(PORT_1)
+                            .build())
+                    .subFlows(Arrays.asList(SubFlowDto.builder()
+                                    .sharedEndpoint(new SubFlowSharedEndpointEncapsulation(1, 0))
+                                    .endpoint(FlowEndpoint.builder()
+                                            .switchId(SWITCH_ID_2)
+                                            .portNumber(PORT_2)
+                                            .build())
+                                    .build(),
+                            SubFlowDto.builder()
+                                    .flowId("test_2")
+                                    .sharedEndpoint(new SubFlowSharedEndpointEncapsulation(2, 0))
+                                    .endpoint(FlowEndpoint.builder()
+                                            .switchId(SWITCH_ID_3)
+                                            .portNumber(PORT_3)
+                                            .build())
+                                    .build()))
+                    .build();
+            yFlowValidator.validate(request);
+        });
     }
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/utils/LoggerContextInitializerTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/utils/LoggerContextInitializerTest.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.wfm.topology.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -29,7 +27,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -52,7 +51,7 @@ public class LoggerContextInitializerTest {
         Optional<CommandContext> result = LoggerContextInitializer.extract(tuple);
 
         //then
-        assertEquals(correlationId, result.get().getCorrelationId());
+        Assertions.assertEquals(correlationId, result.get().getCorrelationId());
     }
 
     @Test
@@ -71,7 +70,7 @@ public class LoggerContextInitializerTest {
         Optional<CommandContext> result = LoggerContextInitializer.extract(tuple);
 
         //then
-        assertEquals(correlationId, result.get().getCorrelationId());
+        Assertions.assertEquals(correlationId, result.get().getCorrelationId());
     }
 
     @Test
@@ -86,6 +85,6 @@ public class LoggerContextInitializerTest {
         Optional<CommandContext> result = LoggerContextInitializer.extract(tuple);
 
         //then
-        assertFalse(result.isPresent());
+        Assertions.assertFalse(result.isPresent());
     }
 }

--- a/src-java/flowmonitoring-topology/flowmonitoring-messaging/build.gradle
+++ b/src-java/flowmonitoring-topology/flowmonitoring-messaging/build.gradle
@@ -12,8 +12,6 @@ dependencies {
     implementation('com.fasterxml.jackson.core:jackson-databind')
 
     implementation 'com.google.guava:guava'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/build.gradle
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     testImplementation('org.apache.storm:storm-core')
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.hamcrest:hamcrest-library'
     testRuntimeOnly 'org.hibernate.validator:hibernate-validator'
@@ -65,4 +65,8 @@ shadowJar {
 
 artifacts {
     archives shadowJar
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/checkstyle/checkstyle-suppressions.xml
@@ -5,4 +5,5 @@
 
 <suppressions>
     <suppress files="src/main/.*Fsm\.java$" checks="JavadocMethod" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
 </suppressions>

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/test/java/org/openkilda/wfm/topology/flowmonitoring/service/ActionServiceTest.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/test/java/org/openkilda/wfm/topology/flowmonitoring/service/ActionServiceTest.java
@@ -15,8 +15,8 @@
 
 package org.openkilda.wfm.topology.flowmonitoring.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -49,16 +49,16 @@ import org.openkilda.wfm.topology.flowmonitoring.bolt.FlowOperationsCarrier;
 import org.openkilda.wfm.topology.flowmonitoring.fsm.FlowLatencyMonitoringFsm;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.util.Arrays;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ActionServiceTest extends InMemoryGraphBasedTest {
 
     private static final Duration NANOSECOND = Duration.ofNanos(1);
@@ -83,7 +83,7 @@ public class ActionServiceTest extends InMemoryGraphBasedTest {
     private FlowOperationsCarrier carrier;
     private ManualClock clock = new ManualClock();
 
-    @Before
+    @BeforeEach
     public void setup() {
         FlowDefaults flowDefaults = new FlowDefaults();
         flowDefaults.setPathComputationStrategy(PathComputationStrategy.LATENCY);

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/test/java/org/openkilda/wfm/topology/flowmonitoring/service/CalculateFlowLatencyServiceTest.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/test/java/org/openkilda/wfm/topology/flowmonitoring/service/CalculateFlowLatencyServiceTest.java
@@ -24,18 +24,18 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.server42.messaging.FlowDirection;
 import org.openkilda.wfm.topology.flowmonitoring.model.Link;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CalculateFlowLatencyServiceTest {
 
     private static final String FLOW_ID = "flow-id";
@@ -57,7 +57,7 @@ public class CalculateFlowLatencyServiceTest {
     private FlowCacheBoltCarrier carrier;
     private CalculateFlowLatencyService service;
 
-    @Before
+    @BeforeEach
     public void setup() {
         service = new CalculateFlowLatencyService(carrier);
     }

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/test/java/org/openkilda/wfm/topology/flowmonitoring/service/FlowCacheServiceTest.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/test/java/org/openkilda/wfm/topology/flowmonitoring/service/FlowCacheServiceTest.java
@@ -15,8 +15,8 @@
 
 package org.openkilda.wfm.topology.flowmonitoring.service;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -50,11 +50,11 @@ import org.openkilda.wfm.topology.flowmonitoring.model.Link;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -65,7 +65,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FlowCacheServiceTest extends InMemoryGraphBasedTest {
     private static final Duration FLOW_RTT_STATS_EXPIRATION_TIME = Duration.ofSeconds(3);
 
@@ -93,7 +93,7 @@ public class FlowCacheServiceTest extends InMemoryGraphBasedTest {
     @Mock
     private Clock clock;
 
-    @Before
+    @BeforeEach
     public void setup() {
         dummyFactory = new PersistenceDummyEntityFactory(persistenceManager);
 

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/test/java/org/openkilda/wfm/topology/flowmonitoring/service/IslCacheServiceTest.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/test/java/org/openkilda/wfm/topology/flowmonitoring/service/IslCacheServiceTest.java
@@ -15,9 +15,9 @@
 
 package org.openkilda.wfm.topology.flowmonitoring.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.IslStatus.ACTIVE;
 
@@ -32,18 +32,18 @@ import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.IslRepository;
 import org.openkilda.wfm.topology.flowmonitoring.model.Link;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class IslCacheServiceTest extends InMemoryGraphBasedTest {
     private static final Duration ISL_RTT_LATENCY_EXPIRATION = Duration.ofSeconds(2);
 
@@ -69,7 +69,7 @@ public class IslCacheServiceTest extends InMemoryGraphBasedTest {
 
     private IslCacheService service;
 
-    @Before
+    @BeforeEach
     public void setup() {
         islRepository = persistenceManager.getRepositoryFactory().createIslRepository();
 

--- a/src-java/isllatency-topology/isllatency-storm-topology/build.gradle
+++ b/src-java/isllatency-topology/isllatency-storm-topology/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     testImplementation('org.apache.storm:storm-core')
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.hamcrest:hamcrest-library'
     testRuntimeOnly 'org.glassfish:javax.el'
@@ -55,4 +55,8 @@ shadowJar {
 
 artifacts {
     archives shadowJar
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/isllatency-topology/isllatency-storm-topology/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/isllatency-topology/isllatency-storm-topology/src/checkstyle/checkstyle-suppressions.xml
@@ -6,4 +6,5 @@
 <suppressions>
     <suppress files="src/main/.*Fsm\.java$" checks="JavadocMethod" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="VariableDeclarationUsageDistance" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
 </suppressions>

--- a/src-java/isllatency-topology/isllatency-storm-topology/src/test/java/org/openkilda/wfm/topology/isllatency/bolts/IslStatsBoltTest.java
+++ b/src-java/isllatency-topology/isllatency-storm-topology/src/test/java/org/openkilda/wfm/topology/isllatency/bolts/IslStatsBoltTest.java
@@ -16,8 +16,6 @@
 package org.openkilda.wfm.topology.isllatency.bolts;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.openkilda.wfm.topology.isllatency.bolts.IslStatsBolt.LATENCY_METRIC_NAME;
 
 import org.openkilda.messaging.Utils;
@@ -26,9 +24,9 @@ import org.openkilda.messaging.info.event.PathNode;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.error.JsonEncodeException;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
@@ -55,9 +53,6 @@ public class IslStatsBoltTest {
     private static final String METRIC_PREFIX = "kilda.";
     private IslStatsBolt statsBolt = new IslStatsBolt(METRIC_PREFIX, 100);
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void buildTsdbTupleFromIslOneWayLatency() throws JsonEncodeException, IOException {
         List<Object> tsdbTuple = statsBolt.buildTsdbTuple(
@@ -66,17 +61,17 @@ public class IslStatsBoltTest {
     }
 
     private void assertTsdbTuple(List<Object> tsdbTuple) throws java.io.IOException {
-        assertThat(tsdbTuple.size(), is(1));
+        MatcherAssert.assertThat(tsdbTuple.size(), is(1));
 
         Datapoint datapoint = Utils.MAPPER.readValue(tsdbTuple.get(0).toString(), Datapoint.class);
-        assertEquals(METRIC_PREFIX + LATENCY_METRIC_NAME, datapoint.getMetric());
-        assertEquals((Long) TIMESTAMP, datapoint.getTime());
-        assertEquals(LATENCY, datapoint.getValue());
+        Assertions.assertEquals(METRIC_PREFIX + LATENCY_METRIC_NAME, datapoint.getMetric());
+        Assertions.assertEquals((Long) TIMESTAMP, datapoint.getTime());
+        Assertions.assertEquals(LATENCY, datapoint.getValue());
 
         Map<String, String> pathNode = datapoint.getTags();
-        assertEquals(SWITCH1_ID_OTSD_FORMAT, pathNode.get("src_switch"));
-        assertEquals(SWITCH2_ID_OTSD_FORMAT, pathNode.get("dst_switch"));
-        assertEquals(SWITCH1_PORT, Integer.parseInt(pathNode.get("src_port")));
-        assertEquals(SWITCH2_PORT, Integer.parseInt(pathNode.get("dst_port")));
+        Assertions.assertEquals(SWITCH1_ID_OTSD_FORMAT, pathNode.get("src_switch"));
+        Assertions.assertEquals(SWITCH2_ID_OTSD_FORMAT, pathNode.get("dst_switch"));
+        Assertions.assertEquals(SWITCH1_PORT, Integer.parseInt(pathNode.get("src_port")));
+        Assertions.assertEquals(SWITCH2_PORT, Integer.parseInt(pathNode.get("dst_port")));
     }
 }

--- a/src-java/isllatency-topology/isllatency-storm-topology/src/test/java/org/openkilda/wfm/topology/isllatency/service/CacheServiceTest.java
+++ b/src-java/isllatency-topology/isllatency-storm-topology/src/test/java/org/openkilda/wfm/topology/isllatency/service/CacheServiceTest.java
@@ -36,8 +36,8 @@ import org.openkilda.persistence.repositories.SwitchRepository;
 import org.openkilda.wfm.share.model.Endpoint;
 import org.openkilda.wfm.topology.isllatency.carriers.CacheCarrier;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CacheServiceTest extends InMemoryGraphBasedTest {
     private static final SwitchId SWITCH_ID_1 = new SwitchId("00:00:00:00:00:00:00:01");
@@ -52,7 +52,7 @@ public class CacheServiceTest extends InMemoryGraphBasedTest {
     private IslRepository islRepository;
     private CacheService cacheService;
 
-    @Before
+    @BeforeEach
     public void setup() {
         switchRepository = persistenceManager.getRepositoryFactory().createSwitchRepository();
         islRepository = persistenceManager.getRepositoryFactory().createIslRepository();
@@ -67,7 +67,7 @@ public class CacheServiceTest extends InMemoryGraphBasedTest {
         cacheService = new CacheService(carrier, persistenceManager.getRepositoryFactory());
     }
 
-    @Test()
+    @Test
     public void handleGetDataFromCacheTest() {
         IslRoundTripLatency forward = new IslRoundTripLatency(SWITCH_ID_1, PORT_1, 1, 0L);
         IslRoundTripLatency reverse = new IslRoundTripLatency(SWITCH_ID_2, PORT_2, 1, 0L);
@@ -76,12 +76,12 @@ public class CacheServiceTest extends InMemoryGraphBasedTest {
         checkHandleGetDataFromCache(reverse, SWITCH_ID_1, PORT_1);
     }
 
-    @Test()
+    @Test
     public void handleGetDataFromCacheNotFromInitCacheActiveTest() {
         testGetDataFromCacheNotFromInitCache(ACTIVE);
     }
 
-    @Test()
+    @Test
     public void handleGetDataFromCacheNotFromInitCacheInactiveTest() {
         testGetDataFromCacheNotFromInitCache(INACTIVE);
     }
@@ -100,19 +100,19 @@ public class CacheServiceTest extends InMemoryGraphBasedTest {
         checkHandleGetDataFromCache(reverse, SWITCH_ID_1, srcPort);
     }
 
-    @Test()
+    @Test
     public void handleGetDataFromCacheNonExistentSwitchTest() {
         IslRoundTripLatency nonExistent = new IslRoundTripLatency(new SwitchId(999), PORT_1, 1, 0L);
         checkHandleGetDataFromCacheDidNotCallEmitCacheData(nonExistent);
     }
 
-    @Test()
+    @Test
     public void handleGetDataFromCacheNonExistentIslTest() {
         IslRoundTripLatency nonExistent = new IslRoundTripLatency(SWITCH_ID_1, 999, 1, 0L);
         checkHandleGetDataFromCacheDidNotCallEmitCacheData(nonExistent);
     }
 
-    @Test()
+    @Test
     public void handleUpdateCacheInactiveTest() {
         IslStatusUpdateNotification notification =
                 new IslStatusUpdateNotification(SWITCH_ID_1, PORT_1, SWITCH_ID_2, PORT_2, INACTIVE);
@@ -129,12 +129,12 @@ public class CacheServiceTest extends InMemoryGraphBasedTest {
         checkHandleGetDataFromCache(reverse, SWITCH_ID_1, PORT_1);
     }
 
-    @Test()
+    @Test
     public void handleUpdateCacheMovedTest() {
         testHandleUpdateCache(MOVED);
     }
 
-    @Test()
+    @Test
     public void handleGetDataFromCacheMovedTest() {
         testGetDataFromCache(MOVED);
     }

--- a/src-java/isllatency-topology/isllatency-storm-topology/src/test/java/org/openkilda/wfm/topology/isllatency/service/IslLatencyServiceTest.java
+++ b/src-java/isllatency-topology/isllatency-storm-topology/src/test/java/org/openkilda/wfm/topology/isllatency/service/IslLatencyServiceTest.java
@@ -15,9 +15,10 @@
 
 package org.openkilda.wfm.topology.isllatency.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.messaging.info.event.IslOneWayLatency;
 import org.openkilda.messaging.info.event.IslRoundTripLatency;
@@ -34,8 +35,9 @@ import org.openkilda.wfm.share.model.Endpoint;
 import org.openkilda.wfm.topology.isllatency.model.IslKey;
 import org.openkilda.wfm.topology.isllatency.model.LatencyRecord;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.LinkedList;
@@ -60,7 +62,7 @@ public class IslLatencyServiceTest extends InMemoryGraphBasedTest {
     private IslRepository islRepository;
     private IslLatencyService islLatencyService;
 
-    @Before
+    @BeforeEach
     public void setup() {
         islLatencyService = new IslLatencyService(
                 persistenceManager.getTransactionManager(), persistenceManager.getRepositoryFactory(),
@@ -74,19 +76,25 @@ public class IslLatencyServiceTest extends InMemoryGraphBasedTest {
         createIsl(firstSwitch, PORT_1, secondSwitch, PORT_2, INITIAL_LATENCY);
     }
 
-    @Test(expected = IslNotFoundException.class)
-    public void updateIslLatencyNonExistentSrcEndpointTest() throws IslNotFoundException, SwitchNotFoundException {
-        islLatencyService.updateIslLatency(NON_EXISTENT_SWITCH_ID, PORT_1, SWITCH_ID_2, PORT_2, 0);
+    @Test
+    public void updateIslLatencyNonExistentSrcEndpointTest() {
+        Assertions.assertThrows(IslNotFoundException.class, () -> {
+            islLatencyService.updateIslLatency(NON_EXISTENT_SWITCH_ID, PORT_1, SWITCH_ID_2, PORT_2, 0);
+        });
     }
 
-    @Test(expected = IslNotFoundException.class)
-    public void updateIslLatencyNonExistentDstEndpointTest() throws IslNotFoundException, SwitchNotFoundException {
-        islLatencyService.updateIslLatency(SWITCH_ID_1, PORT_1, NON_EXISTENT_SWITCH_ID, PORT_2, 0);
+    @Test
+    public void updateIslLatencyNonExistentDstEndpointTest() {
+        Assertions.assertThrows(IslNotFoundException.class, () -> {
+            islLatencyService.updateIslLatency(SWITCH_ID_1, PORT_1, NON_EXISTENT_SWITCH_ID, PORT_2, 0);
+        });
     }
 
-    @Test(expected = IslNotFoundException.class)
-    public void updateIslLatencyNonExistentIslTest() throws IslNotFoundException, SwitchNotFoundException {
-        islLatencyService.updateIslLatency(SWITCH_ID_1, NON_EXISTENT_PORT, SWITCH_ID_2, NON_EXISTENT_PORT, 0);
+    @Test
+    public void updateIslLatencyNonExistentIslTest() {
+        Assertions.assertThrows(IslNotFoundException.class, () -> {
+            islLatencyService.updateIslLatency(SWITCH_ID_1, NON_EXISTENT_PORT, SWITCH_ID_2, NON_EXISTENT_PORT, 0);
+        });
     }
 
     @Test

--- a/src-java/isllatency-topology/isllatency-storm-topology/src/test/java/org/openkilda/wfm/topology/isllatency/service/IslStatsServiceTest.java
+++ b/src-java/isllatency-topology/isllatency-storm-topology/src/test/java/org/openkilda/wfm/topology/isllatency/service/IslStatsServiceTest.java
@@ -16,9 +16,6 @@
 package org.openkilda.wfm.topology.isllatency.service;
 
 import static java.lang.Thread.sleep;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
@@ -37,8 +34,9 @@ import org.openkilda.wfm.share.model.Endpoint;
 import org.openkilda.wfm.topology.isllatency.carriers.IslStatsCarrier;
 import org.openkilda.wfm.topology.isllatency.model.LatencyRecord;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
@@ -59,7 +57,7 @@ public class IslStatsServiceTest {
     private InOrder inOrderCarrier;
     private IslStatsService islStatsService;
 
-    @Before
+    @BeforeEach
     public void setup() {
         carrier = mock(IslStatsCarrier.class);
         inOrderCarrier = inOrder(carrier);
@@ -68,15 +66,15 @@ public class IslStatsServiceTest {
 
     @Test
     public void isRecordStillValidTest() {
-        assertFalse(islStatsService.isRecordStillValid(new LatencyRecord(1, 0)));
+        Assertions.assertFalse(islStatsService.isRecordStillValid(new LatencyRecord(1, 0)));
 
         long expiredTimestamp = Instant.now().minusSeconds(LATENCY_TIMEOUT * 2).toEpochMilli();
-        assertFalse(islStatsService.isRecordStillValid(new LatencyRecord(1, expiredTimestamp)));
+        Assertions.assertFalse(islStatsService.isRecordStillValid(new LatencyRecord(1, expiredTimestamp)));
 
-        assertTrue(islStatsService.isRecordStillValid(new LatencyRecord(1, System.currentTimeMillis())));
+        Assertions.assertTrue(islStatsService.isRecordStillValid(new LatencyRecord(1, System.currentTimeMillis())));
 
         long freshTimestamp = Instant.now().plusSeconds(LATENCY_TIMEOUT * 2).toEpochMilli();
-        assertTrue(islStatsService.isRecordStillValid(new LatencyRecord(1, freshTimestamp)));
+        Assertions.assertTrue(islStatsService.isRecordStillValid(new LatencyRecord(1, freshTimestamp)));
     }
 
     @Test
@@ -429,12 +427,12 @@ public class IslStatsServiceTest {
 
     private void assertLatencyRecords(
             List<LatencyRecord> expected, List<Long> actualLatency, List<Long> actualTimestamp) {
-        assertEquals(expected.size(), actualLatency.size());
-        assertEquals(expected.size(), actualTimestamp.size());
+        Assertions.assertEquals(expected.size(), actualLatency.size());
+        Assertions.assertEquals(expected.size(), actualTimestamp.size());
 
         for (int i = 0; i < expected.size(); i++) {
-            assertEquals(expected.get(i).getLatency(), (long) actualLatency.get(i));
-            assertEquals(expected.get(i).getTimestamp(), (long) actualTimestamp.get(i));
+            Assertions.assertEquals(expected.get(i).getLatency(), (long) actualLatency.get(i));
+            Assertions.assertEquals(expected.get(i).getTimestamp(), (long) actualTimestamp.get(i));
         }
     }
 

--- a/src-java/isllatency-topology/isllatency-storm-topology/src/test/java/org/openkilda/wfm/topology/isllatency/service/OneWayManipulationServiceTest.java
+++ b/src-java/isllatency-topology/isllatency-storm-topology/src/test/java/org/openkilda/wfm/topology/isllatency/service/OneWayManipulationServiceTest.java
@@ -15,7 +15,6 @@
 
 package org.openkilda.wfm.topology.isllatency.service;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -27,8 +26,9 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.error.PipelineException;
 import org.openkilda.wfm.topology.isllatency.carriers.OneWayLatencyManipulationCarrier;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 public class OneWayManipulationServiceTest {
@@ -41,23 +41,23 @@ public class OneWayManipulationServiceTest {
     private OneWayLatencyManipulationCarrier carrier;
     private OneWayLatencyManipulationService oneWayLatencyManipulationService;
 
-    @Before
+    @BeforeEach
     public void setup() {
         carrier = mock(OneWayLatencyManipulationCarrier.class);
         oneWayLatencyManipulationService = new OneWayLatencyManipulationService(carrier);
     }
 
-    @Test()
+    @Test
     public void handleOneWayLatencyNegativeLatencyTest() throws PipelineException {
         runHandleOneWayLatencyTest(-1, ONE_MILLISECOND_IN_NANOSECONDS);
     }
 
-    @Test()
+    @Test
     public void handleOneWayLatencyZeroLatencyTest() throws PipelineException {
         runHandleOneWayLatencyTest(0, ONE_MILLISECOND_IN_NANOSECONDS);
     }
 
-    @Test()
+    @Test
     public void handleOneWayLatencyPositiveLatencyTest() throws PipelineException {
         runHandleOneWayLatencyTest(12, 12 * ONE_WAY_LATENCY_MULTIPLIER);
     }
@@ -72,11 +72,11 @@ public class OneWayManipulationServiceTest {
     }
 
     private void assertIslOneWayLatency(long expectedLatency, IslOneWayLatency actual) {
-        assertEquals(SWITCH_ID_1, actual.getSrcSwitchId());
-        assertEquals(PORT_1, actual.getSrcPortNo());
-        assertEquals(SWITCH_ID_2, actual.getDstSwitchId());
-        assertEquals(PORT_2, actual.getDstPortNo());
-        assertEquals(expectedLatency, actual.getLatency());
+        Assertions.assertEquals(SWITCH_ID_1, actual.getSrcSwitchId());
+        Assertions.assertEquals(PORT_1, actual.getSrcPortNo());
+        Assertions.assertEquals(SWITCH_ID_2, actual.getDstSwitchId());
+        Assertions.assertEquals(PORT_2, actual.getDstPortNo());
+        Assertions.assertEquals(expectedLatency, actual.getLatency());
     }
 
     private IslOneWayLatency createIslOneWayLatency(long latency) {

--- a/src-java/kilda-pce/build.gradle
+++ b/src-java/kilda-pce/build.gradle
@@ -12,7 +12,8 @@ dependencies {
     testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation 'org.hamcrest:hamcrest-library'
     testImplementation 'org.mockito:mockito-junit-jupiter'
 
@@ -22,4 +23,8 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding'
     testAnnotationProcessor 'org.projectlombok:lombok-mapstruct-binding'
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/kilda-pce/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/kilda-pce/src/checkstyle/checkstyle-suppressions.xml
@@ -5,4 +5,5 @@
 
 <suppressions>
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="VariableDeclarationUsageDistance" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
 </suppressions>

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/AvailableNetworkFactoryTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/AvailableNetworkFactoryTest.java
@@ -15,8 +15,8 @@
 
 package org.openkilda.pce;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -39,8 +39,8 @@ import org.openkilda.persistence.repositories.IslRepository.IslImmutableView;
 import org.openkilda.persistence.repositories.RepositoryFactory;
 
 import com.google.common.collect.Lists;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -82,7 +82,7 @@ public class AvailableNetworkFactoryTest {
 
     private AvailableNetworkFactory availableNetworkFactory;
 
-    @Before
+    @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
 

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/PathComputerFactoryTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/PathComputerFactoryTest.java
@@ -15,12 +15,12 @@
 
 package org.openkilda.pce;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import org.openkilda.pce.impl.InMemoryPathComputer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PathComputerFactoryTest {
     @Test

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/BestWeightAndShortestPathFinderTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/BestWeightAndShortestPathFinderTest.java
@@ -18,11 +18,10 @@ package org.openkilda.pce.finder;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.SwitchId;
 import org.openkilda.pce.exception.UnroutableFlowException;
@@ -37,7 +36,7 @@ import com.google.common.collect.Lists;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -82,11 +81,11 @@ public class BestWeightAndShortestPathFinderTest {
         Pair<List<Edge>, List<Edge>> pairPath =
                 pathFinder.findPathWithMinWeight(network, SWITCH_ID_1, SWITCH_ID_4, WEIGHT_FUNCTION).getFoundPath();
         List<Edge> fpath = pairPath.getLeft();
-        assertThat(fpath, Matchers.hasSize(2));
+        MatcherAssert.assertThat(fpath, Matchers.hasSize(2));
         assertEquals(SWITCH_ID_2, fpath.get(1).getSrcSwitch().getSwitchId());
 
         List<Edge> rpath = pairPath.getRight();
-        assertThat(rpath, Matchers.hasSize(2));
+        MatcherAssert.assertThat(rpath, Matchers.hasSize(2));
         assertEquals(SWITCH_ID_2, rpath.get(0).getDestSwitch().getSwitchId());
     }
 
@@ -99,11 +98,11 @@ public class BestWeightAndShortestPathFinderTest {
         Pair<List<Edge>, List<Edge>> pairPath =
                 pathFinder.findPathWithMinWeight(network, SWITCH_ID_4, SWITCH_ID_1, WEIGHT_FUNCTION).getFoundPath();
         List<Edge> fpath = pairPath.getLeft();
-        assertThat(fpath, Matchers.hasSize(2));
+        MatcherAssert.assertThat(fpath, Matchers.hasSize(2));
         assertEquals(SWITCH_ID_2, fpath.get(1).getSrcSwitch().getSwitchId());
 
         List<Edge> rpath = pairPath.getRight();
-        assertThat(rpath, Matchers.hasSize(2));
+        MatcherAssert.assertThat(rpath, Matchers.hasSize(2));
         assertEquals(SWITCH_ID_2, rpath.get(0).getDestSwitch().getSwitchId());
     }
 
@@ -115,11 +114,11 @@ public class BestWeightAndShortestPathFinderTest {
         Pair<List<Edge>, List<Edge>> pairPath =
                 pathFinder.findPathWithMinWeight(network, SWITCH_ID_1, SWITCH_ID_4, WEIGHT_FUNCTION).getFoundPath();
         List<Edge> fpath = pairPath.getLeft();
-        assertThat(fpath, Matchers.hasSize(4));
+        MatcherAssert.assertThat(fpath, Matchers.hasSize(4));
         assertEquals(SWITCH_ID_5, fpath.get(3).getSrcSwitch().getSwitchId());
 
         List<Edge> rpath = pairPath.getRight();
-        assertThat(rpath, Matchers.hasSize(4));
+        MatcherAssert.assertThat(rpath, Matchers.hasSize(4));
         assertEquals(SWITCH_ID_5, rpath.get(0).getDestSwitch().getSwitchId());
     }
 
@@ -131,11 +130,11 @@ public class BestWeightAndShortestPathFinderTest {
         Pair<List<Edge>, List<Edge>> pairPath =
                 pathFinder.findPathWithMinWeight(network, SWITCH_ID_1, SWITCH_ID_5, WEIGHT_FUNCTION).getFoundPath();
         List<Edge> fpath = pairPath.getLeft();
-        assertThat(fpath, Matchers.hasSize(3));
+        MatcherAssert.assertThat(fpath, Matchers.hasSize(3));
         assertEquals(SWITCH_ID_3, fpath.get(2).getSrcSwitch().getSwitchId());
 
         List<Edge> rpath = pairPath.getRight();
-        assertThat(rpath, Matchers.hasSize(3));
+        MatcherAssert.assertThat(rpath, Matchers.hasSize(3));
         assertEquals(SWITCH_ID_3, rpath.get(0).getDestSwitch().getSwitchId());
     }
 
@@ -148,11 +147,11 @@ public class BestWeightAndShortestPathFinderTest {
                 pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_1, SWITCH_ID_3, WEIGHT_FUNCTION,
                         Long.MAX_VALUE, Long.MAX_VALUE).getFoundPath();
         List<Edge> fpath = pairPath.getLeft();
-        assertThat(fpath, Matchers.hasSize(2));
+        MatcherAssert.assertThat(fpath, Matchers.hasSize(2));
         assertEquals(SWITCH_ID_2, fpath.get(1).getSrcSwitch().getSwitchId());
 
         List<Edge> rpath = pairPath.getRight();
-        assertThat(rpath, Matchers.hasSize(2));
+        MatcherAssert.assertThat(rpath, Matchers.hasSize(2));
         assertEquals(SWITCH_ID_2, rpath.get(0).getDestSwitch().getSwitchId());
     }
 
@@ -166,11 +165,11 @@ public class BestWeightAndShortestPathFinderTest {
                 pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_3, SWITCH_ID_1, WEIGHT_FUNCTION,
                         Long.MAX_VALUE, Long.MAX_VALUE).getFoundPath();
         List<Edge> fpath = pairPath.getLeft();
-        assertThat(fpath, Matchers.hasSize(2));
+        MatcherAssert.assertThat(fpath, Matchers.hasSize(2));
         assertEquals(SWITCH_ID_2, fpath.get(1).getSrcSwitch().getSwitchId());
 
         List<Edge> rpath = pairPath.getRight();
-        assertThat(rpath, Matchers.hasSize(2));
+        MatcherAssert.assertThat(rpath, Matchers.hasSize(2));
         assertEquals(SWITCH_ID_2, rpath.get(0).getDestSwitch().getSwitchId());
     }
 
@@ -183,11 +182,11 @@ public class BestWeightAndShortestPathFinderTest {
                 pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_1, SWITCH_ID_3, WEIGHT_FUNCTION,
                         Long.MAX_VALUE, Long.MAX_VALUE).getFoundPath();
         List<Edge> fpath = pairPath.getLeft();
-        assertThat(fpath, Matchers.hasSize(4));
+        MatcherAssert.assertThat(fpath, Matchers.hasSize(4));
         assertEquals(SWITCH_ID_5, fpath.get(3).getSrcSwitch().getSwitchId());
 
         List<Edge> rpath = pairPath.getRight();
-        assertThat(rpath, Matchers.hasSize(4));
+        MatcherAssert.assertThat(rpath, Matchers.hasSize(4));
         assertEquals(SWITCH_ID_5, rpath.get(0).getDestSwitch().getSwitchId());
     }
 
@@ -200,11 +199,11 @@ public class BestWeightAndShortestPathFinderTest {
                 pathFinder.findPathWithWeightCloseToMaxWeight(network, SWITCH_ID_1, SWITCH_ID_5, WEIGHT_FUNCTION,
                         Long.MAX_VALUE, Long.MAX_VALUE).getFoundPath();
         List<Edge> fpath = pairPath.getLeft();
-        assertThat(fpath, Matchers.hasSize(3));
+        MatcherAssert.assertThat(fpath, Matchers.hasSize(3));
         assertEquals(SWITCH_ID_4, fpath.get(2).getSrcSwitch().getSwitchId());
 
         List<Edge> rpath = pairPath.getRight();
-        assertThat(rpath, Matchers.hasSize(3));
+        MatcherAssert.assertThat(rpath, Matchers.hasSize(3));
         assertEquals(SWITCH_ID_4, rpath.get(0).getDestSwitch().getSwitchId());
     }
 
@@ -266,12 +265,12 @@ public class BestWeightAndShortestPathFinderTest {
         Pair<List<Edge>, List<Edge>> pairPath =
                 pathFinder.findPathWithMinWeight(network, SWITCH_ID_E, SWITCH_ID_F, WEIGHT_FUNCTION).getFoundPath();
         List<Edge> fpath = pairPath.getLeft();
-        assertThat(fpath, Matchers.hasSize(2));
+        MatcherAssert.assertThat(fpath, Matchers.hasSize(2));
         assertEquals(SWITCH_ID_E, fpath.get(0).getSrcSwitch().getSwitchId());
         assertEquals(SWITCH_ID_F, fpath.get(1).getDestSwitch().getSwitchId());
 
         List<Edge> rpath = pairPath.getRight();
-        assertThat(rpath, Matchers.hasSize(2));
+        MatcherAssert.assertThat(rpath, Matchers.hasSize(2));
         assertEquals(SWITCH_ID_F, rpath.get(0).getSrcSwitch().getSwitchId());
         assertEquals(SWITCH_ID_E, rpath.get(1).getDestSwitch().getSwitchId());
     }
@@ -309,8 +308,8 @@ public class BestWeightAndShortestPathFinderTest {
 
         //then: system picks 200 path
         List<SwitchId> forwardSwitches = getInvolvedSwitches(pairPath.getLeft());
-        assertThat(forwardSwitches, equalTo(Arrays.asList(SWITCH_ID_1, SWITCH_ID_3, SWITCH_ID_5)));
-        assertThat(getInvolvedSwitches(pairPath.getRight()), equalTo(Lists.reverse(forwardSwitches)));
+        MatcherAssert.assertThat(forwardSwitches, equalTo(Arrays.asList(SWITCH_ID_1, SWITCH_ID_3, SWITCH_ID_5)));
+        MatcherAssert.assertThat(getInvolvedSwitches(pairPath.getRight()), equalTo(Lists.reverse(forwardSwitches)));
 
         return pathResult;
     }
@@ -349,8 +348,8 @@ public class BestWeightAndShortestPathFinderTest {
 
         //then: system picks 198 path
         List<SwitchId> forwardSwitches = getInvolvedSwitches(pairPath.getLeft());
-        assertThat(forwardSwitches, equalTo(Arrays.asList(SWITCH_ID_1, SWITCH_ID_2, SWITCH_ID_5)));
-        assertThat(getInvolvedSwitches(pairPath.getRight()), equalTo(Lists.reverse(forwardSwitches)));
+        MatcherAssert.assertThat(forwardSwitches, equalTo(Arrays.asList(SWITCH_ID_1, SWITCH_ID_2, SWITCH_ID_5)));
+        MatcherAssert.assertThat(getInvolvedSwitches(pairPath.getRight()), equalTo(Lists.reverse(forwardSwitches)));
 
         return pathResult;
     }
@@ -392,8 +391,8 @@ public class BestWeightAndShortestPathFinderTest {
         Pair<List<Edge>, List<Edge>> pairPath = pathResult.getFoundPath();
         //then: pick path1, because its reverse cost is 102 which is the closest to 103
         //system skips path2 even though its forward cost is 101, which is closer to 103 than 100 (path1 forward)
-        assertThat(pairPath.getLeft().get(0).getSrcPort(), equalTo(1));
-        assertThat(pairPath.getRight().get(0).getSrcPort(), equalTo(1));
+        MatcherAssert.assertThat(pairPath.getLeft().get(0).getSrcPort(), equalTo(1));
+        MatcherAssert.assertThat(pairPath.getRight().get(0).getSrcPort(), equalTo(1));
 
         return pathResult;
     }
@@ -415,8 +414,8 @@ public class BestWeightAndShortestPathFinderTest {
                 pathFinder.findPathWithMinWeight(network, SWITCH_ID_1, SWITCH_ID_2, WEIGHT_FUNCTION).getFoundPath();
         //then: pick path2, because its forward cost is 100 which is less than forward 101 of path1
         //system ignores that path1 reverse cost is actually the best of all (99), since it only uses forward
-        assertThat(pairPath.getLeft().get(0).getSrcPort(), equalTo(2));
-        assertThat(pairPath.getRight().get(0).getSrcPort(), equalTo(2));
+        MatcherAssert.assertThat(pairPath.getLeft().get(0).getSrcPort(), equalTo(2));
+        MatcherAssert.assertThat(pairPath.getRight().get(0).getSrcPort(), equalTo(2));
     }
 
     /**
@@ -437,25 +436,30 @@ public class BestWeightAndShortestPathFinderTest {
         //then: no path found
     }
 
-    @Test(expected = UnroutableFlowException.class)
-    public void failToFindASwitch() throws UnroutableFlowException {
-        AvailableNetwork network = buildTestNetwork();
+    @Test
+    public void failToFindASwitch() {
+        assertThrows(UnroutableFlowException.class, () -> {
+            AvailableNetwork network = buildTestNetwork();
 
-        SwitchId srcDpid = new SwitchId("00:00:00:00:00:00:00:ff");
+            SwitchId srcDpid = new SwitchId("00:00:00:00:00:00:00:ff");
 
-        BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
-        pathFinder.findPathWithMinWeight(network, srcDpid, SWITCH_ID_F, WEIGHT_FUNCTION);
+            BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
+            pathFinder.findPathWithMinWeight(network, srcDpid, SWITCH_ID_F, WEIGHT_FUNCTION);
+        });
+
     }
 
-    @Test(expected = UnroutableFlowException.class)
-    public void failToFindASwitchMaxWeightStrategy() throws UnroutableFlowException {
-        AvailableNetwork network = buildTestNetwork();
+    @Test
+    public void failToFindASwitchMaxWeightStrategy() {
+        assertThrows(UnroutableFlowException.class, () -> {
+            AvailableNetwork network = buildTestNetwork();
 
-        SwitchId srcDpid = new SwitchId("00:00:00:00:00:00:00:ff");
+            SwitchId srcDpid = new SwitchId("00:00:00:00:00:00:00:ff");
 
-        BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
-        pathFinder.findPathWithWeightCloseToMaxWeight(network, srcDpid, SWITCH_ID_F, WEIGHT_FUNCTION,
-                Long.MAX_VALUE, Long.MAX_VALUE);
+            BestWeightAndShortestPathFinder pathFinder = new BestWeightAndShortestPathFinder(ALLOWED_DEPTH);
+            pathFinder.findPathWithWeightCloseToMaxWeight(network, srcDpid, SWITCH_ID_F, WEIGHT_FUNCTION,
+                    Long.MAX_VALUE, Long.MAX_VALUE);
+        });
     }
 
     @Test
@@ -480,7 +484,8 @@ public class BestWeightAndShortestPathFinderTest {
         Pair<List<Edge>, List<Edge>> paths =
                 pathFinder.findPathWithMinWeight(network, SWITCH_ID_D, SWITCH_ID_F, WEIGHT_FUNCTION).getFoundPath();
 
-        assertEquals(Arrays.asList(SWITCH_ID_D, SWITCH_ID_A, SWITCH_ID_F), getSwitchIdsFlowPath(paths.getLeft()));
+        assertEquals(Arrays.asList(SWITCH_ID_D, SWITCH_ID_A, SWITCH_ID_F),
+                getSwitchIdsFlowPath(paths.getLeft()));
     }
 
     @Test
@@ -512,8 +517,8 @@ public class BestWeightAndShortestPathFinderTest {
 
         //then: system picks 198 path (since 200 path is no longer '200' due to diversity weight rise)
         List<SwitchId> forwardSwitches = getInvolvedSwitches(pairPath.getLeft());
-        assertThat(forwardSwitches, equalTo(Arrays.asList(SWITCH_ID_1, SWITCH_ID_2, SWITCH_ID_5)));
-        assertThat(getInvolvedSwitches(pairPath.getRight()), equalTo(Lists.reverse(forwardSwitches)));
+        MatcherAssert.assertThat(forwardSwitches, equalTo(Arrays.asList(SWITCH_ID_1, SWITCH_ID_2, SWITCH_ID_5)));
+        MatcherAssert.assertThat(getInvolvedSwitches(pairPath.getRight()), equalTo(Lists.reverse(forwardSwitches)));
 
         return pathResult;
     }
@@ -610,12 +615,12 @@ public class BestWeightAndShortestPathFinderTest {
         Pair<List<Edge>, List<Edge>> paths = pathResult.getFoundPath();
 
         List<Edge> fpath = paths.getLeft();
-        assertThat(fpath, Matchers.hasSize(3));
+        MatcherAssert.assertThat(fpath, Matchers.hasSize(3));
         assertEquals(SWITCH_ID_1, fpath.get(0).getSrcSwitch().getSwitchId());
         assertEquals(SWITCH_ID_3, fpath.get(2).getSrcSwitch().getSwitchId());
 
         List<Edge> rpath = paths.getRight();
-        assertThat(rpath, Matchers.hasSize(3));
+        MatcherAssert.assertThat(rpath, Matchers.hasSize(3));
         assertEquals(SWITCH_ID_5, fpath.get(2).getDestSwitch().getSwitchId());
         assertEquals(SWITCH_ID_3, rpath.get(0).getDestSwitch().getSwitchId());
 
@@ -777,12 +782,12 @@ public class BestWeightAndShortestPathFinderTest {
         Pair<List<Edge>, List<Edge>> pairPath =
                 pathFinder.findPathWithMinWeight(network, SWITCH_ID_A, SWITCH_ID_B, WEIGHT_FUNCTION).getFoundPath();
         List<Edge> forwardPath = pairPath.getLeft();
-        assertThat(forwardPath, Matchers.hasSize(1));
+        MatcherAssert.assertThat(forwardPath, Matchers.hasSize(1));
         assertEquals(SWITCH_ID_A, forwardPath.get(0).getSrcSwitch().getSwitchId());
         assertEquals(SWITCH_ID_B, forwardPath.get(0).getDestSwitch().getSwitchId());
 
         List<Edge> reversePath = pairPath.getRight();
-        assertThat(reversePath, Matchers.hasSize(1));
+        MatcherAssert.assertThat(reversePath, Matchers.hasSize(1));
         assertEquals(SWITCH_ID_B, reversePath.get(0).getSrcSwitch().getSwitchId());
         assertEquals(SWITCH_ID_A, reversePath.get(0).getDestSwitch().getSwitchId());
 
@@ -791,14 +796,14 @@ public class BestWeightAndShortestPathFinderTest {
 
         pairPath = pathFinder.findPathWithMinWeight(network, SWITCH_ID_A, SWITCH_ID_B, WEIGHT_FUNCTION).getFoundPath();
         forwardPath = pairPath.getLeft();
-        assertThat(forwardPath, Matchers.hasSize(2));
+        MatcherAssert.assertThat(forwardPath, Matchers.hasSize(2));
         assertEquals(SWITCH_ID_A, forwardPath.get(0).getSrcSwitch().getSwitchId());
         assertEquals(SWITCH_ID_C, forwardPath.get(0).getDestSwitch().getSwitchId());
         assertEquals(SWITCH_ID_C, forwardPath.get(1).getSrcSwitch().getSwitchId());
         assertEquals(SWITCH_ID_B, forwardPath.get(1).getDestSwitch().getSwitchId());
 
         reversePath = pairPath.getRight();
-        assertThat(reversePath, Matchers.hasSize(2));
+        MatcherAssert.assertThat(reversePath, Matchers.hasSize(2));
         assertEquals(SWITCH_ID_B, reversePath.get(0).getSrcSwitch().getSwitchId());
         assertEquals(SWITCH_ID_C, reversePath.get(0).getDestSwitch().getSwitchId());
         assertEquals(SWITCH_ID_C, reversePath.get(1).getSrcSwitch().getSwitchId());
@@ -809,7 +814,7 @@ public class BestWeightAndShortestPathFinderTest {
 
         pairPath = pathFinder.findPathWithMinWeight(network, SWITCH_ID_A, SWITCH_ID_B, WEIGHT_FUNCTION).getFoundPath();
         forwardPath = pairPath.getLeft();
-        assertThat(forwardPath, Matchers.hasSize(3));
+        MatcherAssert.assertThat(forwardPath, Matchers.hasSize(3));
         assertEquals(SWITCH_ID_A, forwardPath.get(0).getSrcSwitch().getSwitchId());
         assertEquals(SWITCH_ID_D, forwardPath.get(0).getDestSwitch().getSwitchId());
         assertEquals(SWITCH_ID_D, forwardPath.get(1).getSrcSwitch().getSwitchId());
@@ -818,7 +823,7 @@ public class BestWeightAndShortestPathFinderTest {
         assertEquals(SWITCH_ID_B, forwardPath.get(2).getDestSwitch().getSwitchId());
 
         reversePath = pairPath.getRight();
-        assertThat(reversePath, Matchers.hasSize(3));
+        MatcherAssert.assertThat(reversePath, Matchers.hasSize(3));
         assertEquals(SWITCH_ID_B, reversePath.get(0).getSrcSwitch().getSwitchId());
         assertEquals(SWITCH_ID_E, reversePath.get(0).getDestSwitch().getSwitchId());
         assertEquals(SWITCH_ID_E, reversePath.get(1).getSrcSwitch().getSwitchId());

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/DiversityPathFinderTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/DiversityPathFinderTest.java
@@ -19,8 +19,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -49,12 +49,9 @@ import org.openkilda.persistence.repositories.IslRepository.IslImmutableView;
 import org.openkilda.persistence.repositories.RepositoryFactory;
 
 import com.google.common.collect.Lists;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -63,7 +60,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-@RunWith(Parameterized.class)
 public class DiversityPathFinderTest {
     public static final SwitchId SWITCH_ID_1 = new SwitchId(1);
     public static final SwitchId SWITCH_ID_2 = new SwitchId(2);
@@ -92,10 +88,8 @@ public class DiversityPathFinderTest {
 
     private AvailableNetworkFactory availableNetworkFactory;
 
-    @Parameter
-    public PathComputationStrategy pathComputationStrategy;
 
-    @Before
+    @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
 
@@ -112,8 +106,10 @@ public class DiversityPathFinderTest {
         availableNetworkFactory = new AvailableNetworkFactory(config, repositoryFactory);
     }
 
-    @Test
-    public void chooseSamePathTest() throws RecoverableException, UnroutableFlowException {
+    @ParameterizedTest
+    @EnumSource(PathComputationStrategy.class)
+    public void chooseSamePathTest(PathComputationStrategy pathComputationStrategy)
+            throws RecoverableException, UnroutableFlowException {
         // Topology:
         // A----B----C     Already created flow: A-B-C
         //                 Requested flow: A-B-C
@@ -203,8 +199,10 @@ public class DiversityPathFinderTest {
         );
     }
 
-    @Test
-    public void useSameSwitchTest() throws RecoverableException, UnroutableFlowException {
+    @ParameterizedTest
+    @EnumSource(PathComputationStrategy.class)
+    public void useSameSwitchTest(PathComputationStrategy pathComputationStrategy)
+            throws RecoverableException, UnroutableFlowException {
         // Topology:
         //      D
         //      |
@@ -300,8 +298,10 @@ public class DiversityPathFinderTest {
 
     }
 
-    @Test
-    public void chooseLongerPathTest() throws RecoverableException, UnroutableFlowException {
+    @ParameterizedTest
+    @EnumSource(PathComputationStrategy.class)
+    public void chooseLongerPathTest(PathComputationStrategy pathComputationStrategy)
+            throws RecoverableException, UnroutableFlowException {
         // Topology:
         //      D----E
         //      |    |
@@ -398,8 +398,10 @@ public class DiversityPathFinderTest {
         );
     }
 
-    @Test
-    public void choosePathWithoutSingleSwitchFlowTest() throws RecoverableException, UnroutableFlowException {
+    @ParameterizedTest
+    @EnumSource(PathComputationStrategy.class)
+    public void choosePathWithoutSingleSwitchFlowTest(PathComputationStrategy pathComputationStrategy)
+            throws RecoverableException, UnroutableFlowException {
         // Topology:
         // -----E----D
         // |         |
@@ -513,18 +515,5 @@ public class DiversityPathFinderTest {
                 .bandwidth(100)
                 .ignoreBandwidth(false)
                 .build();
-    }
-
-    /**
-     * PathComputationStrategies.
-     */
-    @Parameters(name = "PathComputationStrategy = {0}")
-    public static Object[][] data() {
-        return new Object[][] {
-                {PathComputationStrategy.MAX_LATENCY},
-                {PathComputationStrategy.LATENCY},
-                {PathComputationStrategy.COST},
-                {PathComputationStrategy.COST_AND_AVAILABLE_BANDWIDTH}
-        };
     }
 }

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/FailReasonTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/FailReasonTest.java
@@ -18,7 +18,7 @@ package org.openkilda.pce.finder;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/FilteringByMaxWeightTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/FilteringByMaxWeightTest.java
@@ -29,8 +29,8 @@ import org.openkilda.pce.model.PathWeight;
 import org.openkilda.pce.model.WeightFunction;
 
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -51,7 +51,7 @@ public class FilteringByMaxWeightTest {
     private static final SwitchId SWITCH_ID_5 = new SwitchId("00:00:00:00:00:00:00:05");
 
 
-    @Before
+    @BeforeEach
     public void setUp() {
         /*
          *   Topology:

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/ProtectedPathFinderTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/ProtectedPathFinderTest.java
@@ -20,8 +20,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -51,9 +52,8 @@ import org.openkilda.persistence.repositories.RepositoryFactory;
 
 import com.google.common.collect.Lists;
 import org.hamcrest.MatcherAssert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -94,7 +94,7 @@ public class ProtectedPathFinderTest {
 
     private AvailableNetworkFactory availableNetworkFactory;
 
-    @Before
+    @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
 
@@ -169,7 +169,7 @@ public class ProtectedPathFinderTest {
         PathComputer pathComputer = new InMemoryPathComputer(
                 availableNetworkFactory, new BestWeightAndShortestPathFinder(200), config);
 
-        Exception exception = Assertions.assertThrows(UnroutableFlowException.class, () -> {
+        Exception exception = assertThrows(UnroutableFlowException.class, () -> {
             pathComputer.getPath(flow, Collections.emptyList(), true);
         });
         MatcherAssert.assertThat(exception.getMessage(),
@@ -239,7 +239,7 @@ public class ProtectedPathFinderTest {
         PathComputer pathComputer = new InMemoryPathComputer(
                 availableNetworkFactory, new BestWeightAndShortestPathFinder(200), config);
 
-        Exception exception = Assertions.assertThrows(UnroutableFlowException.class, () -> {
+        Exception exception = assertThrows(UnroutableFlowException.class, () -> {
             pathComputer.getPath(flow, Collections.emptyList(), true);
         });
         MatcherAssert.assertThat(exception.getMessage(),
@@ -515,7 +515,7 @@ public class ProtectedPathFinderTest {
         PathComputer pathComputer = new InMemoryPathComputer(
                 availableNetworkFactory, new BestWeightAndShortestPathFinder(200), config);
 
-        Exception exception = Assertions.assertThrows(UnroutableFlowException.class, () -> {
+        Exception exception = assertThrows(UnroutableFlowException.class, () -> {
             pathComputer.getPath(flow, Collections.emptyList(), true);
         });
         MatcherAssert.assertThat(exception.getMessage(),

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/AvailableNetworkTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/AvailableNetworkTest.java
@@ -20,8 +20,8 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.FlowPath;
 import org.openkilda.model.PathId;
@@ -35,7 +35,7 @@ import org.openkilda.pce.model.WeightFunction;
 
 import com.google.common.collect.Sets;
 import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/CostAndBandwidthPathComputationStrategyTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/CostAndBandwidthPathComputationStrategyTest.java
@@ -17,10 +17,10 @@ package org.openkilda.pce.impl;
 
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowEncapsulationType;
@@ -38,8 +38,7 @@ import org.openkilda.pce.finder.FailReasonType;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.UUID;
@@ -62,7 +61,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
         GetPathsResult path = pathComputer.getPath(f);
         assertNotNull(path);
-        assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
+        MatcherAssert.assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         assertEquals(new SwitchId("00:02"), path.getForward().getSegments().get(0).getDestSwitchId()); // chooses path B
     }
 
@@ -79,7 +78,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
         GetPathsResult path = pathComputer.getPath(f);
         assertNotNull(path);
-        assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
+        MatcherAssert.assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // ====> only difference is it should now have C as first hop .. since B is inactive
         assertEquals(new SwitchId("01:03"), path.getForward().getSegments().get(0).getDestSwitchId()); // chooses path C
     }
@@ -100,7 +99,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
         GetPathsResult path = pathComputer.getPath(f);
         assertNotNull(path);
-        assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
+        MatcherAssert.assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // ====> only difference is it should now have C as first hop .. since B is inactive
         assertEquals(new SwitchId("02:03"), path.getForward().getSegments().get(0).getDestSwitchId()); // chooses path C
     }
@@ -120,24 +119,25 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
         GetPathsResult path = pathComputer.getPath(f);
         assertNotNull(path);
-        assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
+        MatcherAssert.assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // ====> Should choose B .. because default cost (700) cheaper than 2000
         assertEquals(new SwitchId("03:02"), path.getForward().getSegments().get(0).getDestSwitchId()); // chooses path B
     }
 
     @Test
-    public void shouldFailToFindOverDiamondWithNoActiveRoutes() throws UnroutableFlowException, RecoverableException {
-        createDiamond(IslStatus.INACTIVE, IslStatus.INACTIVE, 10, 30, "04:", 1);
+    public void shouldFailToFindOverDiamondWithNoActiveRoutes() {
+        assertThrows(UnroutableFlowException.class, () -> {
+            createDiamond(IslStatus.INACTIVE, IslStatus.INACTIVE, 10, 30, "04:", 1);
 
-        Switch srcSwitch = getSwitchById("04:01");
-        Switch destSwitch = getSwitchById("04:04");
+            Switch srcSwitch = getSwitchById("04:01");
+            Switch destSwitch = getSwitchById("04:04");
 
-        Flow f = getTestFlowBuilder(srcSwitch, destSwitch).build();
+            Flow f = getTestFlowBuilder(srcSwitch, destSwitch).build();
 
-        thrown.expect(UnroutableFlowException.class);
 
-        PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        pathComputer.getPath(f);
+            PathComputer pathComputer = pathComputerFactory.getPathComputer();
+            pathComputer.getPath(f);
+        });
     }
 
 
@@ -157,7 +157,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
         GetPathsResult path = pathComputer.getPath(f1);
         assertNotNull(path);
-        assertThat(path.getForward().getSegments(), Matchers.hasSize(1));
+        MatcherAssert.assertThat(path.getForward().getSegments(), Matchers.hasSize(1));
 
         Switch srcSwitch2 = getSwitchById("05:01");
         Switch destSwitch2 = getSwitchById("05:04");
@@ -169,7 +169,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
 
         path = pathComputer.getPath(f2);
         assertNotNull(path);
-        assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
+        MatcherAssert.assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         assertEquals(new SwitchId("05:02"), path.getForward().getSegments().get(0).getDestSwitchId());
     }
 
@@ -195,7 +195,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
         GetPathsResult path = pathComputer.getPath(f1);
         assertNotNull(path);
-        assertThat(path.getForward().getSegments(), Matchers.hasSize(1));
+        MatcherAssert.assertThat(path.getForward().getSegments(), Matchers.hasSize(1));
 
         Switch srcSwitch2 = getSwitchById("06:01");
         Switch destSwitch2 = getSwitchById("07:04");
@@ -206,7 +206,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
                 .ignoreBandwidth(false)
                 .build();
 
-        Exception exception = Assertions.assertThrows(UnroutableFlowException.class, () -> {
+        Exception exception = assertThrows(UnroutableFlowException.class, () -> {
             pathComputer.getPath(f2);
         });
         MatcherAssert.assertThat(exception.getMessage(), containsString(FailReasonType.NO_CONNECTION.toString()));
@@ -313,7 +313,7 @@ public class CostAndBandwidthPathComputationStrategyTest extends InMemoryPathCom
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
         GetPathsResult path = pathComputer.getPath(f);
         assertNotNull(path);
-        assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
+        MatcherAssert.assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         assertEquals(new SwitchId("00:03"), path.getForward().getSegments().get(0).getDestSwitchId());
     }
 

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/FindPathWithLatencyLimitsTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/FindPathWithLatencyLimitsTest.java
@@ -34,8 +34,8 @@ import org.openkilda.pce.model.FindPathResult;
 import org.openkilda.pce.model.WeightFunction;
 
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -52,7 +52,7 @@ public class FindPathWithLatencyLimitsTest {
 
     private InMemoryPathComputer pathComputer;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         PathComputerConfig pathComputerConfig = new PropertiesBasedConfigurationProvider()
                 .getConfiguration(PathComputerConfig.class);

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/InMemoryPathComputerBaseTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/InMemoryPathComputerBaseTest.java
@@ -18,13 +18,9 @@ package org.openkilda.pce.impl;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -82,12 +78,9 @@ import org.openkilda.persistence.repositories.SwitchRepository;
 import com.google.common.collect.Sets;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -127,10 +120,7 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
     static AvailableNetworkFactory availableNetworkFactory;
     static PathComputerFactory pathComputerFactory;
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    @BeforeClass
+    @BeforeAll
     public static void setUpOnce() {
         switchRepository = repositoryFactory.createSwitchRepository();
         switchPropertiesRepository = repositoryFactory.createSwitchPropertiesRepository();
@@ -149,62 +139,61 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
      * See how it works with a large network.
      */
     @Test
-    public void findPathOverLargeIslands() throws RecoverableException, UnroutableFlowException {
-        final int expectedPathForwardSegmentSize = 139;
+    public void findPathOverLargeIslands() {
+        assertThrows(UnroutableFlowException.class, () -> {
+            final int expectedPathForwardSegmentSize = 139;
 
-        createDiamond(IslStatus.ACTIVE, IslStatus.ACTIVE, 10, 20, "08:", 1);
+            createDiamond(IslStatus.ACTIVE, IslStatus.ACTIVE, 10, 20, "08:", 1);
 
-        for (int i = 0; i < 50; i++) {
-            createDiamond(IslStatus.ACTIVE, IslStatus.ACTIVE, 10, 20, "10:", 4 * i + 1);
-            createDiamond(IslStatus.ACTIVE, IslStatus.ACTIVE, 10, 20, "11:", 4 * i + 1);
-            createDiamond(IslStatus.ACTIVE, IslStatus.ACTIVE, 10, 20, "12:", 4 * i + 1);
-            createDiamond(IslStatus.ACTIVE, IslStatus.ACTIVE, 10, 20, "13:", 4 * i + 1);
-        }
-        for (int i = 0; i < 49; i++) {
-            String prev = format("%02X", 4 * i + 4);
-            String next = format("%02X", 4 * i + 5);
-            connectDiamonds(new SwitchId("10:" + prev), new SwitchId("10:" + next), IslStatus.ACTIVE, 20, 50);
-            connectDiamonds(new SwitchId("11:" + prev), new SwitchId("11:" + next), IslStatus.ACTIVE, 20, 50);
-            connectDiamonds(new SwitchId("12:" + prev), new SwitchId("12:" + next), IslStatus.ACTIVE, 20, 50);
-            connectDiamonds(new SwitchId("13:" + prev), new SwitchId("13:" + next), IslStatus.ACTIVE, 20, 50);
-        }
-        connectDiamonds(new SwitchId("10:99"), new SwitchId("11:22"), IslStatus.ACTIVE, 20, 50);
-        connectDiamonds(new SwitchId("11:99"), new SwitchId("12:22"), IslStatus.ACTIVE, 20, 50);
-        connectDiamonds(new SwitchId("12:99"), new SwitchId("13:22"), IslStatus.ACTIVE, 20, 50);
-        connectDiamonds(new SwitchId("13:99"), new SwitchId("10:22"), IslStatus.ACTIVE, 20, 50);
+            for (int i = 0; i < 50; i++) {
+                createDiamond(IslStatus.ACTIVE, IslStatus.ACTIVE, 10, 20, "10:", 4 * i + 1);
+                createDiamond(IslStatus.ACTIVE, IslStatus.ACTIVE, 10, 20, "11:", 4 * i + 1);
+                createDiamond(IslStatus.ACTIVE, IslStatus.ACTIVE, 10, 20, "12:", 4 * i + 1);
+                createDiamond(IslStatus.ACTIVE, IslStatus.ACTIVE, 10, 20, "13:", 4 * i + 1);
+            }
+            for (int i = 0; i < 49; i++) {
+                String prev = format("%02X", 4 * i + 4);
+                String next = format("%02X", 4 * i + 5);
+                connectDiamonds(new SwitchId("10:" + prev), new SwitchId("10:" + next), IslStatus.ACTIVE, 20, 50);
+                connectDiamonds(new SwitchId("11:" + prev), new SwitchId("11:" + next), IslStatus.ACTIVE, 20, 50);
+                connectDiamonds(new SwitchId("12:" + prev), new SwitchId("12:" + next), IslStatus.ACTIVE, 20, 50);
+                connectDiamonds(new SwitchId("13:" + prev), new SwitchId("13:" + next), IslStatus.ACTIVE, 20, 50);
+            }
+            connectDiamonds(new SwitchId("10:99"), new SwitchId("11:22"), IslStatus.ACTIVE, 20, 50);
+            connectDiamonds(new SwitchId("11:99"), new SwitchId("12:22"), IslStatus.ACTIVE, 20, 50);
+            connectDiamonds(new SwitchId("12:99"), new SwitchId("13:22"), IslStatus.ACTIVE, 20, 50);
+            connectDiamonds(new SwitchId("13:99"), new SwitchId("10:22"), IslStatus.ACTIVE, 20, 50);
 
-        Switch srcSwitch1 = getSwitchById("10:01");
-        Switch destSwitch1 = getSwitchById("11:03");
+            Switch srcSwitch1 = getSwitchById("10:01");
+            Switch destSwitch1 = getSwitchById("11:03");
 
-        // THIS ONE SHOULD WORK
-        Flow f1 = new TestFlowBuilder()
-                .srcSwitch(srcSwitch1)
-                .destSwitch(destSwitch1)
-                .bandwidth(0)
-                .ignoreBandwidth(false)
-                .build();
+            // THIS ONE SHOULD WORK
+            Flow f1 = new TestFlowBuilder()
+                    .srcSwitch(srcSwitch1)
+                    .destSwitch(destSwitch1)
+                    .bandwidth(0)
+                    .ignoreBandwidth(false)
+                    .build();
 
-        PathComputer pathComputer = new InMemoryPathComputer(availableNetworkFactory,
-                new BestWeightAndShortestPathFinder(200), config);
-        GetPathsResult path = pathComputer.getPath(f1);
+            PathComputer pathComputer = new InMemoryPathComputer(availableNetworkFactory,
+                    new BestWeightAndShortestPathFinder(200), config);
+            GetPathsResult path = pathComputer.getPath(f1);
 
-        assertNotNull(path);
-        assertEquals(expectedPathForwardSegmentSize, path.getForward().getSegments().size());
+            assertNotNull(path);
+            assertEquals(expectedPathForwardSegmentSize, path.getForward().getSegments().size());
 
-        Switch srcSwitch2 = getSwitchById("08:01");
-        Switch destSwitch2 = getSwitchById("11:04");
+            Switch srcSwitch2 = getSwitchById("08:01");
+            Switch destSwitch2 = getSwitchById("11:04");
 
-        // THIS ONE SHOULD FAIL
-        Flow f2 = new TestFlowBuilder()
-                .srcSwitch(srcSwitch2)
-                .destSwitch(destSwitch2)
-                .bandwidth(0)
-                .ignoreBandwidth(false)
-                .build();
-
-        thrown.expect(UnroutableFlowException.class);
-
-        pathComputer.getPath(f2);
+            // THIS ONE SHOULD FAIL
+            Flow f2 = new TestFlowBuilder()
+                    .srcSwitch(srcSwitch2)
+                    .destSwitch(destSwitch2)
+                    .bandwidth(0)
+                    .ignoreBandwidth(false)
+                    .build();
+            pathComputer.getPath(f2);
+        });
     }
 
     /**
@@ -264,8 +253,8 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
         GetPathsResult result = pathComputer.getPath(flow, oldFlow.getPathIds(), false);
 
-        assertThat(result.getForward().getSegments(), Matchers.hasSize(2));
-        assertThat(result.getReverse().getSegments(), Matchers.hasSize(2));
+        MatcherAssert.assertThat(result.getForward().getSegments(), Matchers.hasSize(2));
+        MatcherAssert.assertThat(result.getReverse().getSegments(), Matchers.hasSize(2));
     }
 
     /**
@@ -378,7 +367,7 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
         haFlow.setPathComputationStrategy(strategy);
         GetHaPathsResult haPath = pathComputerFactory.getPathComputer().getHaPath(haFlow, false);
 
-        assertFalse(haPath.isBackUpPathComputationWayUsed());
+        Assertions.assertFalse(haPath.isBackUpPathComputationWayUsed());
         assertHaPath(haPath.getForward(), SWITCH_ID_Z, SWITCH_ID_H, true, SWITCH_ID_C, SWITCH_ID_D);
         assertHaPath(haPath.getReverse(), SWITCH_ID_Z, SWITCH_ID_H, false, SWITCH_ID_C, SWITCH_ID_D);
 
@@ -407,7 +396,7 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
         haFlow.setPathComputationStrategy(strategy);
         GetHaPathsResult haPath = pathComputerFactory.getPathComputer().getHaPath(haFlow, false);
 
-        assertFalse(haPath.isBackUpPathComputationWayUsed());
+        Assertions.assertFalse(haPath.isBackUpPathComputationWayUsed());
         assertHaPath(haPath.getForward(), SWITCH_ID_H, SWITCH_ID_B, true, SWITCH_ID_H);
         assertHaPath(haPath.getReverse(), SWITCH_ID_H, SWITCH_ID_B, false, SWITCH_ID_H);
 
@@ -436,7 +425,7 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
         haFlow.setPathComputationStrategy(strategy);
         GetHaPathsResult haPath = pathComputerFactory.getPathComputer().getHaPath(haFlow, false);
 
-        assertFalse(haPath.isBackUpPathComputationWayUsed());
+        Assertions.assertFalse(haPath.isBackUpPathComputationWayUsed());
         assertHaPath(haPath.getForward(), SWITCH_ID_F, SWITCH_ID_B, true, SWITCH_ID_F, SWITCH_ID_H);
         assertHaPath(haPath.getReverse(), SWITCH_ID_F, SWITCH_ID_B, false, SWITCH_ID_F, SWITCH_ID_H);
 
@@ -520,9 +509,9 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
         for (int i = 1; i < paths.size(); i++) {
             Path prev = paths.get(i - 1);
             Path cur = paths.get(i);
-            assertTrue(prev.getMinAvailableBandwidth() >= cur.getMinAvailableBandwidth());
+            Assertions.assertTrue(prev.getMinAvailableBandwidth() >= cur.getMinAvailableBandwidth());
             if (prev.getMinAvailableBandwidth() == cur.getMinAvailableBandwidth()) {
-                assertTrue(prev.getLatency() <= cur.getLatency());
+                Assertions.assertTrue(prev.getLatency() <= cur.getLatency());
             }
         }
     }
@@ -531,9 +520,9 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
         for (int i = 1; i < paths.size(); i++) {
             Path prev = paths.get(i - 1);
             Path cur = paths.get(i);
-            assertTrue(prev.getLatency() <= cur.getLatency());
+            Assertions.assertTrue(prev.getLatency() <= cur.getLatency());
             if (prev.getLatency() == cur.getLatency()) {
-                assertTrue(prev.getMinAvailableBandwidth() >= cur.getMinAvailableBandwidth());
+                Assertions.assertTrue(prev.getMinAvailableBandwidth() >= cur.getMinAvailableBandwidth());
             }
         }
     }
@@ -872,11 +861,11 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
                 .encapsulationType(FlowEncapsulationType.TRANSIT_VLAN)
                 .pathComputationStrategy(pathComputationStrategy)
                 .build();
-        Assert.assertNotEquals(flowA.getFlowId(), flowB.getFlowId());
-        Assert.assertEquals(flowA.getAffinityGroupId(), flowB.getAffinityGroupId());
+        Assertions.assertNotEquals(flowA.getFlowId(), flowB.getFlowId());
+        assertEquals(flowA.getAffinityGroupId(), flowB.getAffinityGroupId());
 
         flowRepository.findById(TEST_FLOW_ID)
-                .ifPresent(entry -> Assert.assertEquals(diversityGroup, entry.getDiverseGroupId()));
+                .ifPresent(entry -> assertEquals(diversityGroup, entry.getDiverseGroupId()));
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
         GetPathsResult affinityPath = pathComputer.getPath(flowB);
@@ -1083,8 +1072,8 @@ public class InMemoryPathComputerBaseTest extends InMemoryGraphBasedTest {
         List<LinkedList<SwitchId>> result =
                 pathComputer.convertFlowPathsToSwitchLists(SWITCH_1, flowPathA, flowPathB);
         assertEquals(2, result.size());
-        assertArrayEquals(switchIdsA, result.get(0).stream().mapToInt(id -> (int) id.toLong()).toArray());
-        assertArrayEquals(switchIdsB, result.get(1).stream().mapToInt(id -> (int) id.toLong()).toArray());
+        Assertions.assertArrayEquals(switchIdsA, result.get(0).stream().mapToInt(id -> (int) id.toLong()).toArray());
+        Assertions.assertArrayEquals(switchIdsB, result.get(1).stream().mapToInt(id -> (int) id.toLong()).toArray());
     }
 
     @Test

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/LatencyPathComputationStrategyBaseTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/LatencyPathComputationStrategyBaseTest.java
@@ -18,12 +18,11 @@ package org.openkilda.pce.impl;
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowEncapsulationType;
@@ -43,8 +42,7 @@ import org.openkilda.pce.finder.FailReasonType;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -70,7 +68,7 @@ public class LatencyPathComputationStrategyBaseTest extends InMemoryPathComputer
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
         GetPathsResult path = pathComputer.getPath(flow);
         assertNotNull(path);
-        assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
+        MatcherAssert.assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // should choose path B because it has lower latency
         assertEquals(new SwitchId("00:02"), path.getForward().getSegments().get(0).getDestSwitchId());
     }
@@ -93,7 +91,7 @@ public class LatencyPathComputationStrategyBaseTest extends InMemoryPathComputer
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
         GetPathsResult path = pathComputer.getPath(flow);
         assertNotNull(path);
-        assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
+        MatcherAssert.assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // should have switch C as first hop since B is inactive
         assertEquals(new SwitchId("00:03"), path.getForward().getSegments().get(0).getDestSwitchId());
     }
@@ -120,7 +118,7 @@ public class LatencyPathComputationStrategyBaseTest extends InMemoryPathComputer
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
         GetPathsResult path = pathComputer.getPath(flow);
         assertNotNull(path);
-        assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
+        MatcherAssert.assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // should now have C as first hop since A - B link is under maintenance
         assertEquals(new SwitchId("00:03"), path.getForward().getSegments().get(0).getDestSwitchId());
     }
@@ -147,7 +145,7 @@ public class LatencyPathComputationStrategyBaseTest extends InMemoryPathComputer
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
         GetPathsResult path = pathComputer.getPath(flow);
         assertNotNull(path);
-        assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
+        MatcherAssert.assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // should now have C as first hop since A - B link is unstable
         assertEquals(new SwitchId("00:03"), path.getForward().getSegments().get(0).getDestSwitchId());
     }
@@ -172,7 +170,7 @@ public class LatencyPathComputationStrategyBaseTest extends InMemoryPathComputer
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
         GetPathsResult path = pathComputer.getPath(flow);
         assertNotNull(path);
-        assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
+        MatcherAssert.assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // it should now have C as first hop since A - B segment has high latency
         assertEquals(new SwitchId("00:03"), path.getForward().getSegments().get(0).getDestSwitchId());
     }
@@ -198,29 +196,30 @@ public class LatencyPathComputationStrategyBaseTest extends InMemoryPathComputer
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
         GetPathsResult path = pathComputer.getPath(flow);
         assertNotNull(path);
-        assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
+        MatcherAssert.assertThat(path.getForward().getSegments(), Matchers.hasSize(2));
         // should choose B because default latency (500_000_000) is less then A-C latency (1_000_000_000)
         assertEquals(new SwitchId("00:02"), path.getForward().getSegments().get(0).getDestSwitchId());
     }
 
     @Test
     public void shouldFailToFindOverDiamondWithNoActiveRoutes() throws UnroutableFlowException, RecoverableException {
-        createDiamond(IslStatus.INACTIVE, IslStatus.INACTIVE, 100L, 1000L);
+        assertThrows(UnroutableFlowException.class, () -> {
+            createDiamond(IslStatus.INACTIVE, IslStatus.INACTIVE, 100L, 1000L);
 
-        Switch srcSwitch = getSwitchById("00:01");
-        Switch destSwitch = getSwitchById("00:04");
+            Switch srcSwitch = getSwitchById("00:01");
+            Switch destSwitch = getSwitchById("00:04");
 
-        Flow flow = new TestFlowBuilder()
-                .srcSwitch(srcSwitch)
-                .destSwitch(destSwitch)
-                .bandwidth(100)
-                .pathComputationStrategy(PathComputationStrategy.LATENCY)
-                .build();
+            Flow flow = new TestFlowBuilder()
+                    .srcSwitch(srcSwitch)
+                    .destSwitch(destSwitch)
+                    .bandwidth(100)
+                    .pathComputationStrategy(PathComputationStrategy.LATENCY)
+                    .build();
 
-        thrown.expect(UnroutableFlowException.class);
+            PathComputer pathComputer = pathComputerFactory.getPathComputer();
+            pathComputer.getPath(flow);
+        });
 
-        PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        pathComputer.getPath(flow);
     }
 
     @Test
@@ -240,7 +239,7 @@ public class LatencyPathComputationStrategyBaseTest extends InMemoryPathComputer
                 .build();
 
         PathComputer pathComputer = pathComputerFactory.getPathComputer();
-        Exception exception = Assertions.assertThrows(UnroutableFlowException.class, () -> {
+        Exception exception = assertThrows(UnroutableFlowException.class, () -> {
             pathComputer.getPath(flow);
         });
         MatcherAssert.assertThat(exception.getMessage(), containsString(FailReasonType.NO_CONNECTION.toString()));
@@ -353,14 +352,16 @@ public class LatencyPathComputationStrategyBaseTest extends InMemoryPathComputer
 
         //then: system returns a path built with backUpPathComputationWayUsed flag
         assertTrue(pathsResult.isBackUpPathComputationWayUsed());
-        assertThat(pathsResult.getForward().getSegments().get(1).getSrcSwitchId(), equalTo(new SwitchId("00:03")));
-        assertThat(pathsResult.getReverse().getSegments().get(1).getSrcSwitchId(), equalTo(new SwitchId("00:03")));
+        MatcherAssert.assertThat(pathsResult.getForward().getSegments().get(1).getSrcSwitchId(),
+                equalTo(new SwitchId("00:03")));
+        MatcherAssert.assertThat(pathsResult.getReverse().getSegments().get(1).getSrcSwitchId(),
+                equalTo(new SwitchId("00:03")));
     }
 
     @Test
     public void shouldReturnEmptyPathWhenPathHasLatencyGreaterThanMaxLatencyTier2()
             throws RecoverableException, UnroutableFlowException {
-        createLinear(100,  "00:", 1, TimeUnit.MILLISECONDS.toNanos(100));
+        createLinear(100, "00:", 1, TimeUnit.MILLISECONDS.toNanos(100));
 
         //when: request a flow with LATENCY strategy and 'max-latency-tier-2' is lower than found path
         Flow flow = Flow.builder()

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/MaxLatencyPathComputationStrategyBaseTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/impl/MaxLatencyPathComputationStrategyBaseTest.java
@@ -22,11 +22,11 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -47,7 +47,8 @@ import org.openkilda.pce.exception.UnroutableFlowException;
 import org.openkilda.pce.finder.BestWeightAndShortestPathFinder;
 import org.openkilda.pce.model.Node;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -56,7 +57,8 @@ import java.util.concurrent.TimeUnit;
 
 public class MaxLatencyPathComputationStrategyBaseTest extends InMemoryPathComputerBaseTest {
 
-    @Test(timeout = 10_000)
+    @Test
+    @Timeout(10)
     public void shouldFindPathInHugeNetworkWithAffinity() throws UnroutableFlowException, RecoverableException {
         SwitchId srcSwitchId = new SwitchId(1);
         SwitchId dstSwitchId = new SwitchId(49);

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/model/PathWeightTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/model/PathWeightTest.java
@@ -15,12 +15,12 @@
 
 package org.openkilda.pce.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.pce.model.PathWeight.Penalty;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.EnumMap;
 

--- a/src-java/kilda-persistence-tinkerpop/build.gradle
+++ b/src-java/kilda-persistence-tinkerpop/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     annotationProcessor 'org.mapstruct:mapstruct-processor'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation('org.apache.tinkerpop:tinkergraph-gremlin:3.3.11') {
         exclude group: 'org.codehaus.groovy'
     }
@@ -66,4 +66,8 @@ task testJar(type: Jar) {
 
 artifacts {
     testArtifacts testJar
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/kilda-persistence-tinkerpop/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/kilda-persistence-tinkerpop/src/checkstyle/checkstyle-suppressions.xml
@@ -5,6 +5,7 @@
 
 <suppressions>
     <suppress files="src/main/.*\.java$" checks="JavadocMethod"/>
+    <suppress files="src/test/.*Test\.java$" checks="JavadocMethod" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="VariableDeclarationUsageDistance"/>
 </suppressions>
 

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/TimeModifyPropertyOnFramesTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/TimeModifyPropertyOnFramesTest.java
@@ -15,9 +15,6 @@
 
 package org.openkilda.persistence.ferma.frames;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-
 import org.openkilda.model.IpSocketAddress;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchId;
@@ -28,8 +25,9 @@ import org.openkilda.persistence.repositories.SwitchRepository;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 import net.jodah.failsafe.function.CheckedSupplier;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -37,7 +35,7 @@ import java.time.Instant;
 public class TimeModifyPropertyOnFramesTest extends InMemoryGraphBasedTest {
     private SwitchRepository switchRepository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         switchRepository = persistenceManager.getRepositoryFactory().createSwitchRepository();
     }
@@ -53,7 +51,7 @@ public class TimeModifyPropertyOnFramesTest extends InMemoryGraphBasedTest {
 
         Instant timeModifyAfter = switchRepository.findById(new SwitchId(1)).get().getTimeModify();
 
-        assertNotEquals(timeModifyBefore, timeModifyAfter);
+        Assertions.assertNotEquals(timeModifyBefore, timeModifyAfter);
     }
 
     @Test
@@ -67,7 +65,7 @@ public class TimeModifyPropertyOnFramesTest extends InMemoryGraphBasedTest {
 
         Instant timeModifyAfter = switchRepository.findById(new SwitchId(1)).get().getTimeModify();
 
-        assertNotEquals(timeModifyBefore, timeModifyAfter);
+        Assertions.assertNotEquals(timeModifyBefore, timeModifyAfter);
     }
 
     @Test
@@ -80,7 +78,7 @@ public class TimeModifyPropertyOnFramesTest extends InMemoryGraphBasedTest {
 
         Instant timeModifyAfter = switchRepository.findById(new SwitchId(1)).get().getTimeModify();
 
-        assertNotEquals(timeModifyBefore, timeModifyAfter);
+        Assertions.assertNotEquals(timeModifyBefore, timeModifyAfter);
     }
 
     @Test
@@ -95,7 +93,7 @@ public class TimeModifyPropertyOnFramesTest extends InMemoryGraphBasedTest {
 
         Instant timeModifyAfter = switchRepository.findById(new SwitchId(1)).get().getTimeModify();
 
-        assertEquals(timeModifyBefore, timeModifyAfter);
+        Assertions.assertEquals(timeModifyBefore, timeModifyAfter);
     }
 
     @Test
@@ -110,7 +108,7 @@ public class TimeModifyPropertyOnFramesTest extends InMemoryGraphBasedTest {
 
         Instant timeModifyAfter = switchRepository.findById(new SwitchId(1)).get().getTimeModify();
 
-        assertEquals(timeModifyBefore, timeModifyAfter);
+        Assertions.assertEquals(timeModifyBefore, timeModifyAfter);
     }
 
 
@@ -126,12 +124,12 @@ public class TimeModifyPropertyOnFramesTest extends InMemoryGraphBasedTest {
 
         Instant timeModifyAfter = switchRepository.findById(new SwitchId(1)).get().getTimeModify();
 
-        assertEquals(timeModifyBefore, timeModifyAfter);
+        Assertions.assertEquals(timeModifyBefore, timeModifyAfter);
     }
 
     private void waitUntilNowIsAfter(Instant before) {
         Failsafe.with(new RetryPolicy<Instant>().withDelay(Duration.ofMillis(1))
-                .handleResultIf(result -> !before.isBefore(result)))
+                        .handleResultIf(result -> !before.isBefore(result)))
                 .get((CheckedSupplier<Instant>) Instant::now);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/ExclusionCookieConverterTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/ExclusionCookieConverterTest.java
@@ -15,12 +15,11 @@
 
 package org.openkilda.persistence.ferma.frames.converters;
 
-import static org.junit.Assert.assertEquals;
-
 import org.openkilda.model.cookie.Cookie;
 import org.openkilda.model.cookie.ExclusionCookie;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ExclusionCookieConverterTest {
     @Test
@@ -32,7 +31,7 @@ public class ExclusionCookieConverterTest {
         Long graphObject = new ExclusionCookieConverter().toGraphProperty(cookie);
 
         // then
-        assertEquals(cookie.getValue(), (long) graphObject);
+        Assertions.assertEquals(cookie.getValue(), (long) graphObject);
     }
 
     @Test
@@ -44,6 +43,6 @@ public class ExclusionCookieConverterTest {
         Cookie actualEntity = new ExclusionCookieConverter().toEntityAttribute(cookie.getValue());
 
         // then
-        assertEquals(cookie, actualEntity);
+        Assertions.assertEquals(cookie, actualEntity);
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/FlowEncapsulationTypeConverterTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/FlowEncapsulationTypeConverterTest.java
@@ -15,22 +15,21 @@
 
 package org.openkilda.persistence.ferma.frames.converters;
 
-import static org.junit.Assert.assertEquals;
-
 import org.openkilda.model.FlowEncapsulationType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class FlowEncapsulationTypeConverterTest {
     @Test
     public void shouldConvertToGraphProperty() {
-        assertEquals("TRANSIT_VLAN",
+        Assertions.assertEquals("TRANSIT_VLAN",
                 FlowEncapsulationTypeConverter.INSTANCE.toGraphProperty(FlowEncapsulationType.TRANSIT_VLAN));
     }
 
     @Test
     public void shouldConvertToEntity() {
-        assertEquals(FlowEncapsulationType.TRANSIT_VLAN,
+        Assertions.assertEquals(FlowEncapsulationType.TRANSIT_VLAN,
                 FlowEncapsulationTypeConverter.INSTANCE.toEntityAttribute("TRANSIT_VLAN"));
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/FlowPathStatusConverterTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/FlowPathStatusConverterTest.java
@@ -15,11 +15,13 @@
 
 package org.openkilda.persistence.ferma.frames.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.model.FlowPathStatus;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
 
 public class FlowPathStatusConverterTest {
     @Test
@@ -35,8 +37,9 @@ public class FlowPathStatusConverterTest {
     public void shouldConvertToEntity() {
         FlowPathStatusConverter converter = new FlowPathStatusConverter();
 
-        assertEquals(FlowPathStatus.ACTIVE, converter.toEntityAttribute("ACTIVE"));
-        assertEquals(FlowPathStatus.ACTIVE, converter.toEntityAttribute("active"));
+        for (String s : Arrays.asList("ACTIVE", "active")) {
+            assertEquals(FlowPathStatus.ACTIVE, converter.toEntityAttribute(s));
+        }
         assertEquals(FlowPathStatus.IN_PROGRESS, converter.toEntityAttribute("In_Progress"));
     }
 }

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/FlowSegmentCookieConverterTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/FlowSegmentCookieConverterTest.java
@@ -15,11 +15,11 @@
 
 package org.openkilda.persistence.ferma.frames.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.model.cookie.FlowSegmentCookie;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FlowSegmentCookieConverterTest {
     @Test

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/FlowStatusConverterTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/FlowStatusConverterTest.java
@@ -15,11 +15,11 @@
 
 package org.openkilda.persistence.ferma.frames.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.model.FlowStatus;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FlowStatusConverterTest {
     @Test

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/IslStatusConverterTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/IslStatusConverterTest.java
@@ -15,11 +15,11 @@
 
 package org.openkilda.persistence.ferma.frames.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.model.IslStatus;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IslStatusConverterTest {
     @Test

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/MeterIdConverterTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/MeterIdConverterTest.java
@@ -15,11 +15,11 @@
 
 package org.openkilda.persistence.ferma.frames.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.model.MeterId;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MeterIdConverterTest {
     @Test

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/PathIdConverterTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/PathIdConverterTest.java
@@ -15,11 +15,11 @@
 
 package org.openkilda.persistence.ferma.frames.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.model.PathId;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PathIdConverterTest {
     @Test

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/SwitchIdConverterTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/SwitchIdConverterTest.java
@@ -15,11 +15,11 @@
 
 package org.openkilda.persistence.ferma.frames.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.model.SwitchId;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SwitchIdConverterTest {
     @Test

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/SwitchStatusConverterTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/frames/converters/SwitchStatusConverterTest.java
@@ -15,11 +15,11 @@
 
 package org.openkilda.persistence.ferma.frames.converters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.model.SwitchStatus;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SwitchStatusConverterTest {
     @Test

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaApplicationRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaApplicationRepositoryTest.java
@@ -15,8 +15,9 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.ApplicationRule;
 import org.openkilda.model.FlowPathDirection;
@@ -25,9 +26,9 @@ import org.openkilda.model.cookie.ExclusionCookie;
 import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.ApplicationRepository;
 
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 
@@ -37,12 +38,12 @@ public class FermaApplicationRepositoryTest extends InMemoryGraphBasedTest {
 
     private static ApplicationRepository applicationRepository;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         applicationRepository = repositoryFactory.createApplicationRepository();
     }
 
-    @Before
+    @BeforeEach
     public void init() {
         applicationRepository.add(buildRuleA());
         applicationRepository.add(buildRuleB());

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaBfdSessionRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaBfdSessionRepositoryTest.java
@@ -15,7 +15,8 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.openkilda.model.BfdSession;
 import org.openkilda.model.SwitchId;
@@ -23,9 +24,10 @@ import org.openkilda.persistence.exceptions.ConstraintViolationException;
 import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.BfdSessionRepository;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
@@ -37,7 +39,7 @@ public class FermaBfdSessionRepositoryTest extends InMemoryGraphBasedTest {
 
     BfdSessionRepository repository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         repository = repositoryFactory.createBfdSessionRepository();
     }
@@ -69,13 +71,14 @@ public class FermaBfdSessionRepositoryTest extends InMemoryGraphBasedTest {
         assertEquals(0, repository.findAll().size());
     }
 
-    @Ignore("Need to fix: in-memory persistence doesn't impose constraints")
-    @Test(expected = ConstraintViolationException.class)
+    @Disabled("Need to fix: in-memory persistence doesn't impose constraints")
+    @Test
     public void discriminatorConflict() {
-        createBfdSession();
-
-        BfdSession bfdSession2 = createBfdSession();
-        bfdSession2.setPort(TEST_PORT + 1);
+        Assertions.assertThrows(ConstraintViolationException.class, () -> {
+            createBfdSession();
+            BfdSession bfdSession2 = createBfdSession();
+            bfdSession2.setPort(TEST_PORT + 1);
+        });
     }
 
     private int getDiscriminator(SwitchId switchId, int port, int randomDiscriminator)
@@ -91,17 +94,19 @@ public class FermaBfdSessionRepositoryTest extends InMemoryGraphBasedTest {
         return bfdSession.getDiscriminator();
     }
 
-    @Ignore("Need to fix: in-memory persistence doesn't impose constraints")
-    @Test(expected = ConstraintViolationException.class)
+    @Disabled("Need to fix: in-memory persistence doesn't impose constraints")
+    @Test
     public void createUseCaseTest() {
+        assertThrows(ConstraintViolationException.class, () -> {
 
-        assertEquals(TEST_DISCRIMINATOR, getDiscriminator(TEST_SWITCH_ID, TEST_PORT, TEST_DISCRIMINATOR));
+            assertEquals(TEST_DISCRIMINATOR, getDiscriminator(TEST_SWITCH_ID, TEST_PORT, TEST_DISCRIMINATOR));
 
-        assertEquals(TEST_DISCRIMINATOR, getDiscriminator(TEST_SWITCH_ID, TEST_PORT, TEST_DISCRIMINATOR));
+            assertEquals(TEST_DISCRIMINATOR, getDiscriminator(TEST_SWITCH_ID, TEST_PORT, TEST_DISCRIMINATOR));
 
-        assertEquals(1, repository.findAll().size());
+            assertEquals(1, repository.findAll().size());
 
-        assertEquals(TEST_DISCRIMINATOR, getDiscriminator(TEST_SWITCH_ID, TEST_PORT + 1, TEST_DISCRIMINATOR));
+            assertEquals(TEST_DISCRIMINATOR, getDiscriminator(TEST_SWITCH_ID, TEST_PORT + 1, TEST_DISCRIMINATOR));
+        });
     }
 
     private void freeDiscriminator(SwitchId switchId, int port) {

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaFlowCookieRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaFlowCookieRepositoryTest.java
@@ -15,14 +15,15 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.model.FlowCookie;
 import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.FlowCookieRepository;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -35,7 +36,7 @@ public class FermaFlowCookieRepositoryTest extends InMemoryGraphBasedTest {
 
     FlowCookieRepository flowCookieRepository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         flowCookieRepository = repositoryFactory.createFlowCookieRepository();
     }

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaFlowEventRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaFlowEventRepositoryTest.java
@@ -15,8 +15,8 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.history.FlowEvent;
 import org.openkilda.model.history.FlowEventAction;
@@ -25,8 +25,8 @@ import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.history.FlowEventActionRepository;
 import org.openkilda.persistence.repositories.history.FlowEventRepository;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -54,7 +54,7 @@ public class FermaFlowEventRepositoryTest extends InMemoryGraphBasedTest {
     private static FlowEventRepository flowEventRepository;
     private static FlowEventActionRepository flowEventActionRepository;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         flowEventRepository = repositoryFactory.createFlowEventRepository();
         flowEventActionRepository = repositoryFactory.createFlowEventActionRepository();

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaFlowMeterRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaFlowMeterRepositoryTest.java
@@ -15,8 +15,9 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.openkilda.model.FlowMeter;
 import org.openkilda.model.MeterId;
@@ -26,9 +27,9 @@ import org.openkilda.persistence.exceptions.PersistenceException;
 import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.FlowMeterRepository;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -43,7 +44,7 @@ public class FermaFlowMeterRepositoryTest extends InMemoryGraphBasedTest {
 
     Switch theSwitch;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         flowMeterRepository = repositoryFactory.createFlowMeterRepository();
 
@@ -61,12 +62,15 @@ public class FermaFlowMeterRepositoryTest extends InMemoryGraphBasedTest {
         assertEquals(TEST_FLOW_ID, foundMeter.getFlowId());
     }
 
-    @Ignore("InMemoryGraph doesn't enforce constraint")
-    @Test(expected = PersistenceException.class)
+    @Disabled("InMemoryGraph doesn't enforce constraint")
+    @Test
     public void shouldNotGetMoreThanOneMetersForPath() {
-        createFlowMeter(1, new PathId(TEST_PATH_ID));
-        createFlowMeter(2, new PathId(TEST_PATH_ID));
-        flowMeterRepository.findByPathId(new PathId(TEST_PATH_ID));
+        assertThrows(PersistenceException.class, () -> {
+
+            createFlowMeter(1, new PathId(TEST_PATH_ID));
+            createFlowMeter(2, new PathId(TEST_PATH_ID));
+            flowMeterRepository.findByPathId(new PathId(TEST_PATH_ID));
+        });
     }
 
     @Test

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaFlowMirrorPathRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaFlowMirrorPathRepositoryTest.java
@@ -15,9 +15,9 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.model.FlowMirrorPath;
 import org.openkilda.model.FlowMirrorPoints;
@@ -36,8 +36,8 @@ import org.openkilda.persistence.repositories.FlowMirrorPointsRepository;
 import org.openkilda.persistence.repositories.MirrorGroupRepository;
 import org.openkilda.persistence.repositories.SwitchRepository;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -65,7 +65,7 @@ public class FermaFlowMirrorPathRepositoryTest extends InMemoryGraphBasedTest {
     FlowMirrorPoints flowMirrorPoints;
     MirrorGroup mirrorGroup;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         flowMirrorPointsRepository = repositoryFactory.createFlowMirrorPointsRepository();
         flowMirrorPathRepository = repositoryFactory.createFlowMirrorPathRepository();

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaFlowMirrorPointsRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaFlowMirrorPointsRepositoryTest.java
@@ -15,9 +15,9 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.model.FlowMirrorPoints;
 import org.openkilda.model.FlowPath;
@@ -34,8 +34,8 @@ import org.openkilda.persistence.repositories.FlowPathRepository;
 import org.openkilda.persistence.repositories.MirrorGroupRepository;
 import org.openkilda.persistence.repositories.SwitchRepository;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 
@@ -57,7 +57,7 @@ public class FermaFlowMirrorPointsRepositoryTest extends InMemoryGraphBasedTest 
     Switch switchB;
     MirrorGroup mirrorGroup;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         flowMirrorPointsRepository = repositoryFactory.createFlowMirrorPointsRepository();
         mirrorGroupRepository = repositoryFactory.createMirrorGroupRepository();

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaFlowPathRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaFlowPathRepositoryTest.java
@@ -17,12 +17,12 @@ package org.openkilda.persistence.ferma.repositories;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openkilda.persistence.ferma.repositories.FermaModelUtils.buildHaFlow;
 import static org.openkilda.persistence.ferma.repositories.FermaModelUtils.buildHaFlowPath;
 import static org.openkilda.persistence.ferma.repositories.FermaModelUtils.buildHaSubFlow;
@@ -57,8 +57,8 @@ import org.openkilda.persistence.repositories.YFlowRepository;
 
 import com.google.common.collect.Sets;
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -101,7 +101,7 @@ public class FermaFlowPathRepositoryTest extends InMemoryGraphBasedTest {
     Switch switchC;
     Flow flow;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         flowRepository = repositoryFactory.createFlowRepository();
         flowPathRepository = repositoryFactory.createFlowPathRepository();
@@ -460,7 +460,7 @@ public class FermaFlowPathRepositoryTest extends InMemoryGraphBasedTest {
         assertTrue(pathIds.contains(flowA.getForwardPathId()));
         assertTrue(pathIds.contains(flowA.getReversePathId()));
     }
-    
+
     @Test
     public void findPathIdsByFlowDiverseGroupIdTest() {
         Flow flowA = createFlow(TEST_FLOW_ID_1, switchA, switchB, GROUP_1, null);

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaFlowRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaFlowRepositoryTest.java
@@ -17,11 +17,11 @@ package org.openkilda.persistence.ferma.repositories;
 
 import static com.google.common.collect.Sets.newHashSet;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowEncapsulationType;
@@ -44,8 +44,8 @@ import org.openkilda.persistence.repositories.SwitchRepository;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -86,7 +86,7 @@ public class FermaFlowRepositoryTest extends InMemoryGraphBasedTest {
     private Switch switchB;
     private Switch switchC;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         flowRepository = repositoryFactory.createFlowRepository();
         flowPathRepository = repositoryFactory.createFlowPathRepository();
@@ -110,13 +110,13 @@ public class FermaFlowRepositoryTest extends InMemoryGraphBasedTest {
         Map<Integer, Collection<Flow>> result = flowRepository.findSwitchFlowsByPort(switchA.getSwitchId(), null);
 
         assertNotNull(result);
-        assertTrue("The map must contain a key for the port", result.containsKey(PORT_1));
-        assertNotNull("The map must contain a non-null value for the test port", result.get(PORT_1));
-        assertEquals("The map must contain exactly two keys", 2, result.size());
-        assertEquals("There must be exactly 4 flows for PORT_1", 4, result.get(PORT_1).size());
-        assertTrue("There must be exactly 4 flows for PORT_1",
-                result.get(PORT_1).stream().map(Flow::getFlowId).collect(Collectors.toList())
-                .containsAll(Arrays.asList(TEST_FLOW_ID, TEST_FLOW_ID_2, TEST_FLOW_ID_3, TEST_FLOW_ID_5)));
+        assertTrue(result.containsKey(PORT_1), "The map must contain a key for the port");
+        assertNotNull(result.get(PORT_1), "The map must contain a non-null value for the test port");
+        assertEquals(2, result.size(), "The map must contain exactly two keys");
+        assertEquals(4, result.get(PORT_1).size(), "There must be exactly 4 flows for PORT_1");
+        assertTrue(result.get(PORT_1).stream().map(Flow::getFlowId).collect(Collectors.toList())
+                        .containsAll(Arrays.asList(TEST_FLOW_ID, TEST_FLOW_ID_2, TEST_FLOW_ID_3, TEST_FLOW_ID_5)),
+                "There must be exactly 4 flows for PORT_1");
     }
 
     @Test
@@ -130,14 +130,14 @@ public class FermaFlowRepositoryTest extends InMemoryGraphBasedTest {
                 Collections.singletonList(PORT_1));
 
         assertNotNull(result);
-        assertTrue("The map must contain a key for the port", result.containsKey(PORT_1));
-        assertFalse("The map must not contain a key for the filtered out port", result.containsKey(PORT_2));
-        assertNotNull("The map must contain a non-null value for the test port", result.get(PORT_1));
-        assertEquals("The map must contain exactly one key", 1, result.size());
-        assertEquals("There must be exactly 3 flows for PORT_1", 3, result.get(PORT_1).size());
-        assertTrue("There must be exactly 3 flows for PORT_1",
-                result.get(PORT_1).stream().map(Flow::getFlowId).collect(Collectors.toList())
-                        .containsAll(Arrays.asList(TEST_FLOW_ID, TEST_FLOW_ID_2, TEST_FLOW_ID_3)));
+        assertTrue(result.containsKey(PORT_1), "The map must contain a key for the port");
+        assertFalse(result.containsKey(PORT_2), "The map must not contain a key for the filtered out port");
+        assertNotNull(result.get(PORT_1), "The map must contain a non-null value for the test port");
+        assertEquals(1, result.size(), "The map must contain exactly one key");
+        assertEquals(3, result.get(PORT_1).size(), "There must be exactly 3 flows for PORT_1");
+        assertTrue(result.get(PORT_1).stream().map(Flow::getFlowId).collect(Collectors.toList())
+                        .containsAll(Arrays.asList(TEST_FLOW_ID, TEST_FLOW_ID_2, TEST_FLOW_ID_3)),
+                "There must be exactly 3 flows for PORT_1");
     }
 
     @Test

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaHaFlowPathRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaHaFlowPathRepositoryTest.java
@@ -15,9 +15,9 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openkilda.persistence.ferma.repositories.FermaModelUtils.buildHaFlowPath;
 import static org.openkilda.persistence.ferma.repositories.FermaModelUtils.buildHaSubFlow;
 import static org.openkilda.persistence.ferma.repositories.FermaModelUtils.buildPath;
@@ -45,8 +45,8 @@ import org.openkilda.persistence.repositories.SwitchRepository;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.List;
@@ -78,7 +78,7 @@ public class FermaHaFlowPathRepositoryTest extends InMemoryGraphBasedTest {
     private HaSubFlow subFlow1;
     private HaSubFlow subFlow2;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         haFlowRepository = repositoryFactory.createHaFlowRepository();
         haFlowPathRepository = repositoryFactory.createHaFlowPathRepository();

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaHaFlowRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaHaFlowRepositoryTest.java
@@ -18,12 +18,12 @@ package org.openkilda.persistence.ferma.repositories;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
 import static java.util.function.Function.identity;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openkilda.persistence.ferma.repositories.FermaModelUtils.buildHaFlow;
 import static org.openkilda.persistence.ferma.repositories.FermaModelUtils.buildHaFlowPath;
 import static org.openkilda.persistence.ferma.repositories.FermaModelUtils.buildHaSubFlow;
@@ -51,8 +51,8 @@ import org.openkilda.persistence.repositories.PathSegmentRepository;
 import org.openkilda.persistence.repositories.SwitchRepository;
 
 import com.google.common.collect.Lists;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -97,7 +97,7 @@ public class FermaHaFlowRepositoryTest extends InMemoryGraphBasedTest {
     private HaSubFlow subFlow2;
     private HaSubFlow subFlow3;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         haFlowRepository = repositoryFactory.createHaFlowRepository();
         haFlowPathRepository = repositoryFactory.createHaFlowPathRepository();

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaHaSubFlowRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaHaSubFlowRepositoryTest.java
@@ -15,9 +15,9 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openkilda.persistence.ferma.repositories.FermaModelUtils.buildHaSubFlow;
 
 import org.openkilda.model.FlowStatus;
@@ -30,8 +30,8 @@ import org.openkilda.persistence.repositories.HaFlowRepository;
 import org.openkilda.persistence.repositories.HaSubFlowRepository;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Map;
@@ -47,7 +47,7 @@ public class FermaHaSubFlowRepositoryTest extends InMemoryGraphBasedTest {
     Switch switch3;
     private HaFlow haFlow;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         haSubFlowRepository = repositoryFactory.createHaSubFlowRepository();
         switch1 = createTestSwitch(SWITCH_ID_1.getId());

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaKildaConfigurationRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaKildaConfigurationRepositoryTest.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.KildaConfiguration;
@@ -23,13 +23,13 @@ import org.openkilda.model.PathComputationStrategy;
 import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.KildaConfigurationRepository;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class FermaKildaConfigurationRepositoryTest extends InMemoryGraphBasedTest {
     static KildaConfigurationRepository kildaConfigurationRepository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         kildaConfigurationRepository = repositoryFactory.createKildaConfigurationRepository();
     }

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaKildaFeatureTogglesRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaKildaFeatureTogglesRepositoryTest.java
@@ -15,20 +15,20 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.KildaFeatureToggles;
 import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.KildaFeatureTogglesRepository;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class FermaKildaFeatureTogglesRepositoryTest extends InMemoryGraphBasedTest {
     KildaFeatureTogglesRepository featureTogglesRepository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         featureTogglesRepository = repositoryFactory.createFeatureTogglesRepository();
     }

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaLagLogicalPortTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaLagLogicalPortTest.java
@@ -15,9 +15,9 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.LagLogicalPort;
 import org.openkilda.model.PhysicalPort;
@@ -28,8 +28,8 @@ import org.openkilda.persistence.repositories.PhysicalPortRepository;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,7 +49,7 @@ public class FermaLagLogicalPortTest extends InMemoryGraphBasedTest {
     LagLogicalPortRepository lagLogicalPortRepository;
     PhysicalPortRepository physicalPortRepository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         lagLogicalPortRepository = repositoryFactory.createLagLogicalPortRepository();
         physicalPortRepository = repositoryFactory.createPhysicalPortRepository();

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaLinkPropsRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaLinkPropsRepositoryTest.java
@@ -15,8 +15,8 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.model.LinkProps;
 import org.openkilda.model.SwitchId;
@@ -25,8 +25,8 @@ import org.openkilda.persistence.repositories.LinkPropsRepository;
 
 import com.google.common.collect.Lists;
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -36,7 +36,7 @@ public class FermaLinkPropsRepositoryTest extends InMemoryGraphBasedTest {
 
     LinkPropsRepository linkPropsRepository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         linkPropsRepository = repositoryFactory.createLinkPropsRepository();
     }

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaMirrorGroupRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaMirrorGroupRepositoryTest.java
@@ -15,8 +15,9 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.GroupId;
 import org.openkilda.model.MirrorDirection;
@@ -28,9 +29,9 @@ import org.openkilda.persistence.exceptions.PersistenceException;
 import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.MirrorGroupRepository;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 
@@ -44,7 +45,7 @@ public class FermaMirrorGroupRepositoryTest extends InMemoryGraphBasedTest {
 
     Switch theSwitch;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         mirrorGroupRepository = repositoryFactory.createMirrorGroupRepository();
 
@@ -62,12 +63,14 @@ public class FermaMirrorGroupRepositoryTest extends InMemoryGraphBasedTest {
         assertEquals(TEST_FLOW_ID, foundMirrorGroup.getFlowId());
     }
 
-    @Ignore("InMemoryGraph doesn't enforce constraint")
-    @Test(expected = PersistenceException.class)
+    @Disabled("InMemoryGraph doesn't enforce constraint")
+    @Test
     public void shouldNotGetMoreThanOneMirrorGroupsForPath() {
-        createMirrorGroup(1, new PathId(TEST_PATH_ID));
-        createMirrorGroup(2, new PathId(TEST_PATH_ID));
-        mirrorGroupRepository.findByPathId(new PathId(TEST_PATH_ID));
+        assertThrows(PersistenceException.class, () -> {
+            createMirrorGroup(1, new PathId(TEST_PATH_ID));
+            createMirrorGroup(2, new PathId(TEST_PATH_ID));
+            mirrorGroupRepository.findByPathId(new PathId(TEST_PATH_ID));
+        });
     }
 
     @Test

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaPathSegmentRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaPathSegmentRepositoryTest.java
@@ -16,9 +16,9 @@
 package org.openkilda.persistence.ferma.repositories;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
 
 import org.openkilda.model.FlowPath;
 import org.openkilda.model.FlowPathStatus;
@@ -29,8 +29,8 @@ import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.FlowPathRepository;
 import org.openkilda.persistence.repositories.PathSegmentRepository;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -40,7 +40,7 @@ public class FermaPathSegmentRepositoryTest extends InMemoryGraphBasedTest {
     PathSegmentRepository pathSegmentRepository;
     FlowPathRepository flowPathRepository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         pathSegmentRepository = repositoryFactory.createPathSegmentRepository();
         flowPathRepository = repositoryFactory.createFlowPathRepository();

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaPhysicalPortTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaPhysicalPortTest.java
@@ -15,9 +15,9 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.LagLogicalPort;
 import org.openkilda.model.PhysicalPort;
@@ -26,9 +26,8 @@ import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.LagLogicalPortRepository;
 import org.openkilda.persistence.repositories.PhysicalPortRepository;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mapstruct.ap.internal.util.Collections;
 
 import java.util.ArrayList;
@@ -52,7 +51,7 @@ public class FermaPhysicalPortTest extends InMemoryGraphBasedTest {
     LagLogicalPortRepository lagLogicalPortRepository;
     PhysicalPortRepository physicalPortRepository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         lagLogicalPortRepository = repositoryFactory.createLagLogicalPortRepository();
         physicalPortRepository = repositoryFactory.createPhysicalPortRepository();
@@ -73,13 +72,13 @@ public class FermaPhysicalPortTest extends InMemoryGraphBasedTest {
         assertEquals(3, ports.size());
         ports.sort(Comparator.comparingInt(PhysicalPort::getPortNumber));
 
-        Assert.assertEquals(PHYSICAL_PORT_NUMBER_1, ports.get(0).getPortNumber());
-        Assert.assertEquals(PHYSICAL_PORT_NUMBER_2, ports.get(1).getPortNumber());
-        Assert.assertEquals(PHYSICAL_PORT_NUMBER_3, ports.get(2).getPortNumber());
+        assertEquals(PHYSICAL_PORT_NUMBER_1, ports.get(0).getPortNumber());
+        assertEquals(PHYSICAL_PORT_NUMBER_2, ports.get(1).getPortNumber());
+        assertEquals(PHYSICAL_PORT_NUMBER_3, ports.get(2).getPortNumber());
 
-        Assert.assertEquals(SWITCH_ID_1, ports.get(0).getSwitchId());
-        Assert.assertEquals(SWITCH_ID_1, ports.get(1).getSwitchId());
-        Assert.assertEquals(SWITCH_ID_2, ports.get(2).getSwitchId());
+        assertEquals(SWITCH_ID_1, ports.get(0).getSwitchId());
+        assertEquals(SWITCH_ID_1, ports.get(1).getSwitchId());
+        assertEquals(SWITCH_ID_2, ports.get(2).getSwitchId());
 
         assertNull(ports.get(0).getLagLogicalPort());
         assertNull(ports.get(1).getLagLogicalPort());

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaPortEventRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaPortEventRepositoryTest.java
@@ -15,16 +15,17 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.SwitchId;
 import org.openkilda.model.history.PortEvent;
 import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.history.PortEventRepository;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -37,7 +38,7 @@ public class FermaPortEventRepositoryTest extends InMemoryGraphBasedTest {
 
     PortEventRepository repository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         repository = repositoryFactory.createPortEventRepository();
     }

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaPortPropertiesRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaPortPropertiesRepositoryTest.java
@@ -15,10 +15,10 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.PortProperties;
 import org.openkilda.model.Switch;
@@ -27,8 +27,8 @@ import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.PortPropertiesRepository;
 import org.openkilda.persistence.repositories.SwitchRepository;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -39,7 +39,7 @@ public class FermaPortPropertiesRepositoryTest extends InMemoryGraphBasedTest {
     SwitchRepository switchRepository;
     PortPropertiesRepository portPropertiesRepository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         switchRepository = repositoryFactory.createSwitchRepository();
         portPropertiesRepository = repositoryFactory.createPortPropertiesRepository();

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaSwitchConnectedDevicesRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaSwitchConnectedDevicesRepositoryTest.java
@@ -16,10 +16,10 @@
 package org.openkilda.persistence.ferma.repositories;
 
 import static com.google.common.collect.Sets.newHashSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openkilda.model.ConnectedDeviceType.ARP;
 import static org.openkilda.model.ConnectedDeviceType.LLDP;
 import static org.openkilda.model.SwitchConnectedDevice.buildUniqueArpIndex;
@@ -35,8 +35,8 @@ import org.openkilda.persistence.repositories.SwitchConnectedDeviceRepository;
 import org.openkilda.persistence.repositories.SwitchRepository;
 
 import com.google.common.collect.Lists;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.Collection;
@@ -78,7 +78,7 @@ public class FermaSwitchConnectedDevicesRepositoryTest extends InMemoryGraphBase
     SwitchRepository switchRepository;
     SwitchConnectedDeviceRepository connectedDeviceRepository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         switchRepository = repositoryFactory.createSwitchRepository();
         connectedDeviceRepository = repositoryFactory.createSwitchConnectedDeviceRepository();

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaSwitchPropertiesRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaSwitchPropertiesRepositoryTest.java
@@ -15,11 +15,11 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.MacAddress;
 import org.openkilda.model.Switch;
@@ -29,8 +29,8 @@ import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.SwitchPropertiesRepository;
 import org.openkilda.persistence.repositories.SwitchRepository;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,7 +45,7 @@ public class FermaSwitchPropertiesRepositoryTest extends InMemoryGraphBasedTest 
     SwitchRepository switchRepository;
     SwitchPropertiesRepository switchPropertiesRepository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         switchRepository = repositoryFactory.createSwitchRepository();
         switchPropertiesRepository = repositoryFactory.createSwitchPropertiesRepository();

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaSwitchRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaSwitchRepositoryTest.java
@@ -15,9 +15,9 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowEncapsulationType;
@@ -37,8 +37,8 @@ import org.openkilda.persistence.repositories.FlowRepository;
 import org.openkilda.persistence.repositories.SwitchRepository;
 
 import com.google.common.collect.Lists;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -54,7 +54,7 @@ public class FermaSwitchRepositoryTest extends InMemoryGraphBasedTest {
     SwitchRepository switchRepository;
     FlowRepository flowRepository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         switchRepository = repositoryFactory.createSwitchRepository();
         flowRepository = repositoryFactory.createFlowRepository();

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaTransitVlanRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaTransitVlanRepositoryTest.java
@@ -15,16 +15,16 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.PathId;
 import org.openkilda.model.TransitVlan;
 import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.TransitVlanRepository;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -37,7 +37,7 @@ public class FermaTransitVlanRepositoryTest extends InMemoryGraphBasedTest {
 
     TransitVlanRepository transitVlanRepository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         transitVlanRepository = repositoryFactory.createTransitVlanRepository();
     }

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaVxlanRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaVxlanRepositoryTest.java
@@ -15,15 +15,16 @@
 
 package org.openkilda.persistence.ferma.repositories;
 
-import static org.junit.Assert.assertEquals;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.model.PathId;
 import org.openkilda.model.Vxlan;
 import org.openkilda.persistence.inmemory.InMemoryGraphBasedTest;
 import org.openkilda.persistence.repositories.VxlanRepository;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 
@@ -34,7 +35,7 @@ public class FermaVxlanRepositoryTest extends InMemoryGraphBasedTest {
 
     VxlanRepository vxlanRepository;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         vxlanRepository = repositoryFactory.createVxlanRepository();
     }

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaYFlowRepositoryTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/ferma/repositories/FermaYFlowRepositoryTest.java
@@ -16,9 +16,9 @@
 package org.openkilda.persistence.ferma.repositories;
 
 import static com.google.common.collect.Sets.newHashSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.Flow;
 import org.openkilda.model.FlowEncapsulationType;
@@ -40,8 +40,8 @@ import org.openkilda.persistence.repositories.FlowRepository;
 import org.openkilda.persistence.repositories.SwitchRepository;
 import org.openkilda.persistence.repositories.YFlowRepository;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -65,7 +65,7 @@ public class FermaYFlowRepositoryTest extends InMemoryGraphBasedTest {
     Switch switch2;
     Switch switch3;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         flowRepository = repositoryFactory.createFlowRepository();
         yFlowRepository = repositoryFactory.createYFlowRepository();

--- a/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/inmemory/InMemoryGraphBasedTest.java
+++ b/src-java/kilda-persistence-tinkerpop/src/test/java/org/openkilda/persistence/inmemory/InMemoryGraphBasedTest.java
@@ -29,8 +29,8 @@ import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.persistence.repositories.RepositoryFactory;
 import org.openkilda.persistence.tx.TransactionManager;
 
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
 
 import java.util.Properties;
@@ -94,7 +94,7 @@ public abstract class InMemoryGraphBasedTest {
     protected static TransactionManager transactionManager;
     protected static RepositoryFactory repositoryFactory;
 
-    @BeforeClass
+    @BeforeAll
     public static void initPersistenceManager() {
         Properties properties = new Properties();
         properties.put("persistence.implementation.default", PersistenceImplementationType.IN_MEMORY_GRAPH.name());
@@ -113,7 +113,7 @@ public abstract class InMemoryGraphBasedTest {
         transactionManager = inMemoryGraphPersistenceManager.getTransactionManager();
     }
 
-    @Before
+    @BeforeEach
     public void cleanTinkerGraph() {
         inMemoryGraphPersistenceImplementation.purgeData();
     }

--- a/src-java/nbworker-topology/nbworker-messaging/build.gradle
+++ b/src-java/nbworker-topology/nbworker-messaging/build.gradle
@@ -14,8 +14,12 @@ dependencies {
     implementation('com.fasterxml.jackson.core:jackson-databind')
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/nbworker-topology/nbworker-messaging/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/nbworker-topology/nbworker-messaging/src/checkstyle/checkstyle-suppressions.xml
@@ -4,4 +4,5 @@
         "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
 
 <suppressions>
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod"/>
 </suppressions>

--- a/src-java/nbworker-topology/nbworker-messaging/src/test/java/org/openkilda/messaging/nbtopology/request/LinkPropsDropTest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/test/java/org/openkilda/messaging/nbtopology/request/LinkPropsDropTest.java
@@ -21,8 +21,8 @@ import org.openkilda.messaging.model.LinkPropsMask;
 import org.openkilda.messaging.model.NetworkEndpointMask;
 import org.openkilda.model.SwitchId;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LinkPropsDropTest {
     StringSerializer serializer = new StringSerializer();
@@ -36,7 +36,7 @@ public class LinkPropsDropTest {
         CommandMessage reconstructedWrapper = (CommandMessage) serializer.deserialize();
         LinkPropsDrop reconstructed = (LinkPropsDrop) reconstructedWrapper.getData();
 
-        Assert.assertEquals(origin, reconstructed);
+        Assertions.assertEquals(origin, reconstructed);
     }
 
     /**

--- a/src-java/nbworker-topology/nbworker-messaging/src/test/java/org/openkilda/messaging/nbtopology/request/LinkPropsPutTest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/test/java/org/openkilda/messaging/nbtopology/request/LinkPropsPutTest.java
@@ -21,8 +21,8 @@ import org.openkilda.messaging.model.LinkPropsDto;
 import org.openkilda.messaging.model.NetworkEndpoint;
 import org.openkilda.model.SwitchId;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
@@ -39,7 +39,7 @@ public class LinkPropsPutTest {
         CommandMessage result = (CommandMessage) serializer.deserialize();
         LinkPropsPut reconstructed = (LinkPropsPut) result.getData();
 
-        Assert.assertEquals(origin, reconstructed);
+        Assertions.assertEquals(origin, reconstructed);
     }
 
     /**

--- a/src-java/nbworker-topology/nbworker-messaging/src/test/java/org/openkilda/messaging/nbtopology/response/LinkPropsResponseTest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/test/java/org/openkilda/messaging/nbtopology/response/LinkPropsResponseTest.java
@@ -25,15 +25,15 @@ import org.openkilda.messaging.nbtopology.request.LinkPropsPut;
 import org.openkilda.messaging.nbtopology.request.LinkPropsPutTest;
 import org.openkilda.messaging.nbtopology.request.LinkPropsRequest;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LinkPropsResponseTest {
     StringSerializer serializer = new StringSerializer();
 
     @Test
     public void serializeLoop() throws Exception {
-        LinkPropsRequest[] requestsBatch = new LinkPropsRequest[] {
+        LinkPropsRequest[] requestsBatch = new LinkPropsRequest[]{
                 makePutRequest(),
                 makeDropRequest()};
 
@@ -45,7 +45,7 @@ public class LinkPropsResponseTest {
 
             InfoMessage reconstructedWrapper = (InfoMessage) serializer.deserialize();
             LinkPropsResponse reconstructed = (LinkPropsResponse) reconstructedWrapper.getData();
-            Assert.assertEquals(origin, reconstructed);
+            Assertions.assertEquals(origin, reconstructed);
         }
     }
 

--- a/src-java/nbworker-topology/nbworker-storm-topology/build.gradle
+++ b/src-java/nbworker-topology/nbworker-storm-topology/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     testImplementation('org.apache.storm:storm-core')
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.hamcrest:hamcrest-library'
     testRuntimeOnly 'org.glassfish:javax.el'
@@ -63,4 +63,8 @@ shadowJar {
 
 artifacts {
     archives shadowJar
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/checkstyle/checkstyle-suppressions.xml
@@ -7,4 +7,5 @@
     <suppress files="src/main/.*Fsm\.java$" checks="JavadocMethod" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="VariableDeclarationUsageDistance" />
     <suppress files="src/main/java/org/openkilda/wfm/topology/nbworker/NbWorkerTopology.java" lines="104" checks="JavadocMethod"/>
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
 </suppressions>

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/share/mappers/LagPortMapperTest.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/share/mappers/LagPortMapperTest.java
@@ -15,15 +15,15 @@
 
 package org.openkilda.wfm.share.mappers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.messaging.nbtopology.response.LagPortDto;
 import org.openkilda.model.LagLogicalPort;
 import org.openkilda.model.SwitchId;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LagPortMapperTest {
     public static final SwitchId SWITCH_ID = new SwitchId("1");

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/share/mappers/RequestedFlowMapperTest.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/share/mappers/RequestedFlowMapperTest.java
@@ -18,8 +18,8 @@ package org.openkilda.wfm.share.mappers;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.messaging.command.flow.FlowRequest;
 import org.openkilda.messaging.model.DetectConnectedDevicesDto;
@@ -31,7 +31,7 @@ import org.openkilda.model.PathComputationStrategy;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchId;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -168,8 +168,8 @@ public class RequestedFlowMapperTest {
         assertTrue(flow.isAllocateProtectedPath());
         assertTrue(flow.isIgnoreBandwidth());
         assertTrue(flow.isPeriodicPings());
-        assertEquals(new DetectConnectedDevices(true, true, true, true, true, true, true, true),
-                flow.getDetectConnectedDevices());
+        assertEquals(new DetectConnectedDevices(true, true, true, true, true,
+                true, true, true), flow.getDetectConnectedDevices());
         assertThat(flow.getVlanStatistics(), containsInAnyOrder(STATISTICS.toArray()));
     }
 }

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/topology/nbworker/bolts/LinkOperationsBoltTest.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/topology/nbworker/bolts/LinkOperationsBoltTest.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.wfm.topology.nbworker.bolts;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import org.openkilda.messaging.model.LinkPropsDto;
@@ -28,37 +28,32 @@ import org.openkilda.persistence.inmemory.InMemoryGraphPersistenceManager;
 import org.openkilda.persistence.repositories.SwitchRepository;
 
 import org.apache.storm.task.TopologyContext;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class LinkOperationsBoltTest {
     private static final SwitchId SWITCH_ID_1 = new SwitchId("00:00:00:00:00:00:00:01");
     private static final SwitchId SWITCH_ID_2 = new SwitchId("00:00:00:00:00:00:00:02");
-
-    @ClassRule
-    public static TemporaryFolder fsData = new TemporaryFolder();
 
     private static InMemoryGraphPersistenceManager persistenceManager;
 
     @Mock
     private TopologyContext topologyContext;
 
-    @BeforeClass
+    @BeforeAll
     public static void initPersistenceManager() {
         persistenceManager = InMemoryGraphPersistenceManager.newInstance();
         persistenceManager.install();
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         persistenceManager.getInMemoryImplementation().purgeData();
 

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/topology/nbworker/services/FlowOperationsServiceTest.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/topology/nbworker/services/FlowOperationsServiceTest.java
@@ -18,12 +18,10 @@ package org.openkilda.wfm.topology.nbworker.services;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.messaging.command.flow.FlowRequest;
 import org.openkilda.messaging.error.InvalidFlowException;
@@ -54,9 +52,10 @@ import org.openkilda.wfm.topology.nbworker.bolts.FlowOperationsCarrier;
 import org.openkilda.wfm.topology.nbworker.services.FlowOperationsService.UpdateFlowResult;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -96,7 +95,7 @@ public class FlowOperationsServiceTest extends InMemoryGraphBasedTest {
     private Switch switchC;
     private Switch switchD;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpOnce() {
         flowRepository = persistenceManager.getRepositoryFactory().createFlowRepository();
         flowPathRepository = persistenceManager.getRepositoryFactory().createFlowPathRepository();
@@ -106,7 +105,7 @@ public class FlowOperationsServiceTest extends InMemoryGraphBasedTest {
                 persistenceManager.getTransactionManager());
     }
 
-    @Before
+    @BeforeEach
     public void init() {
         switchA = createSwitch(SWITCH_ID_1);
         switchB = createSwitch(SWITCH_ID_2);
@@ -166,46 +165,50 @@ public class FlowOperationsServiceTest extends InMemoryGraphBasedTest {
         assertTrue(updatedFlow.isPinned());
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void strictBandwidthAndIgnoreBandwidthPatchConflictTest()
-            throws FlowNotFoundException, InvalidFlowException {
-        String testFlowId = "flow_id";
+    @Test
+    public void strictBandwidthAndIgnoreBandwidthPatchConflictTest() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            String testFlowId = "flow_id";
 
-        Flow flow = new TestFlowBuilder()
-                .flowId(testFlowId)
-                .srcSwitch(switchA)
-                .destSwitch(switchB)
-                .build();
-        flowRepository.add(flow);
+            Flow flow = new TestFlowBuilder()
+                    .flowId(testFlowId)
+                    .srcSwitch(switchA)
+                    .destSwitch(switchB)
+                    .build();
+            flowRepository.add(flow);
 
-        FlowPatch receivedFlow = FlowPatch.builder()
-                .flowId(testFlowId)
-                .strictBandwidth(true)
-                .ignoreBandwidth(true)
-                .build();
+            FlowPatch receivedFlow = FlowPatch.builder()
+                    .flowId(testFlowId)
+                    .strictBandwidth(true)
+                    .ignoreBandwidth(true)
+                    .build();
 
-        flowOperationsService.updateFlow(new FlowCarrierImpl(), receivedFlow);
+            flowOperationsService.updateFlow(new FlowCarrierImpl(), receivedFlow);
+        });
+
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void strictBandwidthAndIgnoreBandwidthFlowConflictTest() throws FlowNotFoundException, InvalidFlowException {
-        String testFlowId = "flow_id";
+    @Test
+    public void strictBandwidthAndIgnoreBandwidthFlowConflictTest() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            String testFlowId = "flow_id";
 
-        Flow flow = new TestFlowBuilder()
-                .flowId(testFlowId)
-                .srcSwitch(switchA)
-                .destSwitch(switchB)
-                .ignoreBandwidth(true)
-                .build();
-        flowRepository.add(flow);
+            Flow flow = new TestFlowBuilder()
+                    .flowId(testFlowId)
+                    .srcSwitch(switchA)
+                    .destSwitch(switchB)
+                    .ignoreBandwidth(true)
+                    .build();
+            flowRepository.add(flow);
 
-        FlowPatch receivedFlow = FlowPatch.builder()
-                .flowId(testFlowId)
-                .strictBandwidth(true)
-                .ignoreBandwidth(false)
-                .build();
+            FlowPatch receivedFlow = FlowPatch.builder()
+                    .flowId(testFlowId)
+                    .strictBandwidth(true)
+                    .ignoreBandwidth(false)
+                    .build();
 
-        flowOperationsService.updateFlow(new FlowCarrierImpl(), receivedFlow);
+            flowOperationsService.updateFlow(new FlowCarrierImpl(), receivedFlow);
+        });
     }
 
     @Test
@@ -256,22 +259,23 @@ public class FlowOperationsServiceTest extends InMemoryGraphBasedTest {
         assertThat(updatedFlow.getVlanStatistics(), containsInAnyOrder(originalVlanStatistics.toArray()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void unableToUpdateVlanStatisticsOldVlansSetNewVlansNullTest()
-            throws FlowNotFoundException, InvalidFlowException {
-        runUnableToUpdateVlanStatisticsTest(VLAN_1, VLAN_2, null, null);
+    @Test
+    public void unableToUpdateVlanStatisticsOldVlansSetNewVlansNullTest() {
+        assertThrows(IllegalArgumentException.class,
+                () -> runUnableToUpdateVlanStatisticsTest(VLAN_1, VLAN_2, null, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void unableToUpdateVlanStatisticsOldVlansSetNewVlansSetTest()
-            throws FlowNotFoundException, InvalidFlowException {
-        runUnableToUpdateVlanStatisticsTest(VLAN_1, VLAN_2, VLAN_2, VLAN_3);
+    @Test
+    public void unableToUpdateVlanStatisticsOldVlansSetNewVlansSetTest() {
+        assertThrows(IllegalArgumentException.class, () ->
+                runUnableToUpdateVlanStatisticsTest(VLAN_1, VLAN_2, VLAN_2, VLAN_3)
+        );
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void unableToUpdateVlanStatisticsOldVlansZeroNewVlansSetTest()
-            throws FlowNotFoundException, InvalidFlowException {
-        runUnableToUpdateVlanStatisticsTest(0, 0, VLAN_1, VLAN_2);
+    @Test
+    public void unableToUpdateVlanStatisticsOldVlansZeroNewVlansSetTest() {
+        assertThrows(IllegalArgumentException.class,
+                () -> runUnableToUpdateVlanStatisticsTest(0, 0, VLAN_1, VLAN_2));
     }
 
     private void runUnableToUpdateVlanStatisticsTest(
@@ -297,50 +301,54 @@ public class FlowOperationsServiceTest extends InMemoryGraphBasedTest {
         flowOperationsService.updateFlow(new FlowCarrierImpl(), receivedFlow);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void unableToSetProtectedPathForInitiallyOneSwitchFlowTest()
-            throws FlowNotFoundException, InvalidFlowException {
-        createFlow(FLOW_ID_1, switchA, switchA, false);
-        FlowPatch receivedFlow = FlowPatch.builder()
-                .flowId(FLOW_ID_1)
-                .allocateProtectedPath(true)
-                .build();
-        flowOperationsService.updateFlow(new FlowCarrierImpl(), receivedFlow);
+    @Test
+    public void unableToSetProtectedPathForInitiallyOneSwitchFlowTest() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            createFlow(FLOW_ID_1, switchA, switchA, false);
+            FlowPatch receivedFlow = FlowPatch.builder()
+                    .flowId(FLOW_ID_1)
+                    .allocateProtectedPath(true)
+                    .build();
+            flowOperationsService.updateFlow(new FlowCarrierImpl(), receivedFlow);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void unableToMakeOneSwitchFlowFromProtectedByUpdatingDstTest()
-            throws FlowNotFoundException, InvalidFlowException {
-        createFlow(FLOW_ID_1, switchA, switchB, true);
-        FlowPatch receivedFlow = FlowPatch.builder()
-                .flowId(FLOW_ID_1)
-                .destination(PatchEndpoint.builder().switchId(SWITCH_ID_1).build())
-                .build();
-        flowOperationsService.updateFlow(new FlowCarrierImpl(), receivedFlow);
+    @Test
+    public void unableToMakeOneSwitchFlowFromProtectedByUpdatingDstTest() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            createFlow(FLOW_ID_1, switchA, switchB, true);
+            FlowPatch receivedFlow = FlowPatch.builder()
+                    .flowId(FLOW_ID_1)
+                    .destination(PatchEndpoint.builder().switchId(SWITCH_ID_1).build())
+                    .build();
+            flowOperationsService.updateFlow(new FlowCarrierImpl(), receivedFlow);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void unableToMakeOneSwitchFlowFromProtectedByUpdatingSrcTest()
-            throws FlowNotFoundException, InvalidFlowException {
-        createFlow(FLOW_ID_1, switchA, switchB, true);
-        FlowPatch receivedFlow = FlowPatch.builder()
-                .flowId(FLOW_ID_1)
-                .source(PatchEndpoint.builder().switchId(SWITCH_ID_2).build())
-                .build();
-        flowOperationsService.updateFlow(new FlowCarrierImpl(), receivedFlow);
+    @Test
+    public void unableToMakeOneSwitchFlowFromProtectedByUpdatingSrcTest() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            createFlow(FLOW_ID_1, switchA, switchB, true);
+            FlowPatch receivedFlow = FlowPatch.builder()
+                    .flowId(FLOW_ID_1)
+                    .source(PatchEndpoint.builder().switchId(SWITCH_ID_2).build())
+                    .build();
+            flowOperationsService.updateFlow(new FlowCarrierImpl(), receivedFlow);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void unableToMakeProtectedOneSwitchFlowTest()
-            throws FlowNotFoundException, InvalidFlowException {
-        createFlow(FLOW_ID_1, switchA, switchB, false);
-        FlowPatch receivedFlow = FlowPatch.builder()
-                .flowId(FLOW_ID_1)
-                .source(PatchEndpoint.builder().switchId(SWITCH_ID_3).build())
-                .destination(PatchEndpoint.builder().switchId(SWITCH_ID_3).build())
-                .allocateProtectedPath(true)
-                .build();
-        flowOperationsService.updateFlow(new FlowCarrierImpl(), receivedFlow);
+    @Test
+    public void unableToMakeProtectedOneSwitchFlowTest() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            createFlow(FLOW_ID_1, switchA, switchB, false);
+            FlowPatch receivedFlow = FlowPatch.builder()
+                    .flowId(FLOW_ID_1)
+                    .source(PatchEndpoint.builder().switchId(SWITCH_ID_3).build())
+                    .destination(PatchEndpoint.builder().switchId(SWITCH_ID_3).build())
+                    .allocateProtectedPath(true)
+                    .build();
+            flowOperationsService.updateFlow(new FlowCarrierImpl(), receivedFlow);
+        });
     }
 
     @Test
@@ -485,7 +493,7 @@ public class FlowOperationsServiceTest extends InMemoryGraphBasedTest {
         UpdateFlowResult result = flowOperationsService.prepareFlowUpdateResult(flowDto, flow).build();
 
         // then: needRerouteFlow flag set to false
-        assertFalse(result.isNeedUpdateFlow());
+        Assertions.assertFalse(result.isNeedUpdateFlow());
     }
 
     @Test
@@ -506,7 +514,7 @@ public class FlowOperationsServiceTest extends InMemoryGraphBasedTest {
 
         UpdateFlowResult result = flowOperationsService.prepareFlowUpdateResult(flowDto, flow).build();
 
-        assertFalse(result.isNeedUpdateFlow());
+        Assertions.assertFalse(result.isNeedUpdateFlow());
     }
 
     @Test
@@ -627,7 +635,8 @@ public class FlowOperationsServiceTest extends InMemoryGraphBasedTest {
 
     @Test
     public void getFlowsForEndpointNotReturnFlowsForOrphanedPaths() throws SwitchNotFoundException {
-        Flow flow = createFlow(FLOW_ID_1, switchA, 1, switchC, 2, FORWARD_PATH_1, REVERSE_PATH_1, switchB);
+        Flow flow = createFlow(FLOW_ID_1, switchA, 1, switchC, 2,
+                FORWARD_PATH_1, REVERSE_PATH_1, switchB);
         createOrphanFlowPaths(flow, switchA, 1, switchC, 2, FORWARD_PATH_3, REVERSE_PATH_3, switchD);
         assertEquals(0, flowOperationsService.getFlowsForEndpoint(switchD.getSwitchId(), null).size());
     }
@@ -710,8 +719,9 @@ public class FlowOperationsServiceTest extends InMemoryGraphBasedTest {
 
     @Test
     public void patchFlowWithLatencyOnlyTest() throws FlowNotFoundException, InvalidFlowException {
-        Flow createdFlow = createFlow(FLOW_ID_1, switchA, 1, switchC, 2, FORWARD_PATH_1, REVERSE_PATH_1, switchB);
-        assertNotEquals(Long.valueOf(100_500L), createdFlow.getMaxLatency());
+        Flow createdFlow = createFlow(FLOW_ID_1, switchA, 1, switchC, 2, FORWARD_PATH_1,
+                REVERSE_PATH_1, switchB);
+        Assertions.assertNotEquals(Long.valueOf(100_500L), createdFlow.getMaxLatency());
         FlowPatch flowPatch = FlowPatch.builder()
                 .flowId(FLOW_ID_1)
                 .maxLatency(100_500L)
@@ -723,9 +733,10 @@ public class FlowOperationsServiceTest extends InMemoryGraphBasedTest {
 
     @Test
     public void patchFlowWithLatencyAndLatencyTier2Test() throws FlowNotFoundException, InvalidFlowException {
-        Flow createdFlow = createFlow(FLOW_ID_1, switchA, 1, switchC, 2, FORWARD_PATH_1, REVERSE_PATH_1, switchB);
-        assertNotEquals(Long.valueOf(100_500L), createdFlow.getMaxLatency());
-        assertNotEquals(Long.valueOf(420_000L), createdFlow.getMaxLatencyTier2());
+        Flow createdFlow = createFlow(FLOW_ID_1, switchA, 1, switchC, 2,
+                FORWARD_PATH_1, REVERSE_PATH_1, switchB);
+        Assertions.assertNotEquals(Long.valueOf(100_500L), createdFlow.getMaxLatency());
+        Assertions.assertNotEquals(Long.valueOf(420_000L), createdFlow.getMaxLatencyTier2());
 
         FlowPatch flowPatch = FlowPatch.builder()
                 .flowId(FLOW_ID_1)
@@ -741,7 +752,8 @@ public class FlowOperationsServiceTest extends InMemoryGraphBasedTest {
 
     @Test
     public void whenFlowWithNullLatency_patchFlowWithLatencyTier2OnlyThrowsAnException() {
-        Flow createdFlow = createFlow(FLOW_ID_1, switchA, 1, switchC, 2, FORWARD_PATH_1, REVERSE_PATH_1, switchB);
+        Flow createdFlow = createFlow(FLOW_ID_1, switchA, 1, switchC, 2,
+                FORWARD_PATH_1, REVERSE_PATH_1, switchB);
         assertNull(createdFlow.getMaxLatency());
 
         FlowPatch flowPatch = FlowPatch.builder()
@@ -749,15 +761,16 @@ public class FlowOperationsServiceTest extends InMemoryGraphBasedTest {
                 .maxLatencyTier2(420_000L)
                 .build();
 
-        assertThrows("Max latency tier 2 cannot be used without max latency parameter",
-                InvalidFlowException.class,
-                () -> flowOperationsService.updateFlow(new FlowCarrierImpl(), flowPatch));
+        assertThrows(InvalidFlowException.class,
+                () -> flowOperationsService.updateFlow(new FlowCarrierImpl(), flowPatch),
+                "Max latency tier 2 cannot be used without max latency parameter");
     }
 
     @Test
     public void whenFlowWithMaxLatency_patchFlowWithLatencyTier2OnlyTest()
             throws FlowNotFoundException, InvalidFlowException {
-        Flow createdFlow = createFlow(FLOW_ID_1, switchA, 1, switchC, 2, FORWARD_PATH_1, REVERSE_PATH_1, switchB, false,
+        Flow createdFlow = createFlow(FLOW_ID_1, switchA, 1, switchC, 2,
+                FORWARD_PATH_1, REVERSE_PATH_1, switchB, false,
                 100_500L, 0L);
         FlowPatch flowPatch = FlowPatch.builder()
                 .flowId(FLOW_ID_1)
@@ -831,7 +844,8 @@ public class FlowOperationsServiceTest extends InMemoryGraphBasedTest {
     private Flow createFlow(String flowId, Switch srcSwitch, int srcPort, Switch dstSwitch, int dstPort,
                             PathId forwardPartId, PathId reversePathId, Switch transitSwitch) {
         return createFlow(
-                flowId, srcSwitch, srcPort, dstSwitch, dstPort, forwardPartId, reversePathId, transitSwitch, false,
+                flowId, srcSwitch, srcPort, dstSwitch, dstPort,
+                forwardPartId, reversePathId, transitSwitch, false,
                 null, null);
     }
 

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/topology/nbworker/services/SwitchOperationsServiceTest.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/topology/nbworker/services/SwitchOperationsServiceTest.java
@@ -15,10 +15,11 @@
 
 package org.openkilda.wfm.topology.nbworker.services;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertNull;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.messaging.model.SwitchLocation;
 import org.openkilda.messaging.model.SwitchPatch;
@@ -58,8 +59,8 @@ import org.openkilda.wfm.share.model.Endpoint;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -93,7 +94,7 @@ public class SwitchOperationsServiceTest extends InMemoryGraphBasedTest {
     private static final MacAddress SERVER_42_MAC_ADDRESS_1 = new MacAddress("42:42:42:42:42:42");
     private static final MacAddress SERVER_42_MAC_ADDRESS_2 = new MacAddress("45:45:45:45:45:45");
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpOnce() {
         RepositoryFactory repositoryFactory = persistenceManager.getRepositoryFactory();
         switchRepository = repositoryFactory.createSwitchRepository();
@@ -159,96 +160,106 @@ public class SwitchOperationsServiceTest extends InMemoryGraphBasedTest {
         assertTrue(portPropertiesRepository.findAll().isEmpty());
     }
 
-    @Test(expected = IllegalSwitchPropertiesException.class)
+    @Test
     public void shouldValidateSupportedEncapsulationTypeWhenUpdatingSwitchProperties() {
-        Switch sw = createSwitch(TEST_SWITCH_ID);
-        createSwitchProperties(sw, Collections.singleton(FlowEncapsulationType.TRANSIT_VLAN), false, false, false);
+        assertThrows(IllegalSwitchPropertiesException.class, () -> {
+            Switch sw = createSwitch(TEST_SWITCH_ID);
+            createSwitchProperties(sw, Collections.singleton(FlowEncapsulationType.TRANSIT_VLAN), false, false, false);
 
-        switchOperationsService.updateSwitchProperties(TEST_SWITCH_ID, new SwitchPropertiesDto());
+            switchOperationsService.updateSwitchProperties(TEST_SWITCH_ID, new SwitchPropertiesDto());
+        });
     }
 
-    @Test(expected = IllegalSwitchPropertiesException.class)
+    @Test
     public void shouldValidateMultiTableFlagWhenUpdatingSwitchProperties() {
-        Switch sw = createSwitch(TEST_SWITCH_ID);
-        createSwitchProperties(sw, Collections.singleton(FlowEncapsulationType.TRANSIT_VLAN), true, true, false);
+        assertThrows(IllegalSwitchPropertiesException.class, () -> {
+            Switch sw = createSwitch(TEST_SWITCH_ID);
+            createSwitchProperties(sw, Collections.singleton(FlowEncapsulationType.TRANSIT_VLAN), true, true, false);
 
-        // user can't disable multiTable without disabling LLDP
-        SwitchPropertiesDto update = new SwitchPropertiesDto();
-        update.setSupportedTransitEncapsulation(
-                Collections.singleton(org.openkilda.messaging.payload.flow.FlowEncapsulationType.TRANSIT_VLAN));
-        update.setMultiTable(false);
-        update.setSwitchLldp(true);
+            // user can't disable multiTable without disabling LLDP
+            SwitchPropertiesDto update = new SwitchPropertiesDto();
+            update.setSupportedTransitEncapsulation(
+                    Collections.singleton(org.openkilda.messaging.payload.flow.FlowEncapsulationType.TRANSIT_VLAN));
+            update.setMultiTable(false);
+            update.setSwitchLldp(true);
 
-        switchOperationsService.updateSwitchProperties(TEST_SWITCH_ID, update);
+            switchOperationsService.updateSwitchProperties(TEST_SWITCH_ID, update);
+        });
     }
 
-    @Test(expected = IllegalSwitchPropertiesException.class)
+    @Test
     public void shouldValidateFlowWithLldpFlagWhenUpdatingSwitchProperties() {
-        Switch firstSwitch = createSwitch(TEST_SWITCH_ID);
-        Switch secondSwitch = createSwitch(TEST_SWITCH_ID_2);
+        assertThrows(IllegalSwitchPropertiesException.class, () -> {
+            Switch firstSwitch = createSwitch(TEST_SWITCH_ID);
+            Switch secondSwitch = createSwitch(TEST_SWITCH_ID_2);
 
-        Flow flow = Flow.builder()
-                .flowId(TEST_FLOW_ID_1)
-                .srcSwitch(firstSwitch)
-                .destSwitch(secondSwitch)
-                .detectConnectedDevices(new DetectConnectedDevices(
-                        true, false, true, false, false, false, false, false))
-                .build();
-        flowRepository.add(flow);
+            Flow flow = Flow.builder()
+                    .flowId(TEST_FLOW_ID_1)
+                    .srcSwitch(firstSwitch)
+                    .destSwitch(secondSwitch)
+                    .detectConnectedDevices(new DetectConnectedDevices(
+                            true, false, true, false, false, false, false, false))
+                    .build();
+            flowRepository.add(flow);
 
-        createSwitchProperties(
-                firstSwitch, Collections.singleton(FlowEncapsulationType.TRANSIT_VLAN), true, false, false);
+            createSwitchProperties(
+                    firstSwitch, Collections.singleton(FlowEncapsulationType.TRANSIT_VLAN), true, false, false);
 
-        // user can't disable multiTable if some flows has enabled detect connected devices via LLDP
-        SwitchPropertiesDto update = new SwitchPropertiesDto();
-        update.setSupportedTransitEncapsulation(
-                Collections.singleton(org.openkilda.messaging.payload.flow.FlowEncapsulationType.TRANSIT_VLAN));
-        update.setMultiTable(false);
-        update.setSwitchLldp(false);
+            // user can't disable multiTable if some flows has enabled detect connected devices via LLDP
+            SwitchPropertiesDto update = new SwitchPropertiesDto();
+            update.setSupportedTransitEncapsulation(
+                    Collections.singleton(org.openkilda.messaging.payload.flow.FlowEncapsulationType.TRANSIT_VLAN));
+            update.setMultiTable(false);
+            update.setSwitchLldp(false);
 
-        switchOperationsService.updateSwitchProperties(TEST_SWITCH_ID, update);
+            switchOperationsService.updateSwitchProperties(TEST_SWITCH_ID, update);
+        });
     }
 
-    @Test(expected = IllegalSwitchPropertiesException.class)
+    @Test
     public void shouldValidateMultiTableFlagWhenUpdatingSwitchPropertiesWithArp() {
-        Switch sw = createSwitch(TEST_SWITCH_ID);
-        createSwitchProperties(sw, Collections.singleton(FlowEncapsulationType.TRANSIT_VLAN), true, false, true);
+        assertThrows(IllegalSwitchPropertiesException.class, () -> {
+            Switch sw = createSwitch(TEST_SWITCH_ID);
+            createSwitchProperties(sw, Collections.singleton(FlowEncapsulationType.TRANSIT_VLAN), true, false, true);
 
-        // user can't disable multiTable without disabling ARP
-        SwitchPropertiesDto update = new SwitchPropertiesDto();
-        update.setSupportedTransitEncapsulation(
-                Collections.singleton(org.openkilda.messaging.payload.flow.FlowEncapsulationType.TRANSIT_VLAN));
-        update.setMultiTable(false);
-        update.setSwitchArp(true);
+            // user can't disable multiTable without disabling ARP
+            SwitchPropertiesDto update = new SwitchPropertiesDto();
+            update.setSupportedTransitEncapsulation(
+                    Collections.singleton(org.openkilda.messaging.payload.flow.FlowEncapsulationType.TRANSIT_VLAN));
+            update.setMultiTable(false);
+            update.setSwitchArp(true);
 
-        switchOperationsService.updateSwitchProperties(TEST_SWITCH_ID, update);
+            switchOperationsService.updateSwitchProperties(TEST_SWITCH_ID, update);
+        });
     }
 
-    @Test(expected = IllegalSwitchPropertiesException.class)
+    @Test
     public void shouldValidateFlowWithArpFlagWhenUpdatingSwitchProperties() {
-        Switch firstSwitch = createSwitch(TEST_SWITCH_ID);
-        Switch secondSwitch = createSwitch(TEST_SWITCH_ID_2);
+        assertThrows(IllegalSwitchPropertiesException.class, () -> {
+            Switch firstSwitch = createSwitch(TEST_SWITCH_ID);
+            Switch secondSwitch = createSwitch(TEST_SWITCH_ID_2);
 
-        Flow flow = Flow.builder()
-                .flowId(TEST_FLOW_ID_1)
-                .srcSwitch(firstSwitch)
-                .destSwitch(secondSwitch)
-                .detectConnectedDevices(
-                        new DetectConnectedDevices(false, true, false, true, false, false, false, false))
-                .build();
-        flowRepository.add(flow);
+            Flow flow = Flow.builder()
+                    .flowId(TEST_FLOW_ID_1)
+                    .srcSwitch(firstSwitch)
+                    .destSwitch(secondSwitch)
+                    .detectConnectedDevices(
+                            new DetectConnectedDevices(false, true, false, true, false, false, false, false))
+                    .build();
+            flowRepository.add(flow);
 
-        createSwitchProperties(firstSwitch,
-                Collections.singleton(FlowEncapsulationType.TRANSIT_VLAN), true, false, false);
+            createSwitchProperties(firstSwitch,
+                    Collections.singleton(FlowEncapsulationType.TRANSIT_VLAN), true, false, false);
 
-        // user can't disable multiTable if some flows has enabled detect connected devices via ARP
-        SwitchPropertiesDto update = new SwitchPropertiesDto();
-        update.setSupportedTransitEncapsulation(
-                Collections.singleton(org.openkilda.messaging.payload.flow.FlowEncapsulationType.TRANSIT_VLAN));
-        update.setMultiTable(false);
-        update.setSwitchArp(false);
+            // user can't disable multiTable if some flows has enabled detect connected devices via ARP
+            SwitchPropertiesDto update = new SwitchPropertiesDto();
+            update.setSupportedTransitEncapsulation(
+                    Collections.singleton(org.openkilda.messaging.payload.flow.FlowEncapsulationType.TRANSIT_VLAN));
+            update.setMultiTable(false);
+            update.setSwitchArp(false);
 
-        switchOperationsService.updateSwitchProperties(TEST_SWITCH_ID, update);
+            switchOperationsService.updateSwitchProperties(TEST_SWITCH_ID, update);
+        });
     }
 
     @Test
@@ -375,151 +386,165 @@ public class SwitchOperationsServiceTest extends InMemoryGraphBasedTest {
         assertEquals(SERVER_42_MAC_ADDRESS_2, updated.get().getServer42MacAddress());
     }
 
-    @Test(expected = IllegalSwitchPropertiesException.class)
+    @Test
     public void shouldValidateServer42VlanWhenEnableFlowRttInSwitchProperties() {
-        // user can't enable server42FlowRtt and do not specify server42Vlan
-        SwitchPropertiesDto properties = new SwitchPropertiesDto();
-        properties.setServer42FlowRtt(true);
-        properties.setServer42Port(SERVER_42_PORT_2);
-        properties.setServer42Vlan(null);
-        properties.setServer42MacAddress(SERVER_42_MAC_ADDRESS_2);
-        runInvalidServer42PropsTest(properties);
+        assertThrows(IllegalSwitchPropertiesException.class, () -> {
+            // user can't enable server42FlowRtt and do not specify server42Vlan
+            SwitchPropertiesDto properties = new SwitchPropertiesDto();
+            properties.setServer42FlowRtt(true);
+            properties.setServer42Port(SERVER_42_PORT_2);
+            properties.setServer42Vlan(null);
+            properties.setServer42MacAddress(SERVER_42_MAC_ADDRESS_2);
+            runInvalidServer42PropsTest(properties);
+        });
     }
 
-    @Test(expected = IllegalSwitchPropertiesException.class)
+    @Test
     public void shouldValidateServer42PortWhenEnableFlowRttInSwitchProperties() {
-        // user can't enable server42FlowRtt and do not specify server42Port
-        SwitchPropertiesDto properties = new SwitchPropertiesDto();
-        properties.setServer42FlowRtt(true);
-        properties.setServer42Port(null);
-        properties.setServer42Vlan(SERVER_42_VLAN_2);
-        properties.setServer42MacAddress(SERVER_42_MAC_ADDRESS_2);
-        runInvalidServer42PropsTest(properties);
+        assertThrows(IllegalSwitchPropertiesException.class, () -> {
+            // user can't enable server42FlowRtt and do not specify server42Port
+            SwitchPropertiesDto properties = new SwitchPropertiesDto();
+            properties.setServer42FlowRtt(true);
+            properties.setServer42Port(null);
+            properties.setServer42Vlan(SERVER_42_VLAN_2);
+            properties.setServer42MacAddress(SERVER_42_MAC_ADDRESS_2);
+            runInvalidServer42PropsTest(properties);
+        });
     }
 
-    @Test(expected = IllegalSwitchPropertiesException.class)
+    @Test
     public void shouldValidateServer42MacAddressWhenEnableFlowRttInSwitchProperties() {
-        // user can't enable server42FlowRtt and do not specify server42MacAddress
-        SwitchPropertiesDto properties = new SwitchPropertiesDto();
-        properties.setServer42FlowRtt(true);
-        properties.setServer42Port(SERVER_42_PORT_2);
-        properties.setServer42Vlan(SERVER_42_VLAN_2);
-        properties.setServer42MacAddress(null);
-        runInvalidServer42PropsTest(properties);
+        assertThrows(IllegalSwitchPropertiesException.class, () -> {
+            // user can't enable server42FlowRtt and do not specify server42MacAddress
+            SwitchPropertiesDto properties = new SwitchPropertiesDto();
+            properties.setServer42FlowRtt(true);
+            properties.setServer42Port(SERVER_42_PORT_2);
+            properties.setServer42Vlan(SERVER_42_VLAN_2);
+            properties.setServer42MacAddress(null);
+            runInvalidServer42PropsTest(properties);
+        });
     }
 
-    @Test(expected = IllegalSwitchPropertiesException.class)
+    @Test
     public void shouldValidateFlowMirrorPointsWhenUpdatingSwitchLldpProperties() {
-        Switch mirrorSwitch = createSwitch(TEST_SWITCH_ID);
+        assertThrows(IllegalSwitchPropertiesException.class, () -> {
+            Switch mirrorSwitch = createSwitch(TEST_SWITCH_ID);
 
-        MirrorGroup mirrorGroup = MirrorGroup.builder()
-                .switchId(TEST_SWITCH_ID)
-                .groupId(new GroupId(12L))
-                .pathId(new PathId("test_path_id"))
-                .flowId(TEST_FLOW_ID_1)
-                .mirrorGroupType(MirrorGroupType.TRAFFIC_INTEGRITY)
-                .mirrorDirection(MirrorDirection.INGRESS)
-                .build();
-        mirrorGroupRepository.add(mirrorGroup);
+            MirrorGroup mirrorGroup = MirrorGroup.builder()
+                    .switchId(TEST_SWITCH_ID)
+                    .groupId(new GroupId(12L))
+                    .pathId(new PathId("test_path_id"))
+                    .flowId(TEST_FLOW_ID_1)
+                    .mirrorGroupType(MirrorGroupType.TRAFFIC_INTEGRITY)
+                    .mirrorDirection(MirrorDirection.INGRESS)
+                    .build();
+            mirrorGroupRepository.add(mirrorGroup);
 
-        FlowMirrorPoints flowMirrorPoints = FlowMirrorPoints.builder()
-                .mirrorGroup(mirrorGroup)
-                .mirrorSwitch(mirrorSwitch)
-                .build();
-        flowMirrorPointsRepository.add(flowMirrorPoints);
+            FlowMirrorPoints flowMirrorPoints = FlowMirrorPoints.builder()
+                    .mirrorGroup(mirrorGroup)
+                    .mirrorSwitch(mirrorSwitch)
+                    .build();
+            flowMirrorPointsRepository.add(flowMirrorPoints);
 
-        createSwitchProperties(
-                mirrorSwitch, Collections.singleton(FlowEncapsulationType.TRANSIT_VLAN), true, false, false);
+            createSwitchProperties(
+                    mirrorSwitch, Collections.singleton(FlowEncapsulationType.TRANSIT_VLAN), true, false, false);
 
-        SwitchPropertiesDto update = new SwitchPropertiesDto();
-        update.setSupportedTransitEncapsulation(
-                Collections.singleton(org.openkilda.messaging.payload.flow.FlowEncapsulationType.TRANSIT_VLAN));
-        update.setMultiTable(true);
-        update.setSwitchLldp(true);
+            SwitchPropertiesDto update = new SwitchPropertiesDto();
+            update.setSupportedTransitEncapsulation(
+                    Collections.singleton(org.openkilda.messaging.payload.flow.FlowEncapsulationType.TRANSIT_VLAN));
+            update.setMultiTable(true);
+            update.setSwitchLldp(true);
 
-        switchOperationsService.updateSwitchProperties(TEST_SWITCH_ID, update);
+            switchOperationsService.updateSwitchProperties(TEST_SWITCH_ID, update);
+        });
     }
 
-    @Test(expected = IllegalSwitchPropertiesException.class)
+    @Test
     public void shouldValidateFlowMirrorPointsWhenUpdatingSwitchArpProperties() {
-        Switch mirrorSwitch = createSwitch(TEST_SWITCH_ID);
+        assertThrows(IllegalSwitchPropertiesException.class, () -> {
+            Switch mirrorSwitch = createSwitch(TEST_SWITCH_ID);
 
-        MirrorGroup mirrorGroup = MirrorGroup.builder()
-                .switchId(TEST_SWITCH_ID)
-                .groupId(new GroupId(12L))
-                .pathId(new PathId("test_path_id"))
-                .flowId(TEST_FLOW_ID_1)
-                .mirrorGroupType(MirrorGroupType.TRAFFIC_INTEGRITY)
-                .mirrorDirection(MirrorDirection.INGRESS)
-                .build();
-        mirrorGroupRepository.add(mirrorGroup);
+            MirrorGroup mirrorGroup = MirrorGroup.builder()
+                    .switchId(TEST_SWITCH_ID)
+                    .groupId(new GroupId(12L))
+                    .pathId(new PathId("test_path_id"))
+                    .flowId(TEST_FLOW_ID_1)
+                    .mirrorGroupType(MirrorGroupType.TRAFFIC_INTEGRITY)
+                    .mirrorDirection(MirrorDirection.INGRESS)
+                    .build();
+            mirrorGroupRepository.add(mirrorGroup);
 
-        FlowMirrorPoints flowMirrorPoints = FlowMirrorPoints.builder()
-                .mirrorGroup(mirrorGroup)
-                .mirrorSwitch(mirrorSwitch)
-                .build();
-        flowMirrorPointsRepository.add(flowMirrorPoints);
+            FlowMirrorPoints flowMirrorPoints = FlowMirrorPoints.builder()
+                    .mirrorGroup(mirrorGroup)
+                    .mirrorSwitch(mirrorSwitch)
+                    .build();
+            flowMirrorPointsRepository.add(flowMirrorPoints);
 
-        createSwitchProperties(
-                mirrorSwitch, Collections.singleton(FlowEncapsulationType.TRANSIT_VLAN), true, false, false);
+            createSwitchProperties(
+                    mirrorSwitch, Collections.singleton(FlowEncapsulationType.TRANSIT_VLAN), true, false, false);
 
-        SwitchPropertiesDto update = new SwitchPropertiesDto();
-        update.setSupportedTransitEncapsulation(
-                Collections.singleton(org.openkilda.messaging.payload.flow.FlowEncapsulationType.TRANSIT_VLAN));
-        update.setMultiTable(true);
-        update.setSwitchArp(true);
+            SwitchPropertiesDto update = new SwitchPropertiesDto();
+            update.setSupportedTransitEncapsulation(
+                    Collections.singleton(org.openkilda.messaging.payload.flow.FlowEncapsulationType.TRANSIT_VLAN));
+            update.setMultiTable(true);
+            update.setSwitchArp(true);
 
-        switchOperationsService.updateSwitchProperties(TEST_SWITCH_ID, update);
+            switchOperationsService.updateSwitchProperties(TEST_SWITCH_ID, update);
+        });
     }
 
-    @Test(expected = IllegalSwitchPropertiesException.class)
+    @Test
     public void shouldValidateFlowWhenUpdatingServer42PortSwitchProperties() {
-        Switch firstSwitch = createSwitch(TEST_SWITCH_ID);
-        Switch secondSwitch = createSwitch(TEST_SWITCH_ID_2);
+        assertThrows(IllegalSwitchPropertiesException.class, () -> {
+            Switch firstSwitch = createSwitch(TEST_SWITCH_ID);
+            Switch secondSwitch = createSwitch(TEST_SWITCH_ID_2);
 
-        Flow flow = Flow.builder()
-                .flowId(TEST_FLOW_ID_1)
-                .srcSwitch(firstSwitch)
-                .srcPort(TEST_FLOW_SRC_PORT)
-                .destSwitch(secondSwitch)
-                .detectConnectedDevices(
-                        new DetectConnectedDevices(false, true, false, true, false, false, false, false))
-                .build();
-        flowRepository.add(flow);
+            Flow flow = Flow.builder()
+                    .flowId(TEST_FLOW_ID_1)
+                    .srcSwitch(firstSwitch)
+                    .srcPort(TEST_FLOW_SRC_PORT)
+                    .destSwitch(secondSwitch)
+                    .detectConnectedDevices(
+                            new DetectConnectedDevices(false, true, false, true, false, false, false, false))
+                    .build();
+            flowRepository.add(flow);
 
-        createSwitchProperties(firstSwitch,
-                Collections.singleton(FlowEncapsulationType.TRANSIT_VLAN), true, false, false);
+            createSwitchProperties(firstSwitch,
+                    Collections.singleton(FlowEncapsulationType.TRANSIT_VLAN), true, false, false);
 
-        SwitchPropertiesDto update = new SwitchPropertiesDto();
-        update.setSupportedTransitEncapsulation(
-                Collections.singleton(org.openkilda.messaging.payload.flow.FlowEncapsulationType.TRANSIT_VLAN));
-        update.setServer42Port(TEST_FLOW_SRC_PORT);
+            SwitchPropertiesDto update = new SwitchPropertiesDto();
+            update.setSupportedTransitEncapsulation(
+                    Collections.singleton(org.openkilda.messaging.payload.flow.FlowEncapsulationType.TRANSIT_VLAN));
+            update.setServer42Port(TEST_FLOW_SRC_PORT);
 
-        switchOperationsService.updateSwitchProperties(TEST_SWITCH_ID, update);
+            switchOperationsService.updateSwitchProperties(TEST_SWITCH_ID, update);
+        });
     }
 
-    @Test(expected = IllegalSwitchPropertiesException.class)
+    @Test
     public void shouldValidateFlowMirrorPathWhenUpdatingServer42PortSwitchProperties() {
-        Switch firstSwitch = createSwitch(TEST_SWITCH_ID);
-        Switch secondSwitch = createSwitch(TEST_SWITCH_ID_2);
+        assertThrows(IllegalSwitchPropertiesException.class, () -> {
+            Switch firstSwitch = createSwitch(TEST_SWITCH_ID);
+            Switch secondSwitch = createSwitch(TEST_SWITCH_ID_2);
 
-        FlowMirrorPath flowMirrorPath = FlowMirrorPath.builder()
-                .pathId(new PathId("test_path_id"))
-                .mirrorSwitch(secondSwitch)
-                .egressSwitch(firstSwitch)
-                .egressPort(TEST_FLOW_SRC_PORT)
-                .build();
-        flowMirrorPathRepository.add(flowMirrorPath);
+            FlowMirrorPath flowMirrorPath = FlowMirrorPath.builder()
+                    .pathId(new PathId("test_path_id"))
+                    .mirrorSwitch(secondSwitch)
+                    .egressSwitch(firstSwitch)
+                    .egressPort(TEST_FLOW_SRC_PORT)
+                    .build();
+            flowMirrorPathRepository.add(flowMirrorPath);
 
-        createSwitchProperties(firstSwitch,
-                Collections.singleton(FlowEncapsulationType.TRANSIT_VLAN), true, false, false);
+            createSwitchProperties(firstSwitch,
+                    Collections.singleton(FlowEncapsulationType.TRANSIT_VLAN), true, false, false);
 
-        SwitchPropertiesDto update = new SwitchPropertiesDto();
-        update.setSupportedTransitEncapsulation(
-                Collections.singleton(org.openkilda.messaging.payload.flow.FlowEncapsulationType.TRANSIT_VLAN));
-        update.setServer42Port(TEST_FLOW_SRC_PORT);
+            SwitchPropertiesDto update = new SwitchPropertiesDto();
+            update.setSupportedTransitEncapsulation(
+                    Collections.singleton(org.openkilda.messaging.payload.flow.FlowEncapsulationType.TRANSIT_VLAN));
+            update.setServer42Port(TEST_FLOW_SRC_PORT);
 
-        switchOperationsService.updateSwitchProperties(TEST_SWITCH_ID, update);
+            switchOperationsService.updateSwitchProperties(TEST_SWITCH_ID, update);
+        });
     }
 
     @Test
@@ -584,37 +609,43 @@ public class SwitchOperationsServiceTest extends InMemoryGraphBasedTest {
         assertEquals(SERVER_42_MAC_ADDRESS_2, updated.get().getServer42MacAddress());
     }
 
-    @Test(expected = IllegalSwitchPropertiesException.class)
+    @Test
     public void shouldValidateServer42VlanWhenEnableIslRttInSwitchProperties() {
-        // user can't enable server42FlowRtt and do not specify server42Vlan
-        SwitchPropertiesDto properties = new SwitchPropertiesDto();
-        properties.setServer42IslRtt(SwitchPropertiesDto.RttState.ENABLED);
-        properties.setServer42Port(SERVER_42_PORT_2);
-        properties.setServer42Vlan(null);
-        properties.setServer42MacAddress(SERVER_42_MAC_ADDRESS_2);
-        runInvalidServer42PropsTest(properties);
+        assertThrows(IllegalSwitchPropertiesException.class, () -> {
+            // user can't enable server42FlowRtt and do not specify server42Vlan
+            SwitchPropertiesDto properties = new SwitchPropertiesDto();
+            properties.setServer42IslRtt(SwitchPropertiesDto.RttState.ENABLED);
+            properties.setServer42Port(SERVER_42_PORT_2);
+            properties.setServer42Vlan(null);
+            properties.setServer42MacAddress(SERVER_42_MAC_ADDRESS_2);
+            runInvalidServer42PropsTest(properties);
+        });
     }
 
-    @Test(expected = IllegalSwitchPropertiesException.class)
+    @Test
     public void shouldValidateServer42PortWhenEnableIslRttInSwitchProperties() {
-        // user can't enable server42FlowRtt and do not specify server42Port
-        SwitchPropertiesDto properties = new SwitchPropertiesDto();
-        properties.setServer42IslRtt(SwitchPropertiesDto.RttState.ENABLED);
-        properties.setServer42Port(null);
-        properties.setServer42Vlan(SERVER_42_VLAN_2);
-        properties.setServer42MacAddress(SERVER_42_MAC_ADDRESS_2);
-        runInvalidServer42PropsTest(properties);
+        assertThrows(IllegalSwitchPropertiesException.class, () -> {
+            // user can't enable server42FlowRtt and do not specify server42Port
+            SwitchPropertiesDto properties = new SwitchPropertiesDto();
+            properties.setServer42IslRtt(SwitchPropertiesDto.RttState.ENABLED);
+            properties.setServer42Port(null);
+            properties.setServer42Vlan(SERVER_42_VLAN_2);
+            properties.setServer42MacAddress(SERVER_42_MAC_ADDRESS_2);
+            runInvalidServer42PropsTest(properties);
+        });
     }
 
-    @Test(expected = IllegalSwitchPropertiesException.class)
+    @Test
     public void shouldValidateServer42MacAddressWhenEnableIslRttInSwitchProperties() {
-        // user can't enable server42FlowRtt and do not specify server42MacAddress
-        SwitchPropertiesDto properties = new SwitchPropertiesDto();
-        properties.setServer42IslRtt(SwitchPropertiesDto.RttState.ENABLED);
-        properties.setServer42Port(SERVER_42_PORT_2);
-        properties.setServer42Vlan(SERVER_42_VLAN_2);
-        properties.setServer42MacAddress(null);
-        runInvalidServer42PropsTest(properties);
+        assertThrows(IllegalSwitchPropertiesException.class, () -> {
+            // user can't enable server42FlowRtt and do not specify server42MacAddress
+            SwitchPropertiesDto properties = new SwitchPropertiesDto();
+            properties.setServer42IslRtt(SwitchPropertiesDto.RttState.ENABLED);
+            properties.setServer42Port(SERVER_42_PORT_2);
+            properties.setServer42Vlan(SERVER_42_VLAN_2);
+            properties.setServer42MacAddress(null);
+            runInvalidServer42PropsTest(properties);
+        });
     }
 
     @Test
@@ -662,9 +693,10 @@ public class SwitchOperationsServiceTest extends InMemoryGraphBasedTest {
         assertTrue(ports.iterator().next().isLacpReply());
     }
 
-    @Test(expected = SwitchNotFoundException.class)
-    public void shouldThrowExceptionDuringGettingLagPorts() throws SwitchNotFoundException {
-        switchOperationsService.getSwitchLagPorts(TEST_SWITCH_ID);
+    @Test
+    public void shouldThrowExceptionDuringGettingLagPorts() {
+        assertThrows(SwitchNotFoundException.class, () -> switchOperationsService.getSwitchLagPorts(TEST_SWITCH_ID));
+
     }
 
     private void runInvalidServer42PropsTest(SwitchPropertiesDto invalidProperties) {

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/topology/nbworker/validators/PathValidatorTest.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/topology/nbworker/validators/PathValidatorTest.java
@@ -15,9 +15,9 @@
 
 package org.openkilda.wfm.topology.nbworker.validators;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openkilda.model.FlowEncapsulationType.TRANSIT_VLAN;
 import static org.openkilda.model.FlowEncapsulationType.VXLAN;
 import static org.openkilda.model.PathComputationStrategy.COST;
@@ -53,9 +53,9 @@ import org.openkilda.persistence.repositories.SwitchRepository;
 import org.openkilda.wfm.topology.nbworker.services.PathsService;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.LinkedList;
@@ -77,7 +77,7 @@ public class PathValidatorTest extends InMemoryGraphBasedTest {
 
     private boolean isSetupDone;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpOnce() {
         RepositoryFactory repositoryFactory = persistenceManager.getRepositoryFactory();
         switchRepository = repositoryFactory.createSwitchRepository();
@@ -91,7 +91,7 @@ public class PathValidatorTest extends InMemoryGraphBasedTest {
         kildaConfiguration.setFlowEncapsulationType(TRANSIT_VLAN);
     }
 
-    @Before
+    @BeforeEach
     public void createTestTopology() {
         if (!isSetupDone) {
             Switch switch0 = Switch.builder().switchId(SWITCH_ID_0).status(SwitchStatus.ACTIVE).build();
@@ -200,8 +200,7 @@ public class PathValidatorTest extends InMemoryGraphBasedTest {
 
         assertFalse(responses.isEmpty());
         assertFalse(responses.get(0).getIsValid());
-        assertEquals("There must be 2 errors: forward and reverse paths",
-                2, responses.get(0).getErrors().size());
+        assertEquals(2, responses.get(0).getErrors().size(), "There must be 2 errors: forward and reverse paths");
         Collections.sort(responses.get(0).getErrors());
         assertEquals(responses.get(0).getErrors().get(0),
                 "There is not enough bandwidth between end points: switch 00:00:00:00:00:00:00:01 port 6 and "
@@ -267,7 +266,7 @@ public class PathValidatorTest extends InMemoryGraphBasedTest {
                 "Requested latency is too low on the path between: switch 00:00:00:00:00:00:00:01 and"
                         + " switch 00:00:00:00:00:00:00:02. Requested 1 ms, but the sum on the path is 5 ms.",
                 "Requested latency is too low on the path between: switch 00:00:00:00:00:00:00:02 and"
-                        +  " switch 00:00:00:00:00:00:00:01. Requested 1 ms, but the sum on the path is 5 ms.");
+                        + " switch 00:00:00:00:00:00:00:01. Requested 1 ms, but the sum on the path is 5 ms.");
 
         Set<String> actualErrorMessages = Sets.newHashSet(responses.get(0).getErrors());
         assertEquals(expectedErrorMessages, actualErrorMessages);
@@ -296,7 +295,7 @@ public class PathValidatorTest extends InMemoryGraphBasedTest {
                 "Requested latency is too low on the path between: switch 00:00:00:00:00:00:00:01 and"
                         + " switch 00:00:00:00:00:00:00:02. Requested 1 ms, but the sum on the path is 5 ms.",
                 "Requested latency is too low on the path between: switch 00:00:00:00:00:00:00:02 and"
-                        +  " switch 00:00:00:00:00:00:00:01. Requested 1 ms, but the sum on the path is 5 ms.");
+                        + " switch 00:00:00:00:00:00:00:01. Requested 1 ms, but the sum on the path is 5 ms.");
 
         Set<String> actualErrorMessages = Sets.newHashSet(responses.get(0).getErrors());
         assertEquals(expectedErrorMessages, actualErrorMessages);
@@ -323,9 +322,9 @@ public class PathValidatorTest extends InMemoryGraphBasedTest {
 
         Set<String> expectedErrorMessages = Sets.newHashSet(
                 "Requested latency tier 2 is too low on the path between: switch 00:00:00:00:00:00:00:01 and"
-                + " switch 00:00:00:00:00:00:00:02. Requested 1 ms, but the sum on the path is 5 ms.",
+                        + " switch 00:00:00:00:00:00:00:02. Requested 1 ms, but the sum on the path is 5 ms.",
                 "Requested latency tier 2 is too low on the path between: switch 00:00:00:00:00:00:00:02 and"
-                +  " switch 00:00:00:00:00:00:00:01. Requested 1 ms, but the sum on the path is 5 ms.");
+                        + " switch 00:00:00:00:00:00:00:01. Requested 1 ms, but the sum on the path is 5 ms.");
 
         Set<String> actualErrors = Sets.newHashSet(responses.get(0).getErrors());
         assertEquals(expectedErrorMessages, actualErrors);
@@ -395,9 +394,9 @@ public class PathValidatorTest extends InMemoryGraphBasedTest {
         assertFalse(responses.get(0).getErrors().isEmpty());
         Set<String> expectedErrorMessages = Sets.newHashSet(
                 "There is no ISL between end points: switch 00:00:00:00:00:00:00:02 port 0 and switch"
-                + " 00:00:00:00:00:00:00:01 port 1.",
+                        + " 00:00:00:00:00:00:00:01 port 1.",
                 "There is no ISL between end points: switch 00:00:00:00:00:00:00:01 port 1 and switch"
-                + " 00:00:00:00:00:00:00:02 port 0.");
+                        + " 00:00:00:00:00:00:00:02 port 0.");
 
         Set<String> actualErrorMessages = Sets.newHashSet(responses.get(0).getErrors());
         assertEquals(expectedErrorMessages, actualErrorMessages);
@@ -423,9 +422,9 @@ public class PathValidatorTest extends InMemoryGraphBasedTest {
         assertFalse(responses.get(0).getErrors().isEmpty());
         Set<String> expectedErrorMessages = Sets.newHashSet(
                 "There is no ISL between end points: switch 00:00:00:00:00:00:00:02 port 0 and switch"
-                + " 00:00:00:00:00:00:00:01 port 1.",
+                        + " 00:00:00:00:00:00:00:01 port 1.",
                 "There is no ISL between end points: switch 00:00:00:00:00:00:00:01 port 1 and switch"
-                + " 00:00:00:00:00:00:00:02 port 0.",
+                        + " 00:00:00:00:00:00:00:02 port 0.",
                 "Path latency cannot be calculated because there is no link at least at one path segment.");
 
         Set<String> actualErrorMessages = Sets.newHashSet(responses.get(0).getErrors());
@@ -457,11 +456,11 @@ public class PathValidatorTest extends InMemoryGraphBasedTest {
         assertFalse(responses.get(0).getIsValid());
         Set<String> expectedErrorMessages = Sets.newHashSet(
                 "There is no ISL between end points: switch 00:00:00:00:00:00:00:03 port 7 and switch"
-                + " 00:00:00:00:00:00:00:00 port 7.",
+                        + " 00:00:00:00:00:00:00:00 port 7.",
                 "There is no ISL between end points: switch 00:00:00:00:00:00:00:00 port 7 and switch"
-                + " 00:00:00:00:00:00:00:03 port 7.",
+                        + " 00:00:00:00:00:00:00:03 port 7.",
                 "The following segment intersects with the flow flow_1: source switch 00:00:00:00:00:00:00:01"
-                + " port 6 and destination switch 00:00:00:00:00:00:00:03 port 6.");
+                        + " port 6 and destination switch 00:00:00:00:00:00:00:03 port 6.");
         Set<String> actualErrorMessages = Sets.newHashSet(responses.get(0).getErrors());
         assertEquals(expectedErrorMessages, actualErrorMessages);
     }
@@ -514,22 +513,22 @@ public class PathValidatorTest extends InMemoryGraphBasedTest {
         assertFalse(responses.get(0).getIsValid());
         assertFalse(responses.get(0).getErrors().isEmpty());
 
-        assertEquals("There must be 7 errors in total: 2 not enough bandwidth (forward and reverse paths), "
-                        + "2 link is not present, 2 latency, and 1 switch is not found",
-                7, responses.get(0).getErrors().size());
+        assertEquals(7, responses.get(0).getErrors().size(),
+                "There must be 7 errors in total: 2 not enough bandwidth (forward and reverse paths), "
+                        + "2 link is not present, 2 latency, and 1 switch is not found");
         Set<String> expectedErrorMessages = Sets.newHashSet(
                 "The following switch has not been found: 00:00:00:00:00:00:00:ff.",
                 "The following switch properties have not been found: 00:00:00:00:00:00:00:ff.",
                 "There is not enough bandwidth between end points: switch 00:00:00:00:00:00:00:03"
-                + " port 6 and switch 00:00:00:00:00:00:00:01 port 6 (reverse path). Requested bandwidth 1000000,"
-                + " but the link supports 10000.",
+                        + " port 6 and switch 00:00:00:00:00:00:00:01 port 6 (reverse path)."
+                        + " Requested bandwidth 1000000, but the link supports 10000.",
                 "There is not enough bandwidth between end points: switch 00:00:00:00:00:00:00:01"
-                + " port 6 and switch 00:00:00:00:00:00:00:03 port 6 (forward path). Requested bandwidth 1000000,"
-                + " but the link supports 10000.",
+                        + " port 6 and switch 00:00:00:00:00:00:00:03 port 6 (forward path)."
+                        + " Requested bandwidth 1000000, but the link supports 10000.",
                 "There is no ISL between end points: switch 00:00:00:00:00:00:00:03 port 7 and"
-                + " switch 00:00:00:00:00:00:00:ff port 7.",
+                        + " switch 00:00:00:00:00:00:00:ff port 7.",
                 "There is no ISL between end points: switch 00:00:00:00:00:00:00:ff port 7 and"
-                + " switch 00:00:00:00:00:00:00:03 port 7.",
+                        + " switch 00:00:00:00:00:00:00:03 port 7.",
                 "Path latency cannot be calculated because there is no link at least at one path segment.");
         assertEquals(expectedErrorMessages, Sets.newHashSet(responses.get(0).getErrors()));
     }
@@ -610,8 +609,8 @@ public class PathValidatorTest extends InMemoryGraphBasedTest {
         List<PathValidationResult> responsesBefore = pathsService.validatePath(request);
 
         assertFalse(responsesBefore.isEmpty());
-        assertTrue("The path using default segments with bandwidth 1003 must be valid",
-                responsesBefore.get(0).getIsValid());
+        assertTrue(responsesBefore.get(0).getIsValid(),
+                "The path using default segments with bandwidth 1003 must be valid");
 
         Optional<Isl> islForward = islRepository.findByEndpoints(SWITCH_ID_3, 7, SWITCH_ID_2, 7);
         assertTrue(islForward.isPresent());
@@ -628,11 +627,11 @@ public class PathValidatorTest extends InMemoryGraphBasedTest {
         List<PathValidationResult> responsesAfter = pathsService.validatePath(request);
 
         assertFalse(responsesAfter.isEmpty());
-        assertFalse("The path must not be valid because the flow %s consumes bandwidth",
-                responsesAfter.get(0).getIsValid());
+        assertFalse(responsesAfter.get(0).getIsValid(),
+                "The path must not be valid because the flow %s consumes bandwidth");
         assertFalse(responsesAfter.get(0).getErrors().isEmpty());
-        assertEquals("There must be 2 errors in total: not enough bandwidth on forward and reverse paths",
-                2, responsesAfter.get(0).getErrors().size());
+        assertEquals(2, responsesAfter.get(0).getErrors().size(),
+                "There must be 2 errors in total: not enough bandwidth on forward and reverse paths");
         assertEquals(responsesAfter.get(0).getErrors().get(0),
                 "There is not enough bandwidth between end points: switch 00:00:00:00:00:00:00:02 port 7 and"
                         + " switch 00:00:00:00:00:00:00:03 port 7 (reverse path). Requested bandwidth 1000, but the"
@@ -654,9 +653,9 @@ public class PathValidatorTest extends InMemoryGraphBasedTest {
         List<PathValidationResult> responseWithReuseResources = pathsService.validatePath(requestWithReuseResources);
 
         assertFalse(responseWithReuseResources.isEmpty());
-        assertTrue("The path must be valid because, although the flow %s consumes bandwidth, the validator"
-                        + " includes the consumed bandwidth to available bandwidth",
-                responseWithReuseResources.get(0).getIsValid());
+        assertTrue(responseWithReuseResources.get(0).getIsValid(),
+                "The path must be valid because, although the flow %s consumes bandwidth, the validator"
+                        + " includes the consumed bandwidth to available bandwidth");
     }
 
     private void createFlow(String flowId, Switch srcSwitch, int srcPort, Switch destSwitch, int destPort) {

--- a/src-java/opentsdb-topology/opentsdb-storm-topology/build.gradle
+++ b/src-java/opentsdb-topology/opentsdb-storm-topology/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation 'org.hibernate.validator:hibernate-validator'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.hamcrest:hamcrest-library'
     testRuntimeOnly 'org.glassfish:javax.el'
@@ -75,4 +75,8 @@ shadowJar {
 
 artifacts {
     archives shadowJar
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/opentsdb-topology/opentsdb-storm-topology/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/opentsdb-topology/opentsdb-storm-topology/src/checkstyle/checkstyle-suppressions.xml
@@ -6,5 +6,6 @@
 <suppressions>
     <suppress files="src/main/.*Fsm\.java$" checks="JavadocMethod" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="VariableDeclarationUsageDistance" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
     <suppress files="src/test/java/org/openkilda/wfm/topology/opentsdb/bolt/OpenTsdbFilterBoltTest.java" lines="140" checks="AvoidEscapedUnicodeCharacters"/>
 </suppressions>

--- a/src-java/opentsdb-topology/opentsdb-storm-topology/src/test/java/org/openkilda/wfm/topology/opentsdb/OpenTsdbTopologyTest.java
+++ b/src-java/opentsdb-topology/opentsdb-storm-topology/src/test/java/org/openkilda/wfm/topology/opentsdb/OpenTsdbTopologyTest.java
@@ -31,10 +31,10 @@ import org.apache.storm.generated.Bolt;
 import org.apache.storm.generated.StormTopology;
 import org.apache.storm.testing.MockedSources;
 import org.apache.storm.tuple.Values;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
@@ -57,20 +57,20 @@ public class OpenTsdbTopologyTest extends StableAbstractStormTest {
     private static ClientAndServer mockServer;
     private static final HttpRequest REQUEST = HttpRequest.request().withMethod("POST").withPath("/api/put");
 
-    @BeforeClass
+    @BeforeAll
     public static void setupOnce() throws Exception {
         StableAbstractStormTest.startCompleteTopology();
 
         mockServer = startClientAndServer(OPENTSDB_PORT);
     }
 
-    @Before
+    @BeforeEach
     public void init() {
         mockServer.when(REQUEST)
                 .respond(HttpResponse.response().withStatusCode(200));
     }
 
-    @After
+    @AfterEach
     public void cleanup() {
         mockServer.reset();
     }

--- a/src-java/opentsdb-topology/opentsdb-storm-topology/src/test/java/org/openkilda/wfm/topology/opentsdb/bolt/OpenTsdbFilterBoltTest.java
+++ b/src-java/opentsdb-topology/opentsdb-storm-topology/src/test/java/org/openkilda/wfm/topology/opentsdb/bolt/OpenTsdbFilterBoltTest.java
@@ -20,8 +20,6 @@ import static org.apache.storm.Constants.SYSTEM_COMPONENT_ID;
 import static org.apache.storm.Constants.SYSTEM_TICK_STREAM_ID;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -36,21 +34,22 @@ import org.openkilda.wfm.topology.opentsdb.bolts.OpenTsdbFilterBolt;
 
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.tuple.Tuple;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class OpenTsdbFilterBoltTest {
 
     private static final String METRIC = "METRIC";
@@ -69,7 +68,7 @@ public class OpenTsdbFilterBoltTest {
     @Captor
     private ArgumentCaptor<List<Object>> argumentCaptor;
 
-    @Before
+    @BeforeEach
     public void init() {
         Mockito.reset(outputCollector, tuple);
 
@@ -86,9 +85,9 @@ public class OpenTsdbFilterBoltTest {
         verify(outputCollector).emit(eq(tuple), argumentCaptor.capture());
         verify(outputCollector).ack(any(Tuple.class));
         List<Object> captured = argumentCaptor.getValue();
-        assertNotNull(captured);
+        Assertions.assertNotNull(captured);
         assertThat(captured.size(), is(1));
-        assertEquals(tuple.getValueByField("datapoint"), captured.get(0));
+        Assertions.assertEquals(tuple.getValueByField("datapoint"), captured.get(0));
     }
 
     @Test
@@ -136,9 +135,9 @@ public class OpenTsdbFilterBoltTest {
         // given
         target.prepare(Collections.emptyMap(), null, outputCollector);
 
-        Datapoint infoData1 = new Datapoint("1", TIMESTAMP, singletonMap("key",  "a"), VALUE);
-        Datapoint infoData2 = new Datapoint("2", TIMESTAMP, singletonMap("key",  "\u0040"), VALUE);
-        assertEquals(infoData1.simpleHashCode(), infoData2.simpleHashCode());
+        Datapoint infoData1 = new Datapoint("1", TIMESTAMP, singletonMap("key", "a"), VALUE);
+        Datapoint infoData2 = new Datapoint("2", TIMESTAMP, singletonMap("key", "@"), VALUE);
+        Assertions.assertEquals(infoData1.simpleHashCode(), infoData2.simpleHashCode());
 
         // when
         when(tuple.contains(eq("datapoint"))).thenReturn(true);

--- a/src-java/ping-topology/ping-messaging/build.gradle
+++ b/src-java/ping-topology/ping-messaging/build.gradle
@@ -15,9 +15,14 @@ dependencies {
 
     implementation 'com.google.guava:guava'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding'
 }
+
+test {
+    useJUnitPlatform()
+}
+

--- a/src-java/ping-topology/ping-messaging/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/ping-topology/ping-messaging/src/checkstyle/checkstyle-suppressions.xml
@@ -4,4 +4,5 @@
         "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
 
 <suppressions>
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod"/>
 </suppressions>

--- a/src-java/ping-topology/ping-messaging/src/test/java/org/openkilda/messaging/command/flow/FlowPingRequestTest.java
+++ b/src-java/ping-topology/ping-messaging/src/test/java/org/openkilda/messaging/command/flow/FlowPingRequestTest.java
@@ -15,12 +15,13 @@
 
 package org.openkilda.messaging.command.flow;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.openkilda.messaging.StringSerializer;
 import org.openkilda.messaging.command.CommandData;
 import org.openkilda.messaging.command.CommandMessage;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FlowPingRequestTest {
     StringSerializer serializer = new StringSerializer();
@@ -34,9 +35,7 @@ public class FlowPingRequestTest {
         CommandMessage decodedWrapper = (CommandMessage) serializer.deserialize();
         CommandData decoded = decodedWrapper.getData();
 
-        Assert.assertEquals(
-                String.format("%s object have been mangled in serialisation/deserialization loop",
-                        origin.getClass().getName()),
-                origin, decoded);
+        assertEquals(origin, decoded, String.format("%s object have been mangled in serialisation/deserialization loop",
+                origin.getClass().getName()));
     }
 }

--- a/src-java/ping-topology/ping-messaging/src/test/java/org/openkilda/messaging/command/flow/HaFlowPingRequestTest.java
+++ b/src-java/ping-topology/ping-messaging/src/test/java/org/openkilda/messaging/command/flow/HaFlowPingRequestTest.java
@@ -15,13 +15,12 @@
 
 package org.openkilda.messaging.command.flow;
 
-import static org.junit.Assert.assertEquals;
-
 import org.openkilda.messaging.StringSerializer;
 import org.openkilda.messaging.command.CommandData;
 import org.openkilda.messaging.command.CommandMessage;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class HaFlowPingRequestTest {
     StringSerializer serializer = new StringSerializer();
@@ -35,6 +34,6 @@ public class HaFlowPingRequestTest {
         CommandMessage decodedWrapper = (CommandMessage) serializer.deserialize();
         CommandData decoded = decodedWrapper.getData();
 
-        assertEquals(origin, decoded);
+        Assertions.assertEquals(origin, decoded);
     }
 }

--- a/src-java/ping-topology/ping-messaging/src/test/java/org/openkilda/messaging/command/flow/YFlowPingRequestTest.java
+++ b/src-java/ping-topology/ping-messaging/src/test/java/org/openkilda/messaging/command/flow/YFlowPingRequestTest.java
@@ -15,13 +15,12 @@
 
 package org.openkilda.messaging.command.flow;
 
-import static org.junit.Assert.assertEquals;
-
 import org.openkilda.messaging.StringSerializer;
 import org.openkilda.messaging.command.CommandData;
 import org.openkilda.messaging.command.CommandMessage;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class YFlowPingRequestTest {
     StringSerializer serializer = new StringSerializer();
@@ -35,6 +34,6 @@ public class YFlowPingRequestTest {
         CommandMessage decodedWrapper = (CommandMessage) serializer.deserialize();
         CommandData decoded = decodedWrapper.getData();
 
-        assertEquals(origin, decoded);
+        Assertions.assertEquals(origin, decoded);
     }
 }

--- a/src-java/ping-topology/ping-messaging/src/test/java/org/openkilda/messaging/info/flow/FlowPingReportTest.java
+++ b/src-java/ping-topology/ping-messaging/src/test/java/org/openkilda/messaging/info/flow/FlowPingReportTest.java
@@ -15,14 +15,15 @@
 
 package org.openkilda.messaging.info.flow;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.openkilda.messaging.StringSerializer;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.InfoMessage;
 import org.openkilda.messaging.model.PingReport;
 import org.openkilda.messaging.model.PingReport.State;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FlowPingReportTest {
     StringSerializer serializer = new StringSerializer();
@@ -37,9 +38,7 @@ public class FlowPingReportTest {
         InfoMessage decodedWrapper = (InfoMessage) serializer.deserialize();
         InfoData decoded = decodedWrapper.getData();
 
-        Assert.assertEquals(
-                String.format("%s object have been mangled in serialisation/deserialization loop",
-                        origin.getClass().getName()),
-                origin, decoded);
+        assertEquals(origin, decoded, String.format("%s object have been mangled in serialisation/deserialization loop",
+                origin.getClass().getName()));
     }
 }

--- a/src-java/ping-topology/ping-messaging/src/test/java/org/openkilda/messaging/info/flow/FlowPingResponseTest.java
+++ b/src-java/ping-topology/ping-messaging/src/test/java/org/openkilda/messaging/info/flow/FlowPingResponseTest.java
@@ -15,6 +15,8 @@
 
 package org.openkilda.messaging.info.flow;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.openkilda.messaging.StringSerializer;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.InfoMessage;
@@ -25,8 +27,7 @@ import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.FlowTransitEncapsulation;
 import org.openkilda.model.SwitchId;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FlowPingResponseTest {
     StringSerializer serializer = new StringSerializer();
@@ -53,9 +54,7 @@ public class FlowPingResponseTest {
         InfoMessage decodedWrapper = (InfoMessage) serializer.deserialize();
         InfoData decoded = decodedWrapper.getData();
 
-        Assert.assertEquals(
-                String.format("%s object have been mangled in serialisation/deserialization loop",
-                        origin.getClass().getName()),
-                origin, decoded);
+        assertEquals(origin, decoded, String.format("%s object have been mangled in serialisation/deserialization loop",
+                origin.getClass().getName()));
     }
 }

--- a/src-java/ping-topology/ping-messaging/src/test/java/org/openkilda/messaging/info/flow/HaFlowPingResponseTest.java
+++ b/src-java/ping-topology/ping-messaging/src/test/java/org/openkilda/messaging/info/flow/HaFlowPingResponseTest.java
@@ -15,15 +15,14 @@
 
 package org.openkilda.messaging.info.flow;
 
-import static org.junit.Assert.assertEquals;
-
 import org.openkilda.messaging.StringSerializer;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.InfoMessage;
 import org.openkilda.messaging.model.Ping.Errors;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class HaFlowPingResponseTest {
     private static final String HA_FLOW_ID = "ha_flow_id1";
@@ -48,6 +47,6 @@ public class HaFlowPingResponseTest {
         InfoMessage decodedWrapper = (InfoMessage) serializer.deserialize();
         InfoData decoded = decodedWrapper.getData();
 
-        assertEquals(origin, decoded);
+        Assertions.assertEquals(origin, decoded);
     }
 }

--- a/src-java/ping-topology/ping-messaging/src/test/java/org/openkilda/messaging/info/flow/UniFlowPingResponseTest.java
+++ b/src-java/ping-topology/ping-messaging/src/test/java/org/openkilda/messaging/info/flow/UniFlowPingResponseTest.java
@@ -15,6 +15,8 @@
 
 package org.openkilda.messaging.info.flow;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.openkilda.messaging.StringSerializer;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.InfoMessage;
@@ -25,8 +27,7 @@ import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.FlowTransitEncapsulation;
 import org.openkilda.model.SwitchId;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UniFlowPingResponseTest {
     StringSerializer serializer = new StringSerializer();
@@ -46,9 +47,7 @@ public class UniFlowPingResponseTest {
         InfoMessage decodedWrapper = (InfoMessage) serializer.deserialize();
         InfoData decoded = decodedWrapper.getData();
 
-        Assert.assertEquals(
-                String.format("%s object have been mangled in serialisation/deserialization loop",
-                        origin.getClass().getName()),
-                origin, decoded);
+        assertEquals(origin, decoded, String.format("%s object have been mangled in serialisation/deserialization loop",
+                origin.getClass().getName()));
     }
 }

--- a/src-java/ping-topology/ping-messaging/src/test/java/org/openkilda/messaging/info/flow/YFlowPingResponseTest.java
+++ b/src-java/ping-topology/ping-messaging/src/test/java/org/openkilda/messaging/info/flow/YFlowPingResponseTest.java
@@ -15,15 +15,14 @@
 
 package org.openkilda.messaging.info.flow;
 
-import static org.junit.Assert.assertEquals;
-
 import org.openkilda.messaging.StringSerializer;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.InfoMessage;
 import org.openkilda.messaging.model.Ping.Errors;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class YFlowPingResponseTest {
     private static final String Y_FLOW_ID = "y_flow_id1";
@@ -48,6 +47,6 @@ public class YFlowPingResponseTest {
         InfoMessage decodedWrapper = (InfoMessage) serializer.deserialize();
         InfoData decoded = decodedWrapper.getData();
 
-        assertEquals(origin, decoded);
+        Assertions.assertEquals(origin, decoded);
     }
 }

--- a/src-java/ping-topology/ping-storm-topology/build.gradle
+++ b/src-java/ping-topology/ping-storm-topology/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     testImplementation('org.apache.storm:storm-core')
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.hamcrest:hamcrest-library'
     testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
@@ -53,4 +53,8 @@ shadowJar {
 
 artifacts {
     archives shadowJar
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/ping-topology/ping-storm-topology/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/ping-topology/ping-storm-topology/src/checkstyle/checkstyle-suppressions.xml
@@ -6,4 +6,5 @@
 <suppressions>
     <suppress files="src/main/.*Fsm\.java$" checks="JavadocMethod" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="VariableDeclarationUsageDistance" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
 </suppressions>

--- a/src-java/ping-topology/ping-storm-topology/src/test/java/org/openkilda/wfm/topology/ping/PingTopologyTest.java
+++ b/src-java/ping-topology/ping-storm-topology/src/test/java/org/openkilda/wfm/topology/ping/PingTopologyTest.java
@@ -18,9 +18,6 @@ package org.openkilda.wfm.topology.ping;
 import static java.lang.String.format;
 import static org.apache.storm.utils.Utils.sleep;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.openkilda.persistence.ferma.repositories.FermaModelUtils.buildHaFlowPath;
 import static org.openkilda.persistence.ferma.repositories.FermaModelUtils.buildHaSubFlow;
 import static org.openkilda.persistence.ferma.repositories.FermaModelUtils.buildPath;
@@ -71,12 +68,12 @@ import com.google.common.collect.Lists;
 import org.apache.storm.Config;
 import org.apache.storm.generated.StormTopology;
 import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -140,7 +137,7 @@ public class PingTopologyTest extends AbstractStormTest {
     private Switch switch3;
     private Switch switch4;
 
-    @BeforeClass
+    @BeforeAll
     public static void setupOnce() throws Exception {
         Properties configOverlay = getZooKeeperProperties(FLOW_PING_TOPOLOGY_TEST_ZOOKEEPER_PORT, ROOT_NODE);
         configOverlay.putAll(getKafkaProperties(FLOW_PING_TOPOLOGY_TEST_KAFKA_PORT));
@@ -185,7 +182,7 @@ public class PingTopologyTest extends AbstractStormTest {
         sleep(TOPOLOGY_START_TIMEOUT);
     }
 
-    @AfterClass
+    @AfterAll
     public static void teardownOnce() throws Exception {
         speakerConsumer.wakeup();
         speakerConsumer.join();
@@ -196,7 +193,7 @@ public class PingTopologyTest extends AbstractStormTest {
         AbstractStormTest.stopZooKafkaAndStorm();
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         persistenceManager.getInMemoryImplementation().purgeData();
         speakerConsumer.clear();
@@ -204,7 +201,7 @@ public class PingTopologyTest extends AbstractStormTest {
         otsdbConsumer.clear();
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         switch1 = createTestSwitch(SWITCH_ID_1);
         switch2 = createTestSwitch(SWITCH_ID_2);
@@ -311,7 +308,7 @@ public class PingTopologyTest extends AbstractStormTest {
         HaFlowPingResponse response = (HaFlowPingResponse) infoMessage.getData();
         Assertions.assertEquals(expectedResponse, response);
 
-        assertTrue(speakerConsumer.isEmpty());
+        Assertions.assertTrue(speakerConsumer.isEmpty());
     }
 
     @Test
@@ -329,7 +326,7 @@ public class PingTopologyTest extends AbstractStormTest {
         HaFlowPingResponse response = (HaFlowPingResponse) infoMessage.getData();
         Assertions.assertEquals(expectedResponse, response);
 
-        assertTrue(speakerConsumer.isEmpty());
+        Assertions.assertTrue(speakerConsumer.isEmpty());
     }
 
     @Test
@@ -372,7 +369,7 @@ public class PingTopologyTest extends AbstractStormTest {
         HaFlowPingResponse response = (HaFlowPingResponse) infoMessage.getData();
         Assertions.assertEquals(expectedResponse, response);
 
-        assertTrue(speakerConsumer.isEmpty());
+        Assertions.assertTrue(speakerConsumer.isEmpty());
     }
 
     @Test
@@ -391,7 +388,7 @@ public class PingTopologyTest extends AbstractStormTest {
         HaFlowPingResponse response = (HaFlowPingResponse) infoMessage.getData();
         Assertions.assertEquals(expectedResponse, response);
 
-        assertTrue(speakerConsumer.isEmpty());
+        Assertions.assertTrue(speakerConsumer.isEmpty());
     }
 
     @Test
@@ -449,7 +446,7 @@ public class PingTopologyTest extends AbstractStormTest {
                 .filter(datapoint -> datapoint.getTags().get("status").equals("error"))
                 .count();
 
-        assertEquals(2, errorCounter);
+        Assertions.assertEquals(2, errorCounter);
 
         haFlowRepository.remove(HA_FLOW_ID_1);
         disableHaFlowAndAssert();
@@ -465,7 +462,7 @@ public class PingTopologyTest extends AbstractStormTest {
             sleep(1000);
         }
 
-        assertTrue(speakerConsumer.isEmpty());
+        Assertions.assertTrue(speakerConsumer.isEmpty());
     }
 
     private void createCompleteHaFlow() {
@@ -594,7 +591,7 @@ public class PingTopologyTest extends AbstractStormTest {
         try {
             request = Utils.MAPPER.writeValueAsString(object);
         } catch (JsonProcessingException e) {
-            fail("Unexpected error: " + e.getMessage());
+            Assertions.fail("Unexpected error: " + e.getMessage());
         }
         kProducer.pushMessageAsync(topic, request);
     }

--- a/src-java/ping-topology/ping-storm-topology/src/test/java/org/openkilda/wfm/topology/ping/bolt/OnDemandResultManagerTest.java
+++ b/src-java/ping-topology/ping-storm-topology/src/test/java/org/openkilda/wfm/topology/ping/bolt/OnDemandResultManagerTest.java
@@ -26,8 +26,8 @@ import org.openkilda.wfm.topology.ping.model.GroupId;
 import org.openkilda.wfm.topology.ping.model.PingContext;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -59,28 +59,28 @@ public class OnDemandResultManagerTest {
 
     private List<PingContext> generatePingContexts() {
         return Lists.newArrayList(PingContext.builder()
-                .haFlowId(HA_FLOW_ID)
-                .haSubFlowId(SUB_FLOW_1_NAME)
-                .direction(FlowDirection.FORWARD)
-                .meters(new PingMeters(1L, 2L, 3L))
-                .build(),
-        PingContext.builder()
-                .haFlowId(HA_FLOW_ID)
-                .haSubFlowId(SUB_FLOW_1_NAME)
-                .direction(FlowDirection.REVERSE)
-                .meters(new PingMeters(1L, 2L, 3L))
-                .build(),
-        PingContext.builder()
-                .haFlowId(HA_FLOW_ID)
-                .haSubFlowId(SUB_FLOW_2_NAME)
-                .direction(FlowDirection.FORWARD)
-                .meters(new PingMeters(1L, 2L, 3L))
-                .build(),
-        PingContext.builder()
-                .haFlowId(HA_FLOW_ID)
-                .haSubFlowId(SUB_FLOW_2_NAME)
-                .direction(FlowDirection.REVERSE)
-                .meters(new PingMeters(1L, 2L, 3L))
-                .build());
+                        .haFlowId(HA_FLOW_ID)
+                        .haSubFlowId(SUB_FLOW_1_NAME)
+                        .direction(FlowDirection.FORWARD)
+                        .meters(new PingMeters(1L, 2L, 3L))
+                        .build(),
+                PingContext.builder()
+                        .haFlowId(HA_FLOW_ID)
+                        .haSubFlowId(SUB_FLOW_1_NAME)
+                        .direction(FlowDirection.REVERSE)
+                        .meters(new PingMeters(1L, 2L, 3L))
+                        .build(),
+                PingContext.builder()
+                        .haFlowId(HA_FLOW_ID)
+                        .haSubFlowId(SUB_FLOW_2_NAME)
+                        .direction(FlowDirection.FORWARD)
+                        .meters(new PingMeters(1L, 2L, 3L))
+                        .build(),
+                PingContext.builder()
+                        .haFlowId(HA_FLOW_ID)
+                        .haSubFlowId(SUB_FLOW_2_NAME)
+                        .direction(FlowDirection.REVERSE)
+                        .meters(new PingMeters(1L, 2L, 3L))
+                        .build());
     }
 }

--- a/src-java/ping-topology/ping-storm-topology/src/test/java/org/openkilda/wfm/topology/ping/bolt/producer/HaPingContextProducerTest.java
+++ b/src-java/ping-topology/ping-storm-topology/src/test/java/org/openkilda/wfm/topology/ping/bolt/producer/HaPingContextProducerTest.java
@@ -40,9 +40,9 @@ import org.openkilda.wfm.topology.ping.model.PingContext;
 import org.openkilda.wfm.topology.ping.model.PingContext.Kinds;
 
 import com.google.common.collect.Lists;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -89,7 +89,7 @@ public class HaPingContextProducerTest {
     private HaSubFlow haSubFlowB;
 
 
-    @Before
+    @BeforeEach
     public void setUp() {
         sharedSwitch = Switch.builder().switchId(SWITCH_ID_1).build();
         ySwitch = Switch.builder().switchId(SWITCH_ID_2).build();
@@ -217,19 +217,19 @@ public class HaPingContextProducerTest {
      * Assert PingContext list are equals bypassing the pingId.
      */
     private void assertPingContextAreEquals(List<PingContext> expected, List<PingContext> actual) {
-        Assert.assertEquals(expected.size(), actual.size());
+        Assertions.assertEquals(expected.size(), actual.size());
         for (int i = 0; i < expected.size(); i++) {
             PingContext expectedPingContext = expected.get(i);
             PingContext actualPingContext = actual.get(i);
             assertPingAreEquals(expectedPingContext.getPing(), actualPingContext.getPing());
-            Assert.assertEquals(expectedPingContext.getGroup().getSize(), actualPingContext.getGroup().getSize());
-            Assert.assertEquals(expectedPingContext.getKind(), actualPingContext.getKind());
-            Assert.assertEquals(expectedPingContext.getHaFlow(), actualPingContext.getHaFlow());
-            Assert.assertEquals(expectedPingContext.getTransitEncapsulation(),
+            Assertions.assertEquals(expectedPingContext.getGroup().getSize(), actualPingContext.getGroup().getSize());
+            Assertions.assertEquals(expectedPingContext.getKind(), actualPingContext.getKind());
+            Assertions.assertEquals(expectedPingContext.getHaFlow(), actualPingContext.getHaFlow());
+            Assertions.assertEquals(expectedPingContext.getTransitEncapsulation(),
                     actualPingContext.getTransitEncapsulation());
-            Assert.assertEquals(expectedPingContext.getTimeout(), actualPingContext.getTimeout());
-            Assert.assertEquals(expectedPingContext.getDirection(), actualPingContext.getDirection());
-            Assert.assertEquals(expectedPingContext.getHaSubFlowId(), actualPingContext.getHaSubFlowId());
+            Assertions.assertEquals(expectedPingContext.getTimeout(), actualPingContext.getTimeout());
+            Assertions.assertEquals(expectedPingContext.getDirection(), actualPingContext.getDirection());
+            Assertions.assertEquals(expectedPingContext.getHaSubFlowId(), actualPingContext.getHaSubFlowId());
         }
     }
 
@@ -237,9 +237,9 @@ public class HaPingContextProducerTest {
      * Assert two Ping objects are equals bypassing the pingId.
      */
     private void assertPingAreEquals(Ping expected, Ping actual) {
-        Assert.assertEquals(expected.getSource(), actual.getSource());
-        Assert.assertEquals(expected.getDest(), actual.getDest());
-        Assert.assertEquals(expected.getTransitEncapsulation(), actual.getTransitEncapsulation());
+        Assertions.assertEquals(expected.getSource(), actual.getSource());
+        Assertions.assertEquals(expected.getDest(), actual.getDest());
+        Assertions.assertEquals(expected.getTransitEncapsulation(), actual.getTransitEncapsulation());
     }
 
     private void createHaFlow(boolean oneIsOneSwitchFlow) {

--- a/src-java/ping-topology/ping-storm-topology/src/test/java/org/openkilda/wfm/topology/ping/bolt/producer/ProducerUtilsTest.java
+++ b/src-java/ping-topology/ping-storm-topology/src/test/java/org/openkilda/wfm/topology/ping/bolt/producer/ProducerUtilsTest.java
@@ -16,6 +16,7 @@
 package org.openkilda.wfm.topology.ping.bolt.producer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openkilda.persistence.ferma.repositories.FermaModelUtils.buildSegments;
 
 import org.openkilda.model.FlowPath;
@@ -23,7 +24,8 @@ import org.openkilda.model.PathId;
 import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchId;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 
 public class ProducerUtilsTest {
 
@@ -44,19 +46,23 @@ public class ProducerUtilsTest {
         assertEquals(expectedResult, result);
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test
     public void getFirstIslPortEmptySegments() {
-        FlowPath flowPath = buildPath(PATH_ID, SWITCH_1, SWITCH_2);
+        assertThrows(IllegalArgumentException.class, () -> {
+            FlowPath flowPath = buildPath(PATH_ID, SWITCH_1, SWITCH_2);
 
-        ProducerUtils.getFirstIslPort(flowPath);
+            ProducerUtils.getFirstIslPort(flowPath);
+        });
     }
 
-    @Test (expected = IllegalStateException.class)
+    @Test
     public void getFirstIslPortNoIngressSegment() {
-        FlowPath flowPath = buildPath(PATH_ID, SWITCH_1, SWITCH_2);
-        flowPath.setSegments(buildSegments(PATH_ID, SWITCH_2, SWITCH_3, SWITCH_1));
+        assertThrows(IllegalStateException.class, () -> {
+            FlowPath flowPath = buildPath(PATH_ID, SWITCH_1, SWITCH_2);
+            flowPath.setSegments(buildSegments(PATH_ID, SWITCH_2, SWITCH_3, SWITCH_1));
 
-        ProducerUtils.getFirstIslPort(flowPath);
+            ProducerUtils.getFirstIslPort(flowPath);
+        });
     }
 
     private FlowPath buildPath(

--- a/src-java/ping-topology/ping-storm-topology/src/test/java/org/openkilda/wfm/topology/ping/model/WindowedCounterTest.java
+++ b/src-java/ping-topology/ping-storm-topology/src/test/java/org/openkilda/wfm/topology/ping/model/WindowedCounterTest.java
@@ -15,30 +15,31 @@
 
 package org.openkilda.wfm.topology.ping.model;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 public class WindowedCounterTest {
     @Test
     public void scenario1() {
         WindowedCounter counter = new WindowedCounter(3);
 
-        Assert.assertEquals(0, counter.getCount());
+        assertEquals(0, counter.getCount());
 
         counter.increment();
-        Assert.assertEquals(1, counter.getCount());
+        assertEquals(1, counter.getCount());
         counter.increment();
-        Assert.assertEquals(2, counter.getCount());
+        assertEquals(2, counter.getCount());
 
         counter.slide();
         counter.slide();
-        Assert.assertEquals(2, counter.getCount());
+        assertEquals(2, counter.getCount());
 
         counter.increment();
-        Assert.assertEquals(3, counter.getCount());
+        assertEquals(3, counter.getCount());
 
         counter.slide();
-        Assert.assertEquals(1, counter.getCount());
+        assertEquals(1, counter.getCount());
     }
 
     @Test
@@ -46,14 +47,14 @@ public class WindowedCounterTest {
         WindowedCounter counter = new WindowedCounter(1);
 
         counter.increment();
-        Assert.assertEquals(1, counter.getCount());
+        assertEquals(1, counter.getCount());
         counter.increment();
-        Assert.assertEquals(2, counter.getCount());
+        assertEquals(2, counter.getCount());
 
         counter.slide();
-        Assert.assertEquals(0, counter.getCount());
+        assertEquals(0, counter.getCount());
 
         counter.increment();
-        Assert.assertEquals(1, counter.getCount());
+        assertEquals(1, counter.getCount());
     }
 }

--- a/src-java/stats-topology/stats-storm-topology/build.gradle
+++ b/src-java/stats-topology/stats-storm-topology/build.gradle
@@ -28,7 +28,8 @@ dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.hamcrest:hamcrest-library'
     testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
@@ -58,4 +59,8 @@ shadowJar {
 
 artifacts {
     archives shadowJar
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/stats-topology/stats-storm-topology/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/stats-topology/stats-storm-topology/src/checkstyle/checkstyle-suppressions.xml
@@ -5,6 +5,7 @@
 
 <suppressions>
     <suppress files="src/main/.*Fsm\.java$" checks="JavadocMethod" />
+    <suppress files="src/test/.*Test\.java$" checks="JavadocMethod" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="VariableDeclarationUsageDistance" />
     <suppress files="src/main/java/org/openkilda/wfm/topology/stats/CypherExecutor.java" lines="81" checks="NonEmptyAtclauseDescription"/>
     <suppress files="src/main/java/org/openkilda/wfm/topology/stats/CypherExecutor.java" lines="85" checks="MissingSwitchDefault"/>

--- a/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java
+++ b/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java
@@ -21,8 +21,8 @@ import static org.apache.storm.utils.Utils.sleep;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.openkilda.model.FlowPathDirection.FORWARD;
 import static org.openkilda.model.FlowPathDirection.REVERSE;
 import static org.openkilda.model.cookie.Cookie.VERIFICATION_BROADCAST_RULE_COOKIE;
@@ -83,12 +83,11 @@ import com.google.common.collect.Sets;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.storm.Config;
 import org.apache.storm.generated.StormTopology;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -157,7 +156,7 @@ public class StatsTopologyTest extends AbstractStormTest {
     private static final String flowId = "f253423454343";
     private static final String Y_FLOW_ID = "Y_flow_1";
 
-    @BeforeClass
+    @BeforeAll
     public static void setupOnce() throws Exception {
         Properties configOverlay = getZooKeeperProperties(STATS_TOPOLOGY_TEST_ZOOKEEPER_PORT, ROOT_NODE);
         configOverlay.putAll(getKafkaProperties(STATS_TOPOLOGY_TEST_KAFKA_PORT));
@@ -192,7 +191,7 @@ public class StatsTopologyTest extends AbstractStormTest {
         sleep(TOPOLOGY_START_TIMEOUT);
     }
 
-    @AfterClass
+    @AfterAll
     public static void teardownOnce() throws Exception {
         otsdbConsumer.wakeup();
         otsdbConsumer.join();
@@ -200,7 +199,7 @@ public class StatsTopologyTest extends AbstractStormTest {
         AbstractStormTest.stopZooKafkaAndStorm();
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         otsdbConsumer.clear();
 
@@ -878,7 +877,7 @@ public class StatsTopologyTest extends AbstractStormTest {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void flowLldpStatsTest() {
         long lldpCookie = 1;
         FlowStatsEntry stats = new FlowStatsEntry(1, lldpCookie, 450, 550L, 10, 10);
@@ -938,19 +937,19 @@ public class StatsTopologyTest extends AbstractStormTest {
                 .filter(entry -> (METRIC_PREFIX + "flow.raw.packets").equals(entry.getMetric()))
                 .collect(Collectors.toList());
 
-        Assert.assertEquals(3, rawPacketsMetric.size());
+        assertEquals(3, rawPacketsMetric.size());
         for (Datapoint entry : rawPacketsMetric) {
             Map<String, String> tags = entry.getTags();
-            Assert.assertEquals(CookieType.SERVER_42_FLOW_RTT_INGRESS.name().toLowerCase(), tags.get("type"));
+            assertEquals(CookieType.SERVER_42_FLOW_RTT_INGRESS.name().toLowerCase(), tags.get("type"));
 
             if (Objects.equals(0, entry.getValue())) {
-                Assert.assertEquals("unknown", tags.get("flowid"));
+                assertEquals("unknown", tags.get("flowid"));
             } else if (Objects.equals(1, entry.getValue())) {
-                Assert.assertEquals(flowId, tags.get("flowid"));
+                assertEquals(flowId, tags.get("flowid"));
             } else if (Objects.equals(2, entry.getValue())) {
-                Assert.assertEquals("unknown", tags.get("flowid"));
+                assertEquals("unknown", tags.get("flowid"));
             } else {
-                Assert.fail(format("Unexpected metric value: %s", entry));
+                fail(format("Unexpected metric value: %s", entry));
             }
         }
     }

--- a/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/bolts/SpeakerStatsRequesterBoltTest.java
+++ b/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/bolts/SpeakerStatsRequesterBoltTest.java
@@ -15,11 +15,10 @@
 
 package org.openkilda.wfm.topology.stats.bolts;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -51,16 +50,17 @@ import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SpeakerStatsRequesterBoltTest {
 
     @Mock
@@ -80,7 +80,7 @@ public class SpeakerStatsRequesterBoltTest {
     @Mock
     private Tuple startTuple;
 
-    @Before
+    @BeforeEach
     public void setup() {
         when(topologyContext.getThisTaskId()).thenReturn(1);
         when(repositoryFactory.createSwitchRepository()).thenReturn(switchRepository);
@@ -90,7 +90,7 @@ public class SpeakerStatsRequesterBoltTest {
         when(input.getFields()).thenReturn(new Fields());
         when(input.getValueByField(FIELD_ID_CONTEXT)).thenReturn("123");
         when(startTuple.getSourceComponent()).thenReturn(ZooKeeperSpout.SPOUT_ID);
-        when(startTuple.getValueByField(FIELD_ID_LIFECYCLE_EVENT))
+        lenient().when(startTuple.getValueByField(FIELD_ID_LIFECYCLE_EVENT))
                 .thenReturn(LifecycleEvent.builder().signal(Signal.START).build());
         when(startTuple.getFields()).thenReturn(new Fields());
 
@@ -175,10 +175,10 @@ public class SpeakerStatsRequesterBoltTest {
         verify(output, times(1)).emit(eq(GRPC_REQUEST_STREAM), any(Tuple.class), values.capture());
 
         Values capturedValues = values.getValue();
-        assertTrue(capturedValues.get(0) instanceof CommandMessage);
+        Assertions.assertTrue(capturedValues.get(0) instanceof CommandMessage);
         CommandMessage commandMessage = (CommandMessage) capturedValues.get(0);
-        assertTrue(commandMessage.getData() instanceof GetPacketInOutStatsRequest);
+        Assertions.assertTrue(commandMessage.getData() instanceof GetPacketInOutStatsRequest);
         GetPacketInOutStatsRequest request = (GetPacketInOutStatsRequest) commandMessage.getData();
-        assertEquals(address, request.getAddress());
+        Assertions.assertEquals(address, request.getAddress());
     }
 }

--- a/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/bolts/metrics/FlowDirectionHelperTest.java
+++ b/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/bolts/metrics/FlowDirectionHelperTest.java
@@ -15,28 +15,24 @@
 
 package org.openkilda.wfm.topology.stats.bolts.metrics;
 
-import static org.junit.Assert.assertEquals;
-
 import org.openkilda.wfm.topology.stats.bolts.metrics.FlowDirectionHelper.Direction;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 
 public class FlowDirectionHelperTest {
     private static final long FORWARD_COOKIE = 0x4000000000000001L;
     private static final long REVERSE_COOKIE = 0x2000000000000001L;
-    private static final long BAD_COOKIE =     0x6000000000000001L;
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+    private static final long BAD_COOKIE = 0x6000000000000001L;
 
     @Test
     public void findDirectionTest() throws Exception {
-        assertEquals(Direction.FORWARD, FlowDirectionHelper.findDirection(FORWARD_COOKIE));
-        assertEquals(Direction.REVERSE, FlowDirectionHelper.findDirection(REVERSE_COOKIE));
+        Assertions.assertEquals(Direction.FORWARD, FlowDirectionHelper.findDirection(FORWARD_COOKIE));
+        Assertions.assertEquals(Direction.REVERSE, FlowDirectionHelper.findDirection(REVERSE_COOKIE));
 
-        thrown.expect(FlowCookieException.class);
-        FlowDirectionHelper.findDirection(BAD_COOKIE);
+        Assertions.assertThrows(FlowCookieException.class, () -> {
+            FlowDirectionHelper.findDirection(BAD_COOKIE);
+        });
     }
 }

--- a/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/service/KildaEntryCacheServiceTest.java
+++ b/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/service/KildaEntryCacheServiceTest.java
@@ -16,8 +16,9 @@
 package org.openkilda.wfm.topology.stats.service;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -70,20 +71,19 @@ import org.openkilda.wfm.topology.stats.model.YFlowDescriptor;
 import org.openkilda.wfm.topology.stats.model.YFlowSubDescriptor;
 
 import com.google.common.collect.Sets;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class KildaEntryCacheServiceTest {
     private static final Long FLOW_UNMASKED_COOKIE = 1L;
     private static final int STAT_VLAN_1 = 5;
@@ -130,7 +130,7 @@ public class KildaEntryCacheServiceTest {
 
     KildaEntryCacheService service;
 
-    @Before
+    @BeforeEach
     public void initService() {
         when(repositoryFactory.createFlowRepository()).thenReturn(flowRepository);
         when(repositoryFactory.createYFlowRepository()).thenReturn(yFlowRepository);
@@ -215,7 +215,7 @@ public class KildaEntryCacheServiceTest {
                         new FlowStatsEntry(
                                 0,
                                 forwardPath.getCookie().toBuilder()
-                                .type(CookieType.SERVER_42_FLOW_RTT_INGRESS).build().getValue(),
+                                        .type(CookieType.SERVER_42_FLOW_RTT_INGRESS).build().getValue(),
                                 0, 0, 0, 0),
                         new FlowStatsEntry(
                                 0, forwardPath.getCookie().toBuilder().looped(true).build().getValue(),
@@ -383,9 +383,9 @@ public class KildaEntryCacheServiceTest {
 
         // source switch
         service.completeAndForwardFlowStats(new FlowStatsData(
-                flow.getSrcSwitchId(), asList(
-                    new FlowStatsEntry(0, forwardPathCookie.getValue(), 0, 0, 0, 0),
-                    new FlowStatsEntry(0, reversePathCookie.getValue(), 0, 0, 0, 0))));
+                flow.getSrcSwitchId(), asList(new FlowStatsEntry(0, forwardPathCookie.getValue(),
+                0, 0, 0, 0), new FlowStatsEntry(0,
+                reversePathCookie.getValue(), 0, 0, 0, 0))));
 
         verify(carrier, atLeastOnce()).emitFlowStats(cookieCacheCaptor.capture());
         List<FlowStatsAndDescriptor> statsEntries = cookieCacheCaptor.getValue().getStatsEntries();
@@ -403,9 +403,9 @@ public class KildaEntryCacheServiceTest {
 
         // transit
         service.completeAndForwardFlowStats(new FlowStatsData(
-                transitSwitch.getSwitchId(), asList(
-                    new FlowStatsEntry(0, forwardPathCookie.getValue(), 0, 0, 0, 0),
-                    new FlowStatsEntry(0, reversePathCookie.getValue(), 0, 0, 0, 0))));
+                transitSwitch.getSwitchId(), asList(new FlowStatsEntry(0, forwardPathCookie.getValue(),
+                0, 0, 0, 0), new FlowStatsEntry(0,
+                reversePathCookie.getValue(), 0, 0, 0, 0))));
         verify(carrier, atLeastOnce()).emitFlowStats(cookieCacheCaptor.capture());
         statsEntries = cookieCacheCaptor.getValue().getStatsEntries();
         assertDescriptionPopulation(statsEntries, 2, 2);
@@ -422,9 +422,9 @@ public class KildaEntryCacheServiceTest {
 
         // egress
         service.completeAndForwardFlowStats(new FlowStatsData(
-                flow.getDestSwitchId(), asList(
-                    new FlowStatsEntry(0, forwardPathCookie.getValue(), 0, 0, 0, 0),
-                    new FlowStatsEntry(0, reversePathCookie.getValue(), 0, 0, 0, 0))));
+                flow.getDestSwitchId(), asList(new FlowStatsEntry(0, forwardPathCookie.getValue(),
+                0, 0, 0, 0), new FlowStatsEntry(0,
+                reversePathCookie.getValue(), 0, 0, 0, 0))));
         verify(carrier, atLeastOnce()).emitFlowStats(cookieCacheCaptor.capture());
         statsEntries = cookieCacheCaptor.getValue().getStatsEntries();
         assertDescriptionPopulation(statsEntries, 2, 2);
@@ -452,8 +452,8 @@ public class KildaEntryCacheServiceTest {
 
         final MeterId forwardMeterId = flow.getForwardPath().getMeterId();
 
-        @SuppressWarnings({"ConstantConditions"})
-        final MeterId forwardProtectedMeterId = flow.getProtectedForwardPath().getMeterId();
+        @SuppressWarnings({"ConstantConditions"}) final MeterId forwardProtectedMeterId =
+                flow.getProtectedForwardPath().getMeterId();
 
         verify(carrier, atLeastOnce()).emitMeterStats(meterCacheCaptor.capture());
         List<MeterStatsAndDescriptor> statsEntries = meterCacheCaptor.getValue().getStatsEntries();
@@ -539,9 +539,9 @@ public class KildaEntryCacheServiceTest {
         service.activate();
 
         // shared endpoint
-        service.completeAndForwardMeterStats(new MeterStatsData(
-                yFlow.getSharedEndpoint().getSwitchId(), Collections.singletonList(
-                    new MeterStatsEntry(yFlow.getSharedEndpointMeterId().getValue(), 0, 0))));
+        service.completeAndForwardMeterStats(new MeterStatsData(yFlow.getSharedEndpoint().getSwitchId(),
+                Collections.singletonList(new MeterStatsEntry(yFlow.getSharedEndpointMeterId().getValue(),
+                        0, 0))));
 
         verify(carrier, atLeastOnce()).emitMeterStats(meterCacheCaptor.capture());
         List<MeterStatsAndDescriptor> statsEntries = meterCacheCaptor.getValue().getStatsEntries();
@@ -553,9 +553,9 @@ public class KildaEntryCacheServiceTest {
                         yFlow.getSharedEndpointMeterId()));
 
         // y-point
-        service.completeAndForwardMeterStats(new MeterStatsData(
-                yFlow.getYPoint(), Collections.singletonList(
-                    new MeterStatsEntry(yFlow.getMeterId().getValue(), 0, 0))));
+        service.completeAndForwardMeterStats(new MeterStatsData(yFlow.getYPoint(),
+                Collections.singletonList(new MeterStatsEntry(yFlow.getMeterId().getValue(),
+                        0, 0))));
         verify(carrier, atLeastOnce()).emitMeterStats(meterCacheCaptor.capture());
         statsEntries = meterCacheCaptor.getValue().getStatsEntries();
         assertDescriptionPopulation(statsEntries, 1, 1);
@@ -859,7 +859,7 @@ public class KildaEntryCacheServiceTest {
                 return;
             }
         }
-        Assert.fail("Cache miss");
+        fail("Cache miss");
     }
 
     private void assertMeterCache(
@@ -871,7 +871,7 @@ public class KildaEntryCacheServiceTest {
                 return;
             }
         }
-        Assert.fail("Cache miss");
+        fail("Cache miss");
     }
 
     private void assertDescriptionPopulation(

--- a/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/service/MeterStatsHandlerTest.java
+++ b/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/service/MeterStatsHandlerTest.java
@@ -15,15 +15,15 @@
 
 package org.openkilda.wfm.topology.stats.service;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.model.cookie.CookieBase.CookieType;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class MeterStatsHandlerTest {
     @Test
     public void shouldRefreshCommonFlowsCookieCache() {


### PR DESCRIPTION
This PR contains the Junit4->Junit5 migration for the following modules:

- [x] stats-topology
- [x] base-topology
- [x] blue-green
- [x] connecteddevices-topology
- [x] kilda-persistence-tinkerpop
- [x] isllatency-topology
- [x] opentsdb-topology
- [x] ping-topology
- [x] flowhs-topology
- [x] flowmonitoring-topology
- [x] nbworker-topology
- [x] kilda-pce
- [ ] floodlight-service
- [ ] floodlightrouter-topology
- [ ] grpc-speaker
- [ ] kilda-configuration
- [ ] kilda-model
- [ ] kilda-persistence-api
- [ ] network-topology
- [ ] northbound-service
- [ ] testing
- [ ] reroute-topology
- [ ] rule-manager
- [ ] server42
- [ ] swmanager-topology


Due to the tight dependencies among these modules, it seems to me that we cannot deliver them in separate PRs, so they should go all together.. 

closes #5242

