### PR TITLE
Feature/show protected paths

### DIFF
--- a/docs/design/solutions/protected-paths/Protected-paths-availability.md
+++ b/docs/design/solutions/protected-paths/Protected-paths-availability.md
@@ -1,0 +1,74 @@
+# Protected paths availability
+
+## Goal
+Provide a read-only operation that allows to know whether a path between selected switches could have a protected path. 
+
+### Use case
+Assume we have the following topology of switches connected to each other with links with the certain costs:
+```
+A-------5----B----1--------C
+ \           |            /
+  \          1           /
+   \         |          /
+    ----1----D----5-----
+```
+Suppose we want to know whether it is possible to create a flow between A and C with a protected path. The answer 
+depends on the specific parameters of the flow. If we say that the flow path cost must be at most 3, then PCE will find
+only one path A-D-B-C, which cannot have a protected path in this topology. If the cost is at most 11, then PCE will find 
+4 paths: A-B-C and A-D-C could have protected paths, while A-D-B-C and A-B-D-C could not.   
+
+## Proposal
+Extend `network/paths` API so that each found path contains a field containing an object representing a protected path.
+If a response doesn't contain any path, it means that PCE cannot find a protected path in the given context. Or, in other 
+words, if a field with a protected path is absent or empty, it is not possible to create a flow with a protected path.
+
+In V1 API, there will be a URL parameter: 
+```
+includeProtectedPath=true
+```
+
+OpenKilda will find all paths between the given switches and return the response:
+```json
+{
+  "paths": [
+    {
+      "bandwidth": 0,
+      "is_backup_path": true,
+      "latency": 0,
+      "latency_ms": 0,
+      "latency_ns": 0,
+      "protected_path": {
+        "bandwidth": 0,
+        "is_backup_path": true,
+        "latency": 0,
+        "latency_ms": 0,
+        "latency_ns": 0,
+        "nodes": [
+          {
+            "input_port": 0,
+            "output_port": 0,
+            "switch_id": "string"
+          }
+        ]
+      },
+      "nodes": [
+        {
+          "input_port": 0,
+          "output_port": 0,
+          "switch_id": "string"
+        }
+      ]
+    }
+  ]
+}
+```
+The field `protected_path` contains the best protected path in the given context, or an empty object if PCE is unable 
+to find any protected path.
+The implementation of this feature will reuse the existing code that finds paths, so that it is future compatible 
+with the changes in PCE or get paths functionality.
+Since there are no any locking and resource allocation, this API cannot guarantee that it will be possible to create 
+a flow with the particular protected path in the future.
+
+### Backward compatibility and consistency
+When a user doesn't use the new parameter ```includeProtectedPath=true```, then the response doesn't contain any new fields from this 
+feature.  

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/flow/PathNodePayload.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/flow/PathNodePayload.java
@@ -17,9 +17,11 @@ package org.openkilda.messaging.payload.flow;
 
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
 import java.io.Serializable;
@@ -28,36 +30,15 @@ import java.io.Serializable;
  * Flow path node NB representation class.
  */
 @Value
+@Builder
+@AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(SnakeCaseStrategy.class)
 public class PathNodePayload implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    /**
-     * Switch id.
-     */
-    @JsonProperty("switch_id")
-    private SwitchId switchId;
-
-    /**
-     * Input port number.
-     */
-    @JsonProperty("input_port")
-    private Integer inputPort;
-
-    /**
-     * Output port number.
-     */
-    @JsonProperty("output_port")
-    private Integer outputPort;
-
-    @JsonCreator
-    public PathNodePayload(
-            @JsonProperty("switch_id") SwitchId switchId,
-            @JsonProperty("input_port") Integer inputPort,
-            @JsonProperty("output_port") Integer outputPort) {
-        this.switchId = switchId;
-        this.inputPort = inputPort;
-        this.outputPort = outputPort;
-    }
+    SwitchId switchId;
+    Integer inputPort;
+    Integer outputPort;
 }

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/network/PathDto.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/network/PathDto.java
@@ -17,53 +17,38 @@ package org.openkilda.messaging.payload.network;
 
 import org.openkilda.messaging.payload.flow.PathNodePayload;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
-import lombok.Value;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+import lombok.experimental.SuperBuilder;
 
 import java.time.Duration;
 import java.util.List;
 
