### PR TITLE
[PART 3] Improvement/5242 migrate junit4 to junit5 v3

### DIFF
--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/build.gradle
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     testImplementation('org.apache.storm:storm-core')
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.hamcrest:hamcrest-library'
     testImplementation 'org.mapstruct:mapstruct-processor'
@@ -55,4 +55,8 @@ shadowJar {
 
 artifacts {
     archives shadowJar
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/checkstyle/checkstyle-suppressions.xml
@@ -6,4 +6,5 @@
 <suppressions>
     <suppress files="src/main/.*Fsm\.java$" checks="JavadocMethod" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="VariableDeclarationUsageDistance" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
 </suppressions>

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/bolts/ControllerToSpeakerProxyBoltTest.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/bolts/ControllerToSpeakerProxyBoltTest.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.wfm.topology.floodlightrouter.bolts;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -48,13 +48,13 @@ import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.TupleImpl;
 import org.apache.storm.tuple.Values;
 import org.apache.storm.utils.Utils;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -62,7 +62,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ControllerToSpeakerProxyBoltTest {
     private static final int TASK_ID_SPOUT = 0;
     private static final int SWITCH_MONITOR_BOLT = 1;
@@ -90,12 +90,12 @@ public class ControllerToSpeakerProxyBoltTest {
 
     private final Map<String, String> topologyConfig = Collections.emptyMap();
 
-    @BeforeClass
+    @BeforeAll
     public static void initPersistenceManager() {
         InMemoryGraphPersistenceManager.newInstance().install();
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         Set<String> regions = new HashSet<>();
         regions.add(REGION_ONE);

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/bolts/SpeakerToNetworkProxyBoltTest.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/bolts/SpeakerToNetworkProxyBoltTest.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.wfm.topology.floodlightrouter.bolts;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -47,19 +47,19 @@ import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.TupleImpl;
 import org.apache.storm.tuple.Values;
 import org.apache.storm.utils.Utils;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SpeakerToNetworkProxyBoltTest {
     private static final int TASK_ID_SPOUT = 0;
     private static final int ZOOKEEPER_SPOUT = 1;
@@ -83,12 +83,12 @@ public class SpeakerToNetworkProxyBoltTest {
 
     private final Map<String, String> topologyConfig = Collections.emptyMap();
 
-    @BeforeClass
+    @BeforeAll
     public static void initPersistenceManager() {
         InMemoryGraphPersistenceManager.newInstance().install();
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         subject = new SpeakerToNetworkProxyBolt(Stream.KILDA_TOPO_DISCO, Duration.ofSeconds(900));
 
@@ -125,7 +125,7 @@ public class SpeakerToNetworkProxyBoltTest {
                 3L, "discovery-confirmation", REGION_ONE);
         Tuple tuple = new TupleImpl(
                 generalTopologyContext, new Values(
-                        switchAlpha.toString(), discoveryConfirmation, new CommandContext(discoveryConfirmation)),
+                switchAlpha.toString(), discoveryConfirmation, new CommandContext(discoveryConfirmation)),
                 TASK_ID_SPOUT, STREAM_SPOUT_DEFAULT);
         subject.execute(tuple);
         ArgumentCaptor<Values> discoReplyValuesCaptor = ArgumentCaptor.forClass(Values.class);

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/model/OneToOneMappingTest.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/model/OneToOneMappingTest.java
@@ -15,18 +15,21 @@
 
 package org.openkilda.wfm.topology.floodlightrouter.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.openkilda.model.SwitchId;
 import org.openkilda.stubs.ManualClock;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.util.Optional;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class OneToOneMappingTest {
     private static final SwitchId SWITCH_ALPHA = new SwitchId(1);
     private static final SwitchId SWITCH_BETA = new SwitchId(2);
@@ -44,15 +47,15 @@ public class OneToOneMappingTest {
         subject.remove(SWITCH_ALPHA);
 
         Optional<String> result = subject.lookup(SWITCH_ALPHA);
-        Assert.assertTrue(result.isPresent());
-        Assert.assertEquals(REGION_A, result.get());
+        assertTrue(result.isPresent());
+        assertEquals(REGION_A, result.get());
 
-        Assert.assertTrue(subject.lookup(SWITCH_ALPHA).isPresent());  // remove is delayed
+        assertTrue(subject.lookup(SWITCH_ALPHA).isPresent());  // remove is delayed
         clock.adjust(staleDelay.plus(Duration.ofSeconds(1)));
-        Assert.assertFalse(subject.lookup(SWITCH_ALPHA).isPresent());  // remove is delayed
+        assertFalse(subject.lookup(SWITCH_ALPHA).isPresent());  // remove is delayed
 
         // active mapping visible despite removed marker
-        Assert.assertTrue(subject.lookup(SWITCH_BETA).isPresent());
+        assertTrue(subject.lookup(SWITCH_BETA).isPresent());
     }
 
     @Test
@@ -65,29 +68,29 @@ public class OneToOneMappingTest {
         subject.add(SWITCH_BETA, REGION_A);
         subject.remove(SWITCH_BETA);
 
-        Assert.assertTrue(subject.lookup(SWITCH_ALPHA).isPresent());
-        Assert.assertTrue(subject.lookup(SWITCH_BETA).isPresent());
+        assertTrue(subject.lookup(SWITCH_ALPHA).isPresent());
+        assertTrue(subject.lookup(SWITCH_BETA).isPresent());
 
         clock.adjust(staleDelay.minus(Duration.ofSeconds(1)));
 
         // make lookup for one of 2 existing records
         Optional<String> result = subject.lookup(SWITCH_ALPHA);
-        Assert.assertTrue(result.isPresent());
-        Assert.assertEquals(REGION_A, result.get());
+        assertTrue(result.isPresent());
+        assertEquals(REGION_A, result.get());
 
         clock.adjust(Duration.ofSeconds(2));
 
         // first record must be still alive, because of recent lookup for it
         result = subject.lookup(SWITCH_ALPHA);
-        Assert.assertTrue(result.isPresent());
-        Assert.assertEquals(REGION_A, result.get());
+        assertTrue(result.isPresent());
+        assertEquals(REGION_A, result.get());
 
         // while second must go away
-        Assert.assertFalse(subject.lookup(SWITCH_BETA).isPresent());
+        assertFalse(subject.lookup(SWITCH_BETA).isPresent());
 
         clock.adjust(staleDelay.plus(Duration.ofSeconds(1)));
         // now first record must go away too
-        Assert.assertFalse(subject.lookup(SWITCH_ALPHA).isPresent());
+        assertFalse(subject.lookup(SWITCH_ALPHA).isPresent());
     }
 
     private OneToOneMapping makeSubject() {

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/service/ControllerToSpeakerProxyServiceTest.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/service/ControllerToSpeakerProxyServiceTest.java
@@ -26,15 +26,15 @@ import org.openkilda.stubs.ManualClock;
 import org.openkilda.wfm.topology.floodlightrouter.model.RegionMappingAdd;
 
 import com.google.common.collect.ImmutableSet;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.util.Set;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ControllerToSpeakerProxyServiceTest {
     private static final String REGION_STATS = "stats";
     private static final String REGION_MANAGEMENT = "management";

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/service/FloodlightTrackerTest.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/service/FloodlightTrackerTest.java
@@ -25,19 +25,19 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import org.openkilda.model.SwitchId;
 import org.openkilda.stubs.ManualClock;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.ap.internal.util.Collections;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Set;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FloodlightTrackerTest {
     private static long DEFAULT_ALIVE_TIMEOUT = 5L;
     private static long DEFAULT_RESPONSE_TIMEOUT = 1L;
@@ -58,7 +58,7 @@ public class FloodlightTrackerTest {
     @Mock
     RegionMonitorCarrier carrier;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         testClock.set(Instant.EPOCH);
         service = new FloodlightTracker(carrier, regions, aliveSetup);

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchMonitorServiceTest.java
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/src/test/java/org/openkilda/wfm/topology/floodlightrouter/service/monitor/SwitchMonitorServiceTest.java
@@ -15,6 +15,8 @@
 
 package org.openkilda.wfm.topology.floodlightrouter.service.monitor;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -41,11 +43,10 @@ import org.openkilda.wfm.topology.floodlightrouter.model.RegionMappingRemove;
 import org.openkilda.wfm.topology.floodlightrouter.model.RegionMappingSet;
 import org.openkilda.wfm.topology.floodlightrouter.service.SwitchMonitorCarrier;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -54,7 +55,7 @@ import java.util.Comparator;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SwitchMonitorServiceTest {
     private static final String REGION_ALPHA = "alpha";
     private static final String REGION_BETA = "beta";
@@ -169,7 +170,7 @@ public class SwitchMonitorServiceTest {
         SwitchMonitorService subject = makeSubject();
 
         SwitchInfoData activate = makeSwitchActivateNotification(SWITCH_ALPHA, 1);
-        Assert.assertFalse(subject.isMonitorExists(activate.getSwitchId()));
+        assertFalse(subject.isMonitorExists(activate.getSwitchId()));
         subject.handleStatusUpdateNotification(activate, REGION_ALPHA);
 
         clock.adjust(Duration.ofMillis(1));
@@ -184,7 +185,7 @@ public class SwitchMonitorServiceTest {
         SwitchMonitorService subject = makeSubject();
 
         SwitchInfoData activate = makeSwitchActivateNotification(SWITCH_ALPHA, 1);
-        Assert.assertFalse(subject.isMonitorExists(activate.getSwitchId()));
+        assertFalse(subject.isMonitorExists(activate.getSwitchId()));
         subject.handleStatusUpdateNotification(activate, REGION_ALPHA);
 
         verifyAutomaticCleanUp(subject, activate.getSwitchId(), false);
@@ -203,7 +204,7 @@ public class SwitchMonitorServiceTest {
         verifyNoMoreInteractions(carrier);
         reset(carrier);
 
-        SwitchInfoData swDeactivate = new SwitchInfoData(swActivate.getSwitchId(),  SwitchChangeType.DEACTIVATED);
+        SwitchInfoData swDeactivate = new SwitchInfoData(swActivate.getSwitchId(), SwitchChangeType.DEACTIVATED);
         subject.handleStatusUpdateNotification(swDeactivate, REGION_ALPHA);
         verify(carrier).regionUpdateNotification(
                 eq(new RegionMappingRemove(swActivate.getSwitchId(), REGION_ALPHA, true)));
@@ -467,18 +468,18 @@ public class SwitchMonitorServiceTest {
     }
 
     private void verifyAutomaticCleanUp(SwitchMonitorService subject, SwitchId switchId, boolean expectRemoval) {
-        Assert.assertTrue(subject.isMonitorExists(switchId));
+        assertTrue(subject.isMonitorExists(switchId));
 
         clock.adjust(subject.getGarbageDelay().minus(Duration.ofSeconds(1)));
         subject.handleTimerTick();
-        Assert.assertTrue(subject.isMonitorExists(switchId));
+        assertTrue(subject.isMonitorExists(switchId));
 
         clock.adjust(Duration.ofSeconds(2));
         subject.handleTimerTick();
         if (expectRemoval) {
-            Assert.assertFalse(subject.isMonitorExists(switchId));
+            assertFalse(subject.isMonitorExists(switchId));
         } else {
-            Assert.assertTrue(subject.isMonitorExists(switchId));
+            assertTrue(subject.isMonitorExists(switchId));
         }
     }
 

--- a/src-java/grpc-speaker/grpc-api/build.gradle
+++ b/src-java/grpc-speaker/grpc-api/build.gradle
@@ -10,8 +10,12 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/grpc-speaker/grpc-api/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/grpc-speaker/grpc-api/src/checkstyle/checkstyle-suppressions.xml
@@ -5,4 +5,5 @@
 
 <suppressions>
     <suppress files="src/main/java/org/openkilda/grpc/speaker/GrpcSpeaker.java" checks="HideUtilityClassConstructor"/>
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
 </suppressions>

--- a/src-java/grpc-speaker/grpc-api/src/test/java/org/openkilda/messaging/info/grpc/ResponseSerialisationTest.java
+++ b/src-java/grpc-speaker/grpc-api/src/test/java/org/openkilda/messaging/info/grpc/ResponseSerialisationTest.java
@@ -15,18 +15,19 @@
 
 package org.openkilda.messaging.info.grpc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.openkilda.messaging.model.grpc.PacketInOutStatsDto;
 import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
 public class ResponseSerialisationTest {
 
-    private ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
     public void getPacketInOutStatsResponseTest() throws IOException {
@@ -35,6 +36,6 @@ public class ResponseSerialisationTest {
 
         String jsonString = mapper.writeValueAsString(response);
         GetPacketInOutStatsResponse objectFromJson = mapper.readValue(jsonString, GetPacketInOutStatsResponse.class);
-        Assert.assertEquals(response, objectFromJson);
+        assertEquals(response, objectFromJson);
     }
 }

--- a/src-java/grpc-speaker/grpc-service/build.gradle
+++ b/src-java/grpc-speaker/grpc-service/build.gradle
@@ -60,7 +60,7 @@ dependencies {
         exclude module: 'commons-logging'
     }
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'io.grpc:grpc-testing'
 
     implementation 'org.mapstruct:mapstruct'
@@ -83,3 +83,7 @@ bootJar {
 }
 
 bootJar.dependsOn generateVersionTxt
+
+test {
+    useJUnitPlatform()
+}

--- a/src-java/grpc-speaker/grpc-service/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/grpc-speaker/grpc-service/src/checkstyle/checkstyle-suppressions.xml
@@ -5,4 +5,5 @@
 
 <suppressions>
     <suppress files="src/main/java/org/openkilda/grpc/speaker/GrpcSpeaker.java" checks="HideUtilityClassConstructor"/>
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
 </suppressions>

--- a/src-java/grpc-speaker/grpc-service/src/test/java/org/openkilda/grpc/speaker/mapper/NoviflowResponseMapperTest.java
+++ b/src-java/grpc-speaker/grpc-service/src/test/java/org/openkilda/grpc/speaker/mapper/NoviflowResponseMapperTest.java
@@ -15,15 +15,16 @@
 
 package org.openkilda.grpc.speaker.mapper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.grpc.speaker.model.PacketInOutStatsResponse;
 
 import io.grpc.noviflow.PacketInOutStats;
 import io.grpc.noviflow.YesNo;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 
 public class NoviflowResponseMapperTest {
@@ -43,8 +44,8 @@ public class NoviflowResponseMapperTest {
 
     @Test
     public void yesNoTest() {
-        Assert.assertTrue(mapper.toBoolean(YesNo.YES));
-        Assert.assertFalse(mapper.toBoolean(YesNo.NO));
+        assertTrue(mapper.toBoolean(YesNo.YES));
+        assertFalse(mapper.toBoolean(YesNo.NO));
         assertNull(mapper.toBoolean(null));
         assertNull(mapper.toBoolean(YesNo.UNRECOGNIZED));
         assertNull(mapper.toBoolean(YesNo.YESNO_RESERVED));

--- a/src-java/kilda-configuration/build.gradle
+++ b/src-java/kilda-configuration/build.gradle
@@ -11,8 +11,12 @@ dependencies {
     implementation 'javax.validation:validation-api'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testRuntimeOnly 'org.hibernate.validator:hibernate-validator'
     testRuntimeOnly 'org.glassfish:javax.el'
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/kilda-configuration/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/kilda-configuration/src/checkstyle/checkstyle-suppressions.xml
@@ -4,4 +4,5 @@
         "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
 
 <suppressions>
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
 </suppressions>

--- a/src-java/kilda-configuration/src/test/java/org/openkilda/config/CompositeConfigurationTest.java
+++ b/src-java/kilda-configuration/src/test/java/org/openkilda/config/CompositeConfigurationTest.java
@@ -15,15 +15,14 @@
 
 package org.openkilda.config;
 
-import static org.junit.Assert.assertEquals;
-
 import com.google.common.collect.ImmutableMap;
 import com.sabre.oss.conf4j.annotation.Configuration;
 import com.sabre.oss.conf4j.annotation.IgnoreKey;
 import com.sabre.oss.conf4j.annotation.Key;
 import com.sabre.oss.conf4j.factory.jdkproxy.JdkProxyStaticConfigurationFactory;
 import com.sabre.oss.conf4j.source.MapConfigurationSource;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CompositeConfigurationTest {
     private JdkProxyStaticConfigurationFactory factory = new JdkProxyStaticConfigurationFactory();
@@ -37,7 +36,7 @@ public class CompositeConfigurationTest {
         TestCompositeConfig testCompositeConfig = factory.createConfiguration(TestCompositeConfig.class, source);
 
         // then
-        assertEquals(10, testCompositeConfig.getTestProperty());
+        Assertions.assertEquals(10, testCompositeConfig.getTestProperty());
     }
 
     @Configuration

--- a/src-java/kilda-configuration/src/test/java/org/openkilda/config/DefaultConfigurationTest.java
+++ b/src-java/kilda-configuration/src/test/java/org/openkilda/config/DefaultConfigurationTest.java
@@ -16,14 +16,13 @@
 package org.openkilda.config;
 
 import static java.util.Collections.emptyMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 import com.sabre.oss.conf4j.annotation.Configuration;
 import com.sabre.oss.conf4j.annotation.Key;
 import com.sabre.oss.conf4j.factory.jdkproxy.JdkProxyStaticConfigurationFactory;
 import com.sabre.oss.conf4j.source.MapConfigurationSource;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DefaultConfigurationTest {
     private JdkProxyStaticConfigurationFactory factory = new JdkProxyStaticConfigurationFactory();
@@ -37,7 +36,7 @@ public class DefaultConfigurationTest {
         KafkaTopicsConfig kafkaTopicsConfig = factory.createConfiguration(KafkaTopicsConfig.class, source);
 
         // then
-        assertEquals("kilda.ctrl", kafkaTopicsConfig.getCtrlTopic());
+        Assertions.assertEquals("kilda.ctrl", kafkaTopicsConfig.getCtrlTopic());
     }
 
     @Test
@@ -49,7 +48,7 @@ public class DefaultConfigurationTest {
         TestConfig testConfig = factory.createConfiguration(TestConfig.class, source);
 
         // then
-        assertNull(testConfig.getTestProperty());
+        Assertions.assertNull(testConfig.getTestProperty());
     }
 
     @Configuration

--- a/src-java/kilda-configuration/src/test/java/org/openkilda/config/converter/EnumLowerCaseConverterTest.java
+++ b/src-java/kilda-configuration/src/test/java/org/openkilda/config/converter/EnumLowerCaseConverterTest.java
@@ -15,10 +15,11 @@
 
 package org.openkilda.config.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class EnumLowerCaseConverterTest {
     private enum TestEnum {
@@ -29,24 +30,26 @@ public class EnumLowerCaseConverterTest {
 
     @Test
     public void toStringTest() {
-        assertEquals("first_value", converter.toString(TestEnum.class, TestEnum.FIRST_VALUE, null));
-        assertEquals("value_2", converter.toString(TestEnum.class, TestEnum.VALUE_2, null));
-        assertNull(converter.toString(TestEnum.class, null, null));
+        Assertions.assertEquals("first_value", converter.toString(TestEnum.class, TestEnum.FIRST_VALUE, null));
+        Assertions.assertEquals("value_2", converter.toString(TestEnum.class, TestEnum.VALUE_2, null));
+        Assertions.assertNull(converter.toString(TestEnum.class, null, null));
     }
 
     @Test
     public void fromValidStringTest() {
-        assertEquals(TestEnum.FIRST_VALUE, converter.fromString(TestEnum.class, "first_value", null));
-        assertEquals(TestEnum.FIRST_VALUE, converter.fromString(TestEnum.class, "First_Value", null));
-        assertEquals(TestEnum.FIRST_VALUE, converter.fromString(TestEnum.class, "FIRST_VALUE", null));
-        assertEquals(TestEnum.VALUE_2, converter.fromString(TestEnum.class, "value_2", null));
-        assertEquals(TestEnum.VALUE_2, converter.fromString(TestEnum.class, "Value_2", null));
-        assertEquals(TestEnum.VALUE_2, converter.fromString(TestEnum.class, "VALUE_2", null));
-        assertNull(converter.fromString(TestEnum.class, null, null));
+        Assertions.assertEquals(TestEnum.FIRST_VALUE, converter.fromString(TestEnum.class, "first_value", null));
+        Assertions.assertEquals(TestEnum.FIRST_VALUE, converter.fromString(TestEnum.class, "First_Value", null));
+        Assertions.assertEquals(TestEnum.FIRST_VALUE, converter.fromString(TestEnum.class, "FIRST_VALUE", null));
+        Assertions.assertEquals(TestEnum.VALUE_2, converter.fromString(TestEnum.class, "value_2", null));
+        Assertions.assertEquals(TestEnum.VALUE_2, converter.fromString(TestEnum.class, "Value_2", null));
+        Assertions.assertEquals(TestEnum.VALUE_2, converter.fromString(TestEnum.class, "VALUE_2", null));
+        Assertions.assertNull(converter.fromString(TestEnum.class, null, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void fromInvalidStringTest() {
-        converter.fromString(TestEnum.class, "123", null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            converter.fromString(TestEnum.class, "123", null);
+        });
     }
 }

--- a/src-java/kilda-configuration/src/test/java/org/openkilda/config/mapping/MappingConfigurationValueProcessorTest.java
+++ b/src-java/kilda-configuration/src/test/java/org/openkilda/config/mapping/MappingConfigurationValueProcessorTest.java
@@ -29,8 +29,8 @@ import com.sabre.oss.conf4j.annotation.Default;
 import com.sabre.oss.conf4j.annotation.Key;
 import com.sabre.oss.conf4j.factory.jdkproxy.JdkProxyStaticConfigurationFactory;
 import com.sabre.oss.conf4j.source.MapConfigurationSource;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MappingConfigurationValueProcessorTest {
     private static final String TEST_VALUE = "test_value";
@@ -40,7 +40,7 @@ public class MappingConfigurationValueProcessorTest {
     private JdkProxyStaticConfigurationFactory factory;
     private MappingStrategy mappingStrategy;
 
-    @Before
+    @BeforeEach
     public void setupFactoryWithMappingStrategy() {
         factory = new JdkProxyStaticConfigurationFactory();
 

--- a/src-java/kilda-configuration/src/test/java/org/openkilda/config/naming/KafkaNamingForConfigurationValueProcessorTest.java
+++ b/src-java/kilda-configuration/src/test/java/org/openkilda/config/naming/KafkaNamingForConfigurationValueProcessorTest.java
@@ -17,15 +17,15 @@ package org.openkilda.config.naming;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
 
 import org.openkilda.config.KafkaTopicsConfig;
 
 import com.google.common.collect.ImmutableMap;
 import com.sabre.oss.conf4j.factory.jdkproxy.JdkProxyStaticConfigurationFactory;
 import com.sabre.oss.conf4j.source.MapConfigurationSource;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class KafkaNamingForConfigurationValueProcessorTest {
     private static final String TEST_PREFIX = "test_prefix";
@@ -33,7 +33,7 @@ public class KafkaNamingForConfigurationValueProcessorTest {
 
     private JdkProxyStaticConfigurationFactory factory;
 
-    @Before
+    @BeforeEach
     public void setupFactoryWithNamingStrategy() {
         factory = new JdkProxyStaticConfigurationFactory();
 
@@ -51,7 +51,7 @@ public class KafkaNamingForConfigurationValueProcessorTest {
         KafkaTopicsConfig kafkaTopicsConfig = factory.createConfiguration(KafkaTopicsConfig.class, source);
 
         // then
-        assertEquals(TEST_PREFIX + "_" + TEST_VALUE, kafkaTopicsConfig.getCtrlTopic());
+        Assertions.assertEquals(TEST_PREFIX + "_" + TEST_VALUE, kafkaTopicsConfig.getCtrlTopic());
     }
 
     @Test
@@ -63,6 +63,6 @@ public class KafkaNamingForConfigurationValueProcessorTest {
         KafkaTopicsConfig kafkaTopicsConfig = factory.createConfiguration(KafkaTopicsConfig.class, source);
 
         // then
-        assertEquals(TEST_PREFIX + "_kilda.ctrl", kafkaTopicsConfig.getCtrlTopic());
+        Assertions.assertEquals(TEST_PREFIX + "_kilda.ctrl", kafkaTopicsConfig.getCtrlTopic());
     }
 }

--- a/src-java/kilda-configuration/src/test/java/org/openkilda/config/provider/ValidatingConfigurationProviderTest.java
+++ b/src-java/kilda-configuration/src/test/java/org/openkilda/config/provider/ValidatingConfigurationProviderTest.java
@@ -15,15 +15,14 @@
 
 package org.openkilda.config.provider;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.sabre.oss.conf4j.annotation.Configuration;
 import com.sabre.oss.conf4j.annotation.Key;
 import com.sabre.oss.conf4j.factory.jdkproxy.JdkProxyStaticConfigurationFactory;
 import com.sabre.oss.conf4j.source.PropertiesConfigurationSource;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 import javax.validation.constraints.Min;
@@ -32,9 +31,6 @@ public class ValidatingConfigurationProviderTest {
     static final String TEST_KEY = "test_key";
     static final int VALID_TEST_VALUE = 100;
     static final int INVALID_TEST_VALUE = -1;
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void shouldPassValidationForValidConfig() {
@@ -61,11 +57,11 @@ public class ValidatingConfigurationProviderTest {
         ValidatingConfigurationProvider provider = new ValidatingConfigurationProvider(
                 new PropertiesConfigurationSource(source), new JdkProxyStaticConfigurationFactory());
 
-        // when
-        expectedException.expect(ConfigurationException.class);
-        provider.getConfiguration(TestConfig.class);
 
-        // then ConfigurationException is thrown
+        assertThrows(ConfigurationException.class, () -> {
+            provider.getConfiguration(TestConfig.class);
+        });
+
     }
 
     @Configuration

--- a/src-java/kilda-model/build.gradle
+++ b/src-java/kilda-model/build.gradle
@@ -11,9 +11,13 @@ dependencies {
     annotationProcessor 'org.mapstruct:mapstruct-processor'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding'
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/kilda-model/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/kilda-model/src/checkstyle/checkstyle-suppressions.xml
@@ -3,4 +3,6 @@
         "-//Puppy Crawl//DTD Suppressions 1.2//EN"
         "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
 
-<suppressions/>
+<suppressions>
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
+</suppressions>

--- a/src-java/kilda-model/src/test/java/org/openkilda/model/IslTest.java
+++ b/src-java/kilda-model/src/test/java/org/openkilda/model/IslTest.java
@@ -15,10 +15,10 @@
 
 package org.openkilda.model;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;

--- a/src-java/kilda-model/src/test/java/org/openkilda/model/MeterIdTest.java
+++ b/src-java/kilda-model/src/test/java/org/openkilda/model/MeterIdTest.java
@@ -15,10 +15,12 @@
 
 package org.openkilda.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.openkilda.model.cookie.Cookie;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MeterIdTest {
 
@@ -26,12 +28,13 @@ public class MeterIdTest {
     public void createMeterIdForValidDefaultRuleTest() {
         for (long id = MeterId.MIN_SYSTEM_RULE_METER_ID; id <= MeterId.MAX_SYSTEM_RULE_METER_ID; id++) {
             long cookie = Cookie.createCookieForDefaultRule(id).getValue();
-            Assert.assertEquals(id, MeterId.createMeterIdForDefaultRule(cookie).getValue());
+            assertEquals(id, MeterId.createMeterIdForDefaultRule(cookie).getValue());
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void createMeterIdForInvalidDefaultRuleTest() {
-        MeterId.createMeterIdForDefaultRule(0x0000000000000123L);
+        assertThrows(IllegalArgumentException.class,
+                () -> MeterId.createMeterIdForDefaultRule(0x0000000000000123L));
     }
 }

--- a/src-java/kilda-model/src/test/java/org/openkilda/model/MeterTest.java
+++ b/src-java/kilda-model/src/test/java/org/openkilda/model/MeterTest.java
@@ -16,10 +16,10 @@
 package org.openkilda.model;
 
 import static com.google.common.collect.Sets.newHashSet;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openkilda.model.SwitchFeature.MAX_BURST_COEFFICIENT_LIMITATION;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 

--- a/src-java/kilda-model/src/test/java/org/openkilda/model/PathSegmentTest.java
+++ b/src-java/kilda-model/src/test/java/org/openkilda/model/PathSegmentTest.java
@@ -15,13 +15,14 @@
 
 package org.openkilda.model;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openkilda.model.cookie.FlowSegmentCookie;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +40,7 @@ public class PathSegmentTest {
 
     private Flow flow;
 
-    @Before
+    @BeforeEach
     public void setup() {
         flow = Flow.builder().flowId(FLOW_ID).srcSwitch(SWITCH_A)
                 .destSwitch(SWITCH_B).pinned(true).build();
@@ -77,9 +78,10 @@ public class PathSegmentTest {
     }
 
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testContainsNodeInvalidInput() {
-        flow.getForwardPath().getSegments().get(0).containsNode(null, 1);
+        assertThrows(IllegalArgumentException.class,
+                () -> flow.getForwardPath().getSegments().get(0).containsNode(null, 1));
     }
 
     @Test

--- a/src-java/kilda-model/src/test/java/org/openkilda/model/SwitchIdTest.java
+++ b/src-java/kilda-model/src/test/java/org/openkilda/model/SwitchIdTest.java
@@ -16,41 +16,36 @@
 package org.openkilda.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 public class SwitchIdTest {
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void colonSeparatedBytesIllegalArgumentExceptionNegativeOffset() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage(String.format(
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+                () -> new SwitchId("00").colonSeparatedBytes(new char[]{'t', 'e', 's', 't'}, -1));
+        assertEquals(thrown.getMessage(), String.format(
                 "Illegal offset value %d (expect offset > 0 and offset %% 2 == 0 and offset < hex.length)", -1));
 
-        new SwitchId("00").colonSeparatedBytes(new char[]{'t', 'e', 's', 't'}, -1);
     }
 
     @Test
     public void colonSeparatedBytesIllegalArgumentExceptionOddOffset() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage(String.format(
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+                () -> new SwitchId("00").colonSeparatedBytes(new char[]{'t', 'e', 's', 't'}, 3));
+        assertEquals(thrown.getMessage(), String.format(
                 "Illegal offset value %d (expect offset > 0 and offset %% 2 == 0 and offset < hex.length)", 3));
 
-        new SwitchId("00").colonSeparatedBytes(new char[]{'t', 'e', 's', 't'}, 3);
     }
 
     @Test
     public void colonSeparatedBytesIllegalArgumentExceptionMoreThenHexLength() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage(String.format(
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+                () -> new SwitchId("00").colonSeparatedBytes(new char[]{'t', 'e', 's', 't'}, 6));
+        assertEquals(thrown.getMessage(), String.format(
                 "Illegal offset value %d (expect offset > 0 and offset %% 2 == 0 and offset < hex.length)", 6));
-
-        new SwitchId("00").colonSeparatedBytes(new char[]{'t', 'e', 's', 't'}, 6);
     }
 
     @Test

--- a/src-java/kilda-model/src/test/java/org/openkilda/model/SwitchPropertiesTest.java
+++ b/src-java/kilda-model/src/test/java/org/openkilda/model/SwitchPropertiesTest.java
@@ -15,13 +15,14 @@
 
 package org.openkilda.model;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.openkilda.model.SwitchProperties.RttState;
 
 import com.google.common.collect.Sets;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -30,15 +31,17 @@ import java.util.stream.Collectors;
 
 public class SwitchPropertiesTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void validatePropRaiseTest() {
-        Switch sw = Switch.builder()
-                .switchId(new SwitchId(1))
-                .build();
-        SwitchProperties sp = SwitchProperties.builder()
-                .switchObj(sw)
-                .build();
-        sp.validateProp(SwitchFeature.BFD);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Switch sw = Switch.builder()
+                    .switchId(new SwitchId(1))
+                    .build();
+            SwitchProperties sp = SwitchProperties.builder()
+                    .switchObj(sw)
+                    .build();
+            sp.validateProp(SwitchFeature.BFD);
+        });
     }
 
     @Test
@@ -52,31 +55,35 @@ public class SwitchPropertiesTest {
         SwitchProperties sp = SwitchProperties.builder()
                 .switchObj(sw)
                 .build();
-        assertTrue(sp.validateProp(SwitchFeature.MULTI_TABLE));
+        Assertions.assertTrue(sp.validateProp(SwitchFeature.MULTI_TABLE));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void setUnsupportedMultiTableFlagTest() {
-        Switch sw = Switch.builder()
-                .switchId(new SwitchId(1))
-                .build();
-        SwitchProperties sp = SwitchProperties.builder()
-                .switchObj(sw)
-                .build();
-        sp.setMultiTable(true);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Switch sw = Switch.builder()
+                    .switchId(new SwitchId(1))
+                    .build();
+            SwitchProperties sp = SwitchProperties.builder()
+                    .switchObj(sw)
+                    .build();
+            sp.setMultiTable(true);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void setUnsupportedTransitEncapsulationTest() {
-        Switch sw = Switch.builder()
-                .switchId(new SwitchId(1))
-                .build();
-        SwitchProperties sp = SwitchProperties.builder()
-                .switchObj(sw)
-                .build();
-        Set<FlowEncapsulationType> flowEncapsulationTypes = new HashSet<>();
-        flowEncapsulationTypes.add(FlowEncapsulationType.VXLAN);
-        sp.setSupportedTransitEncapsulation(flowEncapsulationTypes);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Switch sw = Switch.builder()
+                    .switchId(new SwitchId(1))
+                    .build();
+            SwitchProperties sp = SwitchProperties.builder()
+                    .switchObj(sw)
+                    .build();
+            Set<FlowEncapsulationType> flowEncapsulationTypes = new HashSet<>();
+            flowEncapsulationTypes.add(FlowEncapsulationType.VXLAN);
+            sp.setSupportedTransitEncapsulation(flowEncapsulationTypes);
+        });
     }
 
     @Test
@@ -95,7 +102,7 @@ public class SwitchPropertiesTest {
                 .server42Vlan(2)
                 .server42MacAddress(new MacAddress("00:00:00:00:00:01"))
                 .build();
-        assertTrue(sp.hasServer42IslRttEnabled());
+        Assertions.assertTrue(sp.hasServer42IslRttEnabled());
     }
 
     @Test
@@ -112,7 +119,7 @@ public class SwitchPropertiesTest {
                 .server42Vlan(2)
                 .server42MacAddress(new MacAddress("00:00:00:00:00:01"))
                 .build();
-        assertFalse(sp.hasServer42IslRttEnabled());
+        Assertions.assertFalse(sp.hasServer42IslRttEnabled());
     }
 
     @Test
@@ -129,7 +136,7 @@ public class SwitchPropertiesTest {
                 .server42Vlan(2)
                 .server42MacAddress(new MacAddress("00:00:00:00:00:01"))
                 .build();
-        assertTrue(sp.hasServer42IslRttEnabled());
+        Assertions.assertTrue(sp.hasServer42IslRttEnabled());
     }
 
     @Test
@@ -145,14 +152,14 @@ public class SwitchPropertiesTest {
                 .switchObj(sw)
                 .server42IslRtt(RttState.AUTO)
                 .build();
-        assertFalse(sp1.hasServer42IslRttEnabled());
+        Assertions.assertFalse(sp1.hasServer42IslRttEnabled());
 
         SwitchProperties sp2 = SwitchProperties.builder()
                 .switchObj(sw)
                 .server42IslRtt(RttState.AUTO)
                 .server42Port(1)
                 .build();
-        assertFalse(sp2.hasServer42IslRttEnabled());
+        Assertions.assertFalse(sp2.hasServer42IslRttEnabled());
 
         SwitchProperties sp3 = SwitchProperties.builder()
                 .switchObj(sw)
@@ -160,7 +167,7 @@ public class SwitchPropertiesTest {
                 .server42Port(1)
                 .server42MacAddress(new MacAddress("00:00:00:00:00:01"))
                 .build();
-        assertFalse(sp3.hasServer42IslRttEnabled());
+        Assertions.assertFalse(sp3.hasServer42IslRttEnabled());
 
         SwitchProperties sp4 = SwitchProperties.builder()
                 .switchObj(sw)
@@ -168,7 +175,7 @@ public class SwitchPropertiesTest {
                 .server42Port(1)
                 .server42Vlan(2)
                 .build();
-        assertFalse(sp4.hasServer42IslRttEnabled());
+        Assertions.assertFalse(sp4.hasServer42IslRttEnabled());
     }
 
     @Test
@@ -182,14 +189,14 @@ public class SwitchPropertiesTest {
                 .switchObj(sw)
                 .server42IslRtt(RttState.ENABLED)
                 .build();
-        assertFalse(sp1.hasServer42IslRttEnabled());
+        Assertions.assertFalse(sp1.hasServer42IslRttEnabled());
 
         SwitchProperties sp2 = SwitchProperties.builder()
                 .switchObj(sw)
                 .server42IslRtt(RttState.ENABLED)
                 .server42Port(1)
                 .build();
-        assertFalse(sp2.hasServer42IslRttEnabled());
+        Assertions.assertFalse(sp2.hasServer42IslRttEnabled());
 
         SwitchProperties sp3 = SwitchProperties.builder()
                 .switchObj(sw)
@@ -197,7 +204,7 @@ public class SwitchPropertiesTest {
                 .server42Port(1)
                 .server42MacAddress(new MacAddress("00:00:00:00:00:01"))
                 .build();
-        assertFalse(sp3.hasServer42IslRttEnabled());
+        Assertions.assertFalse(sp3.hasServer42IslRttEnabled());
 
         SwitchProperties sp4 = SwitchProperties.builder()
                 .switchObj(sw)
@@ -205,6 +212,6 @@ public class SwitchPropertiesTest {
                 .server42Port(1)
                 .server42Vlan(2)
                 .build();
-        assertFalse(sp4.hasServer42IslRttEnabled());
+        Assertions.assertFalse(sp4.hasServer42IslRttEnabled());
     }
 }

--- a/src-java/kilda-model/src/test/java/org/openkilda/model/bitops/BitFieldTest.java
+++ b/src-java/kilda-model/src/test/java/org/openkilda/model/bitops/BitFieldTest.java
@@ -15,25 +15,29 @@
 
 package org.openkilda.model.bitops;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BitFieldTest {
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void ensureNoEmptyMasks() {
-        new BitField(0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            new BitField(0);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void ensureNoGapsInMask() {
-        new BitField(5);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            new BitField(5);
+        });
     }
 
     @Test
     public void verifyOffset() {
         BitField field = new BitField(6);
 
-        Assert.assertEquals(1, field.getOffset());
-        Assert.assertEquals(6, field.getMask());
+        Assertions.assertEquals(1, field.getOffset());
+        Assertions.assertEquals(6, field.getMask());
     }
 }

--- a/src-java/kilda-model/src/test/java/org/openkilda/model/cookie/CookieBaseTest.java
+++ b/src-java/kilda-model/src/test/java/org/openkilda/model/cookie/CookieBaseTest.java
@@ -17,7 +17,7 @@ package org.openkilda.model.cookie;
 
 import org.openkilda.model.bitops.BitField;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CookieBaseTest extends GenericCookieTest {
     @Test

--- a/src-java/kilda-model/src/test/java/org/openkilda/model/cookie/FlowSegmentCookieTest.java
+++ b/src-java/kilda-model/src/test/java/org/openkilda/model/cookie/FlowSegmentCookieTest.java
@@ -15,11 +15,12 @@
 
 package org.openkilda.model.cookie;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.openkilda.model.FlowPathDirection;
 import org.openkilda.model.cookie.CookieBase.CookieType;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FlowSegmentCookieTest extends GenericCookieTest {
     @Test
@@ -45,11 +46,11 @@ public class FlowSegmentCookieTest extends GenericCookieTest {
     @Test
     public void changingOfFlowSegmentCookieTypeTest() {
         FlowSegmentCookie flowCookie = new FlowSegmentCookie(FlowPathDirection.FORWARD, 10);
-        Assert.assertEquals(CookieType.SERVICE_OR_FLOW_SEGMENT, flowCookie.getType());
+        assertEquals(CookieType.SERVICE_OR_FLOW_SEGMENT, flowCookie.getType());
 
         FlowSegmentCookie server42Cookie = flowCookie.toBuilder()
                 .type(CookieType.SERVER_42_FLOW_RTT_INGRESS)
                 .build();
-        Assert.assertEquals(CookieType.SERVER_42_FLOW_RTT_INGRESS, server42Cookie.getType());
+        assertEquals(CookieType.SERVER_42_FLOW_RTT_INGRESS, server42Cookie.getType());
     }
 }

--- a/src-java/kilda-model/src/test/java/org/openkilda/model/cookie/FlowSharedSegmentCookieTest.java
+++ b/src-java/kilda-model/src/test/java/org/openkilda/model/cookie/FlowSharedSegmentCookieTest.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.model.cookie;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FlowSharedSegmentCookieTest extends GenericCookieTest {
     @Test

--- a/src-java/kilda-model/src/test/java/org/openkilda/model/cookie/GenericCookieTest.java
+++ b/src-java/kilda-model/src/test/java/org/openkilda/model/cookie/GenericCookieTest.java
@@ -15,9 +15,11 @@
 
 package org.openkilda.model.cookie;
 
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.openkilda.model.bitops.BitField;
 
-import org.junit.Assert;
 
 abstract class GenericCookieTest {
     protected void testFieldsIntersection(BitField[] fields) {
@@ -30,10 +32,10 @@ abstract class GenericCookieTest {
                 }
 
                 long rightField = CookieBase.setField(0L, fields[rightIdx], -1);
-                Assert.assertEquals(
+                assertEquals(
+                        0, (leftField & rightField),
                         String.format(
-                                "Detect cookie fields collision between 0x%016x and 0x%016x", leftField, rightField),
-                        0, (leftField & rightField));
+                                "Detect cookie fields collision between 0x%016x and 0x%016x", leftField, rightField));
             }
         }
     }
@@ -45,7 +47,7 @@ abstract class GenericCookieTest {
     protected void testFieldReadWrite(
             long blank, long expected, BitField field, long valueWrite, long valueRead) {
         long result = CookieBase.setField(blank, field, valueWrite);
-        Assert.assertEquals(expected, result);
-        Assert.assertEquals(valueRead, new Cookie(result).getField(field));
+        assertEquals(expected, result);
+        assertEquals(valueRead, new Cookie(result).getField(field));
     }
 }

--- a/src-java/kilda-model/src/test/java/org/openkilda/model/cookie/ServiceCookieTest.java
+++ b/src-java/kilda-model/src/test/java/org/openkilda/model/cookie/ServiceCookieTest.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.model.cookie;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ServiceCookieTest extends GenericCookieTest {
     @Test

--- a/src-java/kilda-persistence-api/build.gradle
+++ b/src-java/kilda-persistence-api/build.gradle
@@ -14,7 +14,8 @@ dependencies {
     implementation 'net.jodah:failsafe'
     implementation 'org.aspectj:aspectjrt'
 
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
 
     compileOnly 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'
@@ -36,4 +37,8 @@ task testJar(type: Jar) {
 
 artifacts {
     testArtifacts testJar
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/kilda-persistence-api/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/kilda-persistence-api/src/checkstyle/checkstyle-suppressions.xml
@@ -3,4 +3,6 @@
         "-//Puppy Crawl//DTD Suppressions 1.2//EN"
         "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
 
-<suppressions/>
+<suppressions>
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
+</suppressions>

--- a/src-java/kilda-persistence-api/src/test/java/org/openkilda/persistence/repositories/RepositoryAreaBindingTest.java
+++ b/src-java/kilda-persistence-api/src/test/java/org/openkilda/persistence/repositories/RepositoryAreaBindingTest.java
@@ -18,8 +18,8 @@ package org.openkilda.persistence.repositories;
 import org.openkilda.model.Speaker;
 import org.openkilda.persistence.PersistenceArea;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 import java.util.Optional;
@@ -27,14 +27,17 @@ import java.util.Optional;
 public class RepositoryAreaBindingTest {
     @Test
     public void testLookup() {
-        Assert.assertEquals(PersistenceArea.COMMON, RepositoryAreaBinding.INSTANCE.lookup(SpeakerRepository.class));
-        Assert.assertEquals(
-                PersistenceArea.COMMON, RepositoryAreaBinding.INSTANCE.lookup(DummySpeakerRepository.class));
+        Assertions.assertEquals(PersistenceArea.COMMON,
+                RepositoryAreaBinding.INSTANCE.lookup(SpeakerRepository.class));
+        Assertions.assertEquals(PersistenceArea.COMMON,
+                RepositoryAreaBinding.INSTANCE.lookup(DummySpeakerRepository.class));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testLookupFailure() {
-        RepositoryAreaBinding.INSTANCE.lookup(DummyRepositoryBase.class);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            RepositoryAreaBinding.INSTANCE.lookup(DummyRepositoryBase.class);
+        });
     }
 
     private static class DummyRepositoryBase implements Serializable {

--- a/src-java/network-topology/network-messaging/build.gradle
+++ b/src-java/network-topology/network-messaging/build.gradle
@@ -11,8 +11,6 @@ dependencies {
     implementation('com.fasterxml.jackson.core:jackson-databind')
 
     implementation 'com.google.guava:guava'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src-java/network-topology/network-storm-topology/build.gradle
+++ b/src-java/network-topology/network-storm-topology/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     testAnnotationProcessor 'org.mapstruct:mapstruct-processor'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.hamcrest:hamcrest-library'
     testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
@@ -66,4 +66,8 @@ shadowJar {
 
 artifacts {
     archives shadowJar
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/network-topology/network-storm-topology/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/network-topology/network-storm-topology/src/checkstyle/checkstyle-suppressions.xml
@@ -5,5 +5,6 @@
 
 <suppressions>
     <suppress files="src/main/.*Fsm\.java$" checks="JavadocMethod" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="VariableDeclarationUsageDistance" />
 </suppressions>

--- a/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/controller/bfd/AbstractBfdSessionActionTest.java
+++ b/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/controller/bfd/AbstractBfdSessionActionTest.java
@@ -21,8 +21,8 @@ import org.openkilda.messaging.model.SwitchReference;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.share.model.Endpoint;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.net.Inet4Address;
 import java.net.UnknownHostException;
@@ -65,8 +65,8 @@ public abstract class AbstractBfdSessionActionTest {
         BfdSessionAction.ActionResult result = action.consumeSpeakerResponse(requestKey, response)
                 .orElseThrow(expectResultError);
 
-        Assert.assertFalse(result.isSuccess());
-        Assert.assertEquals(NoviBfdSession.Errors.SWITCH_RESPONSE_ERROR, result.getErrorCode());
+        Assertions.assertFalse(result.isSuccess());
+        Assertions.assertEquals(NoviBfdSession.Errors.SWITCH_RESPONSE_ERROR, result.getErrorCode());
     }
 
     protected abstract BfdSessionAction makeAction(String requestKey);

--- a/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/controller/bfd/BfdSessionActionTest.java
+++ b/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/controller/bfd/BfdSessionActionTest.java
@@ -15,6 +15,11 @@
 
 package org.openkilda.wfm.topology.network.controller.bfd;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.openkilda.messaging.floodlight.response.BfdSessionResponse;
 import org.openkilda.messaging.model.NoviBfdSession;
 import org.openkilda.messaging.model.NoviBfdSession.Errors;
@@ -22,15 +27,14 @@ import org.openkilda.messaging.model.SwitchReference;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.topology.network.controller.bfd.BfdSessionAction.ActionResult;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.Inet4Address;
 import java.net.UnknownHostException;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class BfdSessionActionTest {
     private NoviBfdSession payload = NoviBfdSession.builder()
             .target(new SwitchReference(new SwitchId(1), Inet4Address.getByName("192.168.1.1")))
@@ -54,34 +58,34 @@ public class BfdSessionActionTest {
 
         // invalid
         BfdSessionResponse response = new BfdSessionResponse(payload, null);
-        Assert.assertFalse(action.consumeSpeakerResponse(requestKey + "+invalid", response).isPresent());
+        assertFalse(action.consumeSpeakerResponse(requestKey + "+invalid", response).isPresent());
 
         // valid
         ActionResult result = action.consumeSpeakerResponse(requestKey, new BfdSessionResponse(payload, null))
                 .orElseThrow(() -> new AssertionError("Action must produce result"));
-        Assert.assertTrue(result.isSuccess());
+        assertTrue(result.isSuccess());
 
         // extra result
         ActionResult result2 = action
                 .consumeSpeakerResponse(requestKey, new BfdSessionResponse(payload, Errors.NOVI_BFD_UNKNOWN_ERROR))
                 .orElseThrow(() -> new AssertionError("Action must produce result"));
-        Assert.assertTrue(result2.isSuccess()); // because extra result was ignored
+        assertTrue(result2.isSuccess()); // because extra result was ignored
     }
 
     @Test
     public void errorResponse() {
         ActionResult result = makeWithResponse(new BfdSessionResponse(payload, Errors.SWITCH_RESPONSE_ERROR));
 
-        Assert.assertEquals(Errors.SWITCH_RESPONSE_ERROR, result.getErrorCode());
-        Assert.assertFalse(result.isSuccess());
+        assertEquals(Errors.SWITCH_RESPONSE_ERROR, result.getErrorCode());
+        assertFalse(result.isSuccess());
     }
 
     @Test
     public void timeoutResponse() {
         ActionResult result = makeWithResponse(null);
 
-        Assert.assertNull(result.getErrorCode());
-        Assert.assertFalse(result.isSuccess());
+        assertNull(result.getErrorCode());
+        assertFalse(result.isSuccess());
     }
 
     @Test
@@ -90,11 +94,11 @@ public class BfdSessionActionTest {
 
         result = makeWithResponse(
                 new BfdSessionResponse(payload, Errors.NOVI_BFD_DISCRIMINATOR_NOT_FOUND_ERROR), false);
-        Assert.assertFalse(result.isSuccess());
+        assertFalse(result.isSuccess());
 
         result = makeWithResponse(
                 new BfdSessionResponse(payload, Errors.NOVI_BFD_DISCRIMINATOR_NOT_FOUND_ERROR), true);
-        Assert.assertTrue(result.isSuccess());
+        assertTrue(result.isSuccess());
     }
 
     private ActionResult makeWithResponse(BfdSessionResponse response) {

--- a/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkAntiFlapServiceTest.java
+++ b/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkAntiFlapServiceTest.java
@@ -26,13 +26,13 @@ import org.openkilda.wfm.topology.network.controller.AntiFlapFsm;
 import org.openkilda.wfm.topology.network.model.LinkStatus;
 import org.openkilda.wfm.topology.network.model.PortDataHolder;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class NetworkAntiFlapServiceTest {
     private static final long MAX_SPEED = 10000000;
     private static final long CURRENT_SPEED = 999999;
@@ -44,7 +44,7 @@ public class NetworkAntiFlapServiceTest {
     private final Endpoint endpoint1 = Endpoint.of(alphaDatapath, 1);
 
 
-    @Before
+    @BeforeEach
     public void setup() {
         resetMocks();
     }

--- a/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkBfdLogicalPortServiceTest.java
+++ b/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkBfdLogicalPortServiceTest.java
@@ -15,6 +15,7 @@
 
 package org.openkilda.wfm.topology.network.service;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -34,16 +35,15 @@ import org.openkilda.wfm.topology.network.error.ControllerNotFoundException;
 import org.openkilda.wfm.topology.network.model.BfdSessionData;
 import org.openkilda.wfm.topology.network.utils.SwitchOnlineStatusMonitor;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class NetworkBfdLogicalPortServiceTest {
     private static final int LOGICAL_PORT_OFFSET = 200;
 
@@ -61,7 +61,7 @@ public class NetworkBfdLogicalPortServiceTest {
 
     private SwitchOnlineStatusMonitor switchOnlineStatusMonitor;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         switchOnlineStatusMonitor = new SwitchOnlineStatusMonitor();
     }
@@ -122,7 +122,7 @@ public class NetworkBfdLogicalPortServiceTest {
 
         try {
             service.disable(physical);
-            Assert.fail("Expect controller not found exception");
+            fail("Expect controller not found exception");
         } catch (ControllerNotFoundException e) {
             // expected
         }

--- a/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkDecisionMakerServiceTest.java
+++ b/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkDecisionMakerServiceTest.java
@@ -29,13 +29,13 @@ import org.openkilda.messaging.info.event.PathNode;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.share.model.Endpoint;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class NetworkDecisionMakerServiceTest {
     private static final Endpoint endpointAlpha = Endpoint.of(new SwitchId(1), 1);
     private static final Endpoint endpointBeta = Endpoint.of(new SwitchId(2), 1);
@@ -51,7 +51,7 @@ public class NetworkDecisionMakerServiceTest {
     @Mock
     IDecisionMakerCarrier carrier;
 
-    @Before
+    @BeforeEach
     public void setup() {
         reset(carrier);
     }

--- a/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkIntegrationTest.java
+++ b/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkIntegrationTest.java
@@ -28,14 +28,12 @@ import org.openkilda.persistence.inmemory.InMemoryGraphPersistenceManager;
 import org.openkilda.wfm.topology.network.model.NetworkOptions;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.Inet4Address;
 import java.net.InetSocketAddress;
@@ -44,15 +42,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class NetworkIntegrationTest {
     private static final long MAX_SPEED = 10000000;
     private static final long CURRENT_SPEED = 99999;
 
     private static PersistenceManager persistenceManager;
 
-    @ClassRule
-    public static TemporaryFolder fsData = new TemporaryFolder();
 
     private static final NetworkOptions options = NetworkOptions.builder()
             .bfdEnabled(true)
@@ -85,19 +81,19 @@ public class NetworkIntegrationTest {
         // This constructor is required to define exception list for field initializers.
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpOnce() {
         persistenceManager = InMemoryGraphPersistenceManager.newInstance();
         persistenceManager.install();
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         integrationCarrier = new NetworkIntegrationCarrier(options, persistenceManager);
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void switchAdd() {
         Set<SwitchFeature> features = new HashSet<>();
         features.add(SwitchFeature.BFD);

--- a/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkPortServiceTest.java
+++ b/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkPortServiceTest.java
@@ -17,8 +17,8 @@ package org.openkilda.wfm.topology.network.service;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -49,18 +49,18 @@ import org.openkilda.wfm.topology.network.model.LinkStatus;
 import org.openkilda.wfm.topology.network.model.OnlineStatus;
 import org.openkilda.wfm.topology.network.model.PortDataHolder;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.internal.verification.Times;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 
 import java.time.Instant;
 import java.util.Optional;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class NetworkPortServiceTest {
     private static final long MAX_SPEED = 10000000;
     private static final long CURRENT_SPEED = 99999;
@@ -91,7 +91,7 @@ public class NetworkPortServiceTest {
 
     private final SwitchId alphaDatapath = new SwitchId(1);
 
-    @Before
+    @BeforeEach
     public void setup() {
         resetMocks();
     }
@@ -101,9 +101,9 @@ public class NetworkPortServiceTest {
         reset(dashboardLogger);
 
         reset(persistenceManager);
-        when(persistenceManager.getRepositoryFactory()).thenReturn(repositoryFactory);
-        when(persistenceManager.getTransactionManager()).thenReturn(transactionManager);
-        doAnswer(invocation -> {
+        lenient().when(persistenceManager.getRepositoryFactory()).thenReturn(repositoryFactory);
+        lenient().when(persistenceManager.getTransactionManager()).thenReturn(transactionManager);
+        lenient().doAnswer(invocation -> {
             TransactionCallbackWithoutResult tr = invocation.getArgument(0);
             tr.doInTransaction();
             return null;
@@ -111,15 +111,15 @@ public class NetworkPortServiceTest {
 
         reset(portPropertiesRepository);
         reset(portRepository);
-        doAnswer(invocation -> invocation.getArgument(0))
+        lenient().doAnswer(invocation -> invocation.getArgument(0))
                 .when(portPropertiesRepository).add(any());
 
         reset(switchRepository);
         reset(repositoryFactory);
 
-        when(repositoryFactory.createPortPropertiesRepository()).thenReturn(portPropertiesRepository);
-        when(repositoryFactory.createPortRepository()).thenReturn(portRepository);
-        when(repositoryFactory.createSwitchRepository()).thenReturn(switchRepository);
+        lenient().when(repositoryFactory.createPortPropertiesRepository()).thenReturn(portPropertiesRepository);
+        lenient().when(repositoryFactory.createPortRepository()).thenReturn(portRepository);
+        lenient().when(repositoryFactory.createSwitchRepository()).thenReturn(switchRepository);
     }
 
     @Test
@@ -527,7 +527,7 @@ public class NetworkPortServiceTest {
                         .port(endpoint.getPortNumber())
                         .discoveryEnabled(false)
                         .build()));
-        when(switchRepository.findById(alphaDatapath))
+        lenient().when(switchRepository.findById(alphaDatapath))
                 .thenReturn(Optional.of(entry));
     }
 

--- a/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkRoundTripDecisionMakerServiceTest.java
+++ b/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkRoundTripDecisionMakerServiceTest.java
@@ -25,15 +25,15 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.stubs.ManualClock;
 import org.openkilda.wfm.share.model.Endpoint;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class NetworkRoundTripDecisionMakerServiceTest {
     private static final Duration EXPIRE_DELAY = Duration.ofSeconds(4);
 
@@ -42,7 +42,7 @@ public class NetworkRoundTripDecisionMakerServiceTest {
 
     private ManualClock clock;
 
-    @Before
+    @BeforeEach
     public void setup() {
         reset(carrier);
 

--- a/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkSwitchServiceTest.java
+++ b/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkSwitchServiceTest.java
@@ -20,7 +20,7 @@ import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -74,12 +74,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.Inet4Address;
 import java.net.InetSocketAddress;
@@ -90,7 +90,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class NetworkSwitchServiceTest {
     private static final int BFD_LOGICAL_PORT_OFFSET = 1000;
     private static final int BFD_LOGICAL_PORT_MAX_NUMBER = 1999;
@@ -165,7 +165,7 @@ public class NetworkSwitchServiceTest {
     public NetworkSwitchServiceTest() throws UnknownHostException {
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         resetMocks();
     }
@@ -174,36 +174,36 @@ public class NetworkSwitchServiceTest {
         reset(carrier);
 
         reset(persistenceManager);
-        when(persistenceManager.getTransactionManager()).thenReturn(transactionManager);
-        when(persistenceManager.getRepositoryFactory()).thenReturn(repositoryFactory);
+        lenient().when(persistenceManager.getTransactionManager()).thenReturn(transactionManager);
+        lenient().when(persistenceManager.getRepositoryFactory()).thenReturn(repositoryFactory);
 
         reset(transactionManager);
 
-        when(transactionManager.getDefaultRetryPolicy())
+        lenient().when(transactionManager.getDefaultRetryPolicy())
                 .thenReturn(new RetryPolicy<>().withMaxRetries(2));
-        doAnswer(invocation -> {
-            RetryPolicy<?> retryPolicy = invocation.getArgument(0);
-            TransactionCallbackWithoutResult<?> tr = invocation.getArgument(1);
-            Failsafe.with(retryPolicy)
-                    .run(tr::doInTransaction);
-            return null;
-        }).when(transactionManager)
+        lenient()
+                .doAnswer(invocation -> {
+                    RetryPolicy<?> retryPolicy = invocation.getArgument(0);
+                    TransactionCallbackWithoutResult<?> tr = invocation.getArgument(1);
+                    Failsafe.with(retryPolicy).run(tr::doInTransaction);
+                    return null;
+                }).when(transactionManager)
                 .doInTransaction(any(RetryPolicy.class), any(TransactionCallbackWithoutResult.class));
 
         reset(switchRepository, switchPropertiesRepository);
 
-        doAnswer(invocation -> invocation.getArgument(0)).when(switchRepository).add(any());
+        lenient().doAnswer(invocation -> invocation.getArgument(0)).when(switchRepository).add(any());
 
-        when(kildaConfigurationRepository.getOrDefault()).thenReturn(KildaConfiguration.DEFAULTS);
-        when(featureTogglesRepository.getOrDefault()).thenReturn(KildaFeatureToggles.DEFAULTS);
+        lenient().when(kildaConfigurationRepository.getOrDefault()).thenReturn(KildaConfiguration.DEFAULTS);
+        lenient().when(featureTogglesRepository.getOrDefault()).thenReturn(KildaFeatureToggles.DEFAULTS);
 
         reset(repositoryFactory);
-        when(repositoryFactory.createSwitchRepository()).thenReturn(switchRepository);
-        when(repositoryFactory.createSwitchConnectRepository()).thenReturn(switchConnectRepository);
-        when(repositoryFactory.createSwitchPropertiesRepository()).thenReturn(switchPropertiesRepository);
-        when(repositoryFactory.createKildaConfigurationRepository()).thenReturn(kildaConfigurationRepository);
-        when(repositoryFactory.createSpeakerRepository()).thenReturn(speakerRepository);
-        when(repositoryFactory.createFeatureTogglesRepository()).thenReturn(featureTogglesRepository);
+        lenient().when(repositoryFactory.createSwitchRepository()).thenReturn(switchRepository);
+        lenient().when(repositoryFactory.createSwitchConnectRepository()).thenReturn(switchConnectRepository);
+        lenient().when(repositoryFactory.createSwitchPropertiesRepository()).thenReturn(switchPropertiesRepository);
+        lenient().when(repositoryFactory.createKildaConfigurationRepository()).thenReturn(kildaConfigurationRepository);
+        lenient().when(repositoryFactory.createSpeakerRepository()).thenReturn(speakerRepository);
+        lenient().when(repositoryFactory.createFeatureTogglesRepository()).thenReturn(featureTogglesRepository);
     }
 
     @Test

--- a/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkUniIslServiceTest.java
+++ b/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkUniIslServiceTest.java
@@ -39,17 +39,17 @@ import org.openkilda.wfm.topology.network.model.BfdStatusUpdate;
 import org.openkilda.wfm.topology.network.model.IslDataHolder;
 import org.openkilda.wfm.topology.network.model.RoundTripStatus;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class NetworkUniIslServiceTest {
     private final Map<SwitchId, Switch> switchCache = new HashMap<>();
 
@@ -58,7 +58,7 @@ public class NetworkUniIslServiceTest {
     @Mock
     private IUniIslCarrier carrier;
 
-    @Before
+    @BeforeEach
     public void setup() {
         resetMocks();
     }
@@ -412,7 +412,7 @@ public class NetworkUniIslServiceTest {
         service.uniIslDiscovery(endpointAlpha1, IslMapper.INSTANCE.map(normalIsl));
 
         verify(carrier).notifyIslUp(endpointAlpha1, new IslReference(endpointAlpha1, endpointBeta3),
-                                    new IslDataHolder(normalIsl));
+                new IslDataHolder(normalIsl));
         verify(carrier).exhaustedPollModeUpdateRequest(endpointAlpha1, false);
         verifyNoMoreInteractions(carrier);
 
@@ -449,7 +449,7 @@ public class NetworkUniIslServiceTest {
 
         final IslReference reference = new IslReference(endpointAlpha1, endpointBeta3);
         verify(carrier).notifyIslUp(endpointAlpha1, reference,
-                                    new IslDataHolder(normalIsl));
+                new IslDataHolder(normalIsl));
         verify(carrier).exhaustedPollModeUpdateRequest(endpointAlpha1, false);
         verifyNoMoreInteractions(carrier);
         reset(carrier);
@@ -573,7 +573,7 @@ public class NetworkUniIslServiceTest {
         service.uniIslDiscovery(endpointA, IslMapper.INSTANCE.map(link));
 
         verify(carrier).notifyIslUp(endpointA, new IslReference(endpointA, endpointZ),
-                                    new IslDataHolder(link));
+                new IslDataHolder(link));
         verify(carrier).exhaustedPollModeUpdateRequest(endpointA, false);
         verifyNoMoreInteractions(carrier);
         reset(carrier);

--- a/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkWatchListServiceTest.java
+++ b/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkWatchListServiceTest.java
@@ -16,8 +16,7 @@
 package org.openkilda.wfm.topology.network.service;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -29,25 +28,27 @@ import static org.mockito.Mockito.verify;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.share.model.Endpoint;
 
-import org.junit.Before;
-import org.junit.runner.RunWith;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class NetworkWatchListServiceTest {
 
     @Mock
     IWatchListCarrier carrier;
 
-    @Before
+    @BeforeEach
     public void setup() {
         reset(carrier);
     }
 
-    @org.junit.Test
+    @Test
     public void addWatch() {
 
         NetworkWatchListService s = new NetworkWatchListService(carrier, 10, 20, 30);
@@ -58,13 +59,13 @@ public class NetworkWatchListServiceTest {
         s.addWatch(Endpoint.of(new SwitchId(2), 1), 2);
         s.addWatch(Endpoint.of(new SwitchId(2), 2), 3);
 
-        assertThat(s.getEndpoints().size(), is(4));
-        assertThat(s.getTimeouts().size(), is(3));
+        MatcherAssert.assertThat(s.getEndpoints().size(), is(4));
+        MatcherAssert.assertThat(s.getTimeouts().size(), is(3));
 
         verify(carrier, times(4)).discoveryRequest(any(Endpoint.class), anyLong());
     }
 
-    @org.junit.Test
+    @Test
     public void removeWatch() {
         NetworkWatchListService s = new NetworkWatchListService(carrier, 10, 20, 30);
 
@@ -72,23 +73,23 @@ public class NetworkWatchListServiceTest {
         s.addWatch(Endpoint.of(new SwitchId(1), 2), 1);
         s.addWatch(Endpoint.of(new SwitchId(2), 1), 11);
 
-        assertThat(s.getEndpoints().size(), is(3));
+        MatcherAssert.assertThat(s.getEndpoints().size(), is(3));
 
         s.removeWatch(Endpoint.of(new SwitchId(1), 1));
         s.removeWatch(Endpoint.of(new SwitchId(1), 2));
         s.removeWatch(Endpoint.of(new SwitchId(2), 1));
 
-        assertThat(s.getEndpoints().size(), is(0));
-        assertThat(s.getTimeouts().size(), is(2));
+        MatcherAssert.assertThat(s.getEndpoints().size(), is(0));
+        MatcherAssert.assertThat(s.getTimeouts().size(), is(2));
 
         s.tick(100);
 
-        assertThat(s.getTimeouts().size(), is(0));
+        MatcherAssert.assertThat(s.getTimeouts().size(), is(0));
 
         verify(carrier, times(3)).discoveryRequest(any(Endpoint.class), anyLong());
     }
 
-    @org.junit.Test
+    @Test
     public void tick() {
         NetworkWatchListService s = new NetworkWatchListService(carrier, 10, 20, 30);
 
@@ -106,7 +107,7 @@ public class NetworkWatchListServiceTest {
         verify(carrier, times(10)).discoveryRequest(eq(Endpoint.of(new SwitchId(2), 2)), anyLong());
     }
 
-    @org.junit.Test
+    @Test
     public void enableSlowPollFlags() {
         NetworkWatchListService s = new NetworkWatchListService(carrier, 10, 20, 30);
 
@@ -129,7 +130,7 @@ public class NetworkWatchListServiceTest {
                 longThat(time -> Arrays.asList(1L, 11L, 41L, 71L).contains(time)));
     }
 
-    @org.junit.Test
+    @Test
     public void disableSlowPollFlags() {
         NetworkWatchListService s = new NetworkWatchListService(carrier, 10, 15, 30);
 
@@ -161,7 +162,7 @@ public class NetworkWatchListServiceTest {
                 longThat(time -> Arrays.asList(1L, 11L, 41L, 66L, 81L, 96L).contains(time)));
     }
 
-    @org.junit.Test
+    @Test
     public void calculateTimeout() {
         long genericTimeout = 10L;
         long exhaustedTimeout = 15L;

--- a/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkWatcherServiceTest.java
+++ b/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/NetworkWatcherServiceTest.java
@@ -16,7 +16,6 @@
 package org.openkilda.wfm.topology.network.service;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -31,20 +30,21 @@ import org.openkilda.messaging.info.event.PathNode;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.share.model.Endpoint;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class NetworkWatcherServiceTest {
     private final Integer taskId = 0;
 
     @Mock
     IWatcherCarrier carrier;
 
-    @Before
+    @BeforeEach
     public void setup() {
         reset(carrier);
     }
@@ -58,8 +58,8 @@ public class NetworkWatcherServiceTest {
         w.addWatch(Endpoint.of(new SwitchId(2), 1), 2);
         w.addWatch(Endpoint.of(new SwitchId(2), 2), 3);
 
-        assertThat(w.getConfirmedPackets().size(), is(0));
-        assertThat(w.getTimeouts().size(), is(3));
+        MatcherAssert.assertThat(w.getConfirmedPackets().size(), is(0));
+        MatcherAssert.assertThat(w.getTimeouts().size(), is(3));
 
         verify(carrier, times(5)).sendDiscovery(any(DiscoverIslCommandData.class));
     }
@@ -78,9 +78,9 @@ public class NetworkWatcherServiceTest {
         w.confirmation(Endpoint.of(new SwitchId(1), 2), 1);
         w.confirmation(Endpoint.of(new SwitchId(2), 1), 2);
 
-        assertThat(w.getConfirmedPackets().size(), is(2));
-        assertThat(w.getTimeouts().size(), is(5));
-        assertThat(w.getDiscoveryPackets().size(), is(3));
+        MatcherAssert.assertThat(w.getConfirmedPackets().size(), is(2));
+        MatcherAssert.assertThat(w.getTimeouts().size(), is(5));
+        MatcherAssert.assertThat(w.getDiscoveryPackets().size(), is(3));
 
         w.removeWatch(Endpoint.of(new SwitchId(1), 2));
         w.removeWatch(Endpoint.of(new SwitchId(2), 2));
@@ -88,11 +88,11 @@ public class NetworkWatcherServiceTest {
         verify(carrier).clearDiscovery(Endpoint.of(new SwitchId(1), 2));
         verify(carrier).clearDiscovery(Endpoint.of(new SwitchId(2), 2));
 
-        assertThat(w.getConfirmedPackets().size(), is(1));
-        assertThat(w.getDiscoveryPackets().size(), is(2));
+        MatcherAssert.assertThat(w.getConfirmedPackets().size(), is(1));
+        MatcherAssert.assertThat(w.getDiscoveryPackets().size(), is(2));
 
         w.tick(100);
-        assertThat(w.getTimeouts().size(), is(0));
+        MatcherAssert.assertThat(w.getTimeouts().size(), is(0));
     }
 
     @Test
@@ -104,24 +104,24 @@ public class NetworkWatcherServiceTest {
         w.addWatch(Endpoint.of(new SwitchId(2), 1), 2);
         w.addWatch(Endpoint.of(new SwitchId(2), 2), 3);
 
-        assertThat(w.getConfirmedPackets().size(), is(0));
-        assertThat(w.getTimeouts().size(), is(3));
+        MatcherAssert.assertThat(w.getConfirmedPackets().size(), is(0));
+        MatcherAssert.assertThat(w.getTimeouts().size(), is(3));
         verify(carrier, times(5)).sendDiscovery(any(DiscoverIslCommandData.class));
 
         w.confirmation(Endpoint.of(new SwitchId(1), 1), 0);
         w.confirmation(Endpoint.of(new SwitchId(2), 1), 2);
 
-        assertThat(w.getConfirmedPackets().size(), is(2));
+        MatcherAssert.assertThat(w.getConfirmedPackets().size(), is(2));
 
         w.tick(100);
 
-        assertThat(w.getConfirmedPackets().size(), is(0));
+        MatcherAssert.assertThat(w.getConfirmedPackets().size(), is(0));
 
         verify(carrier).discoveryFailed(eq(Endpoint.of(new SwitchId(1), 1)), eq(0L), anyLong());
         verify(carrier).discoveryFailed(eq(Endpoint.of(new SwitchId(2), 1)), eq(2L), anyLong());
         verify(carrier, times(2)).discoveryFailed(any(Endpoint.class), anyLong(), anyLong());
 
-        assertThat(w.getTimeouts().size(), is(0));
+        MatcherAssert.assertThat(w.getTimeouts().size(), is(0));
     }
 
     @Test
@@ -133,13 +133,13 @@ public class NetworkWatcherServiceTest {
         w.addWatch(Endpoint.of(new SwitchId(2), 1), 2);
         w.addWatch(Endpoint.of(new SwitchId(2), 2), 3);
 
-        assertThat(w.getConfirmedPackets().size(), is(0));
-        assertThat(w.getTimeouts().size(), is(3));
+        MatcherAssert.assertThat(w.getConfirmedPackets().size(), is(0));
+        MatcherAssert.assertThat(w.getTimeouts().size(), is(3));
         verify(carrier, times(5)).sendDiscovery(any(DiscoverIslCommandData.class));
 
         w.confirmation(Endpoint.of(new SwitchId(1), 1), 0);
         w.confirmation(Endpoint.of(new SwitchId(2), 1), 2);
-        assertThat(w.getConfirmedPackets().size(), is(2));
+        MatcherAssert.assertThat(w.getConfirmedPackets().size(), is(2));
 
         PathNode source = new PathNode(new SwitchId(1), 1, 0);
         PathNode destination = new PathNode(new SwitchId(2), 1, 0);
@@ -151,16 +151,16 @@ public class NetworkWatcherServiceTest {
 
         w.tick(100);
 
-        assertThat(w.getConfirmedPackets().size(), is(0));
+        MatcherAssert.assertThat(w.getConfirmedPackets().size(), is(0));
 
         verify(carrier).oneWayDiscoveryReceived(eq(new Endpoint(islAlphaBeta.getSource())), eq(0L), eq(islAlphaBeta),
-                                          anyLong());
+                anyLong());
         verify(carrier).oneWayDiscoveryReceived(eq(new Endpoint(islBetaAlpha.getSource())), eq(2L), eq(islBetaAlpha),
-                                          anyLong());
+                anyLong());
         verify(carrier, times(2))
                 .oneWayDiscoveryReceived(any(Endpoint.class), anyLong(), any(IslInfoData.class), anyLong());
 
-        assertThat(w.getTimeouts().size(), is(0));
+        MatcherAssert.assertThat(w.getTimeouts().size(), is(0));
     }
 
     @Test
@@ -183,7 +183,7 @@ public class NetworkWatcherServiceTest {
         verify(carrier).oneWayDiscoveryReceived(eq(new Endpoint(source)), eq(0L), eq(islAlphaBeta), anyLong());
         verify(carrier, never()).discoveryFailed(eq(new Endpoint(source)), anyLong(), anyLong());
 
-        assertThat(w.getConfirmedPackets().size(), is(0));
+        MatcherAssert.assertThat(w.getConfirmedPackets().size(), is(0));
     }
 
     private NetworkWatcherService makeService() {

--- a/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/PollIntegrationTest.java
+++ b/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/service/PollIntegrationTest.java
@@ -28,22 +28,22 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.share.model.Endpoint;
 
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PollIntegrationTest {
     private static final Integer taskId = 0;
 
     @Mock
     IDecisionMakerCarrier carrier;
 
-    @Before
+    @BeforeEach
     public void setup() {
         reset(carrier);
     }
@@ -79,7 +79,7 @@ public class PollIntegrationTest {
         NetworkWatcherService watcherService = new NetworkWatcherService(
                 integrationCarrier, 100, taskId);
         NetworkDecisionMakerService decisionMakerService = new NetworkDecisionMakerService(carrier,
-                                                                                           200, 100);
+                200, 100);
 
         integrationCarrier.configure(watcherService, watchListService, decisionMakerService);
         integrationCarrier.setWatcherCarrier(watcherCarrier);
@@ -93,8 +93,8 @@ public class PollIntegrationTest {
         verify(watcherCarrier).sendDiscovery(discoveryRequestCatcher.capture());
 
         DiscoverIslCommandData request = discoveryRequestCatcher.getValue();
-        Assert.assertEquals(endpoint.getDatapath(), request.getSwitchId());
-        Assert.assertEquals(endpoint.getPortNumber(), request.getPortNumber());
+        Assertions.assertEquals(endpoint.getDatapath(), request.getSwitchId());
+        Assertions.assertEquals(endpoint.getPortNumber(), request.getPortNumber());
 
         IslInfoData expectedDiscoveryEvent = IslInfoData.builder().latency(latency)
                 .source(new PathNode(new SwitchId(1), 1, 0))
@@ -123,7 +123,7 @@ public class PollIntegrationTest {
         NetworkWatcherService watcherService = new NetworkWatcherService(
                 integrationCarrier, 100, taskId);
         NetworkDecisionMakerService decisionMakerService = new NetworkDecisionMakerService(carrier,
-                                                                                           200, 100);
+                200, 100);
 
         integrationCarrier.configure(watcherService, watchListService, decisionMakerService);
 

--- a/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/utils/GenerationTrackerTest.java
+++ b/src-java/network-topology/network-storm-topology/src/test/java/org/openkilda/wfm/topology/network/utils/GenerationTrackerTest.java
@@ -15,8 +15,8 @@
 
 package org.openkilda.wfm.topology.network.utils;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class GenerationTrackerTest {
     private static final long LIMIT = 5;
@@ -26,21 +26,21 @@ public class GenerationTrackerTest {
         GenerationTracker<String> tracker = makeTracker();
 
         long empty = tracker.getLastSeenGeneration();
-        Assert.assertEquals(-1, empty);
-        Assert.assertEquals(empty, tracker.getLastSeenGeneration());
+        Assertions.assertEquals(-1, empty);
+        Assertions.assertEquals(empty, tracker.getLastSeenGeneration());
 
         String firstId = "A";
         long first = tracker.identify(firstId);
-        Assert.assertNotEquals(empty, first);
-        Assert.assertEquals(first, tracker.getLastSeenGeneration());
-        Assert.assertEquals(first, tracker.identify(firstId));
+        Assertions.assertNotEquals(empty, first);
+        Assertions.assertEquals(first, tracker.getLastSeenGeneration());
+        Assertions.assertEquals(first, tracker.identify(firstId));
 
         String secondId = "B";
         long second = tracker.identify(secondId);
-        Assert.assertNotEquals(empty, second);
-        Assert.assertNotEquals(first, second);
-        Assert.assertEquals(second, tracker.getLastSeenGeneration());
-        Assert.assertEquals(second, tracker.identify(secondId));
+        Assertions.assertNotEquals(empty, second);
+        Assertions.assertNotEquals(first, second);
+        Assertions.assertEquals(second, tracker.getLastSeenGeneration());
+        Assertions.assertEquals(second, tracker.identify(secondId));
     }
 
     @Test
@@ -50,12 +50,12 @@ public class GenerationTrackerTest {
         long referenceGeneration = tracker.identify(referenceId);
 
         for (int i = 0; i < LIMIT - 1; i++) {
-            Assert.assertNotEquals(referenceGeneration, tracker.identify(String.format("id-%d", i)));
-            Assert.assertEquals(referenceGeneration, tracker.identify(referenceId));
+            Assertions.assertNotEquals(referenceGeneration, tracker.identify(String.format("id-%d", i)));
+            Assertions.assertEquals(referenceGeneration, tracker.identify(referenceId));
         }
 
         tracker.identify("B");
-        Assert.assertNotEquals(referenceGeneration, tracker.identify(referenceId));
+        Assertions.assertNotEquals(referenceGeneration, tracker.identify(referenceId));
     }
 
     private GenerationTracker<String> makeTracker() {

--- a/src-java/northbound-service/northbound-api/build.gradle
+++ b/src-java/northbound-service/northbound-api/build.gradle
@@ -15,9 +15,13 @@ dependencies {
     implementation 'javax.validation:validation-api'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding'
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/northbound-service/northbound-api/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/northbound-service/northbound-api/src/checkstyle/checkstyle-suppressions.xml
@@ -3,4 +3,6 @@
         "-//Puppy Crawl//DTD Suppressions 1.2//EN"
         "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
 
-<suppressions/>
+<suppressions>
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
+</suppressions>

--- a/src-java/northbound-service/northbound-api/src/test/java/org/openkilda/northbound/dto/JsonSerializationTest.java
+++ b/src-java/northbound-service/northbound-api/src/test/java/org/openkilda/northbound/dto/JsonSerializationTest.java
@@ -17,7 +17,6 @@ package org.openkilda.northbound.dto;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
 
 import org.openkilda.messaging.info.event.SwitchChangeType;
 import org.openkilda.model.FlowPathDirection;
@@ -49,7 +48,8 @@ import org.openkilda.northbound.dto.v1.switches.SwitchValidationResult;
 import org.openkilda.northbound.dto.v1.switches.UnderMaintenanceDto;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -68,7 +68,7 @@ public class JsonSerializationTest {
     @Test
     public void pathDiscrepancyDtoTest() throws IOException {
         PathDiscrepancyDto dto = new PathDiscrepancyDto("rule", "field", "expected", "actual");
-        assertEquals(dto, pass(dto, PathDiscrepancyDto.class));
+        Assertions.assertEquals(dto, pass(dto, PathDiscrepancyDto.class));
     }
 
     @Test
@@ -79,26 +79,26 @@ public class JsonSerializationTest {
                 true, singletonList(0L), singletonList(1L), singletonList(discrepancyDto),
                 10, 11, 2, 4,
                 true, true);
-        assertEquals(dto, pass(dto, FlowValidationDto.class));
+        Assertions.assertEquals(dto, pass(dto, FlowValidationDto.class));
     }
 
     @Test
     public void uniFlowPingOutputTest() throws IOException {
         UniFlowPingOutput dto = new UniFlowPingOutput(true, "err-test", 10);
-        assertEquals(dto, pass(dto, UniFlowPingOutput.class));
+        Assertions.assertEquals(dto, pass(dto, UniFlowPingOutput.class));
     }
 
     @Test
     public void verificationInputTest() throws IOException {
         PingInput dto = new PingInput(10);
-        assertEquals(dto, pass(dto, PingInput.class));
+        Assertions.assertEquals(dto, pass(dto, PingInput.class));
     }
 
     @Test
     public void verificationOutputTest() throws IOException {
         UniFlowPingOutput verification = new UniFlowPingOutput(true, "err-test", 10);
         PingOutput dto = new PingOutput(FLOW_ID, verification, verification, "error");
-        assertEquals(dto, pass(dto, PingOutput.class));
+        Assertions.assertEquals(dto, pass(dto, PingOutput.class));
     }
 
 
@@ -107,40 +107,40 @@ public class JsonSerializationTest {
         LinkDto dto = new LinkDto(-1, 1, 0, 0, 0, LinkStatus.DISCOVERED,
                 LinkStatus.DISCOVERED, LinkStatus.FAILED, 0, false, false,
                 "bfd-session-status", singletonList(new PathDto(SWITCH_ID, 1, 0, 10L)), null);
-        assertEquals(dto, pass(dto, LinkDto.class));
+        Assertions.assertEquals(dto, pass(dto, LinkDto.class));
     }
 
     @Test
     public void pathDtoTest() throws IOException {
         PathDto dto = new PathDto(SWITCH_ID, 1, 0, 10L);
-        assertEquals(dto, pass(dto, PathDto.class));
+        Assertions.assertEquals(dto, pass(dto, PathDto.class));
     }
 
     @Test
     public void linksPropsDtoTest() throws IOException {
         LinkPropsDto dto = new LinkPropsDto(SWITCH_ID, 0, SWITCH_ID, 1, Collections.singletonMap("key", "val"));
-        assertEquals(dto, pass(dto, LinkPropsDto.class));
+        Assertions.assertEquals(dto, pass(dto, LinkPropsDto.class));
     }
 
 
     @Test
     public void deleteMeterResultTest() throws IOException {
         DeleteMeterResult dto = new DeleteMeterResult(true);
-        assertEquals(dto, pass(dto, DeleteMeterResult.class));
+        Assertions.assertEquals(dto, pass(dto, DeleteMeterResult.class));
     }
 
     @Test
     public void rulesValidationResultTest() throws IOException {
         RulesValidationResult dto = new RulesValidationResult(
                 singletonList(0L), singletonList(1L), singletonList(2L));
-        assertEquals(dto, pass(dto, RulesValidationResult.class));
+        Assertions.assertEquals(dto, pass(dto, RulesValidationResult.class));
     }
 
     @Test
     public void rulesSyncResultTest() throws IOException {
         RulesSyncResult dto = new RulesSyncResult(
                 singletonList(0L), singletonList(1L), singletonList(2L), singletonList(3L));
-        assertEquals(dto, pass(dto, RulesSyncResult.class));
+        Assertions.assertEquals(dto, pass(dto, RulesSyncResult.class));
     }
 
     @Test
@@ -154,7 +154,7 @@ public class JsonSerializationTest {
         LogicalPortsSyncDto logicalPorts = new LogicalPortsSyncDto(emptyList(), emptyList(), emptyList(), emptyList(),
                 emptyList(), emptyList(), "");
         SwitchSyncResult dto = new SwitchSyncResult(rules, meters, groups, logicalPorts);
-        assertEquals(dto, pass(dto, SwitchSyncResult.class));
+        Assertions.assertEquals(dto, pass(dto, SwitchSyncResult.class));
     }
 
     @Test
@@ -171,7 +171,7 @@ public class JsonSerializationTest {
                 .groups(groups)
                 .logicalPorts(logicalPorts)
                 .build();
-        assertEquals(dto, pass(dto, SwitchValidationResult.class));
+        Assertions.assertEquals(dto, pass(dto, SwitchValidationResult.class));
     }
 
     @Test
@@ -180,18 +180,18 @@ public class JsonSerializationTest {
                 SwitchChangeType.ACTIVATED, false, "of_version",
                 "manufacturer", "hardware", "software", "serial_number", "pop",
                 new SwitchLocationDto(48.860611, 2.337633, "street", "city", "country"));
-        assertEquals(dto, pass(dto, SwitchDto.class));
+        Assertions.assertEquals(dto, pass(dto, SwitchDto.class));
     }
 
     @Test
     public void switchUnderMaintenanceDtoTest() throws IOException {
         UnderMaintenanceDto dto = new UnderMaintenanceDto(false, false);
-        assertEquals(dto, pass(dto, UnderMaintenanceDto.class));
+        Assertions.assertEquals(dto, pass(dto, UnderMaintenanceDto.class));
     }
 
     @Test
     public void batchResultsTest() throws IOException {
         BatchResults dto = new BatchResults(1, 0, singletonList("qwerty"));
-        assertEquals(dto, pass(dto, BatchResults.class));
+        Assertions.assertEquals(dto, pass(dto, BatchResults.class));
     }
 }

--- a/src-java/northbound-service/northbound/build.gradle
+++ b/src-java/northbound-service/northbound/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     }
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation project(path: ':kilda-persistence-tinkerpop', configuration: 'testArtifacts')
 }
 
@@ -91,3 +91,7 @@ bootJar {
 }
 
 bootJar.dependsOn generateVersionTxt
+
+test {
+    useJUnitPlatform()
+}

--- a/src-java/northbound-service/northbound/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/northbound-service/northbound/src/checkstyle/checkstyle-suppressions.xml
@@ -5,4 +5,5 @@
 
 <suppressions>
     <suppress files="src/main/java/org/openkilda/northbound/Application.java" checks="HideUtilityClassConstructor"/>
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
 </suppressions>

--- a/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/controller/v1/FlowControllerTest.java
+++ b/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/controller/v1/FlowControllerTest.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.controller.v1;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openkilda.messaging.Utils.CORRELATION_ID;
 import static org.openkilda.messaging.Utils.DEFAULT_CORRELATION_ID;
 import static org.openkilda.messaging.Utils.EXTRA_AUTH;
@@ -41,14 +41,14 @@ import org.openkilda.northbound.controller.mock.TestMessageMock;
 import org.openkilda.northbound.utils.RequestCorrelationId;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -60,7 +60,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @ContextConfiguration(classes = TestConfig.class)
 @TestPropertySource("classpath:northbound.properties")
@@ -79,7 +79,7 @@ public class FlowControllerTest {
     @Autowired
     private WebApplicationContext webApplicationContext;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).apply(springSecurity()).build();
         RequestCorrelationId.create(DEFAULT_CORRELATION_ID);
@@ -89,9 +89,9 @@ public class FlowControllerTest {
     @WithMockUser(username = USERNAME, password = PASSWORD, roles = ROLE)
     public void createFlow() throws Exception {
         MvcResult mvcResult = mockMvc.perform(put("/v1/flows")
-                .header(CORRELATION_ID, testCorrelationId())
-                .contentType(APPLICATION_JSON_VALUE)
-                .content(MAPPER.writeValueAsString(TestMessageMock.FLOW)))
+                        .header(CORRELATION_ID, testCorrelationId())
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .content(MAPPER.writeValueAsString(TestMessageMock.FLOW)))
                 .andReturn();
 
         MvcResult result = mockMvc.perform(asyncDispatch(mvcResult))
@@ -108,8 +108,8 @@ public class FlowControllerTest {
     @WithMockUser(username = USERNAME, password = PASSWORD, roles = ROLE)
     public void getFlow() throws Exception {
         MvcResult mvcResult = mockMvc.perform(get("/v1/flows/{flow-id}", TestMessageMock.FLOW_ID)
-                .header(CORRELATION_ID, testCorrelationId())
-                .contentType(APPLICATION_JSON_VALUE))
+                        .header(CORRELATION_ID, testCorrelationId())
+                        .contentType(APPLICATION_JSON_VALUE))
                 .andReturn();
 
         MvcResult result = mockMvc.perform(asyncDispatch(mvcResult))
@@ -126,8 +126,8 @@ public class FlowControllerTest {
     @WithMockUser(username = USERNAME, password = PASSWORD, roles = ROLE)
     public void deleteFlow() throws Exception {
         MvcResult mvcResult = mockMvc.perform(delete("/v1/flows/{flow-id}", TestMessageMock.FLOW_ID)
-                .header(CORRELATION_ID, testCorrelationId())
-                .contentType(APPLICATION_JSON_VALUE))
+                        .header(CORRELATION_ID, testCorrelationId())
+                        .contentType(APPLICATION_JSON_VALUE))
                 .andReturn();
 
         MvcResult result = mockMvc.perform(asyncDispatch(mvcResult))
@@ -143,9 +143,9 @@ public class FlowControllerTest {
     @WithMockUser(username = USERNAME, password = PASSWORD, roles = ROLE)
     public void deleteFlows() throws Exception {
         MvcResult mvcResult = mockMvc.perform(delete("/v1/flows")
-                .header(CORRELATION_ID, testCorrelationId())
-                .header(EXTRA_AUTH, System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(119))
-                .contentType(APPLICATION_JSON_VALUE))
+                        .header(CORRELATION_ID, testCorrelationId())
+                        .header(EXTRA_AUTH, System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(119))
+                        .contentType(APPLICATION_JSON_VALUE))
                 .andReturn();
 
         MvcResult result = mockMvc.perform(asyncDispatch(mvcResult))
@@ -161,8 +161,8 @@ public class FlowControllerTest {
     @WithMockUser(username = USERNAME, password = PASSWORD, roles = ROLE)
     public void shouldFailDeleteFlowsWithoutExtraAuth() throws Exception {
         mockMvc.perform(delete("/v1/flows")
-                .header(CORRELATION_ID, testCorrelationId())
-                .contentType(APPLICATION_JSON_VALUE))
+                        .header(CORRELATION_ID, testCorrelationId())
+                        .contentType(APPLICATION_JSON_VALUE))
                 .andExpect(status().isUnauthorized());
     }
 
@@ -170,9 +170,9 @@ public class FlowControllerTest {
     @WithMockUser(username = USERNAME, password = PASSWORD, roles = ROLE)
     public void updateFlow() throws Exception {
         MvcResult mvcResult = mockMvc.perform(put("/v1/flows/{flow-id}", TestMessageMock.FLOW_ID)
-                .header(CORRELATION_ID, testCorrelationId())
-                .contentType(APPLICATION_JSON_VALUE)
-                .content(MAPPER.writeValueAsString(TestMessageMock.FLOW)))
+                        .header(CORRELATION_ID, testCorrelationId())
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .content(MAPPER.writeValueAsString(TestMessageMock.FLOW)))
                 .andReturn();
 
         MvcResult result = mockMvc.perform(asyncDispatch(mvcResult))
@@ -204,8 +204,8 @@ public class FlowControllerTest {
     @WithMockUser(username = USERNAME, password = PASSWORD, roles = ROLE)
     public void getFlows() throws Exception {
         MvcResult mvcResult = mockMvc.perform(get("/v1/flows", TestMessageMock.FLOW_ID)
-                .header(CORRELATION_ID, testCorrelationId())
-                .contentType(APPLICATION_JSON_VALUE))
+                        .header(CORRELATION_ID, testCorrelationId())
+                        .contentType(APPLICATION_JSON_VALUE))
                 .andReturn();
 
         MvcResult result = mockMvc.perform(asyncDispatch(mvcResult))
@@ -214,7 +214,8 @@ public class FlowControllerTest {
                 .andReturn();
         List<FlowResponsePayload> response = MAPPER.readValue(
                 result.getResponse().getContentAsString(),
-                new TypeReference<List<FlowResponsePayload>>() {});
+                new TypeReference<List<FlowResponsePayload>>() {
+                });
         assertEquals(Collections.singletonList(TestMessageMock.FLOW_RESPONSE_PAYLOAD), response);
     }
 
@@ -222,8 +223,8 @@ public class FlowControllerTest {
     @WithMockUser(username = USERNAME, password = PASSWORD, roles = ROLE)
     public void statusFlow() throws Exception {
         MvcResult mvcResult = mockMvc.perform(get("/v1/flows/status/{flow-id}", TestMessageMock.FLOW_ID)
-                .header(CORRELATION_ID, testCorrelationId())
-                .contentType(APPLICATION_JSON_VALUE))
+                        .header(CORRELATION_ID, testCorrelationId())
+                        .contentType(APPLICATION_JSON_VALUE))
                 .andReturn();
 
         MvcResult result = mockMvc.perform(asyncDispatch(mvcResult))
@@ -239,8 +240,8 @@ public class FlowControllerTest {
     @WithMockUser(username = USERNAME, password = PASSWORD, roles = ROLE)
     public void pathFlow() throws Exception {
         MvcResult mvcResult = mockMvc.perform(get("/v1/flows/{flow-id}/path", TestMessageMock.FLOW_ID)
-                .header(CORRELATION_ID, testCorrelationId())
-                .contentType(APPLICATION_JSON_VALUE))
+                        .header(CORRELATION_ID, testCorrelationId())
+                        .contentType(APPLICATION_JSON_VALUE))
                 .andReturn();
 
         MvcResult result = mockMvc.perform(asyncDispatch(mvcResult))
@@ -255,8 +256,8 @@ public class FlowControllerTest {
     @WithMockUser(username = USERNAME, password = PASSWORD, roles = ROLE)
     public void getNonExistingFlow() throws Exception {
         MvcResult result = mockMvc.perform(get("/v1/flows/{flow-id}", ERROR_FLOW_ID)
-                .header(CORRELATION_ID, DEFAULT_CORRELATION_ID)
-                .contentType(APPLICATION_JSON_VALUE))
+                        .header(CORRELATION_ID, DEFAULT_CORRELATION_ID)
+                        .contentType(APPLICATION_JSON_VALUE))
                 .andExpect(status().isNotFound())
                 .andExpect(content().contentType(APPLICATION_JSON_VALUE))
                 .andReturn();
@@ -268,8 +269,8 @@ public class FlowControllerTest {
     @Test
     public void emptyCredentials() throws Exception {
         MvcResult result = mockMvc.perform(get("/v1/flows/path/{flow-id}", TestMessageMock.FLOW_ID)
-                .header(CORRELATION_ID, DEFAULT_CORRELATION_ID)
-                .contentType(APPLICATION_JSON_VALUE))
+                        .header(CORRELATION_ID, DEFAULT_CORRELATION_ID)
+                        .contentType(APPLICATION_JSON_VALUE))
                 .andExpect(status().isUnauthorized())
                 .andExpect(content().contentType(APPLICATION_JSON_UTF8_VALUE))
                 .andReturn();

--- a/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/controller/v1/SwitchControllerTest.java
+++ b/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/controller/v1/SwitchControllerTest.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.controller.v1;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openkilda.messaging.Utils.CORRELATION_ID;
 import static org.openkilda.messaging.Utils.EXTRA_AUTH;
 import static org.openkilda.messaging.Utils.MAPPER;
@@ -32,13 +32,13 @@ import org.openkilda.northbound.controller.TestConfig;
 import org.openkilda.northbound.utils.RequestCorrelationFilter;
 import org.openkilda.northbound.utils.RequestCorrelationInspectorFilter;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -48,7 +48,7 @@ import org.springframework.web.context.WebApplicationContext;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @ContextConfiguration(classes = TestConfig.class)
 public class SwitchControllerTest {
@@ -62,7 +62,7 @@ public class SwitchControllerTest {
     @Autowired
     private WebApplicationContext webApplicationContext;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
                 .addFilters(new RequestCorrelationInspectorFilter(), new RequestCorrelationFilter())
@@ -76,9 +76,9 @@ public class SwitchControllerTest {
         // given TestMessageMock as kafka topic mocks
         // when
         MvcResult mvcResult = mockMvc.perform(delete("/v1/switches/{switch-id}/rules", TEST_SWITCH_ID)
-                .header(CORRELATION_ID, testCorrelationId())
-                .header(EXTRA_AUTH, System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(119))
-                .contentType(APPLICATION_JSON_VALUE))
+                        .header(CORRELATION_ID, testCorrelationId())
+                        .header(EXTRA_AUTH, System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(119))
+                        .contentType(APPLICATION_JSON_VALUE))
                 .andReturn();
 
         // then
@@ -96,8 +96,8 @@ public class SwitchControllerTest {
         // given TestMessageMock as kafka topic mocks
         // when
         mockMvc.perform(delete("/v1/switches/{switch-id}/rules", TEST_SWITCH_ID)
-                .header(CORRELATION_ID, testCorrelationId())
-                .contentType(APPLICATION_JSON_VALUE))
+                        .header(CORRELATION_ID, testCorrelationId())
+                        .contentType(APPLICATION_JSON_VALUE))
                 // then
                 .andExpect(status().isUnauthorized());
     }

--- a/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/controller/v2/FlowControllerTest.java
+++ b/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/controller/v2/FlowControllerTest.java
@@ -15,7 +15,6 @@
 
 package org.openkilda.northbound.controller.v2;
 
-import static org.junit.Assert.assertEquals;
 import static org.openkilda.messaging.Utils.CORRELATION_ID;
 import static org.openkilda.messaging.Utils.DEFAULT_CORRELATION_ID;
 import static org.openkilda.messaging.Utils.MAPPER;
@@ -33,14 +32,15 @@ import org.openkilda.northbound.controller.mock.TestMessageMock;
 import org.openkilda.northbound.dto.v2.flows.SwapFlowEndpointPayload;
 import org.openkilda.northbound.utils.RequestCorrelationId;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -49,7 +49,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import java.util.UUID;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @ContextConfiguration(classes = TestConfig.class)
 @TestPropertySource("classpath:northbound.properties")
@@ -63,7 +63,7 @@ public class FlowControllerTest {
     @Autowired
     private WebApplicationContext webApplicationContext;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).apply(springSecurity()).build();
         RequestCorrelationId.create(DEFAULT_CORRELATION_ID);
@@ -74,9 +74,9 @@ public class FlowControllerTest {
     public void bulkUpdateFlow() throws Exception {
 
         MvcResult mvcResult = mockMvc.perform(post("/v2/flows/swap-endpoint")
-                .header(CORRELATION_ID, testCorrelationId())
-                .contentType(APPLICATION_JSON_VALUE)
-                .content(MAPPER.writeValueAsString(TestMessageMock.bulkFlow)))
+                        .header(CORRELATION_ID, testCorrelationId())
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .content(MAPPER.writeValueAsString(TestMessageMock.bulkFlow)))
                 .andReturn();
 
         MvcResult result = mockMvc.perform(asyncDispatch(mvcResult))
@@ -85,8 +85,8 @@ public class FlowControllerTest {
                 .andReturn();
         SwapFlowEndpointPayload response
                 = MAPPER.readValue(result.getResponse().getContentAsString(), SwapFlowEndpointPayload.class);
-        assertEquals(TestMessageMock.bulkFlow.getFirstFlow(), response.getFirstFlow());
-        assertEquals(TestMessageMock.bulkFlow.getSecondFlow(), response.getSecondFlow());
+        Assertions.assertEquals(TestMessageMock.bulkFlow.getFirstFlow(), response.getFirstFlow());
+        Assertions.assertEquals(TestMessageMock.bulkFlow.getSecondFlow(), response.getSecondFlow());
     }
 
     @Test
@@ -101,7 +101,7 @@ public class FlowControllerTest {
                 .andReturn();
 
         MessageError response = MAPPER.readValue(result.getResponse().getContentAsString(), MessageError.class);
-        assertEquals(TestMessageMock.DIFFERENT_FLOW_ID_ERROR, response);
+        Assertions.assertEquals(TestMessageMock.DIFFERENT_FLOW_ID_ERROR, response);
     }
 
     private static String testCorrelationId() {

--- a/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/controller/v2/YFlowControllerV2Test.java
+++ b/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/controller/v2/YFlowControllerV2Test.java
@@ -24,19 +24,19 @@ import org.openkilda.northbound.dto.v2.yflows.YFlowCreatePayload;
 import org.openkilda.northbound.dto.v2.yflows.YFlowSharedEndpoint;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebMvcTest(controllers = YFlowControllerV2.class)
 @WebAppConfiguration
 @ContextConfiguration(classes = TestConfig.class)
@@ -63,7 +63,7 @@ public class YFlowControllerV2Test {
                 .andExpect(status().isOk());
     }
 
-    @Ignore
+    @Disabled
     @Test
     @WithMockUser(username = TestConfig.USERNAME, password = TestConfig.PASSWORD, roles = TestConfig.ROLE)
     public void shouldReturnsStatus400WhenEncapsulationTypeNull() throws Exception {
@@ -80,7 +80,7 @@ public class YFlowControllerV2Test {
                 .andExpect(status().isBadRequest());
     }
 
-    @Ignore
+    @Disabled
     @Test
     @WithMockUser(username = TestConfig.USERNAME, password = TestConfig.PASSWORD, roles = TestConfig.ROLE)
     public void shouldReturnsStatus400WhenPathComputationStrategyNull() throws Exception {

--- a/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/converter/FlowMapperTest.java
+++ b/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/converter/FlowMapperTest.java
@@ -19,11 +19,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.northbound.converter.PingMapper.TIMEOUT_ERROR_MESSAGE;
 
 import org.openkilda.messaging.command.flow.FlowMirrorPointCreateRequest;
@@ -67,12 +62,13 @@ import org.openkilda.northbound.dto.v2.flows.FlowStatistics;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import org.assertj.core.util.Lists;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -80,7 +76,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class FlowMapperTest {
     public static final int ENCAPSULATION_ID = 18;
     private static final String FLOW_ID = "flow1";
@@ -169,24 +165,28 @@ public class FlowMapperTest {
                 .build();
         FlowRequest flowRequest = flowMapper.toFlowRequest(flowRequestV2);
 
-        assertEquals(FLOW_ID, flowRequest.getFlowId());
-        assertEquals(SRC_SWITCH_ID, flowRequest.getSource().getSwitchId());
-        assertEquals(SRC_PORT, (int) flowRequest.getSource().getPortNumber());
-        assertEquals(SRC_VLAN, flowRequest.getSource().getOuterVlanId());
-        assertEquals(DST_SWITCH_ID, flowRequest.getDestination().getSwitchId());
-        assertEquals(DST_PORT, (int) flowRequest.getDestination().getPortNumber());
-        assertEquals(DST_VLAN, flowRequest.getDestination().getOuterVlanId());
-        assertEquals(FlowEncapsulationType.TRANSIT_VLAN, flowRequest.getEncapsulationType());
-        assertEquals(DESCRIPTION, flowRequest.getDescription());
-        assertEquals(BANDWIDTH, flowRequest.getBandwidth());
-        assertEquals(LATENCY * MS_TO_NS_MULTIPLIER, (long) flowRequest.getMaxLatency()); // ms to ns
-        assertEquals(LATENCY_TIER2 * MS_TO_NS_MULTIPLIER, (long) flowRequest.getMaxLatencyTier2());
-        assertEquals(PRIORITY, flowRequest.getPriority());
-        assertEquals(DIVERSE_FLOW_ID, flowRequest.getDiverseFlowId());
-        assertEquals(SRC_DETECT_CONNECTED_DEVICES.isLldp(), flowRequest.getDetectConnectedDevices().isSrcLldp());
-        assertEquals(SRC_DETECT_CONNECTED_DEVICES.isArp(), flowRequest.getDetectConnectedDevices().isSrcArp());
-        assertEquals(DST_DETECT_CONNECTED_DEVICES.isLldp(), flowRequest.getDetectConnectedDevices().isDstLldp());
-        assertEquals(DST_DETECT_CONNECTED_DEVICES.isArp(), flowRequest.getDetectConnectedDevices().isDstArp());
+        Assertions.assertEquals(FLOW_ID, flowRequest.getFlowId());
+        Assertions.assertEquals(SRC_SWITCH_ID, flowRequest.getSource().getSwitchId());
+        Assertions.assertEquals(SRC_PORT, (int) flowRequest.getSource().getPortNumber());
+        Assertions.assertEquals(SRC_VLAN, flowRequest.getSource().getOuterVlanId());
+        Assertions.assertEquals(DST_SWITCH_ID, flowRequest.getDestination().getSwitchId());
+        Assertions.assertEquals(DST_PORT, (int) flowRequest.getDestination().getPortNumber());
+        Assertions.assertEquals(DST_VLAN, flowRequest.getDestination().getOuterVlanId());
+        Assertions.assertEquals(FlowEncapsulationType.TRANSIT_VLAN, flowRequest.getEncapsulationType());
+        Assertions.assertEquals(DESCRIPTION, flowRequest.getDescription());
+        Assertions.assertEquals(BANDWIDTH, flowRequest.getBandwidth());
+        Assertions.assertEquals(LATENCY * MS_TO_NS_MULTIPLIER, (long) flowRequest.getMaxLatency()); // ms to ns
+        Assertions.assertEquals(LATENCY_TIER2 * MS_TO_NS_MULTIPLIER, (long) flowRequest.getMaxLatencyTier2());
+        Assertions.assertEquals(PRIORITY, flowRequest.getPriority());
+        Assertions.assertEquals(DIVERSE_FLOW_ID, flowRequest.getDiverseFlowId());
+        Assertions.assertEquals(SRC_DETECT_CONNECTED_DEVICES.isLldp(),
+                flowRequest.getDetectConnectedDevices().isSrcLldp());
+        Assertions.assertEquals(SRC_DETECT_CONNECTED_DEVICES.isArp(),
+                flowRequest.getDetectConnectedDevices().isSrcArp());
+        Assertions.assertEquals(DST_DETECT_CONNECTED_DEVICES.isLldp(),
+                flowRequest.getDetectConnectedDevices().isDstLldp());
+        Assertions.assertEquals(DST_DETECT_CONNECTED_DEVICES.isArp(),
+                flowRequest.getDetectConnectedDevices().isDstArp());
         assertThat(flowRequest.getVlanStatistics(), containsInAnyOrder(FLOW_STATISTICS.getVlans().toArray()));
     }
 
@@ -201,37 +201,42 @@ public class FlowMapperTest {
                 Instant.MIN, Y_FLOW_ID, FLOW_STATISTICS.getVlans());
 
         FlowResponseV2 response = flowMapper.toFlowResponseV2(flowDto);
-        assertEquals(FLOW_ID, response.getFlowId());
-        assertEquals(BANDWIDTH, response.getMaximumBandwidth());
-        assertTrue(response.isIgnoreBandwidth());
-        assertFalse(response.isStrictBandwidth());
-        assertTrue(response.isPeriodicPings());
-        assertFalse(response.isAllocateProtectedPath());
-        assertEquals(CREATE_TIME, response.getCreated());
-        assertEquals(UPDATE_TIME, response.getLastUpdated());
-        assertEquals(SRC_SWITCH_ID, response.getSource().getSwitchId());
-        assertEquals(SRC_PORT, response.getSource().getPortNumber().intValue());
-        assertEquals(SRC_VLAN, response.getSource().getVlanId());
-        assertEquals(SRC_INNER_VLAN, response.getSource().getInnerVlanId());
-        assertEquals(DST_SWITCH_ID, response.getDestination().getSwitchId());
-        assertEquals(DST_PORT, response.getDestination().getPortNumber().intValue());
-        assertEquals(DST_VLAN, response.getDestination().getVlanId());
-        assertEquals(DST_INNER_VLAN, response.getDestination().getInnerVlanId());
-        assertEquals(FlowState.UP.toString(), response.getStatus());
-        assertEquals("Up", response.getStatusDetails().getMainPath());
-        assertEquals("degraded", response.getStatusDetails().getProtectedPath());
-        assertEquals("UP", response.getStatusInfo());
-        assertEquals((Long) (LATENCY / 1_000_000), response.getMaxLatency());
-        assertEquals((Long) (LATENCY_TIER2 / 1_000_000), response.getMaxLatencyTier2());
-        assertEquals(PRIORITY, response.getPriority());
-        assertTrue(response.isPinned());
-        assertEquals(FlowEncapsulationType.TRANSIT_VLAN.toString().toLowerCase(), response.getEncapsulationType());
-        assertEquals(PathComputationStrategy.COST.toString().toLowerCase(), response.getPathComputationStrategy());
-        assertEquals(PathComputationStrategy.LATENCY.toString().toLowerCase(),
+        Assertions.assertEquals(FLOW_ID, response.getFlowId());
+        Assertions.assertEquals(BANDWIDTH, response.getMaximumBandwidth());
+        Assertions.assertTrue(response.isIgnoreBandwidth());
+        Assertions.assertFalse(response.isStrictBandwidth());
+        Assertions.assertTrue(response.isPeriodicPings());
+        Assertions.assertFalse(response.isAllocateProtectedPath());
+        Assertions.assertEquals(CREATE_TIME, response.getCreated());
+        Assertions.assertEquals(UPDATE_TIME, response.getLastUpdated());
+        Assertions.assertEquals(SRC_SWITCH_ID, response.getSource().getSwitchId());
+        Assertions.assertEquals(SRC_PORT, response.getSource().getPortNumber().intValue());
+        Assertions.assertEquals(SRC_VLAN, response.getSource().getVlanId());
+        Assertions.assertEquals(SRC_INNER_VLAN, response.getSource().getInnerVlanId());
+        Assertions.assertEquals(DST_SWITCH_ID, response.getDestination().getSwitchId());
+        Assertions.assertEquals(DST_PORT, response.getDestination().getPortNumber().intValue());
+        Assertions.assertEquals(DST_VLAN, response.getDestination().getVlanId());
+        Assertions.assertEquals(DST_INNER_VLAN, response.getDestination().getInnerVlanId());
+        Assertions.assertEquals(FlowState.UP.toString(), response.getStatus());
+        Assertions.assertEquals("Up", response.getStatusDetails().getMainPath());
+        Assertions.assertEquals("degraded", response.getStatusDetails().getProtectedPath());
+        Assertions.assertEquals("UP", response.getStatusInfo());
+        Assertions.assertEquals((Long) (LATENCY / 1_000_000), response.getMaxLatency());
+        Assertions.assertEquals((Long) (LATENCY_TIER2 / 1_000_000), response.getMaxLatencyTier2());
+        Assertions.assertEquals(PRIORITY, response.getPriority());
+        Assertions.assertTrue(response.isPinned());
+        Assertions.assertEquals(FlowEncapsulationType.TRANSIT_VLAN.toString().toLowerCase(),
+
+                response.getEncapsulationType());
+        Assertions.assertEquals(PathComputationStrategy.COST.toString().toLowerCase(),
+
+                response.getPathComputationStrategy());
+        Assertions.assertEquals(PathComputationStrategy.LATENCY.toString().toLowerCase(),
+
                 response.getTargetPathComputationStrategy());
-        assertEquals(Sets.newHashSet(FLOW_ID_2), response.getDiverseWith());
-        assertEquals(FLOW_ID_2, response.getAffinityWith());
-        assertEquals(FLOW_STATISTICS.getVlans(), response.getStatistics().getVlans());
+        Assertions.assertEquals(Sets.newHashSet(FLOW_ID_2), response.getDiverseWith());
+        Assertions.assertEquals(FLOW_ID_2, response.getAffinityWith());
+        Assertions.assertEquals(FLOW_STATISTICS.getVlans(), response.getStatistics().getVlans());
     }
 
     @Test
@@ -241,75 +246,79 @@ public class FlowMapperTest {
                 .portNumber(SRC_PORT)
                 .vlanId(SRC_VLAN)
                 .build();
-        assertNotNull(flowEndpointV2.getDetectConnectedDevices());
-        assertFalse(flowEndpointV2.getDetectConnectedDevices().isArp());
-        assertFalse(flowEndpointV2.getDetectConnectedDevices().isLldp());
+        Assertions.assertNotNull(flowEndpointV2.getDetectConnectedDevices());
+        Assertions.assertFalse(flowEndpointV2.getDetectConnectedDevices().isArp());
+        Assertions.assertFalse(flowEndpointV2.getDetectConnectedDevices().isLldp());
     }
 
     @Test
     public void testFlowEndpointV2WithoutConnectedDevices2Constructor() {
         FlowEndpointV2 flowEndpointV2 = new FlowEndpointV2(SRC_SWITCH_ID, SRC_PORT, SRC_VLAN, null);
-        assertNotNull(flowEndpointV2.getDetectConnectedDevices());
-        assertFalse(flowEndpointV2.getDetectConnectedDevices().isArp());
-        assertFalse(flowEndpointV2.getDetectConnectedDevices().isLldp());
+        Assertions.assertNotNull(flowEndpointV2.getDetectConnectedDevices());
+        Assertions.assertFalse(flowEndpointV2.getDetectConnectedDevices().isArp());
+        Assertions.assertFalse(flowEndpointV2.getDetectConnectedDevices().isLldp());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testFlowRequestV2InvalidEncapsulation() {
-        FlowRequestV2 flowRequestV2 = FlowRequestV2.builder()
-                .flowId(FLOW_ID)
-                .encapsulationType("abc")
-                .source(new FlowEndpointV2(SRC_SWITCH_ID, SRC_PORT, SRC_VLAN, SRC_DETECT_CONNECTED_DEVICES))
-                .destination(new FlowEndpointV2(DST_SWITCH_ID, DST_PORT, DST_VLAN, DST_DETECT_CONNECTED_DEVICES))
-                .build();
-        flowMapper.toFlowRequest(flowRequestV2);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            FlowRequestV2 flowRequestV2 = FlowRequestV2.builder()
+                    .flowId(FLOW_ID)
+                    .encapsulationType("abc")
+                    .source(new FlowEndpointV2(SRC_SWITCH_ID, SRC_PORT, SRC_VLAN, SRC_DETECT_CONNECTED_DEVICES))
+                    .destination(new FlowEndpointV2(DST_SWITCH_ID, DST_PORT, DST_VLAN, DST_DETECT_CONNECTED_DEVICES))
+                    .build();
+            flowMapper.toFlowRequest(flowRequestV2);
+        });
     }
 
     @Test
     public void testFlowCreatePayloadToFlowRequest() {
         FlowRequest flowRequest = flowMapper.toFlowCreateRequest(FLOW_CREATE_PAYLOAD);
-        assertEquals(FLOW_CREATE_PAYLOAD.getDiverseFlowId(), flowRequest.getDiverseFlowId());
-        assertEquals(Type.CREATE, flowRequest.getType());
+        Assertions.assertEquals(FLOW_CREATE_PAYLOAD.getDiverseFlowId(), flowRequest.getDiverseFlowId());
+        Assertions.assertEquals(Type.CREATE, flowRequest.getType());
         assertFlowDtos(FLOW_CREATE_PAYLOAD, flowRequest);
     }
 
     @Test
     public void testFlowUpdatePayloadToFlowRequest() {
         FlowRequest flowRequest = flowMapper.toFlowUpdateRequest(FLOW_UPDATE_PAYLOAD);
-        assertEquals(FLOW_UPDATE_PAYLOAD.getDiverseFlowId(), flowRequest.getDiverseFlowId());
-        assertEquals(Type.UPDATE, flowRequest.getType());
+        Assertions.assertEquals(FLOW_UPDATE_PAYLOAD.getDiverseFlowId(), flowRequest.getDiverseFlowId());
+        Assertions.assertEquals(Type.UPDATE, flowRequest.getType());
         assertFlowDtos(FLOW_UPDATE_PAYLOAD, flowRequest);
     }
 
     private void assertFlowDtos(FlowPayload expected, FlowRequest actual) {
-        assertEquals(expected.getId(), actual.getFlowId());
-        assertEquals(expected.getMaximumBandwidth(), actual.getBandwidth());
-        assertEquals(expected.isIgnoreBandwidth(), actual.isIgnoreBandwidth());
-        assertEquals(expected.isAllocateProtectedPath(), actual.isAllocateProtectedPath());
-        assertEquals(expected.isPeriodicPings(), actual.isPeriodicPings());
-        assertEquals(expected.isPinned(), actual.isPinned());
-        assertEquals(expected.getDescription(), actual.getDescription());
-        assertEquals(expected.getMaxLatency() * MS_TO_NS_MULTIPLIER, (long) actual.getMaxLatency()); // ms to ns
-        assertEquals(expected.getPriority(), actual.getPriority());
-        assertEquals(expected.getEncapsulationType(), actual.getEncapsulationType().name().toLowerCase());
-        assertEquals(expected.getPathComputationStrategy(), actual.getPathComputationStrategy());
+        Assertions.assertEquals(expected.getId(), actual.getFlowId());
+        Assertions.assertEquals(expected.getMaximumBandwidth(), actual.getBandwidth());
+        Assertions.assertEquals(expected.isIgnoreBandwidth(), actual.isIgnoreBandwidth());
+        Assertions.assertEquals(expected.isAllocateProtectedPath(), actual.isAllocateProtectedPath());
+        Assertions.assertEquals(expected.isPeriodicPings(), actual.isPeriodicPings());
+        Assertions.assertEquals(expected.isPinned(), actual.isPinned());
+        Assertions.assertEquals(expected.getDescription(), actual.getDescription());
+        Assertions.assertEquals(expected.getMaxLatency() * MS_TO_NS_MULTIPLIER,
+                (long) actual.getMaxLatency()); // ms to ns
+        Assertions.assertEquals(expected.getPriority(), actual.getPriority());
+        Assertions.assertEquals(expected.getEncapsulationType(), actual.getEncapsulationType().name().toLowerCase());
+        Assertions.assertEquals(expected.getPathComputationStrategy(), actual.getPathComputationStrategy());
 
-        assertEquals(expected.getSource().getDatapath(), actual.getSource().getSwitchId());
-        assertEquals(expected.getSource().getPortNumber(), actual.getSource().getPortNumber());
-        assertEquals(expected.getSource().getVlanId(), (Integer) actual.getSource().getOuterVlanId());
+        Assertions.assertEquals(expected.getSource().getDatapath(), actual.getSource().getSwitchId());
+        Assertions.assertEquals(expected.getSource().getPortNumber(), actual.getSource().getPortNumber());
+        Assertions.assertEquals(expected.getSource().getVlanId(), (Integer) actual.getSource().getOuterVlanId());
 
-        assertEquals(expected.getSource().getDetectConnectedDevices().isLldp(),
+        Assertions.assertEquals(expected.getSource().getDetectConnectedDevices().isLldp(),
                 actual.getDetectConnectedDevices().isSrcLldp());
-        assertEquals(expected.getSource().getDetectConnectedDevices().isArp(),
+        Assertions.assertEquals(expected.getSource().getDetectConnectedDevices().isArp(),
                 actual.getDetectConnectedDevices().isSrcArp());
 
-        assertEquals(expected.getDestination().getDatapath(), actual.getDestination().getSwitchId());
-        assertEquals(expected.getDestination().getPortNumber(), actual.getDestination().getPortNumber());
-        assertEquals(expected.getDestination().getVlanId(), (Integer) actual.getDestination().getOuterVlanId());
+        Assertions.assertEquals(expected.getDestination().getDatapath(), actual.getDestination().getSwitchId());
+        Assertions.assertEquals(expected.getDestination().getPortNumber(), actual.getDestination().getPortNumber());
+        Assertions.assertEquals(expected.getDestination().getVlanId(),
+                (Integer) actual.getDestination().getOuterVlanId());
 
-        assertEquals(expected.getDestination().getDetectConnectedDevices().isLldp(),
+        Assertions.assertEquals(expected.getDestination().getDetectConnectedDevices().isLldp(),
                 actual.getDetectConnectedDevices().isDstLldp());
-        assertEquals(expected.getDestination().getDetectConnectedDevices().isArp(),
+        Assertions.assertEquals(expected.getDestination().getDetectConnectedDevices().isArp(),
                 actual.getDetectConnectedDevices().isDstArp());
     }
 
@@ -318,10 +327,10 @@ public class FlowMapperTest {
         FlowPatchDto flowPatchDto = new FlowPatchDto(LATENCY, PRIORITY, PERIODIC_PINGS,
                 TARGET_PATH_COMPUTATION_STRATEGY);
         FlowPatch flowPatch = flowMapper.toFlowPatch(flowPatchDto);
-        assertEquals(flowPatchDto.getMaxLatency() * MS_TO_NS_MULTIPLIER, (long) flowPatch.getMaxLatency());
-        assertEquals(flowPatchDto.getPriority(), flowPatch.getPriority());
-        assertEquals(flowPatchDto.getPeriodicPings(), flowPatch.getPeriodicPings());
-        assertEquals(flowPatchDto.getTargetPathComputationStrategy(),
+        Assertions.assertEquals(flowPatchDto.getMaxLatency() * MS_TO_NS_MULTIPLIER, (long) flowPatch.getMaxLatency());
+        Assertions.assertEquals(flowPatchDto.getPriority(), flowPatch.getPriority());
+        Assertions.assertEquals(flowPatchDto.getPeriodicPings(), flowPatch.getPeriodicPings());
+        Assertions.assertEquals(flowPatchDto.getTargetPathComputationStrategy(),
                 flowPatch.getTargetPathComputationStrategy().name().toLowerCase());
     }
 
@@ -335,38 +344,43 @@ public class FlowMapperTest {
                 ENCAPSULATION_TYPE, PATH_COMPUTATION_STRATEGY, TARGET_PATH_COMPUTATION_STRATEGY, FLOW_STATISTICS);
         FlowPatch flowPatch = flowMapper.toFlowPatch(flowPatchDto);
 
-        assertEquals(flowPatchDto.getSource().getSwitchId(), flowPatch.getSource().getSwitchId());
-        assertEquals(flowPatchDto.getSource().getPortNumber(), flowPatch.getSource().getPortNumber());
-        assertEquals(flowPatchDto.getSource().getVlanId(), flowPatch.getSource().getVlanId());
-        assertEquals(flowPatchDto.getSource().getInnerVlanId(), flowPatch.getSource().getInnerVlanId());
-        assertEquals(flowPatchDto.getSource().getDetectConnectedDevices().isLldp(),
+        Assertions.assertEquals(flowPatchDto.getSource().getSwitchId(), flowPatch.getSource().getSwitchId());
+        Assertions.assertEquals(flowPatchDto.getSource().getPortNumber(), flowPatch.getSource().getPortNumber());
+        Assertions.assertEquals(flowPatchDto.getSource().getVlanId(), flowPatch.getSource().getVlanId());
+        Assertions.assertEquals(flowPatchDto.getSource().getInnerVlanId(), flowPatch.getSource().getInnerVlanId());
+        Assertions.assertEquals(flowPatchDto.getSource().getDetectConnectedDevices().isLldp(),
                 flowPatch.getSource().getTrackLldpConnectedDevices());
-        assertEquals(flowPatchDto.getSource().getDetectConnectedDevices().isArp(),
+        Assertions.assertEquals(flowPatchDto.getSource().getDetectConnectedDevices().isArp(),
                 flowPatch.getSource().getTrackArpConnectedDevices());
-        assertEquals(flowPatchDto.getDestination().getSwitchId(), flowPatch.getDestination().getSwitchId());
-        assertEquals(flowPatchDto.getDestination().getPortNumber(), flowPatch.getDestination().getPortNumber());
-        assertEquals(flowPatchDto.getDestination().getVlanId(), flowPatch.getDestination().getVlanId());
-        assertEquals(flowPatchDto.getDestination().getInnerVlanId(), flowPatch.getDestination().getInnerVlanId());
-        assertEquals(flowPatchDto.getDestination().getDetectConnectedDevices().isLldp(),
+        Assertions.assertEquals(flowPatchDto.getDestination().getSwitchId(), flowPatch.getDestination().getSwitchId());
+        Assertions.assertEquals(flowPatchDto.getDestination().getPortNumber(),
+                flowPatch.getDestination().getPortNumber());
+        Assertions.assertEquals(flowPatchDto.getDestination().getVlanId(), flowPatch.getDestination().getVlanId());
+        Assertions.assertEquals(flowPatchDto.getDestination().getInnerVlanId(),
+                flowPatch.getDestination().getInnerVlanId());
+        Assertions.assertEquals(flowPatchDto.getDestination().getDetectConnectedDevices().isLldp(),
                 flowPatch.getDestination().getTrackLldpConnectedDevices());
-        assertEquals(flowPatchDto.getDestination().getDetectConnectedDevices().isArp(),
+        Assertions.assertEquals(flowPatchDto.getDestination().getDetectConnectedDevices().isArp(),
                 flowPatch.getDestination().getTrackArpConnectedDevices());
-        assertEquals(flowPatchDto.getMaxLatency() * MS_TO_NS_MULTIPLIER, (long) flowPatch.getMaxLatency());
-        assertEquals(flowPatchDto.getMaxLatencyTier2() * MS_TO_NS_MULTIPLIER, (long) flowPatch.getMaxLatencyTier2());
-        assertEquals(flowPatchDto.getPriority(), flowPatch.getPriority());
-        assertEquals(flowPatchDto.getPeriodicPings(), flowPatch.getPeriodicPings());
-        assertEquals(flowPatchDto.getTargetPathComputationStrategy(),
+        Assertions.assertEquals(flowPatchDto.getMaxLatency() * MS_TO_NS_MULTIPLIER,
+                (long) flowPatch.getMaxLatency());
+        Assertions.assertEquals(flowPatchDto.getMaxLatencyTier2() * MS_TO_NS_MULTIPLIER,
+                (long) flowPatch.getMaxLatencyTier2());
+        Assertions.assertEquals(flowPatchDto.getPriority(), flowPatch.getPriority());
+        Assertions.assertEquals(flowPatchDto.getPeriodicPings(), flowPatch.getPeriodicPings());
+        Assertions.assertEquals(flowPatchDto.getTargetPathComputationStrategy(),
                 flowPatch.getTargetPathComputationStrategy().name().toLowerCase());
-        assertEquals(flowPatchDto.getDiverseFlowId(), flowPatch.getDiverseFlowId());
-        assertEquals(flowPatchDto.getAffinityFlowId(), flowPatch.getAffinityFlowId());
-        assertEquals(flowPatchDto.getMaximumBandwidth(), flowPatch.getBandwidth());
-        assertEquals(flowPatchDto.getAllocateProtectedPath(), flowPatch.getAllocateProtectedPath());
-        assertEquals(flowPatchDto.getPinned(), flowPatch.getPinned());
-        assertEquals(flowPatchDto.getIgnoreBandwidth(), flowPatch.getIgnoreBandwidth());
-        assertEquals(flowPatchDto.getStrictBandwidth(), flowPatch.getStrictBandwidth());
-        assertEquals(flowPatchDto.getDescription(), flowPatch.getDescription());
-        assertEquals(flowPatchDto.getEncapsulationType(), flowPatch.getEncapsulationType().name().toLowerCase());
-        assertEquals(flowPatchDto.getPathComputationStrategy(),
+        Assertions.assertEquals(flowPatchDto.getDiverseFlowId(), flowPatch.getDiverseFlowId());
+        Assertions.assertEquals(flowPatchDto.getAffinityFlowId(), flowPatch.getAffinityFlowId());
+        Assertions.assertEquals(flowPatchDto.getMaximumBandwidth(), flowPatch.getBandwidth());
+        Assertions.assertEquals(flowPatchDto.getAllocateProtectedPath(), flowPatch.getAllocateProtectedPath());
+        Assertions.assertEquals(flowPatchDto.getPinned(), flowPatch.getPinned());
+        Assertions.assertEquals(flowPatchDto.getIgnoreBandwidth(), flowPatch.getIgnoreBandwidth());
+        Assertions.assertEquals(flowPatchDto.getStrictBandwidth(), flowPatch.getStrictBandwidth());
+        Assertions.assertEquals(flowPatchDto.getDescription(), flowPatch.getDescription());
+        Assertions.assertEquals(flowPatchDto.getEncapsulationType(),
+                flowPatch.getEncapsulationType().name().toLowerCase());
+        Assertions.assertEquals(flowPatchDto.getPathComputationStrategy(),
                 flowPatch.getPathComputationStrategy().name().toLowerCase());
         assertThat(flowPatch.getVlanStatistics(),
                 containsInAnyOrder(flowPatchDto.getStatistics().getVlans().toArray()));
@@ -383,14 +397,15 @@ public class FlowMapperTest {
 
         FlowMirrorPointCreateRequest request = flowMapper.toFlowMirrorPointCreateRequest(FLOW_ID, payload);
 
-        assertEquals(FLOW_ID, request.getFlowId());
-        assertEquals(payload.getMirrorPointId(), request.getMirrorPointId());
-        assertEquals(payload.getMirrorPointDirection(), request.getMirrorPointDirection().toString().toLowerCase());
-        assertEquals(payload.getMirrorPointSwitchId(), request.getMirrorPointSwitchId());
-        assertEquals(payload.getSinkEndpoint().getSwitchId(), request.getSinkEndpoint().getSwitchId());
-        assertEquals(payload.getSinkEndpoint().getPortNumber(), request.getSinkEndpoint().getPortNumber());
-        assertEquals(payload.getSinkEndpoint().getVlanId(), request.getSinkEndpoint().getOuterVlanId());
-        assertEquals(payload.getSinkEndpoint().getInnerVlanId(), request.getSinkEndpoint().getInnerVlanId());
+        Assertions.assertEquals(FLOW_ID, request.getFlowId());
+        Assertions.assertEquals(payload.getMirrorPointId(), request.getMirrorPointId());
+        Assertions.assertEquals(payload.getMirrorPointDirection(),
+                request.getMirrorPointDirection().toString().toLowerCase());
+        Assertions.assertEquals(payload.getMirrorPointSwitchId(), request.getMirrorPointSwitchId());
+        Assertions.assertEquals(payload.getSinkEndpoint().getSwitchId(), request.getSinkEndpoint().getSwitchId());
+        Assertions.assertEquals(payload.getSinkEndpoint().getPortNumber(), request.getSinkEndpoint().getPortNumber());
+        Assertions.assertEquals(payload.getSinkEndpoint().getVlanId(), request.getSinkEndpoint().getOuterVlanId());
+        Assertions.assertEquals(payload.getSinkEndpoint().getInnerVlanId(), request.getSinkEndpoint().getInnerVlanId());
     }
 
     @Test
@@ -410,14 +425,17 @@ public class FlowMapperTest {
 
         FlowMirrorPointResponseV2 apiResponse = flowMapper.toFlowMirrorPointResponseV2(response);
 
-        assertEquals(response.getFlowId(), apiResponse.getFlowId());
-        assertEquals(response.getMirrorPointId(), apiResponse.getMirrorPointId());
-        assertEquals(response.getMirrorPointDirection(), apiResponse.getMirrorPointDirection());
-        assertEquals(response.getMirrorPointSwitchId(), apiResponse.getMirrorPointSwitchId());
-        assertEquals(response.getSinkEndpoint().getSwitchId(), apiResponse.getSinkEndpoint().getSwitchId());
-        assertEquals(response.getSinkEndpoint().getPortNumber(), apiResponse.getSinkEndpoint().getPortNumber());
-        assertEquals(response.getSinkEndpoint().getOuterVlanId(), apiResponse.getSinkEndpoint().getVlanId());
-        assertEquals(response.getSinkEndpoint().getInnerVlanId(), apiResponse.getSinkEndpoint().getInnerVlanId());
+        Assertions.assertEquals(response.getFlowId(), apiResponse.getFlowId());
+        Assertions.assertEquals(response.getMirrorPointId(), apiResponse.getMirrorPointId());
+        Assertions.assertEquals(response.getMirrorPointDirection(), apiResponse.getMirrorPointDirection());
+        Assertions.assertEquals(response.getMirrorPointSwitchId(), apiResponse.getMirrorPointSwitchId());
+        Assertions.assertEquals(response.getSinkEndpoint().getSwitchId(), apiResponse.getSinkEndpoint().getSwitchId());
+        Assertions.assertEquals(response.getSinkEndpoint().getPortNumber(),
+                apiResponse.getSinkEndpoint().getPortNumber());
+        Assertions.assertEquals(response.getSinkEndpoint().getOuterVlanId(),
+                apiResponse.getSinkEndpoint().getVlanId());
+        Assertions.assertEquals(response.getSinkEndpoint().getInnerVlanId(),
+                apiResponse.getSinkEndpoint().getInnerVlanId());
     }
 
     @Test
@@ -452,26 +470,34 @@ public class FlowMapperTest {
 
         FlowMirrorPointsResponseV2 apiResponse = flowMapper.toFlowMirrorPointsResponseV2(response);
 
-        assertEquals(response.getFlowId(), apiResponse.getFlowId());
-        assertEquals(2, apiResponse.getPoints().size());
+        Assertions.assertEquals(response.getFlowId(), apiResponse.getFlowId());
+        Assertions.assertEquals(2, apiResponse.getPoints().size());
 
         FlowMirrorPointPayload firstPayload = apiResponse.getPoints().get(0);
-        assertEquals(firstPoint.getMirrorPointId(), firstPayload.getMirrorPointId());
-        assertEquals(firstPoint.getMirrorPointDirection(), firstPayload.getMirrorPointDirection());
-        assertEquals(firstPoint.getMirrorPointSwitchId(), firstPayload.getMirrorPointSwitchId());
-        assertEquals(firstPoint.getSinkEndpoint().getSwitchId(), firstPayload.getSinkEndpoint().getSwitchId());
-        assertEquals(firstPoint.getSinkEndpoint().getPortNumber(), firstPayload.getSinkEndpoint().getPortNumber());
-        assertEquals(firstPoint.getSinkEndpoint().getOuterVlanId(), firstPayload.getSinkEndpoint().getVlanId());
-        assertEquals(firstPoint.getSinkEndpoint().getInnerVlanId(), firstPayload.getSinkEndpoint().getInnerVlanId());
+        Assertions.assertEquals(firstPoint.getMirrorPointId(), firstPayload.getMirrorPointId());
+        Assertions.assertEquals(firstPoint.getMirrorPointDirection(), firstPayload.getMirrorPointDirection());
+        Assertions.assertEquals(firstPoint.getMirrorPointSwitchId(), firstPayload.getMirrorPointSwitchId());
+        Assertions.assertEquals(firstPoint.getSinkEndpoint().getSwitchId(),
+                firstPayload.getSinkEndpoint().getSwitchId());
+        Assertions.assertEquals(firstPoint.getSinkEndpoint().getPortNumber(),
+                firstPayload.getSinkEndpoint().getPortNumber());
+        Assertions.assertEquals(firstPoint.getSinkEndpoint().getOuterVlanId(),
+                firstPayload.getSinkEndpoint().getVlanId());
+        Assertions.assertEquals(firstPoint.getSinkEndpoint().getInnerVlanId(),
+                firstPayload.getSinkEndpoint().getInnerVlanId());
 
         FlowMirrorPointPayload secondPayload = apiResponse.getPoints().get(1);
-        assertEquals(secondPoint.getMirrorPointId(), secondPayload.getMirrorPointId());
-        assertEquals(secondPoint.getMirrorPointDirection(), secondPayload.getMirrorPointDirection());
-        assertEquals(secondPoint.getMirrorPointSwitchId(), secondPayload.getMirrorPointSwitchId());
-        assertEquals(secondPoint.getSinkEndpoint().getSwitchId(), secondPayload.getSinkEndpoint().getSwitchId());
-        assertEquals(secondPoint.getSinkEndpoint().getPortNumber(), secondPayload.getSinkEndpoint().getPortNumber());
-        assertEquals(secondPoint.getSinkEndpoint().getOuterVlanId(), secondPayload.getSinkEndpoint().getVlanId());
-        assertEquals(secondPoint.getSinkEndpoint().getInnerVlanId(), secondPayload.getSinkEndpoint().getInnerVlanId());
+        Assertions.assertEquals(secondPoint.getMirrorPointId(), secondPayload.getMirrorPointId());
+        Assertions.assertEquals(secondPoint.getMirrorPointDirection(), secondPayload.getMirrorPointDirection());
+        Assertions.assertEquals(secondPoint.getMirrorPointSwitchId(), secondPayload.getMirrorPointSwitchId());
+        Assertions.assertEquals(secondPoint.getSinkEndpoint().getSwitchId(),
+                secondPayload.getSinkEndpoint().getSwitchId());
+        Assertions.assertEquals(secondPoint.getSinkEndpoint().getPortNumber(),
+                secondPayload.getSinkEndpoint().getPortNumber());
+        Assertions.assertEquals(secondPoint.getSinkEndpoint().getOuterVlanId(),
+                secondPayload.getSinkEndpoint().getVlanId());
+        Assertions.assertEquals(secondPoint.getSinkEndpoint().getInnerVlanId(),
+                secondPayload.getSinkEndpoint().getInnerVlanId());
     }
 
     @Test
@@ -481,16 +507,16 @@ public class FlowMapperTest {
                 new UniFlowPingResponse(true, null, new PingMeters(1, 2, 3), null), ERROR_MESSAGE);
         PingOutput output = flowMapper.toPingOutput(response);
 
-        assertEquals(response.getFlowId(), output.getFlowId());
-        assertEquals(response.getError(), output.getError());
+        Assertions.assertEquals(response.getFlowId(), output.getFlowId());
+        Assertions.assertEquals(response.getError(), output.getError());
 
-        assertEquals(response.getForward().isPingSuccess(), output.getForward().isPingSuccess());
-        assertEquals(0, output.getForward().getLatency());
-        assertEquals(TIMEOUT_ERROR_MESSAGE, output.getForward().getError());
+        Assertions.assertEquals(response.getForward().isPingSuccess(), output.getForward().isPingSuccess());
+        Assertions.assertEquals(0, output.getForward().getLatency());
+        Assertions.assertEquals(TIMEOUT_ERROR_MESSAGE, output.getForward().getError());
 
-        assertEquals(response.getReverse().isPingSuccess(), output.getReverse().isPingSuccess());
-        assertEquals(1, output.getReverse().getLatency());
-        assertNull(output.getReverse().getError());
+        Assertions.assertEquals(response.getReverse().isPingSuccess(), output.getReverse().isPingSuccess());
+        Assertions.assertEquals(1, output.getReverse().getLatency());
+        Assertions.assertNull(output.getReverse().getError());
     }
 
     @Test

--- a/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/converter/HaFlowMapperTest.java
+++ b/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/converter/HaFlowMapperTest.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.converter;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.messaging.command.haflow.HaFlowDto;
 import org.openkilda.messaging.command.haflow.HaFlowPartialUpdateRequest;
@@ -53,18 +53,18 @@ import org.openkilda.northbound.dto.v2.haflows.HaSubFlowCreatePayload;
 import org.openkilda.northbound.dto.v2.haflows.HaSubFlowPatchPayload;
 import org.openkilda.northbound.dto.v2.haflows.HaSubFlowUpdatePayload;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class HaFlowMapperTest {
     private static final String HA_FLOW_ID = "ha_flow_id";
     private static final String SUB_FLOW_1_NAME = "flow_1";

--- a/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/converter/LagPortMapperTest.java
+++ b/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/converter/LagPortMapperTest.java
@@ -15,23 +15,22 @@
 
 package org.openkilda.northbound.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.messaging.nbtopology.response.LagPortDto;
 import org.openkilda.messaging.swmanager.response.LagPortResponse;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class LagPortMapperTest {
     public static final int LOGICAL_PORT_NUMBER_1 = 2021;
     public static final int PHYSICAL_PORT_NUMBER_1 = 1;
@@ -49,7 +48,7 @@ public class LagPortMapperTest {
         assertEquals(LOGICAL_PORT_NUMBER_1, dto.getLogicalPortNumber());
         assertEquals(PHYSICAL_PORT_NUMBER_1, dto.getPortNumbers().get(0).intValue());
         assertEquals(PHYSICAL_PORT_NUMBER_2, dto.getPortNumbers().get(1).intValue());
-        assertTrue(dto.isLacpReply());
+        Assertions.assertTrue(dto.isLacpReply());
     }
 
     @Test
@@ -61,7 +60,7 @@ public class LagPortMapperTest {
         assertEquals(LOGICAL_PORT_NUMBER_1, dto.getLogicalPortNumber());
         assertEquals(PHYSICAL_PORT_NUMBER_1, dto.getPortNumbers().get(0).intValue());
         assertEquals(PHYSICAL_PORT_NUMBER_2, dto.getPortNumbers().get(1).intValue());
-        assertFalse(dto.isLacpReply());
+        Assertions.assertFalse(dto.isLacpReply());
     }
 
     @TestConfiguration

--- a/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/converter/LinkMapperTest.java
+++ b/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/converter/LinkMapperTest.java
@@ -15,10 +15,6 @@
 
 package org.openkilda.northbound.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import org.openkilda.messaging.info.event.IslChangeType;
 import org.openkilda.messaging.info.event.IslInfoData;
 import org.openkilda.messaging.info.event.PathNode;
@@ -27,14 +23,15 @@ import org.openkilda.northbound.dto.v1.links.LinkDto;
 import org.openkilda.northbound.dto.v1.links.LinkStatus;
 import org.openkilda.northbound.dto.v1.links.PathDto;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class LinkMapperTest {
     private static final SwitchId SWITCH_ID_1 = new SwitchId(1);
     private static final SwitchId SWITCH_ID_2 = new SwitchId(2);
@@ -82,28 +79,28 @@ public class LinkMapperTest {
 
         LinkDto response = linkMapper.mapResponse(islInfoData);
 
-        assertEquals(2, response.getPath().size());
+        Assertions.assertEquals(2, response.getPath().size());
         assertPathNode(source, response.getPath().get(0));
         assertPathNode(destination, response.getPath().get(1));
 
-        assertEquals(LATENCY, response.getLatency());
-        assertEquals(SPEED, response.getSpeed());
-        assertEquals(AVAILABLE_BANDWIDTH, response.getAvailableBandwidth());
-        assertEquals(MAX_BANDWIDTH, response.getMaxBandwidth());
-        assertEquals(DEFAULT_MAX_BANDWIDTH, response.getDefaultMaxBandwidth());
-        assertEquals(LinkStatus.DISCOVERED, response.getState());
-        assertEquals(LinkStatus.FAILED, response.getActualState());
-        assertEquals(LinkStatus.MOVED, response.getRoundTripStatus());
-        assertEquals(COST, response.getCost());
-        assertFalse(response.isUnderMaintenance());
-        assertTrue(response.isEnableBfd());
-        assertEquals(BFD_SESSION_STATUS, response.getBfdSessionStatus());
-        assertEquals(DESCRIPTION, response.getDescription());
+        Assertions.assertEquals(LATENCY, response.getLatency());
+        Assertions.assertEquals(SPEED, response.getSpeed());
+        Assertions.assertEquals(AVAILABLE_BANDWIDTH, response.getAvailableBandwidth());
+        Assertions.assertEquals(MAX_BANDWIDTH, response.getMaxBandwidth());
+        Assertions.assertEquals(DEFAULT_MAX_BANDWIDTH, response.getDefaultMaxBandwidth());
+        Assertions.assertEquals(LinkStatus.DISCOVERED, response.getState());
+        Assertions.assertEquals(LinkStatus.FAILED, response.getActualState());
+        Assertions.assertEquals(LinkStatus.MOVED, response.getRoundTripStatus());
+        Assertions.assertEquals(COST, response.getCost());
+        Assertions.assertFalse(response.isUnderMaintenance());
+        Assertions.assertTrue(response.isEnableBfd());
+        Assertions.assertEquals(BFD_SESSION_STATUS, response.getBfdSessionStatus());
+        Assertions.assertEquals(DESCRIPTION, response.getDescription());
     }
 
     private void assertPathNode(PathNode expected, PathDto actual) {
-        assertEquals(expected.getSwitchId().toString(), actual.getSwitchId());
-        assertEquals(expected.getPortNo(), actual.getPortNo());
+        Assertions.assertEquals(expected.getSwitchId().toString(), actual.getSwitchId());
+        Assertions.assertEquals(expected.getPortNo(), actual.getPortNo());
     }
 
     @TestConfiguration

--- a/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/converter/SwitchMapperTest.java
+++ b/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/converter/SwitchMapperTest.java
@@ -16,10 +16,10 @@
 package org.openkilda.northbound.converter;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.openkilda.messaging.info.switches.LogicalPortType.BFD;
 import static org.openkilda.messaging.info.switches.LogicalPortType.LAG;
 
@@ -67,12 +67,12 @@ import org.openkilda.northbound.dto.v2.switches.SwitchLocationDtoV2;
 import org.openkilda.northbound.dto.v2.switches.SwitchPatchDto;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
@@ -83,7 +83,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class SwitchMapperTest {
     public static final int LOGICAL_PORT_NUMBER_1 = 1;
     public static final int LOGICAL_PORT_NUMBER_2 = 2;
@@ -305,7 +305,7 @@ public class SwitchMapperTest {
                 ruleInfoDtoV2.getMisconfigured().get(0).getExpected());
         assertRules(Lists.newArrayList(rulesValidationEntryV2.getMisconfigured()).get(0).getDiscrepancies(),
                 ruleInfoDtoV2.getMisconfigured().get(0).getDiscrepancies());
-        assertEquals(Lists.newArrayList(rulesValidationEntryV2.getMisconfigured()).get(0).getId(),
+        assertEquals(newArrayList(rulesValidationEntryV2.getMisconfigured()).get(0).getId(),
                 ruleInfoDtoV2.getMisconfigured().get(0).getId());
     }
 
@@ -376,10 +376,10 @@ public class SwitchMapperTest {
                 .build();
         RulesValidationDto actual = switchMapper.toRulesValidationDtoV1(expected);
 
-        assertEquals(Lists.newArrayList(expected.getExcess()).get(0).getCookie(), actual.getExcess().get(0));
-        assertEquals(Lists.newArrayList(expected.getMissing()).get(0).getCookie(), actual.getMissing().get(0));
-        assertEquals(Lists.newArrayList(expected.getProper()).get(0).getCookie(), actual.getProper().get(0));
-        assertEquals(Lists.newArrayList(expected.getMisconfigured()).get(0).getExpected().getCookie(),
+        assertEquals(newArrayList(expected.getExcess()).get(0).getCookie(), actual.getExcess().get(0));
+        assertEquals(newArrayList(expected.getMissing()).get(0).getCookie(), actual.getMissing().get(0));
+        assertEquals(newArrayList(expected.getProper()).get(0).getCookie(), actual.getProper().get(0));
+        assertEquals(newArrayList(expected.getMisconfigured()).get(0).getExpected().getCookie(),
                 actual.getMisconfigured().get(0));
     }
 
@@ -397,17 +397,17 @@ public class SwitchMapperTest {
         assertEquals(expected.getExpected().getFlowId(), actual.getFlowId());
         assertEquals(expected.getExpected().getCookie(), actual.getCookie());
 
-        assertEquals(expected.getDiscrepancies().getFlags(), Lists.newArrayList(actual.getFlags()));
+        assertEquals(expected.getDiscrepancies().getFlags(), newArrayList(actual.getFlags()));
         assertEquals(expected.getDiscrepancies().getBurstSize(), actual.getBurstSize());
         assertEquals(expected.getDiscrepancies().getRate(), actual.getRate());
 
         assertEquals(expected.getExpected().getRate(), actual.getExpected().getRate());
         assertEquals(expected.getExpected().getBurstSize(), actual.getExpected().getBurstSize());
-        assertEquals(expected.getExpected().getFlags(), Lists.newArrayList(actual.getExpected().getFlags()));
+        assertEquals(expected.getExpected().getFlags(), newArrayList(actual.getExpected().getFlags()));
 
         assertEquals(expected.getDiscrepancies().getRate(), actual.getActual().getRate());
         assertEquals(expected.getDiscrepancies().getBurstSize(), actual.getActual().getBurstSize());
-        assertEquals(expected.getDiscrepancies().getFlags(), Lists.newArrayList(actual.getActual().getFlags()));
+        assertEquals(expected.getDiscrepancies().getFlags(), newArrayList(actual.getActual().getFlags()));
     }
 
     @Test
@@ -526,13 +526,13 @@ public class SwitchMapperTest {
         assertLogicalPorts(expected.getLogicalPorts().getMisconfigured().get(0).getDiscrepancies(),
                 actual.getLogicalPorts().getMisconfigured().get(0));
 
-        assertEquals(Lists.newArrayList(expected.getRules().getExcess()).get(0).getCookie(),
+        assertEquals(newArrayList(expected.getRules().getExcess()).get(0).getCookie(),
                 actual.getRules().getExcess().get(0));
-        assertEquals(Lists.newArrayList(expected.getRules().getMissing()).get(0).getCookie(),
+        assertEquals(newArrayList(expected.getRules().getMissing()).get(0).getCookie(),
                 actual.getRules().getMissing().get(0));
-        assertEquals(Lists.newArrayList(expected.getRules().getProper()).get(0).getCookie(),
+        assertEquals(newArrayList(expected.getRules().getProper()).get(0).getCookie(),
                 actual.getRules().getProper().get(0));
-        assertEquals(Lists.newArrayList(expected.getRules().getMisconfigured()).get(0).getExpected().getCookie(),
+        assertEquals(newArrayList(expected.getRules().getMisconfigured()).get(0).getExpected().getCookie(),
                 actual.getRules().getMisconfigured().get(0));
     }
 
@@ -644,7 +644,7 @@ public class SwitchMapperTest {
     private void assertMeters(MeterInfoEntryV2 expected, MeterInfoDto actual) {
         assertEquals(expected.getMeterId(), actual.getMeterId());
         assertEquals(expected.getFlowId(), actual.getFlowId());
-        assertEquals(expected.getFlags(), Lists.newArrayList(actual.getFlags()));
+        assertEquals(expected.getFlags(), newArrayList(actual.getFlags()));
         assertEquals(expected.getBurstSize(), actual.getBurstSize());
         assertEquals(expected.getCookie(), actual.getCookie());
         assertEquals(expected.getRate(), actual.getRate());

--- a/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/converter/YFlowMapperTest.java
+++ b/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/converter/YFlowMapperTest.java
@@ -15,8 +15,8 @@
 
 package org.openkilda.northbound.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.openkilda.messaging.command.yflow.SubFlowDto;
 import org.openkilda.messaging.command.yflow.SubFlowPartialUpdateDto;
@@ -52,16 +52,16 @@ import org.openkilda.northbound.dto.v2.yflows.YFlowUpdatePayload;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.Instant;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class YFlowMapperTest {
     public static final String ERROR_MESSAGE = "Error";
     public static final String Y_FLOW_ID = "y_flow_id";

--- a/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/service/LinkServiceTest.java
+++ b/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/service/LinkServiceTest.java
@@ -15,11 +15,8 @@
 
 package org.openkilda.northbound.service;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -60,10 +57,10 @@ import org.openkilda.northbound.utils.RequestCorrelationId;
 import org.openkilda.northbound.utils.TestCorrelationIdFactory;
 import org.openkilda.stubs.ManualClock;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,7 +71,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.scheduling.TaskScheduler;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.Clock;
@@ -86,7 +83,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class LinkServiceTest {
     private int requestIdIndex = 0;
 
@@ -110,7 +107,7 @@ public class LinkServiceTest {
     @Value("${bfd.apply.period.seconds}")
     private Long bfdPropertiesApplyPeriod;
 
-    @Before
+    @BeforeEach
     public void reset() {
         Mockito.reset(taskScheduler);
         messageExchanger.resetMockedResponses();
@@ -135,7 +132,7 @@ public class LinkServiceTest {
         List<LinkDto> result =
                 linkService.getLinks(islInfoData.getSource().getSwitchId(), islInfoData.getSource().getPortNo(),
                         islInfoData.getDestination().getSwitchId(), islInfoData.getDestination().getPortNo()).join();
-        assertFalse("List of link shouldn't be empty", result.isEmpty());
+        Assertions.assertFalse(result.isEmpty(), "List of link shouldn't be empty");
 
         LinkDto link = result.get(0);
         assertThat(link.getSpeed(), is(0L));
@@ -145,7 +142,7 @@ public class LinkServiceTest {
         assertThat(link.isUnderMaintenance(), is(false));
         assertThat(link.getState(), is(LinkStatus.DISCOVERED));
 
-        assertFalse(link.getPath().isEmpty());
+        Assertions.assertFalse(link.getPath().isEmpty());
         PathDto path = link.getPath().get(0);
         assertThat(path.getSwitchId(), is(switchId.toString()));
         assertThat(path.getPortNo(), is(1));
@@ -162,7 +159,7 @@ public class LinkServiceTest {
         RequestCorrelationId.create(correlationId);
 
         List<LinkPropsDto> result = linkService.getLinkProps(null, 0, null, 0).join();
-        assertTrue("List of link props should be empty", result.isEmpty());
+        Assertions.assertTrue(result.isEmpty(), "List of link props should be empty");
     }
 
     @Test
@@ -178,7 +175,7 @@ public class LinkServiceTest {
         RequestCorrelationId.create(correlationId);
 
         List<LinkPropsDto> result = linkService.getLinkProps(null, 0, null, 0).join();
-        assertFalse("List of link props shouldn't be empty", result.isEmpty());
+        Assertions.assertFalse(result.isEmpty(), "List of link props shouldn't be empty");
 
         LinkPropsDto dto = result.get(0);
         assertThat(dto.getSrcSwitch(), is(linkPropsData.getLinkProps().getSource().getDatapath().toString()));
@@ -213,7 +210,7 @@ public class LinkServiceTest {
 
         assertThat(result.getFailures(), is(0));
         assertThat(result.getSuccesses(), is(1));
-        assertTrue(result.getMessages().isEmpty());
+        Assertions.assertTrue(result.getMessages().isEmpty());
     }
 
     @Test
@@ -244,11 +241,11 @@ public class LinkServiceTest {
         LinkMaxBandwidthDto result =
                 linkService.updateLinkBandwidth(srcSwitch, srcPort, dstSwitch, dstPort, inputRequest).join();
 
-        assertEquals(srcSwitch.toString(), result.getSrcSwitch());
-        assertEquals(dstSwitch.toString(), result.getDstSwitch());
-        assertEquals(srcPort, result.getSrcPort());
-        assertEquals(dstPort, result.getDstPort());
-        assertEquals(maxBandwidth, result.getMaxBandwidth());
+        Assertions.assertEquals(srcSwitch.toString(), result.getSrcSwitch());
+        Assertions.assertEquals(dstSwitch.toString(), result.getDstSwitch());
+        Assertions.assertEquals(srcPort, result.getSrcPort());
+        Assertions.assertEquals(dstPort, result.getDstPort());
+        Assertions.assertEquals(maxBandwidth, result.getMaxBandwidth());
     }
 
     @Test
@@ -277,7 +274,7 @@ public class LinkServiceTest {
 
         assertThat(result.getFailures(), is(0));
         assertThat(result.getSuccesses(), is(1));
-        assertTrue(result.getMessages().isEmpty());
+        Assertions.assertTrue(result.getMessages().isEmpty());
     }
 
     @Test
@@ -300,13 +297,13 @@ public class LinkServiceTest {
                 islInfoData.getDestination().getSwitchId().toString(),
                 islInfoData.getDestination().getPortNo(), underMaintenance, evacuate);
         List<LinkDto> result = linkService.updateLinkUnderMaintenance(linkUnderMaintenanceDto).join();
-        assertFalse("List of link shouldn't be empty", result.isEmpty());
+        Assertions.assertFalse(result.isEmpty(), "List of link shouldn't be empty");
 
         LinkDto link = result.get(0);
         assertThat(link.isUnderMaintenance(), is(true));
         assertThat(link.getState(), is(LinkStatus.DISCOVERED));
 
-        assertFalse(link.getPath().isEmpty());
+        Assertions.assertFalse(link.getPath().isEmpty());
         PathDto path = link.getPath().get(0);
         assertThat(path.getSwitchId(), is(switchId.toString()));
         assertThat(path.getPortNo(), is(1));
@@ -339,7 +336,7 @@ public class LinkServiceTest {
         // make write request and schedule read request
         CompletableFuture<BfdPropertiesPayload> future = linkService.writeBfdProperties(source, destination, goal);
 
-        Assert.assertFalse(future.isDone());
+        Assertions.assertFalse(future.isDone());
 
         ArgumentCaptor<Runnable> monitorTaskCaptor = ArgumentCaptor.forClass(Runnable.class);
         verify(taskScheduler).schedule(monitorTaskCaptor.capture(), any(Date.class));
@@ -355,12 +352,12 @@ public class LinkServiceTest {
         // make read request
         monitorTaskCaptor.getValue().run();
 
-        Assert.assertTrue(future.isDone());
+        Assertions.assertTrue(future.isDone());
         BfdPropertiesPayload result = future.get();
 
-        Assert.assertEquals(goal, result.getProperties());
-        Assert.assertEquals(goal, result.getEffectiveSource().getProperties());
-        Assert.assertEquals(goal, result.getEffectiveDestination().getProperties());
+        Assertions.assertEquals(goal, result.getProperties());
+        Assertions.assertEquals(goal, result.getEffectiveSource().getProperties());
+        Assertions.assertEquals(goal, result.getEffectiveDestination().getProperties());
     }
 
     @Test
@@ -390,7 +387,7 @@ public class LinkServiceTest {
         // make write request and schedule read request
         CompletableFuture<BfdPropertiesPayload> future = linkService.writeBfdProperties(source, destination, goal);
 
-        Assert.assertFalse(future.isDone());
+        Assertions.assertFalse(future.isDone());
 
         ArgumentCaptor<Runnable> monitorTaskCaptor = ArgumentCaptor.forClass(Runnable.class);
         verify(taskScheduler).schedule(monitorTaskCaptor.capture(), any(Date.class));
@@ -408,7 +405,7 @@ public class LinkServiceTest {
         // make read request and schedule one more read
         monitorTaskCaptor.getValue().run();
         verify(taskScheduler).schedule(monitorTaskCaptor.capture(), any(Date.class));
-        Assert.assertFalse(future.isDone());
+        Assertions.assertFalse(future.isDone());
 
         clock.adjust(Duration.ofSeconds(bfdPropertiesApplyPeriod));
 
@@ -423,13 +420,13 @@ public class LinkServiceTest {
         // make read request and fail due to timeout
         monitorTaskCaptor.getValue().run();
 
-        Assert.assertTrue(future.isDone());
+        Assertions.assertTrue(future.isDone());
         try {
             future.get();
-            Assert.fail("ExecutionException exception expected");
+            Assertions.fail("ExecutionException exception expected");
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();
-            Assert.assertTrue(cause instanceof InconclusiveException);
+            Assertions.assertTrue(cause instanceof InconclusiveException);
         }
     }
 

--- a/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/service/impl/FlowServiceTest.java
+++ b/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/service/impl/FlowServiceTest.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.service.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 import org.openkilda.messaging.info.flow.FlowResponse;
@@ -36,19 +36,19 @@ import org.openkilda.northbound.utils.CorrelationIdFactory;
 import org.openkilda.northbound.utils.RequestCorrelationId;
 import org.openkilda.northbound.utils.TestCorrelationIdFactory;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.RestTemplate;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class FlowServiceTest {
 
     @Autowired
@@ -57,7 +57,7 @@ public class FlowServiceTest {
     @Autowired
     private MessageExchanger messageExchanger;
 
-    @Before
+    @BeforeEach
     public void reset() {
         messageExchanger.resetMockedResponses();
     }

--- a/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/service/impl/SwitchServiceTest.java
+++ b/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/service/impl/SwitchServiceTest.java
@@ -18,7 +18,8 @@ package org.openkilda.northbound.service.impl;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openkilda.messaging.model.ValidationFilter.FLOW_INFO;
 import static org.openkilda.messaging.model.ValidationFilter.GROUPS;
 import static org.openkilda.messaging.model.ValidationFilter.LOGICAL_PORTS;
@@ -46,20 +47,20 @@ import org.openkilda.northbound.service.SwitchService;
 import org.openkilda.northbound.utils.RequestCorrelationId;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.concurrent.ExecutionException;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 public class SwitchServiceTest {
 
     public static final SwitchId SWITCH_ID = new SwitchId(1);
@@ -69,7 +70,7 @@ public class SwitchServiceTest {
     @Autowired
     private MessageExchanger messageExchanger;
 
-    @Before
+    @BeforeEach
     public void reset() {
         messageExchanger.resetMockedResponses();
     }
@@ -124,53 +125,67 @@ public class SwitchServiceTest {
         assertThat(rules.getRemoved(), is(singletonList(excessRule)));
     }
 
-    @Test(expected = MessageException.class)
+    @Test
     public void errorWhileParsingIncludeStringV2ValidationParameters() {
-        String correlationId = createCorrelationId("invalid-include");
-        messageExchanger.mockResponse(correlationId, null);
-        switchService.validateSwitch(SWITCH_ID, "meter|groups", "flow_info");
+        assertThrows(MessageException.class, () -> {
+            String correlationId = createCorrelationId("invalid-include");
+            messageExchanger.mockResponse(correlationId, null);
+            switchService.validateSwitch(SWITCH_ID, "meter|groups", "flow_info");
+        });
     }
 
-    @Test(expected = MessageException.class)
+    @Test
     public void errorWhileParsingExcludeStringV2ValidationParameters() {
-        String correlationId = createCorrelationId("invalid-exclude");
-        messageExchanger.mockResponse(correlationId, null);
-        switchService.validateSwitch(SWITCH_ID, "meters|groups", "flo_info");
+        assertThrows(MessageException.class, () -> {
+            String correlationId = createCorrelationId("invalid-exclude");
+            messageExchanger.mockResponse(correlationId, null);
+            switchService.validateSwitch(SWITCH_ID, "meters|groups", "flo_info");
+        });
     }
 
-    @Test(expected = MessageException.class)
+    @Test
     public void errorWhileParsingExcludeStringWithIncludeValuesV2ValidationParameters() {
-        String correlationId = createCorrelationId("invalid-exclude");
-        messageExchanger.mockResponse(correlationId, null);
-        switchService.validateSwitch(SWITCH_ID, "meters|groups", "meters");
+        assertThrows(MessageException.class, () -> {
+            String correlationId = createCorrelationId("invalid-exclude");
+            messageExchanger.mockResponse(correlationId, null);
+            switchService.validateSwitch(SWITCH_ID, "meters|groups", "meters");
+        });
     }
 
-    @Test(expected = MessageException.class)
+    @Test
     public void errorWhileParsingExcludeStringWithIncludeValuesAndEmptyIncludeV2ValidationParameters() {
-        String correlationId = createCorrelationId("invalid-exclude");
-        messageExchanger.mockResponse(correlationId, null);
-        switchService.validateSwitch(SWITCH_ID, null, "meters");
+        assertThrows(MessageException.class, () -> {
+            String correlationId = createCorrelationId("invalid-exclude");
+            messageExchanger.mockResponse(correlationId, null);
+            switchService.validateSwitch(SWITCH_ID, null, "meters");
+        });
     }
 
-    @Test(expected = MessageException.class)
+    @Test
     public void errorWhileParsingIncludeStringWithExcludeValuesV2ValidationParameters() {
-        String correlationId = createCorrelationId("invalid-exclude");
-        messageExchanger.mockResponse(correlationId, null);
-        switchService.validateSwitch(SWITCH_ID, "flow_info", null);
+        assertThrows(MessageException.class, () -> {
+            String correlationId = createCorrelationId("invalid-exclude");
+            messageExchanger.mockResponse(correlationId, null);
+            switchService.validateSwitch(SWITCH_ID, "flow_info", null);
+        });
     }
 
-    @Test(expected = MessageException.class)
+    @Test
     public void errorWhileV1filterToIncludeV2ValidationParameters() {
-        String correlationId = createCorrelationId("invalid-exclude");
-        messageExchanger.mockResponse(correlationId, null);
-        switchService.validateSwitch(SWITCH_ID, "meter_flow_info", null);
+        assertThrows(MessageException.class, () -> {
+            String correlationId = createCorrelationId("invalid-exclude");
+            messageExchanger.mockResponse(correlationId, null);
+            switchService.validateSwitch(SWITCH_ID, "meter_flow_info", null);
+        });
     }
 
-    @Test(expected = MessageException.class)
+    @Test
     public void errorWhileV1filterToExcludeV2ValidationParameters() {
-        String correlationId = createCorrelationId("invalid-exclude");
-        messageExchanger.mockResponse(correlationId, null);
-        switchService.validateSwitch(SWITCH_ID, null, "meter_flow_info");
+        assertThrows(MessageException.class, () -> {
+            String correlationId = createCorrelationId("invalid-exclude");
+            messageExchanger.mockResponse(correlationId, null);
+            switchService.validateSwitch(SWITCH_ID, null, "meter_flow_info");
+        });
     }
 
     @Test

--- a/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/utils/RequestCorrelationIdTest.java
+++ b/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/utils/RequestCorrelationIdTest.java
@@ -17,12 +17,12 @@ package org.openkilda.northbound.utils;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertThat;
 import static org.openkilda.messaging.Utils.DEFAULT_CORRELATION_ID;
 
 import org.openkilda.northbound.utils.RequestCorrelationId.RequestCorrelationClosable;
 
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
@@ -39,9 +39,9 @@ public class RequestCorrelationIdTest {
                 .create(String.format("test-%s", UUID.randomUUID()))) {
 
             //then
-            assertThat(RequestCorrelationId.getId(), not(equalTo(before)));
+            MatcherAssert.assertThat(RequestCorrelationId.getId(), not(equalTo(before)));
         }
 
-        assertThat(RequestCorrelationId.getId(), equalTo(DEFAULT_CORRELATION_ID));
+        MatcherAssert.assertThat(RequestCorrelationId.getId(), equalTo(DEFAULT_CORRELATION_ID));
     }
 }


### PR DESCRIPTION
This PR should be merged after this one:
https://github.com/telstra/open-kilda/pull/5260

The Junit4->Junit5 migration for the following modules:

- [ ] stats-topology
- [ ] base-topology
- [ ] blue-green
- [ ] connecteddevices-topology
- [ ] kilda-persistence-tinkerpop
- [ ] isllatency-topology
- [ ] opentsdb-topology
- [ ] ping-topology
- [ ] flowhs-topology
- [ ] flowmonitoring-topology
- [ ] nbworker-topology
- [ ] kilda-pce
- [ ] floodlight-service
- [x] floodlightrouter-topology
- [x] grpc-speaker
- [x] kilda-configuration
- [x] kilda-model
- [x] kilda-persistence-api
- [x] network-topology
- [x] northbound-service
- [ ] testing
- [ ] reroute-topology
- [ ] rule-manager
- [ ] server42
- [ ] swmanager-topology

closes: https://github.com/telstra/open-kilda/issues/5242