-@Value
-@Builder
+@Data
+@SuperBuilder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonNaming(SnakeCaseStrategy.class)
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PACKAGE)
+@Setter(value = AccessLevel.PRIVATE)
 public class PathDto {
-    @JsonProperty("bandwidth")
-    private Long bandwidth;
+    Long bandwidth;
+    Long latency;
+    Long latencyNs;
+    Long latencyMs;
+    List<PathNodePayload> nodes;
+    Boolean isBackupPath;
+    ProtectedPathPayload protectedPath;
 
-    @JsonProperty("latency")
-    private Long latency;
-
-    @JsonProperty("latency_ns")
-    private Long latencyNs;
-
-    @JsonProperty("latency_ms")
-    private Long latencyMs;
-
-    @JsonProperty("nodes")
-    private List<PathNodePayload> nodes;
-
-    @JsonProperty("is_backup_path")
-    private Boolean isBackupPath;
-
-    public PathDto(Long bandwidth, Duration latency, List<PathNodePayload> nodes, Boolean isBackupPath) {
-        this(bandwidth, latency.toNanos(), latency.toNanos(), latency.toMillis(), nodes, isBackupPath);
-    }
-
-    @JsonCreator
-    public PathDto(@JsonProperty("bandwidth") Long bandwidth,
-                   @JsonProperty("latency") Long latency,
-                   @JsonProperty("latency_ns") Long latencyNs,
-                   @JsonProperty("latency_ms") Long latencyMs,
-                   @JsonProperty("nodes") List<PathNodePayload> nodes,
-                   @JsonProperty("is_backup_path") Boolean isBackupPath) {
-        this.bandwidth = bandwidth;
-        this.latency = latency;
-        this.latencyNs = latencyNs;
-        this.latencyMs = latencyMs;
-        this.nodes = nodes;
-        this.isBackupPath = isBackupPath;
+    public PathDto(Long bandwidth, Duration latency, List<PathNodePayload> nodes, Boolean isBackupPath,
+                   ProtectedPathPayload protectedPath) {
+        this(bandwidth, latency.toNanos(), latency.toNanos(), latency.toMillis(), nodes, isBackupPath,
+                protectedPath);
     }
 }

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/network/ProtectedPathPayload.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/network/ProtectedPathPayload.java
@@ -1,4 +1,4 @@
-/* Copyright 2019 Telstra Open Source
+/* Copyright 2023 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -13,30 +13,27 @@
  *   limitations under the License.
  */
 
-package org.openkilda.messaging.info.network;
+package org.openkilda.messaging.payload.network;
 
-import org.openkilda.messaging.payload.flow.PathNodePayload;
-
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Value;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+import lombok.experimental.SuperBuilder;
 
-import java.io.Serializable;
-import java.time.Duration;
-import java.util.List;
-
-@Value
-@Builder
-@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@Data
+@Setter(value = AccessLevel.PRIVATE)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@SuperBuilder
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonNaming(value = SnakeCaseStrategy.class)
-public class Path implements Serializable {
-    Long bandwidth;
-    Duration latency;
-    List<PathNodePayload> nodes;
-    Boolean isBackupPath;
-    Path protectedPath;
+@JsonNaming(SnakeCaseStrategy.class)
+public class ProtectedPathPayload extends PathDto {
+    @JsonIgnore
+    ProtectedPathPayload protectedPath;
 }

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/mappers/PathMapper.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/mappers/PathMapper.java
@@ -39,7 +39,8 @@ public abstract class PathMapper {
      */
     public org.openkilda.messaging.info.network.Path map(org.openkilda.pce.Path path) {
         if (path == null || path.getSegments().isEmpty()) {
-            return new org.openkilda.messaging.info.network.Path(0L, Duration.ZERO, new ArrayList<>(), false);
+            return new org.openkilda.messaging.info.network.Path(0L, Duration.ZERO, new ArrayList<>(), false,
+                    null);
         }
 
         List<PathNodePayload> nodes = new ArrayList<>();
@@ -61,7 +62,14 @@ public abstract class PathMapper {
             nodes.add(new PathNodePayload(lastSegment.getDestSwitchId(), lastSegment.getDestPort(), null));
         }
 
+        if (path.getProtectedPath() != null && path.getProtectedPath().getProtectedPath() != null) {
+            throw new IllegalStateException("A protected path to some path cannot have its own protected path.");
+        }
+
+        org.openkilda.messaging.info.network.Path protectedPath =
+                path.getProtectedPath() == null ? null : map(path.getProtectedPath());
+
         return new org.openkilda.messaging.info.network.Path(path.getMinAvailableBandwidth(),
-                Duration.ofNanos(path.getLatency()), nodes, path.isBackupPath());
+                Duration.ofNanos(path.getLatency()), nodes, path.isBackupPath(), protectedPath);
     }
 }

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/FlowPath.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/FlowPath.java
@@ -388,7 +388,7 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    static final class FlowPathDataImpl implements FlowPathData, Serializable {
+    public static final class FlowPathDataImpl implements FlowPathData, Serializable {
         private static final long serialVersionUID = 1L;
         @NonNull PathId pathId;
         @NonNull Switch srcSwitch;
@@ -416,7 +416,8 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
         @Builder.Default
         @ToString.Exclude
         @EqualsAndHashCode.Exclude
-        @NonNull List<PathSegment> segments = new ArrayList<>();
+        @NonNull
+        List<PathSegment> segments = new ArrayList<>();
         Set<FlowApplication> applications;
 
         @Setter(AccessLevel.NONE)
@@ -437,6 +438,7 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
         boolean destWithMultiTable;
         String sharedBandwidthGroupId;
 
+        @Override
         public void setPathId(PathId pathId) {
             this.pathId = pathId;
 

--- a/src-java/kilda-pce/build.gradle
+++ b/src-java/kilda-pce/build.gradle
@@ -8,6 +8,10 @@ dependencies {
     implementation 'com.google.guava:guava'
     implementation 'org.apache.commons:commons-lang3'
 
+    implementation 'org.mapstruct:mapstruct'
+    implementation 'org.mapstruct:mapstruct-processor'
+    annotationProcessor 'org.mapstruct:mapstruct-processor'
+
     implementation 'org.slf4j:slf4j-api'
     testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
 
@@ -24,6 +28,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding'
     testAnnotationProcessor 'org.projectlombok:lombok-mapstruct-binding'
 }
+
 
 test {
     useJUnitPlatform()

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/DiverseWeightsProcessor.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/DiverseWeightsProcessor.java
@@ -1,0 +1,104 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.pce;
+
+import org.openkilda.model.FlowPath;
+import org.openkilda.model.PathId;
+import org.openkilda.pce.impl.AvailableNetwork;
+import org.openkilda.persistence.repositories.FlowPathRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * This class is responsible for setting additional weights on flow paths. This class is used for preparing an available
+ * network object for further processing such as finding diverse or protected paths.
+ */
+@Slf4j
+public final class DiverseWeightsProcessor {
+
+    private DiverseWeightsProcessor() {
+    }
+
+    /**
+     * This method mutates the network by adding diverse weights if it is required based on the provided parameters.
+     * @param parameters parameters of the flow for which the available network is used.
+     * @param reusePathsResources treat these resources as available
+     * @param network mutable available network that will be used for operations on the flow
+     * @param flowPathRepository flow path repository
+     */
+    public static void fillDiverseWeights(FlowParameters parameters,
+                                          Collection<PathId> reusePathsResources,
+                                          AvailableNetwork network,
+                                          FlowPathRepository flowPathRepository) {
+        Set<PathId> flowPathIds = new HashSet<>(flowPathRepository.findPathIdsByFlowDiverseGroupId(
+                parameters.getDiverseGroupId()));
+        if (!reusePathsResources.isEmpty()) {
+            flowPathIds = flowPathIds.stream()
+                    .filter(s -> !reusePathsResources.contains(s))
+                    .collect(Collectors.toSet());
+        }
+
+        Set<PathId> affinityPathIds =
+                new HashSet<>(flowPathRepository.findPathIdsByFlowAffinityGroupId(parameters.getAffinityGroupId()));
+
+        List<FlowPath> flowPathsToProcess = flowPathIds.stream()
+                .map(flowPathRepository::findById)
+                // TODO replace it with Optional::stream once JDK9 is available
+                .flatMap(optional -> optional.map(Stream::of).orElseGet(Stream::empty))
+                .filter(flowPath -> isNeedToAddDiversePenalties(flowPath, affinityPathIds, parameters))
+                .collect(Collectors.toList());
+
+        processDiversityPenalties(parameters, network, flowPathsToProcess);
+    }
+
+    /**
+     * This method mutates the provided network by setting penalties on diverse on the provided diverse paths.
+     * This is needed when calculating a protected path that must be diverse from the main path.
+     * @param parameters parameters of the flow for which the available network is used
+     * @param network mutable available network that will be used for operations on the flow
+     * @param diversePaths a list of paths that must have an increased diversity weight
+     */
+    public static void processDiversityPenalties(FlowParameters parameters, AvailableNetwork network,
+                                                 List<FlowPath> diversePaths) {
+        log.info("processDiversityPenalties start processing for: {}", diversePaths);
+
+        diversePaths.forEach(flowPath -> {
+            network.processDiversityGroupForSingleSwitchFlow(flowPath);
+            network.processDiversitySegments(flowPath.getSegments(),
+                    parameters.getTerminatingSwitchIds());
+            network.processDiversitySegmentsWithPop(flowPath.getSegments());
+        });
+    }
+
+    private static boolean isNeedToAddDiversePenalties(FlowPath path, Set<PathId> affinityPathIds,
+                                                FlowParameters parameters) {
+        if (parameters.isCommonFlow() && Objects.equals(path.getFlowId(), parameters.getFlowId())) {
+            return true; // it is a diverse group for a protected path of a common flow
+        }
+        if (parameters.isHaFlow() && Objects.equals(path.getHaFlowId(), parameters.getHaFlowId())) {
+            return true; // it is a diverse group for a protected path of an HA-flow
+        }
+        return !affinityPathIds.contains(path.getPathId()); // affinity group priority is higher then diversity
+    }
+}

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/FlowParameters.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/FlowParameters.java
@@ -1,0 +1,73 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.pce;
+
+import static com.google.common.collect.Sets.newHashSet;
+
+import org.openkilda.model.Flow;
+import org.openkilda.model.FlowEncapsulationType;
+import org.openkilda.model.HaFlow;
+import org.openkilda.model.HaSubFlow;
+import org.openkilda.model.SwitchId;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.Value;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * This holder class allows to use short common signatures for methods taking simple and HA flows.
+ */
+@Value
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FlowParameters {
+    public FlowParameters(Flow flow) {
+        this(flow.isIgnoreBandwidth(), flow.getBandwidth(), flow.getEncapsulationType(), flow.getFlowId(), null,
+                flow.getYFlowId(), flow.getDiverseGroupId(), flow.getAffinityGroupId(),
+                newHashSet(flow.getSrcSwitchId(), flow.getDestSwitchId()), true, false);
+    }
+
+    public FlowParameters(HaFlow haFlow) {
+        this(haFlow.isIgnoreBandwidth(), haFlow.getMaximumBandwidth(), haFlow.getEncapsulationType(), null,
+                haFlow.getHaFlowId(), null, haFlow.getDiverseGroupId(), haFlow.getAffinityGroupId(),
+                getSwitchIds(haFlow), false, true);
+    }
+
+    boolean ignoreBandwidth;
+    long bandwidth;
+    FlowEncapsulationType encapsulationType;
+    String flowId;
+    String haFlowId;
+    String yFlowId;
+    String diverseGroupId;
+    String affinityGroupId;
+    @NonNull
+    Set<SwitchId> terminatingSwitchIds;
+
+    boolean commonFlow;
+    boolean haFlow;
+
+    private static Set<SwitchId> getSwitchIds(HaFlow haFlow) {
+        Set<SwitchId> result = haFlow.getHaSubFlows().stream()
+                .map(HaSubFlow::getEndpointSwitchId)
+                .collect(Collectors.toSet());
+        result.add(haFlow.getSharedSwitchId());
+        return result;
+    }
+}

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/GetPathsResult.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/GetPathsResult.java
@@ -15,10 +15,14 @@
 
 package org.openkilda.pce;
 
+import org.openkilda.pce.finder.FailReason;
+import org.openkilda.pce.finder.FailReasonType;
+
 import lombok.Builder;
 import lombok.Value;
 
 import java.io.Serializable;
+import java.util.Map;
 
 @Value
 @Builder
@@ -27,4 +31,10 @@ public class GetPathsResult implements Serializable {
     Path forward;
     Path reverse;
     boolean backUpPathComputationWayUsed;
+
+    Map<FailReasonType, FailReason> failReasons;
+
+    public boolean isSuccess() {
+        return (failReasons == null || failReasons.isEmpty()) && forward != null;
+    }
 }

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/Path.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/Path.java
@@ -37,7 +37,7 @@ public class Path implements Serializable {
     SwitchId destSwitchId;
 
     /**
-     * Latency value in nseconds.
+     * Latency value in nanoseconds.
      */
     long latency;
 
@@ -47,6 +47,8 @@ public class Path implements Serializable {
     List<Segment> segments;
 
     boolean isBackupPath;
+
+    Path protectedPath;
 
     @Value
     @Builder(toBuilder = true)

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/PathComputer.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/PathComputer.java
@@ -81,6 +81,15 @@ public interface PathComputer {
             throws UnroutableFlowException, RecoverableException;
 
     /**
+     * Calculates a protected path based on the given parameters and configuration.
+     * @param flow This method calculates a protected path to the main path of this flow.
+     * @param reusePathsResources include these resources as if they are not allocated
+     * @return GetPathResult containing a protected path or an empty path with fail reasons if it is not possible
+     *      to calculate the path.
+     */
+    GetPathsResult getProtectedPath(Flow flow, Collection<PathId> reusePathsResources);
+
+    /**
      * Gets the best N paths. N is a number, not greater than the count param, of all paths that can be found.
      *
      * @param srcSwitch source switchId

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/finder/FailReasonType.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/finder/FailReasonType.java
@@ -21,7 +21,9 @@ public enum FailReasonType {
     LATENCY_LIMIT("Latency limit"),
     MAX_WEIGHT_EXCEEDED("Max weight exceeded"),
     HARD_DIVERSITY_PENALTIES("There is no non-overlapped protected path"),
-    MAX_BANDWIDTH("Failed to find path with requested bandwidth");
+    MAX_BANDWIDTH("Failed to find path with requested bandwidth"),
+    PERSISTENCE_ERROR("Cannot fetch required data from the persistence layer."),
+    UNROUTABLE_FLOW("Unroutable flow exception occurred.");
 
     private final String value;
 

--- a/src-java/kilda-pce/src/main/java/org/openkilda/pce/mapper/PathSegmentMapper.java
+++ b/src-java/kilda-pce/src/main/java/org/openkilda/pce/mapper/PathSegmentMapper.java
@@ -1,0 +1,51 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.pce.mapper;
+
+import org.openkilda.model.PathId;
+import org.openkilda.model.PathSegment;
+import org.openkilda.model.Switch;
+import org.openkilda.pce.Path;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Mapper
+public abstract class PathSegmentMapper {
+
+    public static PathSegmentMapper INSTANCE = Mappers.getMapper(PathSegmentMapper.class);
+
+    /**
+     * Converts PCE's path segment representation into OpenKilda model PathSegment.
+     * @param segments PCE path segment
+     * @return OpenKilda model path segment
+     */
+    public List<PathSegment> toPathSegmentList(List<Path.Segment> segments) {
+        return segments.stream().map(s ->
+                PathSegment.builder()
+                        .pathId(new PathId("A virtual PCE path " + s.hashCode()))
+                        .srcSwitch(Switch.builder().switchId(s.getSrcSwitchId()).build())
+                        .srcPort(s.getSrcPort())
+                        .destSwitch(Switch.builder().switchId(s.getDestSwitchId()).build())
+                        .destPort(s.getDestPort())
+                        .latency(s.getLatency())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/ProtectedPathFinderTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/ProtectedPathFinderTest.java
@@ -22,7 +22,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -174,10 +178,14 @@ public class ProtectedPathFinderTest {
         });
         MatcherAssert.assertThat(exception.getMessage(),
                 containsString(FailReasonType.HARD_DIVERSITY_PENALTIES.toString()));
+
+        GetPathsResult getPathsResult = pathComputer.getProtectedPath(flow, Collections.emptyList());
+        assertFalse(getPathsResult.getFailReasons().isEmpty());
+        assertTrue(getPathsResult.getFailReasons().containsKey(FailReasonType.UNROUTABLE_FLOW));
     }
 
     @Test
-    public void shouldNotFindAnyProtectedPath() throws RecoverableException, UnroutableFlowException {
+    public void shouldNotFindAnyProtectedPath() throws RecoverableException {
         // Topology:
         //      D----E
         //      |    |
@@ -244,6 +252,10 @@ public class ProtectedPathFinderTest {
         });
         MatcherAssert.assertThat(exception.getMessage(),
                 containsString(FailReasonType.HARD_DIVERSITY_PENALTIES.toString()));
+
+        GetPathsResult getPathsResult = pathComputer.getProtectedPath(flow, Collections.emptyList());
+        assertFalse(getPathsResult.getFailReasons().isEmpty());
+        assertTrue(getPathsResult.getFailReasons().containsKey(FailReasonType.UNROUTABLE_FLOW));
     }
 
     @Test
@@ -338,6 +350,10 @@ public class ProtectedPathFinderTest {
                 () -> assertThat(lastReverseSegment.getSrcSwitchId(), equalTo(switchD.getSwitchId())),
                 () -> assertThat(lastReverseSegment.getDestSwitchId(), equalTo(switchA.getSwitchId()))
         );
+
+        GetPathsResult getPathsResult = pathComputer.getProtectedPath(flow, Collections.emptyList());
+        assertNull(getPathsResult.getFailReasons());
+        assertNotNull(getPathsResult.getForward());
     }
 
     @Test

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/mapper/PathSegmentMapperTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/mapper/PathSegmentMapperTest.java
@@ -1,0 +1,85 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.pce.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.openkilda.model.PathId;
+import org.openkilda.model.PathSegment;
+import org.openkilda.model.Switch;
+import org.openkilda.model.SwitchId;
+import org.openkilda.pce.Path.Segment;
+
+import com.google.common.collect.Sets;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+public class PathSegmentMapperTest {
+
+    @Test
+    public void toPathSegmentTest() {
+        Segment segment1 = Segment.builder()
+                .latency(12L)
+                .srcSwitchId(new SwitchId("00:01"))
+                .srcPort(1)
+                .destSwitchId(new SwitchId("00:02"))
+                .destPort(2)
+                .build();
+
+        Segment segment2 = Segment.builder()
+                .latency(22L)
+                .srcSwitchId(new SwitchId("00:02"))
+                .srcPort(3)
+                .destSwitchId(new SwitchId("00:03"))
+                .destPort(4)
+                .build();
+
+        List<PathSegment> actualMappedSegments =
+                PathSegmentMapper.INSTANCE.toPathSegmentList(Arrays.asList(segment1, segment2));
+
+        Set<PathSegment> expectedSegments = Sets.newHashSet(
+                PathSegment.builder()
+                        .pathId(new PathId("A virtual PCE path " + segment1.hashCode()))
+                        .latency(12L)
+                        .srcSwitch(Switch.builder()
+                                .switchId(new SwitchId("00:01"))
+                                .build())
+                        .srcPort(1)
+                        .destSwitch(Switch.builder()
+                                .switchId(new SwitchId("00:02"))
+                                .build())
+                        .destPort(2)
+                        .build(),
+                PathSegment.builder()
+                        .pathId(new PathId("A virtual PCE path " + segment2.hashCode()))
+                        .latency(22L)
+                        .srcSwitch(Switch.builder()
+                                .switchId(new SwitchId("00:02"))
+                                .build())
+                        .srcPort(3)
+                        .destSwitch(Switch.builder()
+                                .switchId(new SwitchId("00:03"))
+                                .build())
+                        .destPort(4)
+                        .build());
+
+        assertEquals(actualMappedSegments.size(), 2);
+        assertEquals(expectedSegments, Sets.newHashSet(actualMappedSegments));
+    }
+}

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetPathsRequest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetPathsRequest.java
@@ -52,13 +52,17 @@ public class GetPathsRequest extends BaseRequest {
     @JsonProperty("max_path_count")
     Integer maxPathCount;
 
+    @JsonProperty("protected")
+    Boolean includeProtectedPathAvailability;
+
     public GetPathsRequest(@JsonProperty("src_switch_id") SwitchId srcSwitchId,
                            @JsonProperty("dst_switch_id") SwitchId dstSwitchId,
                            @JsonProperty("encapsulation_type") FlowEncapsulationType encapsulationType,
                            @JsonProperty("path_computation_strategy") PathComputationStrategy pathComputationStrategy,
                            @JsonProperty("max_latency") Duration maxLatency,
                            @JsonProperty("max_latency_tier2") Duration maxLatencyTier2,
-                           @JsonProperty("max_path_count") Integer maxPathCount) {
+                           @JsonProperty("max_path_count") Integer maxPathCount,
+                           @JsonProperty("protected") Boolean includeProtectedPathAvailability) {
         this.srcSwitchId = srcSwitchId;
         this.dstSwitchId = dstSwitchId;
         this.encapsulationType = encapsulationType;
@@ -66,5 +70,6 @@ public class GetPathsRequest extends BaseRequest {
         this.maxLatency = maxLatency;
         this.maxLatencyTier2 = maxLatencyTier2;
         this.maxPathCount = maxPathCount;
+        this.includeProtectedPathAvailability = includeProtectedPathAvailability;
     }
 }

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/PathsBolt.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/PathsBolt.java
@@ -67,9 +67,16 @@ public class PathsBolt extends PersistenceOperationsBolt {
 
     private List<PathsInfoData> getPaths(GetPathsRequest request) {
         try {
-            return pathService.getPaths(request.getSrcSwitchId(), request.getDstSwitchId(),
-                    request.getEncapsulationType(), request.getPathComputationStrategy(), request.getMaxLatency(),
-                    request.getMaxLatencyTier2(), request.getMaxPathCount());
+            if (Boolean.TRUE.equals(request.getIncludeProtectedPathAvailability())) {
+                return pathService.getPathsWithProtectedPath(request.getSrcSwitchId(),
+                        request.getDstSwitchId(), request.getEncapsulationType(), request.getPathComputationStrategy(),
+                        request.getMaxLatency(), request.getMaxLatencyTier2(), request.getMaxPathCount());
+            } else {
+                return pathService.getPaths(request.getSrcSwitchId(), request.getDstSwitchId(),
+                        request.getEncapsulationType(), request.getPathComputationStrategy(), request.getMaxLatency(),
+                        request.getMaxLatencyTier2(), request.getMaxPathCount());
+            }
+
         } catch (IllegalArgumentException e) {
             throw new MessageException(ErrorType.DATA_INVALID, e.getMessage(), "Bad request.");
         } catch (RecoverableException e) {
@@ -80,7 +87,7 @@ public class PathsBolt extends PersistenceOperationsBolt {
             throw new MessageException(ErrorType.NOT_FOUND, e.getMessage(), "Switch properties not found.");
         } catch (UnroutableFlowException e) {
             throw new MessageException(ErrorType.NOT_FOUND, e.getMessage(),
-                    String.format("Couldn't found any path from switch '%s' to switch '%s'.",
+                    String.format("Couldn't find any path from switch '%s' to switch '%s'.",
                             request.getSrcSwitchId(), request.getDstSwitchId()));
         }
     }

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/main/java/org/openkilda/wfm/topology/nbworker/services/PathsService.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/main/java/org/openkilda/wfm/topology/nbworker/services/PathsService.java
@@ -18,18 +18,25 @@ package org.openkilda.wfm.topology.nbworker.services;
 import org.openkilda.messaging.command.flow.PathValidateRequest;
 import org.openkilda.messaging.info.network.PathValidationResult;
 import org.openkilda.messaging.info.network.PathsInfoData;
+import org.openkilda.model.Flow;
 import org.openkilda.model.FlowEncapsulationType;
+import org.openkilda.model.FlowPath;
 import org.openkilda.model.KildaConfiguration;
 import org.openkilda.model.PathComputationStrategy;
+import org.openkilda.model.PathId;
+import org.openkilda.model.Switch;
 import org.openkilda.model.SwitchId;
 import org.openkilda.model.SwitchProperties;
 import org.openkilda.pce.AvailableNetworkFactory;
+import org.openkilda.pce.GetPathsResult;
 import org.openkilda.pce.Path;
 import org.openkilda.pce.PathComputer;
 import org.openkilda.pce.PathComputerConfig;
 import org.openkilda.pce.PathComputerFactory;
 import org.openkilda.pce.exception.RecoverableException;
 import org.openkilda.pce.exception.UnroutableFlowException;
+import org.openkilda.pce.mapper.PathSegmentMapper;
+import org.openkilda.persistence.repositories.FlowPathRepository;
 import org.openkilda.persistence.repositories.FlowRepository;
 import org.openkilda.persistence.repositories.IslRepository;
 import org.openkilda.persistence.repositories.KildaConfigurationRepository;
@@ -42,13 +49,17 @@ import org.openkilda.wfm.share.mappers.PathMapper;
 import org.openkilda.wfm.share.mappers.PathValidationDataMapper;
 import org.openkilda.wfm.topology.nbworker.validators.PathValidator;
 
+import lombok.Builder;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -60,6 +71,7 @@ public class PathsService {
     private final KildaConfigurationRepository kildaConfigurationRepository;
     private final IslRepository islRepository;
     private final FlowRepository flowRepository;
+    private final FlowPathRepository flowPathRepository;
 
     public PathsService(RepositoryFactory repositoryFactory, PathComputerConfig pathComputerConfig) {
         switchRepository = repositoryFactory.createSwitchRepository();
@@ -71,15 +83,174 @@ public class PathsService {
                 pathComputerConfig, new AvailableNetworkFactory(pathComputerConfig, repositoryFactory));
         pathComputer = pathComputerFactory.getPathComputer();
         defaultMaxPathCount = pathComputerConfig.getMaxPathCount();
+        flowPathRepository = repositoryFactory.createFlowPathRepository();
     }
 
     /**
-     * Get paths.
+     * Get paths based on the given parameters. Some parameters might be defaulted using OpenKilda configuration.
      */
     public List<PathsInfoData> getPaths(
             SwitchId srcSwitchId, SwitchId dstSwitchId, FlowEncapsulationType requestEncapsulationType,
             PathComputationStrategy requestPathComputationStrategy, Duration maxLatency, Duration maxLatencyTier2,
             Integer maxPathCount) throws RecoverableException, SwitchNotFoundException, UnroutableFlowException {
+
+        return getPaths(
+                validateAndDefaultGetPathRequestParameters(
+                    srcSwitchId,
+                    dstSwitchId,
+                    requestEncapsulationType,
+                    requestPathComputationStrategy,
+                    maxLatency,
+                    maxLatencyTier2,
+                    maxPathCount)
+                )
+                .stream()
+                .map(PathMapper.INSTANCE::map)
+                .map(path -> PathsInfoData.builder().path(path).build())
+                .collect(Collectors.toList());
+    }
+
+    private List<Path> getPaths(GetPathsRequestParameters getPathsRequestParameters)
+            throws UnroutableFlowException, RecoverableException {
+        return pathComputer.getNPaths(
+                getPathsRequestParameters.getSrcSwitchId(),
+                getPathsRequestParameters.getDstSwitchId(),
+                getPathsRequestParameters.getMaxPathCount(),
+                getPathsRequestParameters.getFlowEncapsulationType(),
+                getPathsRequestParameters.getPathComputationStrategy(),
+                getPathsRequestParameters.getMaxLatency(),
+                getPathsRequestParameters.getMaxLatencyTier2());
+    }
+
+    /**
+     * This method finds paths between the given switches with the given constraints. This version calculates whether
+     * a protected path can be created for each found path.
+     *
+     * @param srcSwitchId a source switch ID
+     * @param dstSwitchId a destination switch ID
+     * @param requestEncapsulationType encapsulation type from the request
+     * @param requestPathComputationStrategy path computation strategy from the request
+     * @param maxLatency max latency from the request
+     * @param maxLatencyTier2 max latency tier 2 from the request
+     * @param maxPathCount find no more than this number of paths
+     * @return a list of paths.
+     * @throws RecoverableException an exception from path computer
+     * @throws SwitchNotFoundException an exception from PCE
+     * @throws UnroutableFlowException an exception from PCE
+     */
+    public List<PathsInfoData> getPathsWithProtectedPath(
+            SwitchId srcSwitchId, SwitchId dstSwitchId, FlowEncapsulationType requestEncapsulationType,
+            PathComputationStrategy requestPathComputationStrategy, Duration maxLatency, Duration maxLatencyTier2,
+            Integer maxPathCount)
+            throws RecoverableException, SwitchNotFoundException, UnroutableFlowException {
+
+        GetPathsRequestParameters getPathsRequestParameters = validateAndDefaultGetPathRequestParameters(
+                srcSwitchId,
+                dstSwitchId,
+                requestEncapsulationType,
+                requestPathComputationStrategy,
+                maxLatency,
+                maxLatencyTier2,
+                maxPathCount);
+        log.info("getPathsWithProtectedPath: {}", getPathsRequestParameters);
+
+        return getPaths(getPathsRequestParameters)
+                .stream()
+                .map(path ->
+                    Path.builder()
+                            .segments(path.getSegments())
+                            .isBackupPath(path.isBackupPath())
+                            .minAvailableBandwidth(path.getMinAvailableBandwidth())
+                            .latency(path.getLatency())
+                            .srcSwitchId(path.getSrcSwitchId())
+                            .destSwitchId(path.getDestSwitchId())
+                            .protectedPath(getProtectedPath(path, getPathsRequestParameters))
+                            .build())
+                .map(PathMapper.INSTANCE::map)
+                .map(path -> PathsInfoData.builder().path(path).build())
+                .collect(Collectors.toList());
+    }
+
+    private Path getProtectedPath(Path path, GetPathsRequestParameters getPathsRequestParameters) {
+        Flow flow = createVirtualFlow(path,
+                getPathsRequestParameters.getFlowEncapsulationType(),
+                getPathsRequestParameters.getPathComputationStrategy(),
+                getPathsRequestParameters.getMaxLatency(),
+                getPathsRequestParameters.getMaxLatencyTier2());
+        GetPathsResult pathsResult = pathComputer.getProtectedPath(flow, Collections.emptyList());
+
+        if (pathsResult.isSuccess() && pathsResult.getForward().equals(path)) {
+            log.error("getProtectedPath calculated the protected path that is equal to the main path! main: {}, "
+                    + "protected: {}", path, pathsResult.getForward());
+            return null;
+        }
+
+        return pathsResult.isSuccess() ? pathsResult.getForward() : null;
+    }
+
+    private Flow createVirtualFlow(Path path,
+                                   FlowEncapsulationType encapsulationType,
+                                   PathComputationStrategy pathComputationStrategy,
+                                   Duration maxLatency,
+                                   Duration maxLatencyTier2) {
+        String diverseGroupId = UUID.randomUUID().toString();
+        if (!flowPathRepository.findByFlowGroupId(diverseGroupId).isEmpty()) {
+            log.error("There is a flow with the same diverse group ID as the virtual flow. group ID: {}",
+                    diverseGroupId);
+        }
+
+        Flow flow = Flow.builder()
+                .description("A virtual flow for computing a protected path to this flow")
+                .flowId("")
+                .srcSwitch(Switch.builder().switchId(path.getSrcSwitchId()).build())
+                .destSwitch(Switch.builder().switchId(path.getDestSwitchId()).build())
+                .bandwidth(path.getMinAvailableBandwidth())
+                .encapsulationType(encapsulationType)
+                .maxLatency(maxLatency != null ? maxLatency.toNanos() : null)
+                .maxLatencyTier2(maxLatencyTier2 != null ? maxLatencyTier2.toNanos() : null)
+                .pathComputationStrategy(pathComputationStrategy)
+                .diverseGroupId(diverseGroupId)
+                .allocateProtectedPath(true)
+                .build();
+
+        flow.setForwardPath(FlowPath.builder()
+                .pathId(new PathId("A virtual forward flow path for computing a protected path"))
+                .latency(path.getLatency())
+                .bandwidth(path.getMinAvailableBandwidth())
+                .srcSwitch(Switch.builder().switchId(path.getSrcSwitchId()).build())
+                .destSwitch(Switch.builder().switchId(path.getDestSwitchId()).build())
+                .segments(PathSegmentMapper.INSTANCE.toPathSegmentList(path.getSegments()))
+                .build());
+
+        flow.setReversePath(FlowPath.builder()
+                .pathId(new PathId("A virtual reverse flow path for computing a protected path"))
+                .latency(path.getLatency())
+                .bandwidth(path.getMinAvailableBandwidth())
+                .srcSwitch(Switch.builder().switchId(path.getDestSwitchId()).build())
+                .destSwitch(Switch.builder().switchId(path.getSrcSwitchId()).build())
+                .segments(PathSegmentMapper.INSTANCE.toPathSegmentList(getReversedPathSegments(path.getSegments())))
+                .build());
+
+        return flow;
+    }
+
+    private List<Path.Segment> getReversedPathSegments(List<Path.Segment> pathSegments) {
+        List<Path.Segment> reversedSegments = new LinkedList<>();
+        pathSegments.forEach(p -> reversedSegments.add(0, Path.Segment.builder()
+                        .srcSwitchId(p.getSrcSwitchId())
+                        .srcPort(p.getSrcPort())
+                        .destSwitchId(p.getDestSwitchId())
+                        .destPort(p.getDestPort())
+                        .latency(p.getLatency())
+                .build()));
+
+        return reversedSegments;
+    }
+
+    private GetPathsRequestParameters validateAndDefaultGetPathRequestParameters(
+            SwitchId srcSwitchId, SwitchId dstSwitchId, FlowEncapsulationType requestEncapsulationType,
+            PathComputationStrategy requestPathComputationStrategy, Duration maxLatency, Duration maxLatencyTier2,
+            Integer maxPathCount) throws SwitchNotFoundException {
         if (Objects.equals(srcSwitchId, dstSwitchId)) {
             throw new IllegalArgumentException(
                     String.format("Source and destination switch IDs are equal: '%s'", srcSwitchId));
@@ -92,6 +263,7 @@ public class PathsService {
         }
 
         KildaConfiguration kildaConfiguration = kildaConfigurationRepository.getOrDefault();
+
         FlowEncapsulationType flowEncapsulationType = Optional.ofNullable(requestEncapsulationType)
                 .orElse(kildaConfiguration.getFlowEncapsulationType());
 
@@ -99,8 +271,8 @@ public class PathsService {
                 () -> new SwitchPropertiesNotFoundException(srcSwitchId));
         if (!srcProperties.getSupportedTransitEncapsulation().contains(flowEncapsulationType)) {
             throw new IllegalArgumentException(String.format("Switch %s doesn't support %s encapsulation type. Choose "
-                    + "one of the supported encapsulation types %s or update switch properties and add needed "
-                    + "encapsulation type.", srcSwitchId, flowEncapsulationType,
+                            + "one of the supported encapsulation types %s or update switch properties and add needed "
+                            + "encapsulation type.", srcSwitchId, flowEncapsulationType,
                     srcProperties.getSupportedTransitEncapsulation()));
         }
 
@@ -108,8 +280,8 @@ public class PathsService {
                 () -> new SwitchPropertiesNotFoundException(dstSwitchId));
         if (!dstProperties.getSupportedTransitEncapsulation().contains(flowEncapsulationType)) {
             throw new IllegalArgumentException(String.format("Switch %s doesn't support %s encapsulation type. Choose "
-                    + "one of the supported encapsulation types %s or update switch properties and add needed "
-                    + "encapsulation type.", dstSwitchId, requestEncapsulationType,
+                            + "one of the supported encapsulation types %s or update switch properties and add needed "
+                            + "encapsulation type.", dstSwitchId, requestEncapsulationType,
                     dstProperties.getSupportedTransitEncapsulation()));
         }
 
@@ -124,12 +296,15 @@ public class PathsService {
             throw new IllegalArgumentException(String.format("Incorrect maxPathCount: %s", maxPathCount));
         }
 
-        List<Path> flowPaths = pathComputer.getNPaths(srcSwitchId, dstSwitchId, maxPathCount, flowEncapsulationType,
-                pathComputationStrategy, maxLatency, maxLatencyTier2);
-
-        return flowPaths.stream().map(PathMapper.INSTANCE::map)
-                .map(path -> PathsInfoData.builder().path(path).build())
-                .collect(Collectors.toList());
+        return GetPathsRequestParameters.builder()
+                .srcSwitchId(srcSwitchId)
+                .dstSwitchId(dstSwitchId)
+                .maxPathCount(maxPathCount)
+                .flowEncapsulationType(flowEncapsulationType)
+                .pathComputationStrategy(pathComputationStrategy)
+                .maxLatency(maxLatency)
+                .maxLatencyTier2(maxLatencyTier2)
+                .build();
     }
 
     /**
@@ -148,5 +323,17 @@ public class PathsService {
         return Collections.singletonList(pathValidator.validatePath(
                 PathValidationDataMapper.INSTANCE.toPathValidationData(request.getPathValidationPayload())
         ));
+    }
+
+    @Value
+    @Builder
+    private static class GetPathsRequestParameters {
+        SwitchId srcSwitchId;
+        SwitchId dstSwitchId;
+        FlowEncapsulationType flowEncapsulationType;
+        PathComputationStrategy pathComputationStrategy;
+        Duration maxLatency;
+        Duration maxLatencyTier2;
+        Integer maxPathCount;
     }
 }

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/topology/nbworker/services/PathsServiceTest.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/test/java/org/openkilda/wfm/topology/nbworker/services/PathsServiceTest.java
@@ -18,6 +18,10 @@ package org.openkilda.wfm.topology.nbworker.services;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openkilda.model.FlowEncapsulationType.TRANSIT_VLAN;
@@ -208,7 +212,7 @@ public class PathsServiceTest extends InMemoryGraphBasedTest {
     @Test
     public void findNPathsByTransitVlanAndNullMaxLatency()
             throws SwitchNotFoundException, RecoverableException, UnroutableFlowException {
-        // as max latency param is null LATENCY starategy will be used instead. It means all 500 paths will be returned
+        // as max latency param is null LATENCY strategy will be used instead. It means all 500 paths will be returned
         List<PathsInfoData> paths = pathsService.getPaths(SWITCH_ID_1, SWITCH_ID_2, TRANSIT_VLAN, MAX_LATENCY, null,
                 null, MAX_PATH_COUNT);
         assertTransitVlanAndLatencyPaths(paths);
@@ -293,6 +297,47 @@ public class PathsServiceTest extends InMemoryGraphBasedTest {
         List<PathsInfoData> paths = pathsService.getPaths(SWITCH_ID_1, SWITCH_ID_2, null, COST,
                 null, null, MAX_PATH_COUNT);
         assertVxlanAndCostPathes(paths);
+    }
+
+    @Test
+    public void whenTwoPathsExist_findPathsWithProtectedPath()
+            throws UnroutableFlowException, SwitchNotFoundException, RecoverableException {
+        kildaConfigurationRepository.find().ifPresent(config -> config.setFlowEncapsulationType(VXLAN));
+
+        List<PathsInfoData> paths = pathsService.getPathsWithProtectedPath(
+                SWITCH_ID_1, SWITCH_ID_2, VXLAN, COST, Duration.ofMillis(10L), Duration.ofMillis(11L), 1);
+
+        assertFalse(paths.isEmpty());
+        assertNotNull(paths.get(0).getPath());
+        assertNotNull(paths.get(0).getPath().getProtectedPath());
+        assertNotEquals(paths.get(0).getPath(), paths.get(0).getPath().getProtectedPath());
+    }
+
+    @Test
+    public void whenTooLowLatencyRequested_andMaxLatencyStrategy_noPathsWithProtectedTest()
+            throws UnroutableFlowException, SwitchNotFoundException, RecoverableException {
+        kildaConfigurationRepository.find().ifPresent(config -> config.setFlowEncapsulationType(VXLAN));
+
+        List<PathsInfoData> paths = pathsService.getPathsWithProtectedPath(
+                SWITCH_ID_1, SWITCH_ID_2, VXLAN, MAX_LATENCY,
+                Duration.ofNanos(18901L), Duration.ofMillis(0L), 5);
+
+        assertFalse(paths.isEmpty(), "There must be at least one path.");
+        assertNull(paths.get(0).getPath().getProtectedPath(),
+                "Found path must not have a protected path in this test topology");
+    }
+
+    @Test
+    public void whenOnlySwitchesInRequest_returnsPathsWithProtectedTest() throws UnroutableFlowException,
+            SwitchNotFoundException, RecoverableException {
+        kildaConfigurationRepository.find().ifPresent(config -> config.setFlowEncapsulationType(VXLAN));
+        kildaConfigurationRepository.find().ifPresent(config -> config.setPathComputationStrategy(COST));
+
+        List<PathsInfoData> paths = pathsService.getPathsWithProtectedPath(
+                SWITCH_ID_1, SWITCH_ID_2, null, COST,
+                null, null, 500);
+
+        assertFalse(paths.isEmpty(), "There must be at least one path.");
     }
 
     private void assertMaxLatencyPaths(List<PathsInfoData> paths, Duration maxLatency, long expectedCount,

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/controller/v1/NetworkController.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/controller/v1/NetworkController.java
@@ -75,13 +75,15 @@ public class NetworkController extends BaseController {
             @RequestParam(value = "max_latency_tier2", required = false) Long maxLatencyTier2Ms,
             @ApiParam(value = "Maximum count of paths which will be calculated. "
                     + "If maximum path count is not specified, default value from OpenKilda Configuration will be used")
-            @RequestParam(value = "max_path_count", required = false) Integer maxPathCount) {
+            @RequestParam(value = "max_path_count", required = false) Integer maxPathCount,
+            @ApiParam(value = "Calculate and show a protected path for each found paths")
+            @RequestParam(value = "include_protected", required = false) Boolean includeProtectedPath) {
 
         Duration maxLatency = maxLatencyMs != null ? Duration.ofMillis(maxLatencyMs) : null;
         Duration maxLatencyTier2 = maxLatencyTier2Ms != null ? Duration.ofMillis(maxLatencyTier2Ms) : null;
 
         return networkService.getPaths(srcSwitchId, dstSwitchId, encapsulationType, pathComputationStrategy, maxLatency,
-                maxLatencyTier2, maxPathCount);
+                maxLatencyTier2, maxPathCount, includeProtectedPath);
     }
 
     /**

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/converter/ProtectedPathMapper.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/converter/ProtectedPathMapper.java
@@ -1,4 +1,4 @@
-/* Copyright 2018 Telstra Open Source
+/* Copyright 2023 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -16,27 +16,15 @@
 package org.openkilda.northbound.converter;
 
 import org.openkilda.messaging.info.network.Path;
-import org.openkilda.messaging.info.network.PathValidationResult;
-import org.openkilda.messaging.model.FlowPathDto;
-import org.openkilda.messaging.payload.flow.GroupFlowPathPayload;
-import org.openkilda.messaging.payload.flow.GroupFlowPathPayload.FlowProtectedPathsPayload;
-import org.openkilda.messaging.payload.network.PathDto;
-import org.openkilda.northbound.dto.v2.flows.PathValidateResponse;
+import org.openkilda.messaging.payload.network.ProtectedPathPayload;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring", uses = ProtectedPathMapper.class)
-public interface PathMapper {
-
+@Mapper(componentModel = "spring")
+public interface ProtectedPathMapper {
     @Mapping(target = "latency", expression = "java(data.getLatency().toNanos())")
     @Mapping(target = "latencyNs", expression = "java(data.getLatency().toNanos())")
     @Mapping(target = "latencyMs", expression = "java(data.getLatency().toMillis())")
-    PathDto mapToPathDto(Path data);
-
-    GroupFlowPathPayload mapGroupFlowPathPayload(FlowPathDto data);
-
-    FlowProtectedPathsPayload mapFlowProtectedPathPayload(FlowPathDto.FlowProtectedPathDto data);
-
-    PathValidateResponse toPathValidateResponse(PathValidationResult data);
+    ProtectedPathPayload map(Path data);
 }

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/NetworkService.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/NetworkService.java
@@ -32,11 +32,22 @@ public interface NetworkService {
 
     /**
      * Gets paths between two switches.
+     * @param srcSwitch a source switch ID
+     * @param dstSwitch a destination switch ID
+     * @param encapsulationType include only switches that support this encapsulation type
+     * @param pathComputationStrategy use this path computation strategy to find paths
+     * @param maxLatencyMs latency value for latency-based path computation strategies
+     * @param maxLatencyTier2 latency tier 2 value for latency-based path computation strategies
+     * @param maxPathCount find no more than this number of paths
+     * @param includeProtectedPathAvailability calculate whether it is possible to create a protected path for the
+     *      found paths
+     * @return a PathDto containing the list of paths together with their parameters
      */
     CompletableFuture<PathsDto> getPaths(
             SwitchId srcSwitch, SwitchId dstSwitch, FlowEncapsulationType encapsulationType,
             PathComputationStrategy pathComputationStrategy, Duration maxLatencyMs, Duration maxLatencyTier2,
-            Integer maxPathCount);
+            Integer maxPathCount, Boolean includeProtectedPathAvailability);
+
 
     /**
      * Validates that a flow with the given path can possibly be created. If it is not possible,

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/impl/NetworkServiceImpl.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/impl/NetworkServiceImpl.java
@@ -64,11 +64,12 @@ public class NetworkServiceImpl implements NetworkService {
     public CompletableFuture<PathsDto> getPaths(
             SwitchId srcSwitch, SwitchId dstSwitch, FlowEncapsulationType encapsulationType,
             PathComputationStrategy pathComputationStrategy, Duration maxLatency, Duration maxLatencyTier2,
-            Integer maxPathCount) {
+            Integer maxPathCount, Boolean includeProtectedPath) {
         log.info("API request: Get Paths: srcSwitch {}, dstSwitch {}, encapsulationType {}, "
-                + "pathComputationStrategy {}, maxLatency {}, maxLatencyTier2 {}, maxPathCount {}",
+                + "pathComputationStrategy {}, maxLatency {}, maxLatencyTier2 {}, maxPathCount {},"
+                + "includeProtectedPath {}",
                 srcSwitch, dstSwitch, encapsulationType, pathComputationStrategy,
-                maxLatency, maxLatencyTier2, maxPathCount);
+                maxLatency, maxLatencyTier2, maxPathCount, includeProtectedPath);
 
         String correlationId = RequestCorrelationId.getId();
 
@@ -85,13 +86,13 @@ public class NetworkServiceImpl implements NetworkService {
         }
 
         GetPathsRequest request = new GetPathsRequest(srcSwitch, dstSwitch, encapsulationType, pathComputationStrategy,
-                maxLatency, maxLatencyTier2, maxPathCount);
+                maxLatency, maxLatencyTier2, maxPathCount, includeProtectedPath);
         CommandMessage message = new CommandMessage(request, System.currentTimeMillis(), correlationId);
 
         return messagingChannel.sendAndGetChunked(nbworkerTopic, message)
                 .thenApply(paths -> {
                     List<PathDto> pathsDtoList = paths.stream().map(PathsInfoData.class::cast)
-                            .map(p -> pathMapper.mapToPath(p.getPath()))
+                            .map(p -> pathMapper.mapToPathDto(p.getPath()))
                             .collect(Collectors.toList());
                     return new PathsDto(pathsDtoList);
                 });

--- a/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/converter/PathMapperTest.java
+++ b/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/converter/PathMapperTest.java
@@ -1,0 +1,111 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.northbound.converter;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.openkilda.messaging.info.network.Path;
+import org.openkilda.messaging.payload.flow.PathNodePayload;
+import org.openkilda.messaging.payload.network.PathDto;
+import org.openkilda.model.SwitchId;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(SpringRunner.class)
+public class PathMapperTest {
+
+    @TestConfiguration
+    @ComponentScan({"org.openkilda.northbound.converter"})
+    static class Config {
+        // nothing to define here
+    }
+
+    public static final int NANOS = 12_345_678;
+    public static final long BANDWIDTH = 100_000L;
+    @Autowired
+    private PathMapper pathMapper;
+
+    @Test
+    public void whenNoProtectedPath_convertToPathDtoTest() {
+        PathDto pathDto = pathMapper.mapToPathDto(getPath(getNodes()));
+
+        assertThat(pathDto.getIsBackupPath()).isEqualTo(false);
+        assertThat(pathDto.getProtectedPath()).isNull();
+        assertThat(pathDto.getBandwidth()).isEqualTo(BANDWIDTH);
+        assertThat(pathDto.getNodes()).isEqualTo(getNodes());
+        assertThat(pathDto.getLatency()).isEqualTo(Duration.ofNanos(NANOS).toNanos());
+        assertThat(pathDto.getLatencyNs()).isEqualTo(Duration.ofNanos(NANOS).toNanos());
+        assertThat(pathDto.getLatencyMs()).isEqualTo(Duration.ofNanos(NANOS).toMillis());
+    }
+
+    @Test
+    public void whenPathWithProtectedPath_convertToPathDtoTest() {
+        PathDto pathDto = pathMapper.mapToPathDto(getPathWithProtectedPath(getPath(getNodes()), getNodes()));
+
+        assertThat(pathDto.getIsBackupPath()).isEqualTo(false);
+        assertThat(pathDto.getProtectedPath()).isNotNull();
+        assertThat(pathDto.getBandwidth()).isEqualTo(BANDWIDTH);
+        assertThat(pathDto.getNodes()).isEqualTo(getNodes());
+        assertThat(pathDto.getLatency()).isEqualTo(Duration.ofNanos(NANOS).toNanos());
+        assertThat(pathDto.getLatencyNs()).isEqualTo(Duration.ofNanos(NANOS).toNanos());
+        assertThat(pathDto.getLatencyMs()).isEqualTo(Duration.ofNanos(NANOS).toMillis());
+
+        assertThat(pathDto.getProtectedPath().getIsBackupPath()).isEqualTo(false);
+        assertThat(pathDto.getProtectedPath().getProtectedPath()).isNull();
+        assertThat(pathDto.getProtectedPath().getBandwidth()).isEqualTo(BANDWIDTH);
+        assertThat(pathDto.getProtectedPath().getNodes()).isEqualTo(getNodes());
+        assertThat(pathDto.getProtectedPath().getLatency()).isEqualTo(Duration.ofNanos(NANOS).toNanos());
+        assertThat(pathDto.getProtectedPath().getLatencyNs()).isEqualTo(Duration.ofNanos(NANOS).toNanos());
+        assertThat(pathDto.getProtectedPath().getLatencyMs()).isEqualTo(Duration.ofNanos(NANOS).toMillis());
+    }
+
+    private Path getPath(List<PathNodePayload> nodes) {
+        return getPathWithProtectedPath(null, nodes);
+    }
+
+    private Path getPathWithProtectedPath(Path protectedPath, List<PathNodePayload> nodes) {
+        return Path.builder()
+                .protectedPath(protectedPath)
+                .latency(Duration.ofNanos(NANOS))
+                .bandwidth(BANDWIDTH)
+                .isBackupPath(false)
+                .nodes(nodes)
+                .build();
+    }
+
+    private List<PathNodePayload> getNodes() {
+        return Arrays.asList(
+                PathNodePayload.builder()
+                        .inputPort(1)
+                        .outputPort(2)
+                        .switchId(new SwitchId("00:01"))
+                        .build(),
+                PathNodePayload.builder()
+                        .inputPort(2)
+                        .outputPort(3)
+                        .switchId(new SwitchId("00:02"))
+                        .build());
+    }
+}


### PR DESCRIPTION
This feature adds calculation of a protected path for each path returned by `/network/paths` API end point and, if the path exists, adds it to the payload under the `protected_path` property.
To enable this functionality a user must specify a request param `include_protected` = true. If this parameter is omitted or false, `network/paths/` behaves as if this feature doesn't exist (nothing new in the response payload).
When a protected path doesn't exist for some path, payload doesn't contain the `protected_path` property (maybe worth to change it and show and empty object to highlight that the logic has been executed).


Closes https://github.com/telstra/open-kilda/issues/5097