### PR TITLE
[PART 4] open-kilda-5242 Migrate all unit tests from JUnit4 to JUnit5 v4

### DIFF
--- a/src-java/reroute-topology/reroute-messaging/build.gradle
+++ b/src-java/reroute-topology/reroute-messaging/build.gradle
@@ -11,8 +11,6 @@ dependencies {
     implementation('com.fasterxml.jackson.core:jackson-databind')
 
     implementation 'com.google.guava:guava'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src-java/reroute-topology/reroute-storm-topology/build.gradle
+++ b/src-java/reroute-topology/reroute-storm-topology/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compileOnly('org.apache.storm:storm-core')
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.hamcrest:hamcrest-library'
     testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
@@ -50,4 +50,8 @@ shadowJar {
 
 artifacts {
     archives shadowJar
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/reroute-topology/reroute-storm-topology/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/reroute-topology/reroute-storm-topology/src/checkstyle/checkstyle-suppressions.xml
@@ -6,4 +6,5 @@
 <suppressions>
     <suppress files="src/main/.*Fsm\.java$" checks="JavadocMethod" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="VariableDeclarationUsageDistance" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
 </suppressions>

--- a/src-java/reroute-topology/reroute-storm-topology/src/test/java/org/openkilda/wfm/topology/reroute/service/ExtendableTimeWindowTest.java
+++ b/src-java/reroute-topology/reroute-storm-topology/src/test/java/org/openkilda/wfm/topology/reroute/service/ExtendableTimeWindowTest.java
@@ -15,13 +15,13 @@
 
 package org.openkilda.wfm.topology.reroute.service;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -33,7 +33,7 @@ public class ExtendableTimeWindowTest {
 
     private Clock clock;
 
-    @Before
+    @BeforeEach
     public void init() {
         clock = mock(Clock.class);
         when(clock.getZone()).thenReturn(ZoneId.systemDefault());

--- a/src-java/reroute-topology/reroute-storm-topology/src/test/java/org/openkilda/wfm/topology/reroute/service/OperationQueueServiceTest.java
+++ b/src-java/reroute-topology/reroute-storm-topology/src/test/java/org/openkilda/wfm/topology/reroute/service/OperationQueueServiceTest.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.wfm.topology.reroute.service;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.openkilda.messaging.command.flow.FlowRerouteRequest.createManualFlowRerouteRequest;
 
@@ -23,7 +23,7 @@ import org.openkilda.messaging.command.flow.FlowPathSwapRequest;
 import org.openkilda.wfm.topology.reroute.bolts.OperationQueueCarrier;
 import org.openkilda.wfm.topology.reroute.service.OperationQueueService.FlowQueueData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 

--- a/src-java/reroute-topology/reroute-storm-topology/src/test/java/org/openkilda/wfm/topology/reroute/service/RerouteQueueServiceTest.java
+++ b/src-java/reroute-topology/reroute-storm-topology/src/test/java/org/openkilda/wfm/topology/reroute/service/RerouteQueueServiceTest.java
@@ -17,14 +17,15 @@ package org.openkilda.wfm.topology.reroute.service;
 
 import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.MINUTES;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -53,18 +54,18 @@ import org.openkilda.wfm.topology.reroute.model.FlowThrottlingData.FlowThrottlin
 import org.openkilda.wfm.topology.reroute.model.RerouteQueue;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Optional;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RerouteQueueServiceTest {
 
     private static final String CORRELATION_ID = "CORRELATION_ID";
@@ -89,17 +90,17 @@ public class RerouteQueueServiceTest {
 
     private RerouteQueueService rerouteQueueService;
 
-    @Before
+    @BeforeEach
     public void setup() {
         flow = Flow.builder().flowId(FLOW_ID).srcSwitch(SWITCH_A)
                 .destSwitch(SWITCH_B).priority(2)
                 .build();
-        when(flowRepository.findById(FLOW_ID)).thenReturn(Optional.of(flow));
+        lenient().when(flowRepository.findById(FLOW_ID)).thenReturn(Optional.of(flow));
 
 
         yFlow = YFlow.builder().yFlowId(YFLOW_ID).sharedEndpoint(new SharedEndpoint(SWITCH_A.getSwitchId(), 10))
                 .priority(2).build();
-        when(yFlowRepository.findById(YFLOW_ID)).thenReturn(Optional.of(yFlow));
+        lenient().when(yFlowRepository.findById(YFLOW_ID)).thenReturn(Optional.of(yFlow));
 
         RepositoryFactory repositoryFactory = mock(RepositoryFactory.class);
         when(repositoryFactory.createFlowRepository()).thenReturn(flowRepository);

--- a/src-java/reroute-topology/reroute-storm-topology/src/test/java/org/openkilda/wfm/topology/reroute/service/RerouteServiceTest.java
+++ b/src-java/reroute-topology/reroute-storm-topology/src/test/java/org/openkilda/wfm/topology/reroute/service/RerouteServiceTest.java
@@ -18,14 +18,15 @@ package org.openkilda.wfm.topology.reroute.service;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -73,12 +74,12 @@ import org.openkilda.persistence.tx.TransactionManager;
 import org.openkilda.wfm.topology.reroute.bolts.MessageSender;
 import org.openkilda.wfm.topology.reroute.model.FlowThrottlingData;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -88,7 +89,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RerouteServiceTest {
 
     private static final SwitchId SWITCH_ID_A = new SwitchId(1L);
@@ -154,15 +155,15 @@ public class RerouteServiceTest {
     @Mock
     MessageSender carrier;
 
-    @Before
+    @BeforeEach
     public void setup() throws Throwable {
-        doAnswer(invocation -> {
+        lenient().doAnswer(invocation -> {
             TransactionCallbackWithoutResult<?> arg = invocation.getArgument(0);
             arg.doInTransaction();
             return null;
         }).when(transactionManager).doInTransaction(Mockito.<TransactionCallbackWithoutResult<?>>any());
 
-        doAnswer(invocation -> {
+        lenient().doAnswer(invocation -> {
             TransactionCallback<?, ?> arg = invocation.getArgument(0);
             return arg.doInTransaction();
         }).when(transactionManager).doInTransaction(Mockito.<TransactionCallback<?, ?>>any());
@@ -435,8 +436,8 @@ public class RerouteServiceTest {
         rerouteService.processSingleSwitchFlowStatusUpdate(
                 new SwitchStateChanged(oneSwitchFlow.getSrcSwitchId(), SwitchStatus.INACTIVE));
 
-        assertEquals(format("Switch %s is inactive", oneSwitchFlow.getSrcSwitchId()),
-                FlowStatus.DOWN, oneSwitchFlow.getStatus());
+        assertEquals(FlowStatus.DOWN, oneSwitchFlow.getStatus(),
+                format("Switch %s is inactive", oneSwitchFlow.getSrcSwitchId()));
     }
 
     @Test

--- a/src-java/rule-manager/rule-manager-api/build.gradle
+++ b/src-java/rule-manager/rule-manager-api/build.gradle
@@ -22,5 +22,9 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok-mapstruct-binding'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/rule-manager/rule-manager-api/src/test/java/org/openkilda/rulemanager/FlowSpeakerCommandDataTest.java
+++ b/src-java/rule-manager/rule-manager-api/src/test/java/org/openkilda/rulemanager/FlowSpeakerCommandDataTest.java
@@ -16,11 +16,11 @@
 package org.openkilda.rulemanager;
 
 import static com.google.common.collect.Sets.newHashSet;
-import static org.junit.Assert.assertEquals;
 
 import org.openkilda.rulemanager.match.FieldMatch;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class FlowSpeakerCommandDataTest {
     @Test
@@ -30,7 +30,7 @@ public class FlowSpeakerCommandDataTest {
                         FieldMatch.builder().field(Field.VLAN_VID).value(1).build(),
                         FieldMatch.builder().field(Field.VLAN_VID).value(2).build()))
                 .build();
-        assertEquals(1, command.getMatch().size());
+        Assertions.assertEquals(1, command.getMatch().size());
     }
 
     @Test
@@ -40,7 +40,7 @@ public class FlowSpeakerCommandDataTest {
                         FieldMatch.builder().field(Field.VLAN_VID).value(1).build(),
                         FieldMatch.builder().field(Field.VLAN_VID).value(1).build()))
                 .build();
-        assertEquals(1, command.getMatch().size());
+        Assertions.assertEquals(1, command.getMatch().size());
     }
 
     @Test
@@ -50,6 +50,6 @@ public class FlowSpeakerCommandDataTest {
                         FieldMatch.builder().field(Field.VLAN_VID).value(1).build(),
                         FieldMatch.builder().field(Field.IN_PORT).value(1).build()))
                 .build();
-        assertEquals(2, command.getMatch().size());
+        Assertions.assertEquals(2, command.getMatch().size());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/build.gradle
+++ b/src-java/rule-manager/rule-manager-implementation/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     testRuntimeOnly 'org.slf4j:slf4j-simple'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.hamcrest:hamcrest-library'
     testImplementation 'org.mockito:mockito-junit-jupiter'
 
@@ -27,4 +27,8 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding'
     testAnnotationProcessor 'org.projectlombok:lombok-mapstruct-binding'
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/rule-manager/rule-manager-implementation/src/checkstyle/checkstyle-suppressions.xml
@@ -3,4 +3,6 @@
         "-//Puppy Crawl//DTD Suppressions 1.2//EN"
         "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
 
-<suppressions/>
+<suppressions>
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
+</suppressions>

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/RuleManagerHaFlowRulesTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/RuleManagerHaFlowRulesTest.java
@@ -17,7 +17,6 @@ package org.openkilda.rulemanager;
 
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.SwitchFeature.METERS;
@@ -50,8 +49,9 @@ import org.openkilda.rulemanager.adapter.InMemoryDataAdapter;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -115,7 +115,7 @@ public class RuleManagerHaFlowRulesTest {
 
     private RuleManagerImpl ruleManager;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RuleManagerConfig config = mock(RuleManagerConfig.class);
         when(config.getBroadcastRateLimit()).thenReturn(200);
@@ -133,25 +133,25 @@ public class RuleManagerHaFlowRulesTest {
         List<SpeakerData> forwardSpeakerData = ruleManager.buildRulesHaFlowPath(
                 haFlow.getForwardPath(), false, adapter);
 
-        assertEquals(7, forwardSpeakerData.size());
+        Assertions.assertEquals(7, forwardSpeakerData.size());
 
         Map<SwitchId, List<SpeakerData>> forwardCommands = groupBySwitchId(forwardSpeakerData);
-        assertEquals(3, forwardCommands.get(SWITCH_ID_1).size());
-        assertEquals(2, getFlowCount(forwardCommands.get(SWITCH_ID_1)));
-        assertEquals(1, getMeterCount(forwardCommands.get(SWITCH_ID_1)));
+        Assertions.assertEquals(3, forwardCommands.get(SWITCH_ID_1).size());
+        Assertions.assertEquals(2, getFlowCount(forwardCommands.get(SWITCH_ID_1)));
+        Assertions.assertEquals(1, getMeterCount(forwardCommands.get(SWITCH_ID_1)));
         assertFlowTables(forwardCommands.get(SWITCH_ID_1), INPUT, INGRESS);
 
-        assertEquals(2, forwardCommands.get(SWITCH_ID_2).size());
-        assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_2)));
-        assertEquals(1, getGroupCount(forwardCommands.get(SWITCH_ID_2)));
+        Assertions.assertEquals(2, forwardCommands.get(SWITCH_ID_2).size());
+        Assertions.assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_2)));
+        Assertions.assertEquals(1, getGroupCount(forwardCommands.get(SWITCH_ID_2)));
         assertFlowTables(forwardCommands.get(SWITCH_ID_2), TRANSIT);
 
-        assertEquals(1, forwardCommands.get(SWITCH_ID_3).size());
-        assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_3)));
+        Assertions.assertEquals(1, forwardCommands.get(SWITCH_ID_3).size());
+        Assertions.assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_3)));
         assertFlowTables(forwardCommands.get(SWITCH_ID_3), EGRESS);
 
-        assertEquals(1, forwardCommands.get(SWITCH_ID_4).size());
-        assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_4)));
+        Assertions.assertEquals(1, forwardCommands.get(SWITCH_ID_4).size());
+        Assertions.assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_4)));
         assertFlowTables(forwardCommands.get(SWITCH_ID_4), EGRESS);
     }
 
@@ -162,26 +162,26 @@ public class RuleManagerHaFlowRulesTest {
         List<SpeakerData> reverseSpeakerData = ruleManager.buildRulesHaFlowPath(
                 haFlow.getReversePath(), false, adapter);
 
-        assertEquals(10, reverseSpeakerData.size());
+        Assertions.assertEquals(10, reverseSpeakerData.size());
 
         Map<SwitchId, List<SpeakerData>> switchCommandMap = groupBySwitchId(reverseSpeakerData);
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_1).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_1)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_1).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_1)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_1), EGRESS);
 
-        assertEquals(3, switchCommandMap.get(SWITCH_ID_2).size());
-        assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_2)));
-        assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_2)));
+        Assertions.assertEquals(3, switchCommandMap.get(SWITCH_ID_2).size());
+        Assertions.assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_2)));
+        Assertions.assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_2)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_2), TRANSIT, TRANSIT);
 
-        assertEquals(3, switchCommandMap.get(SWITCH_ID_3).size());
-        assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_3)));
-        assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_3)));
+        Assertions.assertEquals(3, switchCommandMap.get(SWITCH_ID_3).size());
+        Assertions.assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_3)));
+        Assertions.assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_3)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_3), INPUT, INGRESS);
 
-        assertEquals(3, switchCommandMap.get(SWITCH_ID_4).size());
-        assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_4)));
-        assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_4)));
+        Assertions.assertEquals(3, switchCommandMap.get(SWITCH_ID_4).size());
+        Assertions.assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_4)));
+        Assertions.assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_4)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_4), INPUT, INGRESS);
     }
 
@@ -191,37 +191,37 @@ public class RuleManagerHaFlowRulesTest {
         DataAdapter adapter = buildAdapter(haFlow);
         List<SpeakerData> forwardSpeakerData = ruleManager.buildRulesHaFlowPath(
                 haFlow.getForwardPath(), false, adapter);
-        assertEquals(10, forwardSpeakerData.size());
+        Assertions.assertEquals(10, forwardSpeakerData.size());
 
         Map<SwitchId, List<SpeakerData>> switchCommandMap = groupBySwitchId(forwardSpeakerData);
-        assertEquals(3, switchCommandMap.get(SWITCH_ID_1).size());
-        assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_1)));
-        assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_1)));
+        Assertions.assertEquals(3, switchCommandMap.get(SWITCH_ID_1).size());
+        Assertions.assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_1)));
+        Assertions.assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_1)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_1), INPUT, INGRESS);
 
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_2).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_2)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_2).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_2)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_2), TRANSIT);
 
-        assertEquals(2, switchCommandMap.get(SWITCH_ID_3).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_3)));
-        assertEquals(1, getGroupCount(switchCommandMap.get(SWITCH_ID_3)));
+        Assertions.assertEquals(2, switchCommandMap.get(SWITCH_ID_3).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_3)));
+        Assertions.assertEquals(1, getGroupCount(switchCommandMap.get(SWITCH_ID_3)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_3), TRANSIT);
 
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_4).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_4)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_4).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_4)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_4), TRANSIT);
 
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_5).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_5)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_5).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_5)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_5), EGRESS);
 
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_6).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_6)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_6).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_6)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_6), TRANSIT);
 
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_7).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_7)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_7).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_7)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_7), EGRESS);
     }
 
@@ -231,38 +231,38 @@ public class RuleManagerHaFlowRulesTest {
         DataAdapter adapter = buildAdapter(haFlow);
         List<SpeakerData> reverseSpeakerData = ruleManager.buildRulesHaFlowPath(
                 haFlow.getReversePath(), false, adapter);
-        assertEquals(13, reverseSpeakerData.size());
+        Assertions.assertEquals(13, reverseSpeakerData.size());
 
         Map<SwitchId, List<SpeakerData>> switchCommandMap = groupBySwitchId(reverseSpeakerData);
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_1).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_1)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_1).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_1)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_1), EGRESS);
 
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_2).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_2)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_2).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_2)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_2), TRANSIT);
 
-        assertEquals(3, switchCommandMap.get(SWITCH_ID_3).size());
-        assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_3)));
-        assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_3)));
+        Assertions.assertEquals(3, switchCommandMap.get(SWITCH_ID_3).size());
+        Assertions.assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_3)));
+        Assertions.assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_3)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_3), TRANSIT, TRANSIT);
 
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_4).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_4)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_4).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_4)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_4), TRANSIT);
 
-        assertEquals(3, switchCommandMap.get(SWITCH_ID_5).size());
-        assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_5)));
-        assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_5)));
+        Assertions.assertEquals(3, switchCommandMap.get(SWITCH_ID_5).size());
+        Assertions.assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_5)));
+        Assertions.assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_5)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_5), INPUT, INGRESS);
 
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_6).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_6)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_6).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_6)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_6), TRANSIT);
 
-        assertEquals(3, switchCommandMap.get(SWITCH_ID_7).size());
-        assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_7)));
-        assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_7)));
+        Assertions.assertEquals(3, switchCommandMap.get(SWITCH_ID_7).size());
+        Assertions.assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_7)));
+        Assertions.assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_7)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_7), INPUT, INGRESS);
     }
 
@@ -273,25 +273,25 @@ public class RuleManagerHaFlowRulesTest {
         List<SpeakerData> forwardSpeakerData = ruleManager.buildRulesHaFlowPath(
                 haFlow.getForwardPath(), false, adapter);
 
-        assertEquals(7, forwardSpeakerData.size());
+        Assertions.assertEquals(7, forwardSpeakerData.size());
 
         Map<SwitchId, List<SpeakerData>> forwardCommands = groupBySwitchId(forwardSpeakerData);
-        assertEquals(3, forwardCommands.get(SWITCH_ID_1).size());
-        assertEquals(2, getFlowCount(forwardCommands.get(SWITCH_ID_1)));
-        assertEquals(1, getMeterCount(forwardCommands.get(SWITCH_ID_1)));
+        Assertions.assertEquals(3, forwardCommands.get(SWITCH_ID_1).size());
+        Assertions.assertEquals(2, getFlowCount(forwardCommands.get(SWITCH_ID_1)));
+        Assertions.assertEquals(1, getMeterCount(forwardCommands.get(SWITCH_ID_1)));
         assertFlowTables(forwardCommands.get(SWITCH_ID_1), INPUT, INGRESS);
 
-        assertEquals(1, forwardCommands.get(SWITCH_ID_2).size());
-        assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_2)));
+        Assertions.assertEquals(1, forwardCommands.get(SWITCH_ID_2).size());
+        Assertions.assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_2)));
         assertFlowTables(forwardCommands.get(SWITCH_ID_2), TRANSIT);
 
-        assertEquals(2, forwardCommands.get(SWITCH_ID_3).size());
-        assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_3)));
-        assertEquals(1, getGroupCount(forwardCommands.get(SWITCH_ID_3)));
+        Assertions.assertEquals(2, forwardCommands.get(SWITCH_ID_3).size());
+        Assertions.assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_3)));
+        Assertions.assertEquals(1, getGroupCount(forwardCommands.get(SWITCH_ID_3)));
         assertFlowTables(forwardCommands.get(SWITCH_ID_3), TRANSIT);
 
-        assertEquals(1, forwardCommands.get(SWITCH_ID_4).size());
-        assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_4)));
+        Assertions.assertEquals(1, forwardCommands.get(SWITCH_ID_4).size());
+        Assertions.assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_4)));
         assertFlowTables(forwardCommands.get(SWITCH_ID_4), EGRESS);
     }
 
@@ -302,25 +302,25 @@ public class RuleManagerHaFlowRulesTest {
         List<SpeakerData> reverseSpeakerData = ruleManager.buildRulesHaFlowPath(
                 haFlow.getReversePath(), false, adapter);
 
-        assertEquals(9, reverseSpeakerData.size());
+        Assertions.assertEquals(9, reverseSpeakerData.size());
 
         Map<SwitchId, List<SpeakerData>> switchCommandMap = groupBySwitchId(reverseSpeakerData);
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_1).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_1)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_1).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_1)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_1), EGRESS);
 
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_2).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_2)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_2).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_2)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_2), TRANSIT);
 
-        assertEquals(4, switchCommandMap.get(SWITCH_ID_3).size());
-        assertEquals(3, getFlowCount(switchCommandMap.get(SWITCH_ID_3)));
-        assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_3)));
+        Assertions.assertEquals(4, switchCommandMap.get(SWITCH_ID_3).size());
+        Assertions.assertEquals(3, getFlowCount(switchCommandMap.get(SWITCH_ID_3)));
+        Assertions.assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_3)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_3), INPUT, INGRESS, TRANSIT);
 
-        assertEquals(3, switchCommandMap.get(SWITCH_ID_4).size());
-        assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_4)));
-        assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_4)));
+        Assertions.assertEquals(3, switchCommandMap.get(SWITCH_ID_4).size());
+        Assertions.assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_4)));
+        Assertions.assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_4)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_4), INPUT, INGRESS);
     }
 
@@ -331,16 +331,16 @@ public class RuleManagerHaFlowRulesTest {
         List<SpeakerData> reverseSpeakerData = ruleManager.buildRulesHaFlowPath(
                 haFlow.getReversePath(), true, false, true, false, adapter);
 
-        assertEquals(5, reverseSpeakerData.size());
+        Assertions.assertEquals(5, reverseSpeakerData.size());
 
         Map<SwitchId, List<SpeakerData>> switchCommandMap = groupBySwitchId(reverseSpeakerData);
-        assertEquals(2, switchCommandMap.get(SWITCH_ID_3).size());
-        assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_3)));
+        Assertions.assertEquals(2, switchCommandMap.get(SWITCH_ID_3).size());
+        Assertions.assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_3)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_3), INPUT, INGRESS);
 
-        assertEquals(3, switchCommandMap.get(SWITCH_ID_4).size());
-        assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_4)));
-        assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_4)));
+        Assertions.assertEquals(3, switchCommandMap.get(SWITCH_ID_4).size());
+        Assertions.assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_4)));
+        Assertions.assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_4)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_4), INPUT, INGRESS);
     }
 
@@ -351,20 +351,20 @@ public class RuleManagerHaFlowRulesTest {
         List<SpeakerData> reverseSpeakerData = ruleManager.buildRulesHaFlowPath(
                 haFlow.getReversePath(), true, false, false, true, adapter);
 
-        assertEquals(4, reverseSpeakerData.size());
+        Assertions.assertEquals(4, reverseSpeakerData.size());
 
         Map<SwitchId, List<SpeakerData>> switchCommandMap = groupBySwitchId(reverseSpeakerData);
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_1).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_1)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_1).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_1)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_1), EGRESS);
 
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_2).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_2)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_2).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_2)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_2), TRANSIT);
 
-        assertEquals(2, switchCommandMap.get(SWITCH_ID_3).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_3)));
-        assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_3)));
+        Assertions.assertEquals(2, switchCommandMap.get(SWITCH_ID_3).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_3)));
+        Assertions.assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_3)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_3), TRANSIT);
     }
 
@@ -375,21 +375,21 @@ public class RuleManagerHaFlowRulesTest {
         List<SpeakerData> forwardSpeakerData = ruleManager.buildRulesHaFlowPath(
                 haFlow.getForwardPath(), false, adapter);
 
-        assertEquals(6, forwardSpeakerData.size());
+        Assertions.assertEquals(6, forwardSpeakerData.size());
 
         Map<SwitchId, List<SpeakerData>> forwardCommands = groupBySwitchId(forwardSpeakerData);
-        assertEquals(3, forwardCommands.get(SWITCH_ID_1).size());
-        assertEquals(2, getFlowCount(forwardCommands.get(SWITCH_ID_1)));
-        assertEquals(1, getMeterCount(forwardCommands.get(SWITCH_ID_1)));
+        Assertions.assertEquals(3, forwardCommands.get(SWITCH_ID_1).size());
+        Assertions.assertEquals(2, getFlowCount(forwardCommands.get(SWITCH_ID_1)));
+        Assertions.assertEquals(1, getMeterCount(forwardCommands.get(SWITCH_ID_1)));
         assertFlowTables(forwardCommands.get(SWITCH_ID_1), INPUT, INGRESS);
 
-        assertEquals(1, forwardCommands.get(SWITCH_ID_2).size());
-        assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_2)));
+        Assertions.assertEquals(1, forwardCommands.get(SWITCH_ID_2).size());
+        Assertions.assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_2)));
         assertFlowTables(forwardCommands.get(SWITCH_ID_2), TRANSIT);
 
-        assertEquals(2, forwardCommands.get(SWITCH_ID_3).size());
-        assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_3)));
-        assertEquals(1, getGroupCount(forwardCommands.get(SWITCH_ID_3)));
+        Assertions.assertEquals(2, forwardCommands.get(SWITCH_ID_3).size());
+        Assertions.assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_3)));
+        Assertions.assertEquals(1, getGroupCount(forwardCommands.get(SWITCH_ID_3)));
         assertFlowTables(forwardCommands.get(SWITCH_ID_3), EGRESS);
     }
 
@@ -400,20 +400,20 @@ public class RuleManagerHaFlowRulesTest {
         List<SpeakerData> reverseSpeakerData = ruleManager.buildRulesHaFlowPath(
                 haFlow.getReversePath(), false, adapter);
 
-        assertEquals(7, reverseSpeakerData.size());
+        Assertions.assertEquals(7, reverseSpeakerData.size());
 
         Map<SwitchId, List<SpeakerData>> switchCommandMap = groupBySwitchId(reverseSpeakerData);
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_1).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_1)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_1).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_1)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_1), EGRESS);
 
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_2).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_2)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_2).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_2)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_2), TRANSIT);
 
-        assertEquals(5, switchCommandMap.get(SWITCH_ID_3).size());
-        assertEquals(4, getFlowCount(switchCommandMap.get(SWITCH_ID_3)));
-        assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_3)));
+        Assertions.assertEquals(5, switchCommandMap.get(SWITCH_ID_3).size());
+        Assertions.assertEquals(4, getFlowCount(switchCommandMap.get(SWITCH_ID_3)));
+        Assertions.assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_3)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_3), INPUT, INGRESS, INPUT, INGRESS);
     }
 
@@ -424,12 +424,12 @@ public class RuleManagerHaFlowRulesTest {
         List<SpeakerData> reverseSpeakerData = ruleManager.buildRulesHaFlowPath(
                 haFlow.getReversePath(), true, false, true, false, adapter);
 
-        assertEquals(5, reverseSpeakerData.size());
+        Assertions.assertEquals(5, reverseSpeakerData.size());
 
         Map<SwitchId, List<SpeakerData>> switchCommandMap = groupBySwitchId(reverseSpeakerData);
-        assertEquals(5, switchCommandMap.get(SWITCH_ID_3).size());
-        assertEquals(4, getFlowCount(switchCommandMap.get(SWITCH_ID_3)));
-        assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_3)));
+        Assertions.assertEquals(5, switchCommandMap.get(SWITCH_ID_3).size());
+        Assertions.assertEquals(4, getFlowCount(switchCommandMap.get(SWITCH_ID_3)));
+        Assertions.assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_3)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_3), INPUT, INGRESS, INPUT, INGRESS);
     }
 
@@ -440,15 +440,15 @@ public class RuleManagerHaFlowRulesTest {
         List<SpeakerData> reverseSpeakerData = ruleManager.buildRulesHaFlowPath(
                 haFlow.getReversePath(), true, false, false, true, adapter);
 
-        assertEquals(2, reverseSpeakerData.size());
+        Assertions.assertEquals(2, reverseSpeakerData.size());
 
         Map<SwitchId, List<SpeakerData>> switchCommandMap = groupBySwitchId(reverseSpeakerData);
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_1).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_1)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_1).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_1)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_1), EGRESS);
 
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_2).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_2)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_2).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_2)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_2), TRANSIT);
     }
 
@@ -459,17 +459,17 @@ public class RuleManagerHaFlowRulesTest {
         List<SpeakerData> forwardSpeakerData = ruleManager.buildRulesHaFlowPath(
                 haFlow.getForwardPath(), false, adapter);
 
-        assertEquals(6, forwardSpeakerData.size());
+        Assertions.assertEquals(6, forwardSpeakerData.size());
 
         Map<SwitchId, List<SpeakerData>> forwardCommands = groupBySwitchId(forwardSpeakerData);
-        assertEquals(4, forwardCommands.get(SWITCH_ID_1).size());
-        assertEquals(2, getFlowCount(forwardCommands.get(SWITCH_ID_1)));
-        assertEquals(1, getGroupCount(forwardCommands.get(SWITCH_ID_1)));
-        assertEquals(1, getMeterCount(forwardCommands.get(SWITCH_ID_1)));
+        Assertions.assertEquals(4, forwardCommands.get(SWITCH_ID_1).size());
+        Assertions.assertEquals(2, getFlowCount(forwardCommands.get(SWITCH_ID_1)));
+        Assertions.assertEquals(1, getGroupCount(forwardCommands.get(SWITCH_ID_1)));
+        Assertions.assertEquals(1, getMeterCount(forwardCommands.get(SWITCH_ID_1)));
         assertFlowTables(forwardCommands.get(SWITCH_ID_1), INPUT, INGRESS);
 
-        assertEquals(2, forwardCommands.get(SWITCH_ID_2).size());
-        assertEquals(2, getFlowCount(forwardCommands.get(SWITCH_ID_2)));
+        Assertions.assertEquals(2, forwardCommands.get(SWITCH_ID_2).size());
+        Assertions.assertEquals(2, getFlowCount(forwardCommands.get(SWITCH_ID_2)));
         assertFlowTables(forwardCommands.get(SWITCH_ID_2), EGRESS, EGRESS);
     }
 
@@ -480,17 +480,17 @@ public class RuleManagerHaFlowRulesTest {
         List<SpeakerData> reverseSpeakerData = ruleManager.buildRulesHaFlowPath(
                 haFlow.getReversePath(), false, adapter);
 
-        assertEquals(9, reverseSpeakerData.size());
+        Assertions.assertEquals(9, reverseSpeakerData.size());
 
         Map<SwitchId, List<SpeakerData>> switchCommandMap = groupBySwitchId(reverseSpeakerData);
-        assertEquals(3, switchCommandMap.get(SWITCH_ID_1).size());
-        assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_1)));
-        assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_1)));
+        Assertions.assertEquals(3, switchCommandMap.get(SWITCH_ID_1).size());
+        Assertions.assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_1)));
+        Assertions.assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_1)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_1), EGRESS, EGRESS);
 
-        assertEquals(6, switchCommandMap.get(SWITCH_ID_2).size());
-        assertEquals(4, getFlowCount(switchCommandMap.get(SWITCH_ID_2)));
-        assertEquals(2, getMeterCount(switchCommandMap.get(SWITCH_ID_2)));
+        Assertions.assertEquals(6, switchCommandMap.get(SWITCH_ID_2).size());
+        Assertions.assertEquals(4, getFlowCount(switchCommandMap.get(SWITCH_ID_2)));
+        Assertions.assertEquals(2, getMeterCount(switchCommandMap.get(SWITCH_ID_2)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_2), INPUT, INGRESS, INPUT, INGRESS);
     }
 
@@ -501,21 +501,21 @@ public class RuleManagerHaFlowRulesTest {
         List<SpeakerData> forwardSpeakerData = ruleManager.buildRulesHaFlowPath(
                 haFlow.getForwardPath(), false, adapter);
 
-        assertEquals(6, forwardSpeakerData.size());
+        Assertions.assertEquals(6, forwardSpeakerData.size());
 
         Map<SwitchId, List<SpeakerData>> forwardCommands = groupBySwitchId(forwardSpeakerData);
-        assertEquals(4, forwardCommands.get(SWITCH_ID_1).size());
-        assertEquals(2, getFlowCount(forwardCommands.get(SWITCH_ID_1)));
-        assertEquals(1, getMeterCount(forwardCommands.get(SWITCH_ID_1)));
-        assertEquals(1, getGroupCount(forwardCommands.get(SWITCH_ID_1)));
+        Assertions.assertEquals(4, forwardCommands.get(SWITCH_ID_1).size());
+        Assertions.assertEquals(2, getFlowCount(forwardCommands.get(SWITCH_ID_1)));
+        Assertions.assertEquals(1, getMeterCount(forwardCommands.get(SWITCH_ID_1)));
+        Assertions.assertEquals(1, getGroupCount(forwardCommands.get(SWITCH_ID_1)));
         assertFlowTables(forwardCommands.get(SWITCH_ID_1), INPUT, INGRESS);
 
-        assertEquals(1, forwardCommands.get(SWITCH_ID_2).size());
-        assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_2)));
+        Assertions.assertEquals(1, forwardCommands.get(SWITCH_ID_2).size());
+        Assertions.assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_2)));
         assertFlowTables(forwardCommands.get(SWITCH_ID_2), TRANSIT);
 
-        assertEquals(1, forwardCommands.get(SWITCH_ID_3).size());
-        assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_3)));
+        Assertions.assertEquals(1, forwardCommands.get(SWITCH_ID_3).size());
+        Assertions.assertEquals(1, getFlowCount(forwardCommands.get(SWITCH_ID_3)));
         assertFlowTables(forwardCommands.get(SWITCH_ID_3), EGRESS);
     }
 
@@ -526,21 +526,21 @@ public class RuleManagerHaFlowRulesTest {
         List<SpeakerData> reverseSpeakerData = ruleManager.buildRulesHaFlowPath(
                 haFlow.getReversePath(), false, adapter);
 
-        assertEquals(8, reverseSpeakerData.size());
+        Assertions.assertEquals(8, reverseSpeakerData.size());
 
         Map<SwitchId, List<SpeakerData>> switchCommandMap = groupBySwitchId(reverseSpeakerData);
-        assertEquals(4, switchCommandMap.get(SWITCH_ID_1).size());
-        assertEquals(3, getFlowCount(switchCommandMap.get(SWITCH_ID_1)));
-        assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_1)));
+        Assertions.assertEquals(4, switchCommandMap.get(SWITCH_ID_1).size());
+        Assertions.assertEquals(3, getFlowCount(switchCommandMap.get(SWITCH_ID_1)));
+        Assertions.assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_1)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_1), INPUT, INGRESS, EGRESS);
 
-        assertEquals(1, switchCommandMap.get(SWITCH_ID_2).size());
-        assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_2)));
+        Assertions.assertEquals(1, switchCommandMap.get(SWITCH_ID_2).size());
+        Assertions.assertEquals(1, getFlowCount(switchCommandMap.get(SWITCH_ID_2)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_2), TRANSIT);
 
-        assertEquals(3, switchCommandMap.get(SWITCH_ID_3).size());
-        assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_3)));
-        assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_3)));
+        Assertions.assertEquals(3, switchCommandMap.get(SWITCH_ID_3).size());
+        Assertions.assertEquals(2, getFlowCount(switchCommandMap.get(SWITCH_ID_3)));
+        Assertions.assertEquals(1, getMeterCount(switchCommandMap.get(SWITCH_ID_3)));
         assertFlowTables(switchCommandMap.get(SWITCH_ID_3), INPUT, INGRESS);
     }
 
@@ -783,7 +783,7 @@ public class RuleManagerHaFlowRulesTest {
                 .collect(Collectors.toList());
 
         Arrays.sort(expectedTables);
-        assertEquals(Arrays.asList(expectedTables), actualTables);
+        Assertions.assertEquals(Arrays.asList(expectedTables), actualTables);
     }
 
     private int getFlowCount(Collection<SpeakerData> commands) {

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/RuleManagerServiceRulesTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/RuleManagerServiceRulesTest.java
@@ -16,8 +16,8 @@
 package org.openkilda.rulemanager;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.SwitchFeature.METERS;
@@ -82,8 +82,8 @@ import org.openkilda.rulemanager.factory.generator.service.server42.Server42IslR
 import org.openkilda.rulemanager.factory.generator.service.server42.Server42IslRttTurningRuleGenerator;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -137,7 +137,7 @@ public class RuleManagerServiceRulesTest {
                     .build()))
             .build();
 
-    @Before
+    @BeforeEach
     public void setup() {
         RuleManagerConfig config = mock(RuleManagerConfig.class);
         when(config.getBroadcastRateLimit()).thenReturn(200);

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/Utils.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/Utils.java
@@ -17,6 +17,7 @@ package org.openkilda.rulemanager;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.model.LagLogicalPort;
 import org.openkilda.model.MacAddress;
@@ -31,7 +32,6 @@ import org.openkilda.rulemanager.utils.RoutingMetadata;
 
 import com.google.common.collect.Lists;
 import lombok.Value;
-import org.junit.Assert;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -161,7 +161,7 @@ public final class Utils {
     public static void assertEqualsMatch(Set<FieldMatch> expected, Set<FieldMatch> actual) {
         Set<FullComparableMatch> expectedSet = expected.stream().map(FullComparableMatch::new).collect(toSet());
         Set<FullComparableMatch> actualSet = actual.stream().map(FullComparableMatch::new).collect(toSet());
-        Assert.assertEquals(expectedSet, actualSet);
+        assertEquals(expectedSet, actualSet);
     }
 
     private Utils() {

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/adapter/PersistenceDataAdapterTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/adapter/PersistenceDataAdapterTest.java
@@ -16,8 +16,6 @@
 package org.openkilda.rulemanager.adapter;
 
 import static java.util.Collections.singleton;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -49,18 +47,19 @@ import org.openkilda.persistence.repositories.TransitVlanRepository;
 import org.openkilda.persistence.repositories.VxlanRepository;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PersistenceDataAdapterTest {
 
     @Mock
@@ -83,7 +82,7 @@ public class PersistenceDataAdapterTest {
     private static final SwitchId SWITCH_ID_1 = new SwitchId(1);
     private static final SwitchId SWITCH_ID_2 = new SwitchId(2);
 
-    @Before
+    @BeforeEach
     public void setup() {
         RepositoryFactory repositoryFactory = mock(RepositoryFactory.class);
         when(repositoryFactory.createFlowRepository()).thenReturn(flowRepository);
@@ -116,8 +115,8 @@ public class PersistenceDataAdapterTest {
 
         Map<PathId, FlowPath> actual = adapter.getCommonFlowPaths();
 
-        assertEquals(1, actual.size());
-        assertEquals(flowPath, actual.get(pathId));
+        Assertions.assertEquals(1, actual.size());
+        Assertions.assertEquals(flowPath, actual.get(pathId));
 
         adapter.getCommonFlowPaths();
 
@@ -146,7 +145,7 @@ public class PersistenceDataAdapterTest {
 
         Flow actual = adapter.getFlow(pathId);
 
-        assertEquals(flow, actual);
+        Assertions.assertEquals(flow, actual);
 
         adapter.getFlow(new PathId("test"));
 
@@ -169,8 +168,8 @@ public class PersistenceDataAdapterTest {
                 .persistenceManager(persistenceManager)
                 .build();
 
-        assertEquals(sw1, adapter.getSwitch(SWITCH_ID_1));
-        assertEquals(sw2, adapter.getSwitch(SWITCH_ID_2));
+        Assertions.assertEquals(sw1, adapter.getSwitch(SWITCH_ID_1));
+        Assertions.assertEquals(sw2, adapter.getSwitch(SWITCH_ID_2));
 
         verify(switchRepository).findByIds(switchIds);
         verifyNoMoreInteractions(switchRepository);
@@ -193,8 +192,8 @@ public class PersistenceDataAdapterTest {
                 .persistenceManager(persistenceManager)
                 .build();
 
-        assertEquals(switchProperties1, adapter.getSwitchProperties(SWITCH_ID_1));
-        assertEquals(switchProperties2, adapter.getSwitchProperties(SWITCH_ID_2));
+        Assertions.assertEquals(switchProperties1, adapter.getSwitchProperties(SWITCH_ID_1));
+        Assertions.assertEquals(switchProperties2, adapter.getSwitchProperties(SWITCH_ID_2));
 
         verify(switchPropertiesRepository).findBySwitchIds(switchIds);
         verifyNoMoreInteractions(switchPropertiesRepository);
@@ -220,8 +219,8 @@ public class PersistenceDataAdapterTest {
                 .keepMultitableForFlow(true)
                 .build();
 
-        assertTrue(adapter.getSwitchProperties(SWITCH_ID_1).isMultiTable());
-        assertTrue(adapter.getSwitchProperties(SWITCH_ID_2).isMultiTable());
+        Assertions.assertTrue(adapter.getSwitchProperties(SWITCH_ID_1).isMultiTable());
+        Assertions.assertTrue(adapter.getSwitchProperties(SWITCH_ID_2).isMultiTable());
     }
 
     @Test
@@ -242,8 +241,8 @@ public class PersistenceDataAdapterTest {
 
         FlowTransitEncapsulation actual = adapter.getTransitEncapsulation(pathId, null);
 
-        assertEquals(FlowEncapsulationType.TRANSIT_VLAN, actual.getType());
-        assertEquals(transitVlan.getVlan(), actual.getId().intValue());
+        Assertions.assertEquals(FlowEncapsulationType.TRANSIT_VLAN, actual.getType());
+        Assertions.assertEquals(transitVlan.getVlan(), actual.getId().intValue());
 
         adapter.getTransitEncapsulation(pathId, null);
 
@@ -270,8 +269,8 @@ public class PersistenceDataAdapterTest {
 
         FlowTransitEncapsulation actual = adapter.getTransitEncapsulation(pathId, null);
 
-        assertEquals(FlowEncapsulationType.VXLAN, actual.getType());
-        assertEquals(vxlan.getVni(), actual.getId().intValue());
+        Assertions.assertEquals(FlowEncapsulationType.VXLAN, actual.getType());
+        Assertions.assertEquals(vxlan.getVni(), actual.getId().intValue());
 
         adapter.getTransitEncapsulation(pathId, null);
 
@@ -300,7 +299,7 @@ public class PersistenceDataAdapterTest {
 
         YFlow actual = adapter.getYFlow(pathId);
 
-        assertEquals(yFlow, actual);
+        Assertions.assertEquals(yFlow, actual);
 
         adapter.getYFlow(new PathId("test"));
 

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/EgressRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/EgressRuleGeneratorTest.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.flow;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.model.SwitchFeature.NOVIFLOW_PUSH_POP_VXLAN;
 import static org.openkilda.model.SwitchFeature.RESET_COUNTS_FLAG;
 import static org.openkilda.rulemanager.Utils.assertEqualsMatch;
@@ -54,7 +52,8 @@ import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -98,7 +97,7 @@ public class EgressRuleGeneratorTest {
         );
         assertEgressCommands(commands, OfTable.EGRESS, VLAN_ENCAPSULATION, expectedApplyActions);
     }
-    
+
     @Test
     public void buildVlanMultiTableOuterVlanEgressRuleTest() {
         FlowPath path = buildPath(true);
@@ -277,16 +276,16 @@ public class EgressRuleGeneratorTest {
 
     private void assertEgressCommands(List<SpeakerData> commands, OfTable table,
                                       FlowTransitEncapsulation encapsulation, List<Action> expectedApplyActions) {
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(SWITCH_2.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(SWITCH_2.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(SWITCH_2.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(SWITCH_2.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(COOKIE, flowCommandData.getCookie());
-        assertEquals(table, flowCommandData.getTable());
-        assertEquals(Priority.FLOW_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(COOKIE, flowCommandData.getCookie());
+        Assertions.assertEquals(table, flowCommandData.getTable());
+        Assertions.assertEquals(Priority.FLOW_PRIORITY, flowCommandData.getPriority());
 
 
         Set<FieldMatch> expectedMatch;
@@ -300,25 +299,25 @@ public class EgressRuleGeneratorTest {
         Instructions expectedInstructions = Instructions.builder()
                 .applyActions(expectedApplyActions)
                 .build();
-        assertEquals(expectedInstructions, flowCommandData.getInstructions());
-        assertTrue(flowCommandData.getFlags().isEmpty());
+        Assertions.assertEquals(expectedInstructions, flowCommandData.getInstructions());
+        Assertions.assertTrue(flowCommandData.getFlags().isEmpty());
     }
 
     @Test
     public void oneSwitchFlowEgressRuleTest() {
-        FlowPath path =  FlowPath.builder()
+        FlowPath path = FlowPath.builder()
                 .pathId(PATH_ID)
                 .srcSwitch(SWITCH_1)
                 .destSwitch(SWITCH_1)
                 .build();
 
         EgressRuleGenerator generator = EgressRuleGenerator.builder().flowPath(path).build();
-        assertEquals(0, generator.generateCommands(SWITCH_1).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_1).size());
     }
 
     @Test
     public void pathWithoutSegmentsFlowEgressRuleTest() {
-        FlowPath path =  FlowPath.builder()
+        FlowPath path = FlowPath.builder()
                 .pathId(PATH_ID)
                 .srcSwitch(SWITCH_1)
                 .destSwitch(SWITCH_2)
@@ -326,7 +325,7 @@ public class EgressRuleGeneratorTest {
                 .build();
 
         EgressRuleGenerator generator = EgressRuleGenerator.builder().flowPath(path).build();
-        assertEquals(0, generator.generateCommands(SWITCH_2).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_2).size());
     }
 
     private Set<FieldMatch> buildExpectedVlanMatch(int port, int vlanId) {

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/InputArpRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/InputArpRuleGeneratorTest.java
@@ -15,8 +15,7 @@
 
 package org.openkilda.rulemanager.factory.generator.flow;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openkilda.rulemanager.Utils.assertEqualsMatch;
 import static org.openkilda.rulemanager.Utils.buildSwitch;
 import static org.openkilda.rulemanager.Utils.getCommand;
@@ -42,7 +41,8 @@ import org.openkilda.rulemanager.match.FieldMatch;
 import org.openkilda.rulemanager.utils.RoutingMetadata;
 
 import com.google.common.collect.Sets;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -77,7 +77,7 @@ public class InputArpRuleGeneratorTest {
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
         assertEquals(SW.getSwitchId(), flowCommandData.getSwitchId());
         assertEquals(SW.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
         assertEquals(new PortColourCookie(CookieType.ARP_INPUT_CUSTOMER_TYPE, PORT_NUMBER_1),
                 flowCommandData.getCookie());
@@ -95,7 +95,7 @@ public class InputArpRuleGeneratorTest {
                 .goToTable(OfTable.PRE_INGRESS)
                 .build();
         assertEquals(expectedInstructions, flowCommandData.getInstructions());
-        assertTrue(flowCommandData.getFlags().isEmpty());
+        Assertions.assertTrue(flowCommandData.getFlags().isEmpty());
     }
 
     @Test

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/InputLldpRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/InputLldpRuleGeneratorTest.java
@@ -15,8 +15,7 @@
 
 package org.openkilda.rulemanager.factory.generator.flow;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openkilda.rulemanager.Utils.assertEqualsMatch;
 import static org.openkilda.rulemanager.Utils.buildSwitch;
 import static org.openkilda.rulemanager.Utils.getCommand;
@@ -42,7 +41,8 @@ import org.openkilda.rulemanager.match.FieldMatch;
 import org.openkilda.rulemanager.utils.RoutingMetadata;
 
 import com.google.common.collect.Sets;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -77,7 +77,7 @@ public class InputLldpRuleGeneratorTest {
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
         assertEquals(SW.getSwitchId(), flowCommandData.getSwitchId());
         assertEquals(SW.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
         assertEquals(new PortColourCookie(CookieType.LLDP_INPUT_CUSTOMER_TYPE, PORT_NUMBER_1),
                 flowCommandData.getCookie());
@@ -95,7 +95,7 @@ public class InputLldpRuleGeneratorTest {
                 .goToTable(OfTable.PRE_INGRESS)
                 .build();
         assertEquals(expectedInstructions, flowCommandData.getInstructions());
-        assertTrue(flowCommandData.getFlags().isEmpty());
+        Assertions.assertTrue(flowCommandData.getFlags().isEmpty());
     }
 
     @Test

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/MultiTableIngressRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/MultiTableIngressRuleGeneratorTest.java
@@ -16,8 +16,6 @@
 package org.openkilda.rulemanager.factory.generator.flow;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.SwitchFeature.METERS;
@@ -71,8 +69,9 @@ import org.openkilda.rulemanager.match.FieldMatch;
 import org.openkilda.rulemanager.utils.RoutingMetadata;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -133,7 +132,7 @@ public class MultiTableIngressRuleGeneratorTest {
 
     RuleManagerConfig config;
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = mock(RuleManagerConfig.class);
         when(config.getFlowMeterBurstCoefficient()).thenReturn(BURST_COEFFICIENT);
@@ -148,7 +147,7 @@ public class MultiTableIngressRuleGeneratorTest {
         List<Action> expectedActions = newArrayList(
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -160,7 +159,7 @@ public class MultiTableIngressRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -172,7 +171,7 @@ public class MultiTableIngressRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -180,7 +179,7 @@ public class MultiTableIngressRuleGeneratorTest {
         Flow flow = buildFlow(PATH, OUTER_VLAN_ID_1, TRANSIT_VLAN_ID);
         MultiTableIngressRuleGenerator generator = buildGenerator(PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(TRANSIT_VLAN_ID, FEATURES);
-        assertTrue(transformActions.isEmpty());
+        Assertions.assertTrue(transformActions.isEmpty());
     }
 
 
@@ -190,7 +189,7 @@ public class MultiTableIngressRuleGeneratorTest {
         MultiTableIngressRuleGenerator generator = buildGenerator(PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(INNER_VLAN_ID_1, FEATURES);
         List<Action> expectedActions = newArrayList(new PopVlanAction(), buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -199,7 +198,7 @@ public class MultiTableIngressRuleGeneratorTest {
         MultiTableIngressRuleGenerator generator = buildGenerator(PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList(buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -208,7 +207,7 @@ public class MultiTableIngressRuleGeneratorTest {
         MultiTableIngressRuleGenerator generator = buildGenerator(PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList(buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -221,7 +220,7 @@ public class MultiTableIngressRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -232,7 +231,7 @@ public class MultiTableIngressRuleGeneratorTest {
         List<Action> expectedActions = newArrayList(
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -241,7 +240,7 @@ public class MultiTableIngressRuleGeneratorTest {
         MultiTableIngressRuleGenerator generator = buildGenerator(ONE_SWITCH_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(INNER_VLAN_ID_1, FEATURES);
         List<Action> expectedActions = newArrayList(new PopVlanAction());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -255,7 +254,7 @@ public class MultiTableIngressRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -267,7 +266,7 @@ public class MultiTableIngressRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -276,7 +275,7 @@ public class MultiTableIngressRuleGeneratorTest {
         MultiTableIngressRuleGenerator generator = buildGenerator(ONE_SWITCH_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList();
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -290,7 +289,7 @@ public class MultiTableIngressRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -302,7 +301,7 @@ public class MultiTableIngressRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -311,7 +310,7 @@ public class MultiTableIngressRuleGeneratorTest {
         MultiTableIngressRuleGenerator generator = buildGenerator(ONE_SWITCH_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList();
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -359,7 +358,7 @@ public class MultiTableIngressRuleGeneratorTest {
         Flow flow = buildFlow(ONE_SWITCH_PATH, 0, 0, OUTER_VLAN_ID_2, 0);
         MultiTableIngressRuleGenerator generator = buildGenerator(ONE_SWITCH_PATH, flow, VLAN_ENCAPSULATION);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
         FlowSpeakerData inputCustomerCommand = (FlowSpeakerData) commands.get(1);
@@ -382,13 +381,13 @@ public class MultiTableIngressRuleGeneratorTest {
         Flow flow = buildFlow(PATH, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
         MultiTableIngressRuleGenerator generator = buildGenerator(PATH, flow, VLAN_ENCAPSULATION);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(4, commands.size());
+        Assertions.assertEquals(4, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
         FlowSpeakerData preIngressCommand = (FlowSpeakerData) commands.get(1);
         FlowSpeakerData inputCustomerCommand = (FlowSpeakerData) commands.get(2);
         MeterSpeakerData meterCommand = (MeterSpeakerData) commands.get(3);
-        assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
+        Assertions.assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
 
         Set<FieldMatch> expectedPreIngressMatch = Sets.newHashSet(
                 FieldMatch.builder().field(Field.IN_PORT).value(PORT_NUMBER_1).build(),
@@ -429,11 +428,11 @@ public class MultiTableIngressRuleGeneratorTest {
         Flow flow = buildFlow(PATH, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
         MultiTableIngressRuleGenerator generator = buildGenerator(PATH, flow, VLAN_ENCAPSULATION, overlapping);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
         MeterSpeakerData meterCommand = (MeterSpeakerData) commands.get(1);
-        assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
+        Assertions.assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
 
         RoutingMetadata ingressMetadata = RoutingMetadata.builder().outerVlanId(OUTER_VLAN_ID_1)
                 .build(SWITCH_1.getFeatures());
@@ -460,12 +459,12 @@ public class MultiTableIngressRuleGeneratorTest {
         Flow flow = buildFlow(PATH, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
         MultiTableIngressRuleGenerator generator = buildGenerator(PATH, flow, VLAN_ENCAPSULATION, overlapping);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(3, commands.size());
+        Assertions.assertEquals(3, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
         FlowSpeakerData preIngressCommand = (FlowSpeakerData) commands.get(1);
         MeterSpeakerData meterCommand = (MeterSpeakerData) commands.get(2);
-        assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
+        Assertions.assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
 
         RoutingMetadata ingressMetadata = RoutingMetadata.builder().outerVlanId(OUTER_VLAN_ID_1)
                 .build(SWITCH_1.getFeatures());
@@ -499,12 +498,12 @@ public class MultiTableIngressRuleGeneratorTest {
     private void assertIngressCommand(
             FlowSpeakerData command, int expectedPriority, Set<FieldMatch> expectedMatch,
             List<Action> expectedApplyActions, MeterId expectedMeter, OfMetadata expectedMetadata) {
-        assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
 
-        assertEquals(COOKIE, command.getCookie());
-        assertEquals(OfTable.INGRESS, command.getTable());
-        assertEquals(expectedPriority, command.getPriority());
+        Assertions.assertEquals(COOKIE, command.getCookie());
+        Assertions.assertEquals(OfTable.INGRESS, command.getTable());
+        Assertions.assertEquals(expectedPriority, command.getPriority());
 
         assertEqualsMatch(expectedMatch, command.getMatch());
 
@@ -514,19 +513,19 @@ public class MultiTableIngressRuleGeneratorTest {
                 .goToMeter(expectedMeter)
                 .writeMetadata(expectedMetadata)
                 .build();
-        assertEquals(expectedInstructions, command.getInstructions());
-        assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
+        Assertions.assertEquals(expectedInstructions, command.getInstructions());
+        Assertions.assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
     }
 
     private void assertPreIngressCommand(
             FlowSpeakerData command, CookieBase cookie, int expectedPriority, Set<FieldMatch> expectedMatch,
             List<Action> expectedApplyActions, OfMetadata expectedMetadata) {
-        assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
-        assertEquals(cookie, command.getCookie());
-        assertEquals(OfTable.PRE_INGRESS, command.getTable());
-        assertEquals(expectedPriority, command.getPriority());
-        assertTrue(command.getDependsOn().isEmpty());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(cookie, command.getCookie());
+        Assertions.assertEquals(OfTable.PRE_INGRESS, command.getTable());
+        Assertions.assertEquals(expectedPriority, command.getPriority());
+        Assertions.assertTrue(command.getDependsOn().isEmpty());
 
         assertEqualsMatch(expectedMatch, command.getMatch());
 
@@ -535,36 +534,36 @@ public class MultiTableIngressRuleGeneratorTest {
                 .applyActions(expectedApplyActions)
                 .goToTable(OfTable.INGRESS)
                 .build();
-        assertEquals(expectedInstructions, command.getInstructions());
-        assertTrue(command.getFlags().isEmpty());
+        Assertions.assertEquals(expectedInstructions, command.getInstructions());
+        Assertions.assertTrue(command.getFlags().isEmpty());
     }
 
     private void assertInputCustomerCommand(
             FlowSpeakerData command, CookieBase cookie, Set<FieldMatch> expectedMatch) {
-        assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
-        assertEquals(cookie, command.getCookie());
-        assertEquals(OfTable.INPUT, command.getTable());
-        assertEquals(Priority.INGRESS_CUSTOMER_PORT_RULE_PRIORITY_MULTITABLE, command.getPriority());
-        assertTrue(command.getDependsOn().isEmpty());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(cookie, command.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, command.getTable());
+        Assertions.assertEquals(Priority.INGRESS_CUSTOMER_PORT_RULE_PRIORITY_MULTITABLE, command.getPriority());
+        Assertions.assertTrue(command.getDependsOn().isEmpty());
 
         assertEqualsMatch(expectedMatch, command.getMatch());
 
         Instructions expectedInstructions = Instructions.builder()
                 .goToTable(OfTable.PRE_INGRESS)
                 .build();
-        assertEquals(expectedInstructions, command.getInstructions());
-        assertTrue(command.getFlags().isEmpty());
+        Assertions.assertEquals(expectedInstructions, command.getInstructions());
+        Assertions.assertTrue(command.getFlags().isEmpty());
     }
 
     private void assertMeterCommand(MeterSpeakerData command) {
-        assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
-        assertEquals(METER_ID, command.getMeterId());
-        assertEquals(Sets.newHashSet(MeterFlag.BURST, MeterFlag.KBPS, MeterFlag.STATS), command.getFlags());
-        assertEquals(BANDWIDTH, command.getRate());
-        assertEquals((long) (BANDWIDTH * BURST_COEFFICIENT), command.getBurst());
-        assertTrue(command.getDependsOn().isEmpty());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(METER_ID, command.getMeterId());
+        Assertions.assertEquals(Sets.newHashSet(MeterFlag.BURST, MeterFlag.KBPS, MeterFlag.STATS), command.getFlags());
+        Assertions.assertEquals(BANDWIDTH, command.getRate());
+        Assertions.assertEquals((long) (BANDWIDTH * BURST_COEFFICIENT), command.getBurst());
+        Assertions.assertTrue(command.getDependsOn().isEmpty());
 
     }
 

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/MultiTableIngressYRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/MultiTableIngressYRuleGeneratorTest.java
@@ -16,8 +16,6 @@
 package org.openkilda.rulemanager.factory.generator.flow;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.SwitchFeature.METERS;
@@ -65,8 +63,9 @@ import org.openkilda.rulemanager.match.FieldMatch;
 import org.openkilda.rulemanager.utils.RoutingMetadata;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -133,7 +132,7 @@ public class MultiTableIngressYRuleGeneratorTest {
     public static final UUID SHARED_METER_UUID = UUID.fromString("dc8b54d3-3f25-4c5b-9d90-5f59d2836bc2");
 
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = mock(RuleManagerConfig.class);
         when(config.getFlowMeterBurstCoefficient()).thenReturn(BURST_COEFFICIENT);
@@ -148,7 +147,7 @@ public class MultiTableIngressYRuleGeneratorTest {
         List<Action> expectedActions = newArrayList(
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -160,7 +159,7 @@ public class MultiTableIngressYRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -172,7 +171,7 @@ public class MultiTableIngressYRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -180,7 +179,7 @@ public class MultiTableIngressYRuleGeneratorTest {
         Flow flow = buildFlow(PATH, OUTER_VLAN_ID_1, TRANSIT_VLAN_ID);
         MultiTableIngressYRuleGenerator generator = buildGenerator(PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(TRANSIT_VLAN_ID, FEATURES);
-        assertTrue(transformActions.isEmpty());
+        Assertions.assertTrue(transformActions.isEmpty());
     }
 
 
@@ -190,7 +189,7 @@ public class MultiTableIngressYRuleGeneratorTest {
         MultiTableIngressYRuleGenerator generator = buildGenerator(PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(INNER_VLAN_ID_1, FEATURES);
         List<Action> expectedActions = newArrayList(new PopVlanAction(), buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -199,7 +198,7 @@ public class MultiTableIngressYRuleGeneratorTest {
         MultiTableIngressYRuleGenerator generator = buildGenerator(PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList(buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -208,7 +207,7 @@ public class MultiTableIngressYRuleGeneratorTest {
         MultiTableIngressYRuleGenerator generator = buildGenerator(PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList(buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -221,7 +220,7 @@ public class MultiTableIngressYRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -232,7 +231,7 @@ public class MultiTableIngressYRuleGeneratorTest {
         List<Action> expectedActions = newArrayList(
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -241,7 +240,7 @@ public class MultiTableIngressYRuleGeneratorTest {
         MultiTableIngressYRuleGenerator generator = buildGenerator(ONE_SWITCH_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(INNER_VLAN_ID_1, FEATURES);
         List<Action> expectedActions = newArrayList(new PopVlanAction());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -255,7 +254,7 @@ public class MultiTableIngressYRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -267,7 +266,7 @@ public class MultiTableIngressYRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -276,7 +275,7 @@ public class MultiTableIngressYRuleGeneratorTest {
         MultiTableIngressYRuleGenerator generator = buildGenerator(ONE_SWITCH_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList();
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -290,7 +289,7 @@ public class MultiTableIngressYRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -302,7 +301,7 @@ public class MultiTableIngressYRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -311,7 +310,7 @@ public class MultiTableIngressYRuleGeneratorTest {
         MultiTableIngressYRuleGenerator generator = buildGenerator(ONE_SWITCH_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList();
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -359,11 +358,11 @@ public class MultiTableIngressYRuleGeneratorTest {
         Flow flow = buildFlow(PATH, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
         MultiTableIngressYRuleGenerator generator = buildGenerator(PATH, flow, VLAN_ENCAPSULATION);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
         MeterSpeakerData meterCommand = (MeterSpeakerData) commands.get(1);
-        assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
+        Assertions.assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
 
         RoutingMetadata ingressMetadata = RoutingMetadata.builder().outerVlanId(OUTER_VLAN_ID_1)
                 .build(SWITCH_1.getFeatures());
@@ -390,11 +389,11 @@ public class MultiTableIngressYRuleGeneratorTest {
         Flow flow = buildFlow(PATH, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
         MultiTableIngressYRuleGenerator generator = buildGenerator(PATH, flow, VLAN_ENCAPSULATION, overlapping);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
         MeterSpeakerData meterCommand = (MeterSpeakerData) commands.get(1);
-        assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
+        Assertions.assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
 
         RoutingMetadata ingressMetadata = RoutingMetadata.builder().outerVlanId(OUTER_VLAN_ID_1)
                 .build(SWITCH_1.getFeatures());
@@ -421,11 +420,11 @@ public class MultiTableIngressYRuleGeneratorTest {
         Flow flow = buildFlow(PATH, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
         MultiTableIngressYRuleGenerator generator = buildGenerator(PATH, flow, VLAN_ENCAPSULATION, overlapping);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
         MeterSpeakerData meterCommand = (MeterSpeakerData) commands.get(1);
-        assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
+        Assertions.assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
 
         RoutingMetadata ingressMetadata = RoutingMetadata.builder().outerVlanId(OUTER_VLAN_ID_1)
                 .build(SWITCH_1.getFeatures());
@@ -453,10 +452,10 @@ public class MultiTableIngressYRuleGeneratorTest {
         Flow flow = buildFlow(PATH, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
         MultiTableIngressYRuleGenerator generator = buildGenerator(PATH, flow, VLAN_ENCAPSULATION, overlapping, false);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
-        assertEquals(newArrayList(SHARED_METER_UUID), new ArrayList<>(ingressCommand.getDependsOn()));
+        Assertions.assertEquals(newArrayList(SHARED_METER_UUID), new ArrayList<>(ingressCommand.getDependsOn()));
 
         RoutingMetadata ingressMetadata = RoutingMetadata.builder().outerVlanId(OUTER_VLAN_ID_1)
                 .build(SWITCH_1.getFeatures());
@@ -482,7 +481,7 @@ public class MultiTableIngressYRuleGeneratorTest {
                 FlowSideAdapter.makeIngressAdapter(oneSwitchFlow, ONE_SWITCH_PATH));
         Flow flow = buildFlow(PATH, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
 
-        MultiTableIngressYRuleGenerator generator =  MultiTableIngressYRuleGenerator.builder()
+        MultiTableIngressYRuleGenerator generator = MultiTableIngressYRuleGenerator.builder()
                 .config(config)
                 .flowPath(PATH)
                 .flow(flow)
@@ -494,10 +493,10 @@ public class MultiTableIngressYRuleGeneratorTest {
                 .build();
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
-        assertTrue(ingressCommand.getDependsOn().isEmpty());
+        Assertions.assertTrue(ingressCommand.getDependsOn().isEmpty());
 
         RoutingMetadata ingressMetadata = RoutingMetadata.builder().outerVlanId(OUTER_VLAN_ID_1)
                 .build(SWITCH_1.getFeatures());
@@ -520,12 +519,12 @@ public class MultiTableIngressYRuleGeneratorTest {
     private void assertIngressCommand(
             FlowSpeakerData command, int expectedPriority, Set<FieldMatch> expectedMatch,
             List<Action> expectedApplyActions, MeterId expectedMeter, OfMetadata expectedMetadata) {
-        assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
 
-        assertEquals(COOKIE, command.getCookie());
-        assertEquals(OfTable.INGRESS, command.getTable());
-        assertEquals(expectedPriority, command.getPriority());
+        Assertions.assertEquals(COOKIE, command.getCookie());
+        Assertions.assertEquals(OfTable.INGRESS, command.getTable());
+        Assertions.assertEquals(expectedPriority, command.getPriority());
 
         assertEqualsMatch(expectedMatch, command.getMatch());
 
@@ -535,18 +534,18 @@ public class MultiTableIngressYRuleGeneratorTest {
                 .goToMeter(expectedMeter)
                 .writeMetadata(expectedMetadata)
                 .build();
-        assertEquals(expectedInstructions, command.getInstructions());
-        assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
+        Assertions.assertEquals(expectedInstructions, command.getInstructions());
+        Assertions.assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
     }
 
     private void assertMeterCommand(MeterSpeakerData command) {
-        assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
-        assertEquals(SHARED_METER_ID, command.getMeterId());
-        assertEquals(Sets.newHashSet(MeterFlag.BURST, MeterFlag.KBPS, MeterFlag.STATS), command.getFlags());
-        assertEquals(BANDWIDTH, command.getRate());
-        assertEquals((long) (BANDWIDTH * BURST_COEFFICIENT), command.getBurst());
-        assertTrue(command.getDependsOn().isEmpty());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(SHARED_METER_ID, command.getMeterId());
+        Assertions.assertEquals(Sets.newHashSet(MeterFlag.BURST, MeterFlag.KBPS, MeterFlag.STATS), command.getFlags());
+        Assertions.assertEquals(BANDWIDTH, command.getRate());
+        Assertions.assertEquals((long) (BANDWIDTH * BURST_COEFFICIENT), command.getBurst());
+        Assertions.assertTrue(command.getDependsOn().isEmpty());
 
     }
 

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/MultiTableServer42IngressRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/MultiTableServer42IngressRuleGeneratorTest.java
@@ -16,9 +16,6 @@
 package org.openkilda.rulemanager.factory.generator.flow;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.SwitchFeature.METERS;
@@ -73,8 +70,9 @@ import org.openkilda.rulemanager.match.FieldMatch;
 import org.openkilda.rulemanager.utils.RoutingMetadata;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -147,7 +145,7 @@ public class MultiTableServer42IngressRuleGeneratorTest {
 
     RuleManagerConfig config;
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = mock(RuleManagerConfig.class);
         when(config.getServer42FlowRttUdpPortOffset()).thenReturn(PORT_OFFSET);
@@ -162,7 +160,7 @@ public class MultiTableServer42IngressRuleGeneratorTest {
                 SetFieldAction.builder().field(Field.ETH_SRC).value(SWITCH_ID_1.toMacAddressAsLong()).build(),
                 SetFieldAction.builder().field(Field.ETH_DST).value(SWITCH_ID_2.toMacAddressAsLong()).build(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -175,7 +173,7 @@ public class MultiTableServer42IngressRuleGeneratorTest {
                 SetFieldAction.builder().field(Field.ETH_DST).value(SWITCH_ID_2.toMacAddressAsLong()).build(),
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -188,7 +186,7 @@ public class MultiTableServer42IngressRuleGeneratorTest {
                 SetFieldAction.builder().field(Field.ETH_DST).value(SWITCH_ID_2.toMacAddressAsLong()).build(),
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -199,7 +197,7 @@ public class MultiTableServer42IngressRuleGeneratorTest {
         List<Action> expectedActions = newArrayList(
                 SetFieldAction.builder().field(Field.ETH_SRC).value(SWITCH_ID_1.toMacAddressAsLong()).build(),
                 SetFieldAction.builder().field(Field.ETH_DST).value(SWITCH_ID_2.toMacAddressAsLong()).build());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -208,7 +206,7 @@ public class MultiTableServer42IngressRuleGeneratorTest {
         MultiTableServer42IngressRuleGenerator generator = buildGenerator(PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(INNER_VLAN_ID_1, FEATURES);
         List<Action> expectedActions = newArrayList(new PopVlanAction(), buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -217,7 +215,7 @@ public class MultiTableServer42IngressRuleGeneratorTest {
         MultiTableServer42IngressRuleGenerator generator = buildGenerator(PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList(buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -226,7 +224,7 @@ public class MultiTableServer42IngressRuleGeneratorTest {
         MultiTableServer42IngressRuleGenerator generator = buildGenerator(PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList(buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -235,7 +233,7 @@ public class MultiTableServer42IngressRuleGeneratorTest {
                 .switchProperties(SWITCH_PROPERTIES)
                 .flowPath(ONE_SWITCH_PATH)
                 .build();
-        assertEquals(0, generator.generateCommands(SWITCH_1).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_1).size());
     }
 
     @Test
@@ -244,7 +242,7 @@ public class MultiTableServer42IngressRuleGeneratorTest {
                 .switchProperties(null)
                 .flowPath(PATH)
                 .build();
-        assertEquals(0, generator.generateCommands(SWITCH_1).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_1).size());
     }
 
     @Test
@@ -253,7 +251,7 @@ public class MultiTableServer42IngressRuleGeneratorTest {
                 .switchProperties(SwitchProperties.builder().multiTable(false).server42FlowRtt(true).build())
                 .flowPath(PATH)
                 .build();
-        assertEquals(0, generator.generateCommands(SWITCH_1).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_1).size());
     }
 
     @Test
@@ -262,7 +260,7 @@ public class MultiTableServer42IngressRuleGeneratorTest {
                 .switchProperties(SwitchProperties.builder().multiTable(true).server42FlowRtt(false).build())
                 .flowPath(PATH)
                 .build();
-        assertEquals(0, generator.generateCommands(SWITCH_1).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_1).size());
     }
 
     @Test
@@ -270,7 +268,7 @@ public class MultiTableServer42IngressRuleGeneratorTest {
         Flow flow = buildFlow(PATH, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
         MultiTableServer42IngressRuleGenerator generator = buildGenerator(PATH, flow, VLAN_ENCAPSULATION);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(3, commands.size());
+        Assertions.assertEquals(3, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
         FlowSpeakerData preIngressCommand = (FlowSpeakerData) commands.get(1);
@@ -301,7 +299,7 @@ public class MultiTableServer42IngressRuleGeneratorTest {
         Flow flow = buildFlow(PATH, OUTER_VLAN_ID_1, 0);
         MultiTableServer42IngressRuleGenerator generator = buildGenerator(PATH, flow, VXLAN_ENCAPSULATION);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(3, commands.size());
+        Assertions.assertEquals(3, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
         FlowSpeakerData preIngressCommand = (FlowSpeakerData) commands.get(1);
@@ -327,7 +325,7 @@ public class MultiTableServer42IngressRuleGeneratorTest {
         Flow flow = buildFlow(PATH, 0, 0);
         MultiTableServer42IngressRuleGenerator generator = buildGenerator(PATH, flow, VLAN_ENCAPSULATION);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
         FlowSpeakerData inputCustomerCommand = (FlowSpeakerData) commands.get(1);
@@ -355,8 +353,8 @@ public class MultiTableServer42IngressRuleGeneratorTest {
         MultiTableServer42IngressRuleGenerator generator = MultiTableServer42IngressRuleGenerator.builder()
                 .overlappingIngressAdapters(new HashSet<>()).build();
         FlowEndpoint ingressEndpoint = new FlowEndpoint(SWITCH_ID_1, PORT_NUMBER_1, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
-        assertTrue(generator.needToBuildServer42PreIngressRule(ingressEndpoint));
-        assertTrue(generator.needToBuildServer42InputRule(ingressEndpoint));
+        Assertions.assertTrue(generator.needToBuildServer42PreIngressRule(ingressEndpoint));
+        Assertions.assertTrue(generator.needToBuildServer42InputRule(ingressEndpoint));
     }
 
     @Test
@@ -364,8 +362,8 @@ public class MultiTableServer42IngressRuleGeneratorTest {
         MultiTableServer42IngressRuleGenerator generator = MultiTableServer42IngressRuleGenerator.builder()
                 .overlappingIngressAdapters(new HashSet<>()).build();
         FlowEndpoint ingressEndpoint = new FlowEndpoint(SWITCH_ID_1, PORT_NUMBER_1, 0, 0);
-        assertFalse(generator.needToBuildServer42PreIngressRule(ingressEndpoint));
-        assertTrue(generator.needToBuildServer42InputRule(ingressEndpoint));
+        Assertions.assertFalse(generator.needToBuildServer42PreIngressRule(ingressEndpoint));
+        Assertions.assertTrue(generator.needToBuildServer42InputRule(ingressEndpoint));
     }
 
     @Test
@@ -373,8 +371,8 @@ public class MultiTableServer42IngressRuleGeneratorTest {
         Flow overlappingFlow = buildOverlappingFlow(PORT_NUMBER_1, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
         MultiTableServer42IngressRuleGenerator generator = buildGenerator(overlappingFlow);
         FlowEndpoint ingressEndpoint = new FlowEndpoint(SWITCH_ID_1, PORT_NUMBER_1, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
-        assertFalse(generator.needToBuildServer42PreIngressRule(ingressEndpoint));
-        assertFalse(generator.needToBuildServer42InputRule(ingressEndpoint));
+        Assertions.assertFalse(generator.needToBuildServer42PreIngressRule(ingressEndpoint));
+        Assertions.assertFalse(generator.needToBuildServer42InputRule(ingressEndpoint));
     }
 
     @Test
@@ -382,8 +380,8 @@ public class MultiTableServer42IngressRuleGeneratorTest {
         Flow overlappingFlow = buildOverlappingFlow(PORT_NUMBER_2, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
         MultiTableServer42IngressRuleGenerator generator = buildGenerator(overlappingFlow);
         FlowEndpoint ingressEndpoint = new FlowEndpoint(SWITCH_ID_1, PORT_NUMBER_1, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
-        assertFalse(generator.needToBuildServer42PreIngressRule(ingressEndpoint));
-        assertTrue(generator.needToBuildServer42InputRule(ingressEndpoint));
+        Assertions.assertFalse(generator.needToBuildServer42PreIngressRule(ingressEndpoint));
+        Assertions.assertTrue(generator.needToBuildServer42InputRule(ingressEndpoint));
     }
 
     @Test
@@ -391,8 +389,8 @@ public class MultiTableServer42IngressRuleGeneratorTest {
         Flow overlappingFlow = buildOverlappingFlow(PORT_NUMBER_1, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
         MultiTableServer42IngressRuleGenerator generator = buildGenerator(overlappingFlow);
         FlowEndpoint ingressEndpoint = new FlowEndpoint(SWITCH_ID_1, PORT_NUMBER_1, 0, 0);
-        assertFalse(generator.needToBuildServer42PreIngressRule(ingressEndpoint));
-        assertFalse(generator.needToBuildServer42InputRule(ingressEndpoint));
+        Assertions.assertFalse(generator.needToBuildServer42PreIngressRule(ingressEndpoint));
+        Assertions.assertFalse(generator.needToBuildServer42InputRule(ingressEndpoint));
     }
 
     @Test
@@ -400,8 +398,8 @@ public class MultiTableServer42IngressRuleGeneratorTest {
         Flow overlappingFlow = buildOverlappingFlow(PORT_NUMBER_1, 0, 0);
         MultiTableServer42IngressRuleGenerator generator = buildGenerator(overlappingFlow);
         FlowEndpoint ingressEndpoint = new FlowEndpoint(SWITCH_ID_1, PORT_NUMBER_1, OUTER_VLAN_ID_1, 0);
-        assertTrue(generator.needToBuildServer42PreIngressRule(ingressEndpoint));
-        assertFalse(generator.needToBuildServer42InputRule(ingressEndpoint));
+        Assertions.assertTrue(generator.needToBuildServer42PreIngressRule(ingressEndpoint));
+        Assertions.assertFalse(generator.needToBuildServer42InputRule(ingressEndpoint));
     }
 
     @Test
@@ -409,26 +407,26 @@ public class MultiTableServer42IngressRuleGeneratorTest {
         Flow overlappingFlow = buildOverlappingFlow(PORT_NUMBER_1, OUTER_VLAN_ID_2, INNER_VLAN_ID_1);
         MultiTableServer42IngressRuleGenerator generator = buildGenerator(overlappingFlow);
         FlowEndpoint ingressEndpoint = new FlowEndpoint(SWITCH_ID_1, PORT_NUMBER_1, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
-        assertTrue(generator.needToBuildServer42PreIngressRule(ingressEndpoint));
-        assertFalse(generator.needToBuildServer42InputRule(ingressEndpoint));
+        Assertions.assertTrue(generator.needToBuildServer42PreIngressRule(ingressEndpoint));
+        Assertions.assertFalse(generator.needToBuildServer42InputRule(ingressEndpoint));
     }
 
     private void assertIngressCommand(
             FlowSpeakerData command, int expectedPriority, Set<FieldMatch> expectedMatch,
             List<Action> expectedApplyActions) {
-        assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
 
-        assertEquals(SERVER_42_INGRESS_COOKIE, command.getCookie());
-        assertEquals(OfTable.INGRESS, command.getTable());
-        assertEquals(expectedPriority, command.getPriority());
+        Assertions.assertEquals(SERVER_42_INGRESS_COOKIE, command.getCookie());
+        Assertions.assertEquals(OfTable.INGRESS, command.getTable());
+        Assertions.assertEquals(expectedPriority, command.getPriority());
         assertEqualsMatch(expectedMatch, command.getMatch());
 
         Instructions expectedInstructions = Instructions.builder()
                 .applyActions(expectedApplyActions)
                 .build();
-        assertEquals(expectedInstructions, command.getInstructions());
-        assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
+        Assertions.assertEquals(expectedInstructions, command.getInstructions());
+        Assertions.assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
     }
 
     private void assertPreIngressCommand(FlowSpeakerData command, List<Action> expectedApplyActions) {
@@ -436,12 +434,12 @@ public class MultiTableServer42IngressRuleGeneratorTest {
                 .portNumber(SERVER_42_PORT_NUMBER)
                 .vlanId(OUTER_VLAN_ID_1).build();
 
-        assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
-        assertEquals(cookie, command.getCookie());
-        assertEquals(OfTable.PRE_INGRESS, command.getTable());
-        assertEquals(Priority.SERVER_42_PRE_INGRESS_FLOW_PRIORITY, command.getPriority());
-        assertTrue(command.getDependsOn().isEmpty());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(cookie, command.getCookie());
+        Assertions.assertEquals(OfTable.PRE_INGRESS, command.getTable());
+        Assertions.assertEquals(Priority.SERVER_42_PRE_INGRESS_FLOW_PRIORITY, command.getPriority());
+        Assertions.assertTrue(command.getDependsOn().isEmpty());
 
         Set<FieldMatch> expectedMatch = Sets.newHashSet(
                 FieldMatch.builder().field(Field.IN_PORT).value(SERVER_42_PORT_NUMBER).build(),
@@ -454,17 +452,17 @@ public class MultiTableServer42IngressRuleGeneratorTest {
                 .applyActions(expectedApplyActions)
                 .goToTable(OfTable.INGRESS)
                 .build();
-        assertEquals(expectedInstructions, command.getInstructions());
-        assertTrue(command.getFlags().isEmpty());
+        Assertions.assertEquals(expectedInstructions, command.getInstructions());
+        Assertions.assertTrue(command.getFlags().isEmpty());
     }
 
     private void assertInputCommand(FlowSpeakerData command) {
-        assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
-        assertEquals(new PortColourCookie(SERVER_42_FLOW_RTT_INPUT, PORT_NUMBER_1), command.getCookie());
-        assertEquals(OfTable.INPUT, command.getTable());
-        assertEquals(Priority.SERVER_42_FLOW_RTT_INPUT_PRIORITY, command.getPriority());
-        assertTrue(command.getDependsOn().isEmpty());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(new PortColourCookie(SERVER_42_FLOW_RTT_INPUT, PORT_NUMBER_1), command.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, command.getTable());
+        Assertions.assertEquals(Priority.SERVER_42_FLOW_RTT_INPUT_PRIORITY, command.getPriority());
+        Assertions.assertTrue(command.getDependsOn().isEmpty());
 
         Set<FieldMatch> expectedMatch = Sets.newHashSet(
                 FieldMatch.builder().field(Field.IN_PORT).value(SERVER_42_PORT_NUMBER).build(),
@@ -485,8 +483,8 @@ public class MultiTableServer42IngressRuleGeneratorTest {
                 .writeMetadata(mapMetadata(RoutingMetadata.builder().inputPort(PORT_NUMBER_1)
                         .build(SWITCH_1.getFeatures())))
                 .build();
-        assertEquals(expectedInstructions, command.getInstructions());
-        assertTrue(command.getFlags().isEmpty());
+        Assertions.assertEquals(expectedInstructions, command.getInstructions());
+        Assertions.assertTrue(command.getFlags().isEmpty());
     }
 
     private MultiTableServer42IngressRuleGenerator buildGenerator(

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/SingleTableIngressRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/SingleTableIngressRuleGeneratorTest.java
@@ -16,8 +16,6 @@
 package org.openkilda.rulemanager.factory.generator.flow;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.SwitchFeature.METERS;
@@ -62,8 +60,9 @@ import org.openkilda.rulemanager.action.SetFieldAction;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -122,7 +121,7 @@ public class SingleTableIngressRuleGeneratorTest {
 
     RuleManagerConfig config;
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = mock(RuleManagerConfig.class);
         when(config.getFlowMeterBurstCoefficient()).thenReturn(BURST_COEFFICIENT);
@@ -137,7 +136,7 @@ public class SingleTableIngressRuleGeneratorTest {
         List<Action> expectedActions = newArrayList(
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -149,7 +148,7 @@ public class SingleTableIngressRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -157,7 +156,7 @@ public class SingleTableIngressRuleGeneratorTest {
         Flow flow = buildFlow(PATH, TRANSIT_VLAN_ID, 0);
         SingleTableIngressRuleGenerator generator = buildGenerator(PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(TRANSIT_VLAN_ID, FEATURES);
-        assertTrue(transformActions.isEmpty());
+        Assertions.assertTrue(transformActions.isEmpty());
     }
 
     @Test
@@ -166,7 +165,7 @@ public class SingleTableIngressRuleGeneratorTest {
         SingleTableIngressRuleGenerator generator = buildGenerator(PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(OUTER_VLAN_ID_1, FEATURES);
         List<Action> expectedActions = newArrayList(new PopVlanAction(), buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -175,7 +174,7 @@ public class SingleTableIngressRuleGeneratorTest {
         SingleTableIngressRuleGenerator generator = buildGenerator(PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList(buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -186,7 +185,7 @@ public class SingleTableIngressRuleGeneratorTest {
         List<Action> expectedActions = newArrayList(
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -195,7 +194,7 @@ public class SingleTableIngressRuleGeneratorTest {
         SingleTableIngressRuleGenerator generator = buildGenerator(ONE_SWITCH_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(OUTER_VLAN_ID_1, FEATURES);
         List<Action> expectedActions = newArrayList(new PopVlanAction());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -207,7 +206,7 @@ public class SingleTableIngressRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -216,7 +215,7 @@ public class SingleTableIngressRuleGeneratorTest {
         SingleTableIngressRuleGenerator generator = buildGenerator(ONE_SWITCH_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList();
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -247,7 +246,7 @@ public class SingleTableIngressRuleGeneratorTest {
         Flow flow = buildFlow(ONE_SWITCH_PATH, 0, OUTER_VLAN_ID_2);
         SingleTableIngressRuleGenerator generator = buildGenerator(ONE_SWITCH_PATH, flow, VLAN_ENCAPSULATION);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
 
@@ -266,11 +265,11 @@ public class SingleTableIngressRuleGeneratorTest {
         Flow flow = buildFlow(PATH, OUTER_VLAN_ID_1, 0);
         SingleTableIngressRuleGenerator generator = buildGenerator(PATH, flow, VLAN_ENCAPSULATION);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
         MeterSpeakerData meterCommand = (MeterSpeakerData) commands.get(1);
-        assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
+        Assertions.assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
 
         Set<FieldMatch> expectedIngressMatch = Sets.newHashSet(
                 FieldMatch.builder().field(Field.IN_PORT).value(PORT_NUMBER_1).build(),
@@ -289,30 +288,30 @@ public class SingleTableIngressRuleGeneratorTest {
     private void assertIngressCommand(
             FlowSpeakerData command, int expectedPriority, Set<FieldMatch> expectedMatch,
             List<Action> expectedApplyActions, MeterId expectedMeter) {
-        assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
 
-        assertEquals(COOKIE, command.getCookie());
-        assertEquals(OfTable.INPUT, command.getTable());
-        assertEquals(expectedPriority, command.getPriority());
+        Assertions.assertEquals(COOKIE, command.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, command.getTable());
+        Assertions.assertEquals(expectedPriority, command.getPriority());
         assertEqualsMatch(expectedMatch, command.getMatch());
 
         Instructions expectedInstructions = Instructions.builder()
                 .applyActions(expectedApplyActions)
                 .goToMeter(expectedMeter)
                 .build();
-        assertEquals(expectedInstructions, command.getInstructions());
-        assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
+        Assertions.assertEquals(expectedInstructions, command.getInstructions());
+        Assertions.assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
     }
 
     private void assertMeterCommand(MeterSpeakerData command) {
-        assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
-        assertEquals(METER_ID, command.getMeterId());
-        assertEquals(Sets.newHashSet(MeterFlag.BURST, MeterFlag.KBPS, MeterFlag.STATS), command.getFlags());
-        assertEquals(BANDWIDTH, command.getRate());
-        assertEquals((long) (BANDWIDTH * BURST_COEFFICIENT), command.getBurst());
-        assertTrue(command.getDependsOn().isEmpty());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(METER_ID, command.getMeterId());
+        Assertions.assertEquals(Sets.newHashSet(MeterFlag.BURST, MeterFlag.KBPS, MeterFlag.STATS), command.getFlags());
+        Assertions.assertEquals(BANDWIDTH, command.getRate());
+        Assertions.assertEquals((long) (BANDWIDTH * BURST_COEFFICIENT), command.getBurst());
+        Assertions.assertTrue(command.getDependsOn().isEmpty());
 
     }
 

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/SingleTableIngressYRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/SingleTableIngressYRuleGeneratorTest.java
@@ -16,8 +16,6 @@
 package org.openkilda.rulemanager.factory.generator.flow;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.SwitchFeature.METERS;
@@ -62,8 +60,9 @@ import org.openkilda.rulemanager.action.SetFieldAction;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -128,8 +127,7 @@ public class SingleTableIngressYRuleGeneratorTest {
     public static final UUID SHARED_METER_UUID = UUID.fromString("dc8b54d3-3f25-4c5b-9d90-5f59d2836bc2");
 
 
-
-    @Before
+    @BeforeEach
     public void setup() {
         config = mock(RuleManagerConfig.class);
         when(config.getFlowMeterBurstCoefficient()).thenReturn(BURST_COEFFICIENT);
@@ -144,7 +142,7 @@ public class SingleTableIngressYRuleGeneratorTest {
         List<Action> expectedActions = newArrayList(
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -156,7 +154,7 @@ public class SingleTableIngressYRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -164,7 +162,7 @@ public class SingleTableIngressYRuleGeneratorTest {
         Flow flow = buildFlow(PATH, TRANSIT_VLAN_ID, 0);
         SingleTableIngressYRuleGenerator generator = buildGenerator(PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(TRANSIT_VLAN_ID, FEATURES);
-        assertTrue(transformActions.isEmpty());
+        Assertions.assertTrue(transformActions.isEmpty());
     }
 
     @Test
@@ -173,7 +171,7 @@ public class SingleTableIngressYRuleGeneratorTest {
         SingleTableIngressYRuleGenerator generator = buildGenerator(PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(OUTER_VLAN_ID_1, FEATURES);
         List<Action> expectedActions = newArrayList(new PopVlanAction(), buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -182,7 +180,7 @@ public class SingleTableIngressYRuleGeneratorTest {
         SingleTableIngressYRuleGenerator generator = buildGenerator(PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList(buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -193,7 +191,7 @@ public class SingleTableIngressYRuleGeneratorTest {
         List<Action> expectedActions = newArrayList(
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -202,7 +200,7 @@ public class SingleTableIngressYRuleGeneratorTest {
         SingleTableIngressYRuleGenerator generator = buildGenerator(ONE_SWITCH_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(OUTER_VLAN_ID_1, FEATURES);
         List<Action> expectedActions = newArrayList(new PopVlanAction());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -214,7 +212,7 @@ public class SingleTableIngressYRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -223,7 +221,7 @@ public class SingleTableIngressYRuleGeneratorTest {
         SingleTableIngressYRuleGenerator generator = buildGenerator(ONE_SWITCH_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList();
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -254,11 +252,11 @@ public class SingleTableIngressYRuleGeneratorTest {
         Flow flow = buildFlow(PATH, OUTER_VLAN_ID_1, 0);
         SingleTableIngressYRuleGenerator generator = buildGenerator(PATH, flow, VLAN_ENCAPSULATION);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
         MeterSpeakerData meterCommand = (MeterSpeakerData) commands.get(1);
-        assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
+        Assertions.assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
 
         Set<FieldMatch> expectedIngressMatch = Sets.newHashSet(
                 FieldMatch.builder().field(Field.IN_PORT).value(PORT_NUMBER_1).build(),
@@ -279,10 +277,10 @@ public class SingleTableIngressYRuleGeneratorTest {
         Flow flow = buildFlow(PATH, OUTER_VLAN_ID_1, 0);
         SingleTableIngressYRuleGenerator generator = buildGenerator(PATH, flow, VLAN_ENCAPSULATION, false);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
-        assertEquals(newArrayList(SHARED_METER_UUID), new ArrayList<>(ingressCommand.getDependsOn()));
+        Assertions.assertEquals(newArrayList(SHARED_METER_UUID), new ArrayList<>(ingressCommand.getDependsOn()));
 
         Set<FieldMatch> expectedIngressMatch = Sets.newHashSet(
                 FieldMatch.builder().field(Field.IN_PORT).value(PORT_NUMBER_1).build(),
@@ -312,10 +310,10 @@ public class SingleTableIngressYRuleGeneratorTest {
                 .build();
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
-        assertTrue(ingressCommand.getDependsOn().isEmpty());
+        Assertions.assertTrue(ingressCommand.getDependsOn().isEmpty());
 
         Set<FieldMatch> expectedIngressMatch = Sets.newHashSet(
                 FieldMatch.builder().field(Field.IN_PORT).value(PORT_NUMBER_1).build(),
@@ -333,30 +331,30 @@ public class SingleTableIngressYRuleGeneratorTest {
     private void assertIngressCommand(
             FlowSpeakerData command, int expectedPriority, Set<FieldMatch> expectedMatch,
             List<Action> expectedApplyActions, MeterId expectedMeter) {
-        assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
 
-        assertEquals(COOKIE, command.getCookie());
-        assertEquals(OfTable.INPUT, command.getTable());
-        assertEquals(expectedPriority, command.getPriority());
+        Assertions.assertEquals(COOKIE, command.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, command.getTable());
+        Assertions.assertEquals(expectedPriority, command.getPriority());
         assertEqualsMatch(expectedMatch, command.getMatch());
 
         Instructions expectedInstructions = Instructions.builder()
                 .applyActions(expectedApplyActions)
                 .goToMeter(expectedMeter)
                 .build();
-        assertEquals(expectedInstructions, command.getInstructions());
-        assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
+        Assertions.assertEquals(expectedInstructions, command.getInstructions());
+        Assertions.assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
     }
 
     private void assertMeterCommand(MeterSpeakerData command) {
-        assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
-        assertEquals(SHARED_METER_ID, command.getMeterId());
-        assertEquals(Sets.newHashSet(MeterFlag.BURST, MeterFlag.KBPS, MeterFlag.STATS), command.getFlags());
-        assertEquals(BANDWIDTH, command.getRate());
-        assertEquals((long) (BANDWIDTH * BURST_COEFFICIENT), command.getBurst());
-        assertTrue(command.getDependsOn().isEmpty());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(SHARED_METER_ID, command.getMeterId());
+        Assertions.assertEquals(Sets.newHashSet(MeterFlag.BURST, MeterFlag.KBPS, MeterFlag.STATS), command.getFlags());
+        Assertions.assertEquals(BANDWIDTH, command.getRate());
+        Assertions.assertEquals((long) (BANDWIDTH * BURST_COEFFICIENT), command.getBurst());
+        Assertions.assertTrue(command.getDependsOn().isEmpty());
 
     }
 

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/SingleTableServer42IngressRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/SingleTableServer42IngressRuleGeneratorTest.java
@@ -16,7 +16,6 @@
 package org.openkilda.rulemanager.factory.generator.flow;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.SwitchFeature.METERS;
@@ -67,8 +66,9 @@ import org.openkilda.rulemanager.action.noviflow.OpenFlowOxms;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -146,7 +146,7 @@ public class SingleTableServer42IngressRuleGeneratorTest {
 
     RuleManagerConfig config;
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = mock(RuleManagerConfig.class);
         when(config.getServer42FlowRttUdpPortOffset()).thenReturn(PORT_OFFSET);
@@ -164,7 +164,7 @@ public class SingleTableServer42IngressRuleGeneratorTest {
                 SetFieldAction.builder().field(Field.UDP_DST).value(SERVER_42_FLOW_RTT_FORWARD_UDP_PORT).build(),
                 COPY_FIELD_ACTION,
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -180,7 +180,7 @@ public class SingleTableServer42IngressRuleGeneratorTest {
                 COPY_FIELD_ACTION,
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -195,7 +195,7 @@ public class SingleTableServer42IngressRuleGeneratorTest {
                 SetFieldAction.builder().field(Field.UDP_DST).value(SERVER_42_FLOW_RTT_FORWARD_UDP_PORT).build(),
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -209,7 +209,7 @@ public class SingleTableServer42IngressRuleGeneratorTest {
                 SetFieldAction.builder().field(Field.UDP_SRC).value(SERVER_42_FLOW_RTT_FORWARD_UDP_PORT).build(),
                 SetFieldAction.builder().field(Field.UDP_DST).value(SERVER_42_FLOW_RTT_FORWARD_UDP_PORT).build(),
                 COPY_FIELD_ACTION);
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -218,7 +218,7 @@ public class SingleTableServer42IngressRuleGeneratorTest {
         SingleTableServer42IngressRuleGenerator generator = buildGenerator(PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(OUTER_VLAN_ID_1, FEATURES);
         List<Action> expectedActions = newArrayList(new PopVlanAction(), COPY_FIELD_ACTION, buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -228,7 +228,7 @@ public class SingleTableServer42IngressRuleGeneratorTest {
         List<Action> transformActions = generator.buildTransformActions(
                 OUTER_VLAN_ID_1, Sets.newHashSet(NOVIFLOW_PUSH_POP_VXLAN));
         List<Action> expectedActions = newArrayList(new PopVlanAction(), buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -237,7 +237,7 @@ public class SingleTableServer42IngressRuleGeneratorTest {
         SingleTableServer42IngressRuleGenerator generator = buildGenerator(PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList(COPY_FIELD_ACTION, buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -246,7 +246,7 @@ public class SingleTableServer42IngressRuleGeneratorTest {
                 .switchProperties(SWITCH_PROPERTIES)
                 .flowPath(ONE_SWITCH_PATH)
                 .build();
-        assertEquals(0, generator.generateCommands(SWITCH_1).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_1).size());
     }
 
     @Test
@@ -255,7 +255,7 @@ public class SingleTableServer42IngressRuleGeneratorTest {
                 .switchProperties(null)
                 .flowPath(PATH)
                 .build();
-        assertEquals(0, generator.generateCommands(SWITCH_1).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_1).size());
     }
 
     @Test
@@ -264,7 +264,7 @@ public class SingleTableServer42IngressRuleGeneratorTest {
                 .switchProperties(SwitchProperties.builder().multiTable(true).server42FlowRtt(true).build())
                 .flowPath(PATH)
                 .build();
-        assertEquals(0, generator.generateCommands(SWITCH_1).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_1).size());
     }
 
     @Test
@@ -273,7 +273,7 @@ public class SingleTableServer42IngressRuleGeneratorTest {
                 .switchProperties(SwitchProperties.builder().multiTable(false).server42FlowRtt(false).build())
                 .flowPath(PATH)
                 .build();
-        assertEquals(0, generator.generateCommands(SWITCH_1).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_1).size());
     }
 
     @Test
@@ -281,7 +281,7 @@ public class SingleTableServer42IngressRuleGeneratorTest {
         Flow flow = buildFlow(PATH, 0);
         SingleTableServer42IngressRuleGenerator generator = buildGenerator(PATH, flow, VLAN_ENCAPSULATION);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
 
@@ -309,7 +309,7 @@ public class SingleTableServer42IngressRuleGeneratorTest {
         Flow flow = buildFlow(PATH, OUTER_VLAN_ID_1);
         SingleTableServer42IngressRuleGenerator generator = buildGenerator(PATH, flow, VXLAN_ENCAPSULATION);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
 
@@ -331,19 +331,19 @@ public class SingleTableServer42IngressRuleGeneratorTest {
     private void assertIngressCommand(
             FlowSpeakerData command, int expectedPriority, Set<FieldMatch> expectedMatch,
             List<Action> expectedApplyActions) {
-        assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
 
-        assertEquals(SERVER_42_INGRESS_COOKIE, command.getCookie());
-        assertEquals(OfTable.INPUT, command.getTable());
-        assertEquals(expectedPriority, command.getPriority());
+        Assertions.assertEquals(SERVER_42_INGRESS_COOKIE, command.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, command.getTable());
+        Assertions.assertEquals(expectedPriority, command.getPriority());
         assertEqualsMatch(expectedMatch, command.getMatch());
 
         Instructions expectedInstructions = Instructions.builder()
                 .applyActions(expectedApplyActions)
                 .build();
-        assertEquals(expectedInstructions, command.getInstructions());
-        assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
+        Assertions.assertEquals(expectedInstructions, command.getInstructions());
+        Assertions.assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
     }
 
     private SingleTableServer42IngressRuleGenerator buildGenerator(

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/TransitRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/TransitRuleGeneratorTest.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.flow;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.model.SwitchFeature.NOVIFLOW_PUSH_POP_VXLAN;
 import static org.openkilda.model.SwitchFeature.RESET_COUNTS_FLAG;
 import static org.openkilda.rulemanager.Utils.assertEqualsMatch;
@@ -45,7 +43,8 @@ import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
@@ -132,16 +131,16 @@ public class TransitRuleGeneratorTest {
 
     private void assertTransitCommands(List<SpeakerData> commands, OfTable table,
                                        FlowTransitEncapsulation encapsulation) {
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(SWITCH_1.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(COOKIE, flowCommandData.getCookie());
-        assertEquals(table, flowCommandData.getTable());
-        assertEquals(Priority.FLOW_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(COOKIE, flowCommandData.getCookie());
+        Assertions.assertEquals(table, flowCommandData.getTable());
+        Assertions.assertEquals(Priority.FLOW_PRIORITY, flowCommandData.getPriority());
 
 
         Set<FieldMatch> expectedMatch;
@@ -155,8 +154,8 @@ public class TransitRuleGeneratorTest {
         Instructions expectedInstructions = Instructions.builder()
                 .applyActions(Lists.newArrayList(new PortOutAction(new PortNumber(PORT_NUMBER_2))))
                 .build();
-        assertEquals(expectedInstructions, flowCommandData.getInstructions());
-        assertTrue(flowCommandData.getFlags().isEmpty());
+        Assertions.assertEquals(expectedInstructions, flowCommandData.getInstructions());
+        Assertions.assertTrue(flowCommandData.getFlags().isEmpty());
     }
 
     private Set<FieldMatch> buildExpectedVlanMatch(int port, int vlanId) {
@@ -191,6 +190,6 @@ public class TransitRuleGeneratorTest {
                 .multiTable(true)
                 .encapsulation(VLAN_ENCAPSULATION)
                 .build();
-        assertEquals(0, generator.generateCommands(SWITCH_1).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_1).size());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/TransitYRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/TransitYRuleGeneratorTest.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.flow;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.SwitchFeature.METERS;
@@ -52,8 +50,9 @@ import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
@@ -90,7 +89,7 @@ public class TransitYRuleGeneratorTest {
 
     RuleManagerConfig config;
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = mock(RuleManagerConfig.class);
         when(config.getFlowMeterBurstCoefficient()).thenReturn(BURST_COEFFICIENT);
@@ -212,20 +211,20 @@ public class TransitYRuleGeneratorTest {
 
     private void assertTransitCommand(List<SpeakerData> commands, OfTable table,
                                       FlowTransitEncapsulation encapsulation, MeterId sharedMeterId) {
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(SWITCH_1.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), flowCommandData.getOfVersion().toString());
 
         if (sharedMeterId != null) {
-            assertTrue(flowCommandData.getDependsOn().contains(SHARED_METER_UUID));
+            Assertions.assertTrue(flowCommandData.getDependsOn().contains(SHARED_METER_UUID));
         } else {
-            assertTrue(flowCommandData.getDependsOn().isEmpty());
+            Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
         }
 
-        assertEquals(COOKIE, flowCommandData.getCookie());
-        assertEquals(table, flowCommandData.getTable());
-        assertEquals(Priority.Y_FLOW_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(COOKIE, flowCommandData.getCookie());
+        Assertions.assertEquals(table, flowCommandData.getTable());
+        Assertions.assertEquals(Priority.Y_FLOW_PRIORITY, flowCommandData.getPriority());
 
 
         Set<FieldMatch> expectedMatch;
@@ -240,23 +239,23 @@ public class TransitYRuleGeneratorTest {
                 .applyActions(Lists.newArrayList(new PortOutAction(new PortNumber(PORT_NUMBER_2))))
                 .goToMeter(sharedMeterId)
                 .build();
-        assertEquals(expectedInstructions, flowCommandData.getInstructions());
-        assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), flowCommandData.getFlags());
+        Assertions.assertEquals(expectedInstructions, flowCommandData.getInstructions());
+        Assertions.assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), flowCommandData.getFlags());
     }
 
     private void assertTransitCommands(List<SpeakerData> commands, OfTable table,
                                        FlowTransitEncapsulation encapsulation) {
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         MeterSpeakerData meterCommandData = getCommand(MeterSpeakerData.class, commands);
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(SWITCH_1.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
 
-        assertEquals(COOKIE, flowCommandData.getCookie());
-        assertEquals(table, flowCommandData.getTable());
-        assertEquals(Priority.Y_FLOW_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(COOKIE, flowCommandData.getCookie());
+        Assertions.assertEquals(table, flowCommandData.getTable());
+        Assertions.assertEquals(Priority.Y_FLOW_PRIORITY, flowCommandData.getPriority());
 
 
         Set<FieldMatch> expectedMatch;
@@ -271,8 +270,8 @@ public class TransitYRuleGeneratorTest {
                 .applyActions(Lists.newArrayList(new PortOutAction(new PortNumber(PORT_NUMBER_2))))
                 .goToMeter(SHARED_METER_ID)
                 .build();
-        assertEquals(expectedInstructions, flowCommandData.getInstructions());
-        assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), flowCommandData.getFlags());
+        Assertions.assertEquals(expectedInstructions, flowCommandData.getInstructions());
+        Assertions.assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), flowCommandData.getFlags());
     }
 
     private Set<FieldMatch> buildExpectedVlanMatch(int port, int vlanId) {
@@ -309,6 +308,6 @@ public class TransitYRuleGeneratorTest {
                 .config(config)
                 .externalMeterCommandUuid(UUID.randomUUID())
                 .build();
-        assertEquals(0, generator.generateCommands(SWITCH_1).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_1).size());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/haflow/EgressHaRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/haflow/EgressHaRuleGeneratorTest.java
@@ -15,9 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.flow.haflow;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.rulemanager.Utils.assertEqualsMatch;
 import static org.openkilda.rulemanager.Utils.getCommand;
 
@@ -51,7 +48,8 @@ import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -205,7 +203,7 @@ public class EgressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 .build();
 
         EgressHaRuleGenerator generator = EgressHaRuleGenerator.builder().subPath(subPath).build();
-        assertEquals(0, generator.generateCommands(SWITCH_1).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_1).size());
     }
 
     @Test
@@ -218,7 +216,7 @@ public class EgressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 .build();
 
         EgressHaRuleGenerator generator = EgressHaRuleGenerator.builder().subPath(path).build();
-        assertEquals(0, generator.generateCommands(SWITCH_2).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_2).size());
     }
 
     @Test
@@ -229,21 +227,21 @@ public class EgressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 METER_COMMAND_UUID, true);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         MeterSpeakerData meterCommand = getCommand(MeterSpeakerData.class, commands);
 
-        assertEquals(METER_ID, flowCommand.getInstructions().getGoToMeter());
-        assertEquals(Lists.newArrayList(METER_COMMAND_UUID), flowCommand.getDependsOn());
+        Assertions.assertEquals(METER_ID, flowCommand.getInstructions().getGoToMeter());
+        Assertions.assertEquals(Lists.newArrayList(METER_COMMAND_UUID), flowCommand.getDependsOn());
 
-        assertEquals(METER_ID, meterCommand.getMeterId());
-        assertEquals(METER_COMMAND_UUID, meterCommand.getUuid());
-        assertEquals(MeteredRuleGenerator.FLOW_METER_STATS, meterCommand.getFlags());
-        assertEquals(BANDWIDTH, meterCommand.getRate());
-        assertEquals(Math.round(BANDWIDTH * BURST_COEFFICIENT), meterCommand.getBurst());
-        assertEquals(0, meterCommand.getDependsOn().size());
-        assertEquals(SWITCH_2.getSwitchId(), meterCommand.getSwitchId());
-        assertEquals(SWITCH_2.getOfVersion(), meterCommand.getOfVersion().toString());
+        Assertions.assertEquals(METER_ID, meterCommand.getMeterId());
+        Assertions.assertEquals(METER_COMMAND_UUID, meterCommand.getUuid());
+        Assertions.assertEquals(MeteredRuleGenerator.FLOW_METER_STATS, meterCommand.getFlags());
+        Assertions.assertEquals(BANDWIDTH, meterCommand.getRate());
+        Assertions.assertEquals(Math.round(BANDWIDTH * BURST_COEFFICIENT), meterCommand.getBurst());
+        Assertions.assertEquals(0, meterCommand.getDependsOn().size());
+        Assertions.assertEquals(SWITCH_2.getSwitchId(), meterCommand.getSwitchId());
+        Assertions.assertEquals(SWITCH_2.getOfVersion(), meterCommand.getOfVersion().toString());
     }
 
     @Test
@@ -254,11 +252,11 @@ public class EgressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 METER_COMMAND_UUID, false);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
 
-        assertEquals(METER_ID, flowCommand.getInstructions().getGoToMeter());
-        assertEquals(Lists.newArrayList(METER_COMMAND_UUID), flowCommand.getDependsOn());
+        Assertions.assertEquals(METER_ID, flowCommand.getInstructions().getGoToMeter());
+        Assertions.assertEquals(Lists.newArrayList(METER_COMMAND_UUID), flowCommand.getDependsOn());
     }
 
     @Test
@@ -269,10 +267,10 @@ public class EgressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 METER_COMMAND_UUID, true);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
-        assertNull(flowCommand.getInstructions().getGoToMeter());
-        assertTrue(flowCommand.getDependsOn().isEmpty());
+        Assertions.assertNull(flowCommand.getInstructions().getGoToMeter());
+        Assertions.assertTrue(flowCommand.getDependsOn().isEmpty());
     }
 
     @Test
@@ -283,25 +281,25 @@ public class EgressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 METER_COMMAND_UUID, true);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
-        assertNull(flowCommand.getInstructions().getGoToMeter());
-        assertTrue(flowCommand.getDependsOn().isEmpty());
+        Assertions.assertNull(flowCommand.getInstructions().getGoToMeter());
+        Assertions.assertTrue(flowCommand.getDependsOn().isEmpty());
     }
 
     private void assertEgressCommands(
             List<SpeakerData> commands, FlowTransitEncapsulation encapsulation, Switch expectedSwitch,
             List<Action> expectedApplyActions, FlowSegmentCookie expectedCookie) {
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(expectedSwitch.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(expectedSwitch.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(expectedSwitch.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(expectedSwitch.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(expectedCookie, flowCommandData.getCookie());
-        assertEquals(OfTable.EGRESS, flowCommandData.getTable());
-        assertEquals(Priority.FLOW_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(expectedCookie, flowCommandData.getCookie());
+        Assertions.assertEquals(OfTable.EGRESS, flowCommandData.getTable());
+        Assertions.assertEquals(Priority.FLOW_PRIORITY, flowCommandData.getPriority());
 
         Set<FieldMatch> expectedMatch;
         if (encapsulation.getType().equals(FlowEncapsulationType.TRANSIT_VLAN)) {
@@ -314,8 +312,8 @@ public class EgressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         Instructions expectedInstructions = Instructions.builder()
                 .applyActions(expectedApplyActions)
                 .build();
-        assertEquals(expectedInstructions, flowCommandData.getInstructions());
-        assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), flowCommandData.getFlags());
+        Assertions.assertEquals(expectedInstructions, flowCommandData.getInstructions());
+        Assertions.assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), flowCommandData.getFlags());
     }
 
     private EgressHaRuleGenerator buildMeterlessGenerator(

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/haflow/HaRuleGeneratorBaseTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/haflow/HaRuleGeneratorBaseTest.java
@@ -47,7 +47,7 @@ import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -113,7 +113,7 @@ public class HaRuleGeneratorBaseTest {
 
     RuleManagerConfig config;
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = mock(RuleManagerConfig.class);
         when(config.getFlowMeterBurstCoefficient()).thenReturn(BURST_COEFFICIENT);

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/haflow/IngressHaRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/haflow/IngressHaRuleGeneratorTest.java
@@ -16,9 +16,6 @@
 package org.openkilda.rulemanager.factory.generator.flow.haflow;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.model.cookie.CookieBase.CookieType.MULTI_TABLE_INGRESS_RULES;
 import static org.openkilda.rulemanager.Utils.assertEqualsMatch;
 import static org.openkilda.rulemanager.Utils.getCommand;
@@ -61,7 +58,8 @@ import org.openkilda.rulemanager.utils.RoutingMetadata;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -82,7 +80,7 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         List<Action> transformActions = generator.buildTransformActions(INNER_VLAN_ID_1, FEATURES);
         List<Action> expectedActions = newArrayList(
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -93,7 +91,7 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         List<Action> expectedActions = newArrayList(
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -104,7 +102,7 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         List<Action> expectedActions = newArrayList(
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(TRANSIT_VLAN_ID).build());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -112,7 +110,7 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         HaFlow haFlow = buildHaFlow(FORWARD_PATH, OUTER_VLAN_ID_1, TRANSIT_VLAN_ID);
         IngressHaRuleGenerator generator = buildMeterlessGenerator(FORWARD_PATH, haFlow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(TRANSIT_VLAN_ID, FEATURES);
-        assertTrue(transformActions.isEmpty());
+        Assertions.assertTrue(transformActions.isEmpty());
     }
 
     @Test
@@ -121,7 +119,7 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         IngressHaRuleGenerator generator = buildMeterlessGenerator(FORWARD_PATH, haFlow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(INNER_VLAN_ID_1, FEATURES);
         List<Action> expectedActions = newArrayList(new PopVlanAction(), buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -130,7 +128,7 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         IngressHaRuleGenerator generator = buildMeterlessGenerator(FORWARD_PATH, haFlow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList(buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -139,15 +137,17 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         IngressHaRuleGenerator generator = buildMeterlessGenerator(FORWARD_PATH, haFlow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList(buildPushVxlan());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void unableToBuildIngressRulesForForwardOneSwitchPathTest() {
-        FlowPath oneSwitchForward = buildSubPath(SWITCH_1, SWITCH_1, FORWARD_COOKIE, HA_SUB_FLOW);
-        HaFlow haFlow = buildHaFlow(SWITCH_1, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
-        IngressHaRuleGenerator generator = buildMeterlessGenerator(oneSwitchForward, haFlow, VLAN_ENCAPSULATION);
-        generator.generateCommands(SWITCH_1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            FlowPath oneSwitchForward = buildSubPath(SWITCH_1, SWITCH_1, FORWARD_COOKIE, HA_SUB_FLOW);
+            HaFlow haFlow = buildHaFlow(SWITCH_1, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
+            IngressHaRuleGenerator generator = buildMeterlessGenerator(oneSwitchForward, haFlow, VLAN_ENCAPSULATION);
+            generator.generateCommands(SWITCH_1);
+        });
     }
 
     @Test
@@ -161,7 +161,7 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_1).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -173,7 +173,7 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         List<Action> expectedActions = newArrayList(
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_1).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -183,7 +183,7 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         IngressHaRuleGenerator generator = buildMeterlessGenerator(oneSwitchReverse, haFlow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(INNER_VLAN_ID_1, FEATURES);
         List<Action> expectedActions = newArrayList(new PopVlanAction());
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -199,7 +199,7 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_1).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -213,7 +213,7 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_1).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -224,7 +224,7 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         IngressHaRuleGenerator generator = buildMeterlessGenerator(oneSwitchReverse, haFlow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList();
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -240,7 +240,7 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_1).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -254,7 +254,7 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_1).build()
         );
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -265,7 +265,7 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         IngressHaRuleGenerator generator = buildMeterlessGenerator(oneSwitchReverse, haFlow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildTransformActions(0, FEATURES);
         List<Action> expectedActions = newArrayList();
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -275,7 +275,7 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 haflow.getHaSubFlows().iterator().next());
         IngressHaRuleGenerator generator = buildMeterlessGenerator(oneSwitchReverse, haflow, VLAN_ENCAPSULATION);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
         FlowSpeakerData inputCustomerCommand = (FlowSpeakerData) commands.get(1);
@@ -301,13 +301,13 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         IngressHaRuleGenerator generator = buildGenerator(subPath, haFlow, VLAN_ENCAPSULATION, true,
                 METER_ID, null, true, new HashSet<>());
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(4, commands.size());
+        Assertions.assertEquals(4, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
         FlowSpeakerData preIngressCommand = (FlowSpeakerData) commands.get(1);
         FlowSpeakerData inputCustomerCommand = (FlowSpeakerData) commands.get(2);
         MeterSpeakerData meterCommand = (MeterSpeakerData) commands.get(3);
-        assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
+        Assertions.assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
 
         Set<FieldMatch> expectedPreIngressMatch = Sets.newHashSet(
                 FieldMatch.builder().field(Field.IN_PORT).value(PORT_NUMBER_1).build(),
@@ -318,7 +318,7 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         RoutingMetadata preIngressMetadata = RoutingMetadata.builder().outerVlanId(OUTER_VLAN_ID_1)
                 .build(SWITCH_1.getFeatures());
         assertPreIngressCommand(preIngressCommand, SWITCH_2, preIngressCookie, Priority.FLOW_PRIORITY,
-                expectedPreIngressMatch,  newArrayList(new PopVlanAction()), mapMetadata(preIngressMetadata));
+                expectedPreIngressMatch, newArrayList(new PopVlanAction()), mapMetadata(preIngressMetadata));
 
         assertInputCustomerCommand(inputCustomerCommand, SWITCH_2,
                 new PortColourCookie(MULTI_TABLE_INGRESS_RULES, PORT_NUMBER_1),
@@ -355,7 +355,7 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         IngressHaRuleGenerator generator = buildGenerator(subPath, haFlow, VLAN_ENCAPSULATION, false, null, null,
                 false, overlapping);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
 
@@ -388,12 +388,12 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         IngressHaRuleGenerator generator = buildGenerator(subPath, haFlow, VLAN_ENCAPSULATION, true, METER_ID, null,
                 true, overlapping);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(3, commands.size());
+        Assertions.assertEquals(3, commands.size());
 
         FlowSpeakerData ingressCommand = (FlowSpeakerData) commands.get(0);
         FlowSpeakerData preIngressCommand = (FlowSpeakerData) commands.get(1);
         MeterSpeakerData meterCommand = (MeterSpeakerData) commands.get(2);
-        assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
+        Assertions.assertEquals(newArrayList(meterCommand.getUuid()), new ArrayList<>(ingressCommand.getDependsOn()));
 
         RoutingMetadata ingressMetadata = RoutingMetadata.builder().outerVlanId(OUTER_VLAN_ID_1)
                 .build(SWITCH_2.getFeatures());
@@ -432,12 +432,12 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 METER_COMMAND_UUID, true, Sets.newHashSet(FlowSideAdapter.makeIngressAdapter(haFlow, subPath)));
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         MeterSpeakerData meterCommand = getCommand(MeterSpeakerData.class, commands);
 
-        assertEquals(METER_ID, flowCommand.getInstructions().getGoToMeter());
-        assertEquals(Lists.newArrayList(METER_COMMAND_UUID), flowCommand.getDependsOn());
+        Assertions.assertEquals(METER_ID, flowCommand.getInstructions().getGoToMeter());
+        Assertions.assertEquals(newArrayList(METER_COMMAND_UUID), flowCommand.getDependsOn());
         assertMeterCommand(SWITCH_2, METER_COMMAND_UUID, meterCommand);
     }
 
@@ -449,11 +449,11 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 METER_COMMAND_UUID, false, Sets.newHashSet(FlowSideAdapter.makeIngressAdapter(haFlow, subPath)));
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
 
-        assertEquals(METER_ID, flowCommand.getInstructions().getGoToMeter());
-        assertEquals(Lists.newArrayList(METER_COMMAND_UUID), flowCommand.getDependsOn());
+        Assertions.assertEquals(METER_ID, flowCommand.getInstructions().getGoToMeter());
+        Assertions.assertEquals(newArrayList(METER_COMMAND_UUID), flowCommand.getDependsOn());
     }
 
     @Test
@@ -464,10 +464,10 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 METER_COMMAND_UUID, true, Sets.newHashSet(FlowSideAdapter.makeIngressAdapter(haFlow, subPath)));
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
-        assertNull(flowCommand.getInstructions().getGoToMeter());
-        assertTrue(flowCommand.getDependsOn().isEmpty());
+        Assertions.assertNull(flowCommand.getInstructions().getGoToMeter());
+        Assertions.assertTrue(flowCommand.getDependsOn().isEmpty());
     }
 
     @Test
@@ -477,22 +477,22 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 METER_COMMAND_UUID, true, Sets.newHashSet(FlowSideAdapter.makeIngressAdapter(haFlow, FORWARD_PATH)));
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
-        assertNull(flowCommand.getInstructions().getGoToMeter());
-        assertTrue(flowCommand.getDependsOn().isEmpty());
+        Assertions.assertNull(flowCommand.getInstructions().getGoToMeter());
+        Assertions.assertTrue(flowCommand.getDependsOn().isEmpty());
     }
 
     private void assertIngressCommand(
-            FlowSpeakerData command, Switch expectedSwitch, FlowSegmentCookie expectedCookie,  int expectedPriority,
+            FlowSpeakerData command, Switch expectedSwitch, FlowSegmentCookie expectedCookie, int expectedPriority,
             Set<FieldMatch> expectedMatch, List<Action> expectedApplyActions, MeterId expectedMeter,
             UUID expectedMeterUuid) {
-        assertEquals(expectedSwitch.getSwitchId(), command.getSwitchId());
-        assertEquals(expectedSwitch.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(expectedSwitch.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(expectedSwitch.getOfVersion(), command.getOfVersion().toString());
 
-        assertEquals(expectedCookie, command.getCookie());
-        assertEquals(OfTable.INGRESS, command.getTable());
-        assertEquals(expectedPriority, command.getPriority());
+        Assertions.assertEquals(expectedCookie, command.getCookie());
+        Assertions.assertEquals(OfTable.INGRESS, command.getTable());
+        Assertions.assertEquals(expectedPriority, command.getPriority());
 
         assertEqualsMatch(expectedMatch, command.getMatch());
 
@@ -502,25 +502,25 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 .goToMeter(expectedMeter)
                 .writeMetadata(null)
                 .build();
-        assertEquals(expectedInstructions, command.getInstructions());
-        assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
+        Assertions.assertEquals(expectedInstructions, command.getInstructions());
+        Assertions.assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
 
         List<UUID> expectedDependencies = new ArrayList<>();
         if (expectedMeterUuid != null) {
             expectedDependencies.add(expectedMeterUuid);
         }
-        assertEquals(expectedDependencies, command.getDependsOn());
+        Assertions.assertEquals(expectedDependencies, command.getDependsOn());
     }
 
     private void assertPreIngressCommand(
             FlowSpeakerData command, Switch expectedSwitch, CookieBase cookie, int expectedPriority,
             Set<FieldMatch> expectedMatch, List<Action> expectedApplyActions, OfMetadata expectedMetadata) {
-        assertEquals(expectedSwitch.getSwitchId(), command.getSwitchId());
-        assertEquals(expectedSwitch.getOfVersion(), command.getOfVersion().toString());
-        assertEquals(cookie, command.getCookie());
-        assertEquals(OfTable.PRE_INGRESS, command.getTable());
-        assertEquals(expectedPriority, command.getPriority());
-        assertTrue(command.getDependsOn().isEmpty());
+        Assertions.assertEquals(expectedSwitch.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(expectedSwitch.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(cookie, command.getCookie());
+        Assertions.assertEquals(OfTable.PRE_INGRESS, command.getTable());
+        Assertions.assertEquals(expectedPriority, command.getPriority());
+        Assertions.assertTrue(command.getDependsOn().isEmpty());
 
         assertEqualsMatch(expectedMatch, command.getMatch());
 
@@ -529,41 +529,41 @@ public class IngressHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 .applyActions(expectedApplyActions)
                 .goToTable(OfTable.INGRESS)
                 .build();
-        assertEquals(expectedInstructions, command.getInstructions());
-        assertTrue(command.getFlags().isEmpty());
+        Assertions.assertEquals(expectedInstructions, command.getInstructions());
+        Assertions.assertTrue(command.getFlags().isEmpty());
     }
 
     private void assertInputCustomerCommand(
             FlowSpeakerData command, Switch expectedSwitch, CookieBase cookie, Set<FieldMatch> expectedMatch) {
-        assertEquals(expectedSwitch.getSwitchId(), command.getSwitchId());
-        assertEquals(expectedSwitch.getOfVersion(), command.getOfVersion().toString());
-        assertEquals(cookie, command.getCookie());
-        assertEquals(OfTable.INPUT, command.getTable());
-        assertEquals(Priority.INGRESS_CUSTOMER_PORT_RULE_PRIORITY_MULTITABLE, command.getPriority());
-        assertTrue(command.getDependsOn().isEmpty());
+        Assertions.assertEquals(expectedSwitch.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(expectedSwitch.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(cookie, command.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, command.getTable());
+        Assertions.assertEquals(Priority.INGRESS_CUSTOMER_PORT_RULE_PRIORITY_MULTITABLE, command.getPriority());
+        Assertions.assertTrue(command.getDependsOn().isEmpty());
 
         assertEqualsMatch(expectedMatch, command.getMatch());
 
         Instructions expectedInstructions = Instructions.builder()
                 .goToTable(OfTable.PRE_INGRESS)
                 .build();
-        assertEquals(expectedInstructions, command.getInstructions());
-        assertTrue(command.getFlags().isEmpty());
+        Assertions.assertEquals(expectedInstructions, command.getInstructions());
+        Assertions.assertTrue(command.getFlags().isEmpty());
     }
 
     private void assertMeterCommand(Switch expectedSwitch, UUID expectedUuid, MeterSpeakerData command) {
         assertMeterCommand(expectedSwitch, command);
-        assertEquals(expectedUuid, command.getUuid());
+        Assertions.assertEquals(expectedUuid, command.getUuid());
     }
 
     private void assertMeterCommand(Switch expectedSwitch, MeterSpeakerData command) {
-        assertEquals(expectedSwitch.getSwitchId(), command.getSwitchId());
-        assertEquals(expectedSwitch.getOfVersion(), command.getOfVersion().toString());
-        assertEquals(METER_ID, command.getMeterId());
-        assertEquals(Sets.newHashSet(MeterFlag.BURST, MeterFlag.KBPS, MeterFlag.STATS), command.getFlags());
-        assertEquals(BANDWIDTH, command.getRate());
-        assertEquals(Math.round(BANDWIDTH * BURST_COEFFICIENT), command.getBurst());
-        assertTrue(command.getDependsOn().isEmpty());
+        Assertions.assertEquals(expectedSwitch.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(expectedSwitch.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(METER_ID, command.getMeterId());
+        Assertions.assertEquals(Sets.newHashSet(MeterFlag.BURST, MeterFlag.KBPS, MeterFlag.STATS), command.getFlags());
+        Assertions.assertEquals(BANDWIDTH, command.getRate());
+        Assertions.assertEquals(Math.round(BANDWIDTH * BURST_COEFFICIENT), command.getBurst());
+        Assertions.assertTrue(command.getDependsOn().isEmpty());
 
     }
 

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/haflow/TransitHaRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/haflow/TransitHaRuleGeneratorTest.java
@@ -15,9 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.flow.haflow;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.rulemanager.Utils.assertEqualsMatch;
 import static org.openkilda.rulemanager.Utils.getCommand;
 
@@ -40,7 +37,8 @@ import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
@@ -66,16 +64,16 @@ public class TransitHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
     private void assertTransitCommands(
             List<SpeakerData> commands, FlowTransitEncapsulation expectedEncapsulation,
             FlowSegmentCookie expectedCookie) {
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(SWITCH_1.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(expectedCookie, flowCommandData.getCookie());
-        assertEquals(OfTable.TRANSIT, flowCommandData.getTable());
-        assertEquals(Priority.FLOW_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(expectedCookie, flowCommandData.getCookie());
+        Assertions.assertEquals(OfTable.TRANSIT, flowCommandData.getTable());
+        Assertions.assertEquals(Priority.FLOW_PRIORITY, flowCommandData.getPriority());
 
         Set<FieldMatch> expectedMatch;
         if (expectedEncapsulation.getType().equals(FlowEncapsulationType.TRANSIT_VLAN)) {
@@ -88,8 +86,8 @@ public class TransitHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         Instructions expectedInstructions = Instructions.builder()
                 .applyActions(Lists.newArrayList(new PortOutAction(new PortNumber(PORT_NUMBER_2))))
                 .build();
-        assertEquals(expectedInstructions, flowCommandData.getInstructions());
-        assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), flowCommandData.getFlags());
+        Assertions.assertEquals(expectedInstructions, flowCommandData.getInstructions());
+        Assertions.assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), flowCommandData.getFlags());
     }
 
     @Test
@@ -107,7 +105,7 @@ public class TransitHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 .outPort(PORT_NUMBER_2)
                 .encapsulation(VLAN_ENCAPSULATION)
                 .build();
-        assertEquals(0, generator.generateCommands(SWITCH_1).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_1).size());
     }
 
     @Test
@@ -116,21 +114,21 @@ public class TransitHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 METER_COMMAND_UUID, true);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         MeterSpeakerData meterCommand = getCommand(MeterSpeakerData.class, commands);
 
-        assertEquals(METER_ID, flowCommand.getInstructions().getGoToMeter());
-        assertEquals(Lists.newArrayList(METER_COMMAND_UUID), flowCommand.getDependsOn());
+        Assertions.assertEquals(METER_ID, flowCommand.getInstructions().getGoToMeter());
+        Assertions.assertEquals(Lists.newArrayList(METER_COMMAND_UUID), flowCommand.getDependsOn());
 
-        assertEquals(METER_ID, meterCommand.getMeterId());
-        assertEquals(METER_COMMAND_UUID, meterCommand.getUuid());
-        assertEquals(MeteredRuleGenerator.FLOW_METER_STATS, meterCommand.getFlags());
-        assertEquals(BANDWIDTH, meterCommand.getRate());
-        assertEquals(Math.round(BANDWIDTH * BURST_COEFFICIENT), meterCommand.getBurst());
-        assertEquals(0, meterCommand.getDependsOn().size());
-        assertEquals(SWITCH_2.getSwitchId(), meterCommand.getSwitchId());
-        assertEquals(SWITCH_2.getOfVersion(), meterCommand.getOfVersion().toString());
+        Assertions.assertEquals(METER_ID, meterCommand.getMeterId());
+        Assertions.assertEquals(METER_COMMAND_UUID, meterCommand.getUuid());
+        Assertions.assertEquals(MeteredRuleGenerator.FLOW_METER_STATS, meterCommand.getFlags());
+        Assertions.assertEquals(BANDWIDTH, meterCommand.getRate());
+        Assertions.assertEquals(Math.round(BANDWIDTH * BURST_COEFFICIENT), meterCommand.getBurst());
+        Assertions.assertEquals(0, meterCommand.getDependsOn().size());
+        Assertions.assertEquals(SWITCH_2.getSwitchId(), meterCommand.getSwitchId());
+        Assertions.assertEquals(SWITCH_2.getOfVersion(), meterCommand.getOfVersion().toString());
     }
 
     @Test
@@ -139,11 +137,11 @@ public class TransitHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
                 VLAN_ENCAPSULATION, true, METER_ID, METER_COMMAND_UUID, false);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
 
-        assertEquals(METER_ID, flowCommand.getInstructions().getGoToMeter());
-        assertEquals(Lists.newArrayList(METER_COMMAND_UUID), flowCommand.getDependsOn());
+        Assertions.assertEquals(METER_ID, flowCommand.getInstructions().getGoToMeter());
+        Assertions.assertEquals(Lists.newArrayList(METER_COMMAND_UUID), flowCommand.getDependsOn());
     }
 
     @Test
@@ -151,10 +149,10 @@ public class TransitHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         TransitHaRuleGenerator generator = buildGenerator(VLAN_ENCAPSULATION, true, null, METER_COMMAND_UUID, true);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
-        assertNull(flowCommand.getInstructions().getGoToMeter());
-        assertTrue(flowCommand.getDependsOn().isEmpty());
+        Assertions.assertNull(flowCommand.getInstructions().getGoToMeter());
+        Assertions.assertTrue(flowCommand.getDependsOn().isEmpty());
     }
 
     @Test
@@ -162,10 +160,10 @@ public class TransitHaRuleGeneratorTest extends HaRuleGeneratorBaseTest {
         TransitHaRuleGenerator generator = buildGenerator(VLAN_ENCAPSULATION, true, METER_ID, METER_COMMAND_UUID, true);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
-        assertNull(flowCommand.getInstructions().getGoToMeter());
-        assertTrue(flowCommand.getDependsOn().isEmpty());
+        Assertions.assertNull(flowCommand.getInstructions().getGoToMeter());
+        Assertions.assertTrue(flowCommand.getDependsOn().isEmpty());
     }
 
     private TransitHaRuleGenerator buildMeterlessGenerator(

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/haflow/YPointForwardEgressHaRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/haflow/YPointForwardEgressHaRuleGeneratorTest.java
@@ -16,9 +16,7 @@
 package org.openkilda.rulemanager.factory.generator.flow.haflow;
 
 import static com.google.common.collect.Sets.newHashSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openkilda.rulemanager.Utils.assertEqualsMatch;
 import static org.openkilda.rulemanager.Utils.getCommand;
 
@@ -57,7 +55,8 @@ import org.openkilda.rulemanager.group.WatchPort;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -78,7 +77,7 @@ public class YPointForwardEgressHaRuleGeneratorTest extends HaRuleGeneratorBaseT
                 OUTER_VLAN_ID_1, INNER_VLAN_ID_1, OUTER_VLAN_ID_2, INNER_VLAN_ID_1);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -104,7 +103,7 @@ public class YPointForwardEgressHaRuleGeneratorTest extends HaRuleGeneratorBaseT
                 OUTER_VLAN_ID_1, 0, OUTER_VLAN_ID_2, INNER_VLAN_ID_1);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -129,7 +128,7 @@ public class YPointForwardEgressHaRuleGeneratorTest extends HaRuleGeneratorBaseT
                 0, 0, OUTER_VLAN_ID_2, INNER_VLAN_ID_1);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -154,7 +153,7 @@ public class YPointForwardEgressHaRuleGeneratorTest extends HaRuleGeneratorBaseT
                 OUTER_VLAN_ID_1, 0, OUTER_VLAN_ID_2, 0);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -176,7 +175,7 @@ public class YPointForwardEgressHaRuleGeneratorTest extends HaRuleGeneratorBaseT
                 OUTER_VLAN_ID_1, 0, 0, 0);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -197,7 +196,7 @@ public class YPointForwardEgressHaRuleGeneratorTest extends HaRuleGeneratorBaseT
         YPointForwardEgressHaRuleGenerator generator = buildGenerator(VLAN_ENCAPSULATION, 0, 0, 0, 0);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -219,7 +218,7 @@ public class YPointForwardEgressHaRuleGeneratorTest extends HaRuleGeneratorBaseT
                 OUTER_VLAN_ID_1, INNER_VLAN_ID_1, OUTER_VLAN_ID_2, INNER_VLAN_ID_1);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -247,7 +246,7 @@ public class YPointForwardEgressHaRuleGeneratorTest extends HaRuleGeneratorBaseT
                 OUTER_VLAN_ID_1, 0, OUTER_VLAN_ID_2, INNER_VLAN_ID_1);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -274,7 +273,7 @@ public class YPointForwardEgressHaRuleGeneratorTest extends HaRuleGeneratorBaseT
                 0, 0, OUTER_VLAN_ID_2, INNER_VLAN_ID_1);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -301,7 +300,7 @@ public class YPointForwardEgressHaRuleGeneratorTest extends HaRuleGeneratorBaseT
                 OUTER_VLAN_ID_1, 0, OUTER_VLAN_ID_2, 0);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -327,7 +326,7 @@ public class YPointForwardEgressHaRuleGeneratorTest extends HaRuleGeneratorBaseT
                 OUTER_VLAN_ID_1, 0, 0, 0);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -350,7 +349,7 @@ public class YPointForwardEgressHaRuleGeneratorTest extends HaRuleGeneratorBaseT
         YPointForwardEgressHaRuleGenerator generator = buildGenerator(VXLAN_ENCAPSULATION, 0, 0, 0, 0);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -370,21 +369,21 @@ public class YPointForwardEgressHaRuleGeneratorTest extends HaRuleGeneratorBaseT
     public void nullSubPathsTest() {
         Exception exception = assertThrows(IllegalArgumentException.class,
                 () -> buildGenerator(null).generateCommands(SWITCH_1));
-        assertTrue(exception.getMessage().contains("can't be null"));
+        Assertions.assertTrue(exception.getMessage().contains("can't be null"));
     }
 
     @Test
     public void emptySubPathsTest() {
         Exception exception = assertThrows(IllegalArgumentException.class,
                 () -> buildGenerator(new ArrayList<>()).generateCommands(SWITCH_1));
-        assertTrue(exception.getMessage().contains("require 2 sub paths"));
+        Assertions.assertTrue(exception.getMessage().contains("require 2 sub paths"));
     }
 
     @Test
     public void singleSubPathsTest() {
         Exception exception = assertThrows(IllegalArgumentException.class,
                 () -> buildGenerator(Lists.newArrayList(buildSubPath(null))).generateCommands(SWITCH_1));
-        assertTrue(exception.getMessage().contains("require 2 sub paths"));
+        Assertions.assertTrue(exception.getMessage().contains("require 2 sub paths"));
     }
 
     @Test
@@ -393,7 +392,7 @@ public class YPointForwardEgressHaRuleGeneratorTest extends HaRuleGeneratorBaseT
         FlowPath subPath2 = buildSubPath(PATH_ID_2, SWITCH_1, SWITCH_3, FORWARD_COOKIE_2, null);
         RuleGenerator generator = buildGenerator(Lists.newArrayList(subPath1, subPath2));
         Exception exception = assertThrows(IllegalArgumentException.class, () -> generator.generateCommands(SWITCH_2));
-        assertTrue(exception.getMessage().contains("different destination switch"));
+        Assertions.assertTrue(exception.getMessage().contains("different destination switch"));
     }
 
     @Test
@@ -402,7 +401,7 @@ public class YPointForwardEgressHaRuleGeneratorTest extends HaRuleGeneratorBaseT
         FlowPath subPath2 = buildSubPath(PATH_ID_2, SWITCH_2, SWITCH_2, FORWARD_COOKIE_2, null);
         RuleGenerator generator = buildGenerator(Lists.newArrayList(subPath1, subPath2));
         Exception exception = assertThrows(IllegalArgumentException.class, () -> generator.generateCommands(SWITCH_2));
-        assertTrue(exception.getMessage().contains("must be multi switch paths"));
+        Assertions.assertTrue(exception.getMessage().contains("must be multi switch paths"));
     }
 
     @Test
@@ -411,7 +410,7 @@ public class YPointForwardEgressHaRuleGeneratorTest extends HaRuleGeneratorBaseT
         FlowPath subPath2 = buildSubPath(PATH_ID_2, SWITCH_1, SWITCH_2, FORWARD_COOKIE_2, null);
         Exception exception = assertThrows(IllegalArgumentException.class,
                 () -> buildGenerator(Lists.newArrayList(subPath1, subPath2)).generateCommands(SWITCH_2));
-        assertTrue(exception.getMessage().contains("must have forward direction"));
+        Assertions.assertTrue(exception.getMessage().contains("must have forward direction"));
     }
 
     private static Set<FieldMatch> buildExpectedVlanMatch() {
@@ -430,34 +429,34 @@ public class YPointForwardEgressHaRuleGeneratorTest extends HaRuleGeneratorBaseT
     }
 
     private void assertGroup(GroupSpeakerData group, Set<Action> firstBucketActions, Set<Action> secondBucketActions) {
-        assertEquals(GROUP_ID, group.getGroupId());
-        assertEquals(SWITCH_2.getSwitchId(), group.getSwitchId());
-        assertEquals(SWITCH_2.getOfVersion(), group.getOfVersion().toString());
-        assertEquals(GroupType.ALL, group.getType());
-        assertEquals(0, group.getDependsOn().size());
-        assertEquals(2, group.getBuckets().size());
+        Assertions.assertEquals(GROUP_ID, group.getGroupId());
+        Assertions.assertEquals(SWITCH_2.getSwitchId(), group.getSwitchId());
+        Assertions.assertEquals(SWITCH_2.getOfVersion(), group.getOfVersion().toString());
+        Assertions.assertEquals(GroupType.ALL, group.getType());
+        Assertions.assertEquals(0, group.getDependsOn().size());
+        Assertions.assertEquals(2, group.getBuckets().size());
         for (Bucket bucket : group.getBuckets()) {
-            assertEquals(WatchGroup.ANY, bucket.getWatchGroup());
-            assertEquals(WatchPort.ANY, bucket.getWatchPort());
+            Assertions.assertEquals(WatchGroup.ANY, bucket.getWatchGroup());
+            Assertions.assertEquals(WatchPort.ANY, bucket.getWatchPort());
         }
-        assertEquals(firstBucketActions, group.getBuckets().get(0).getWriteActions());
-        assertEquals(secondBucketActions, group.getBuckets().get(1).getWriteActions());
+        Assertions.assertEquals(firstBucketActions, group.getBuckets().get(0).getWriteActions());
+        Assertions.assertEquals(secondBucketActions, group.getBuckets().get(1).getWriteActions());
     }
 
     private void assertCommand(
             FlowSpeakerData command, Set<FieldMatch> expectedMatch, List<Action> expectedApplyActions,
             UUID expectedGroupUuid) {
-        assertEquals(SWITCH_2.getSwitchId(), command.getSwitchId());
-        assertEquals(SWITCH_2.getOfVersion(), command.getOfVersion().toString());
-        assertEquals(HA_FLOW_PATH.getCookie(), command.getCookie());
-        assertEquals(OfTable.EGRESS, command.getTable());
-        assertEquals(Priority.FLOW_PRIORITY, command.getPriority());
-        assertEquals(newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
+        Assertions.assertEquals(SWITCH_2.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(SWITCH_2.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(HA_FLOW_PATH.getCookie(), command.getCookie());
+        Assertions.assertEquals(OfTable.EGRESS, command.getTable());
+        Assertions.assertEquals(Priority.FLOW_PRIORITY, command.getPriority());
+        Assertions.assertEquals(newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
         assertEqualsMatch(expectedMatch, command.getMatch());
 
         Instructions expectedInstructions = Instructions.builder().applyActions(expectedApplyActions).build();
-        assertEquals(expectedInstructions, command.getInstructions());
-        assertEquals(Lists.newArrayList(expectedGroupUuid), command.getDependsOn());
+        Assertions.assertEquals(expectedInstructions, command.getInstructions());
+        Assertions.assertEquals(Lists.newArrayList(expectedGroupUuid), command.getDependsOn());
     }
 
     private YPointForwardEgressHaRuleGenerator buildGenerator(

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/haflow/YPointForwardIngressHaRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/haflow/YPointForwardIngressHaRuleGeneratorTest.java
@@ -17,8 +17,7 @@ package org.openkilda.rulemanager.factory.generator.flow.haflow;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openkilda.model.cookie.CookieBase.CookieType.MULTI_TABLE_INGRESS_RULES;
 import static org.openkilda.rulemanager.Constants.Priority.DEFAULT_FLOW_PRIORITY;
 import static org.openkilda.rulemanager.Constants.Priority.DOUBLE_VLAN_FLOW_PRIORITY;
@@ -72,7 +71,8 @@ import org.openkilda.rulemanager.utils.RoutingMetadata;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -716,13 +716,13 @@ public class YPointForwardIngressHaRuleGeneratorTest extends HaRuleGeneratorBase
         RoutingMetadata preIngressMetadata = RoutingMetadata.builder().outerVlanId(OUTER_VLAN_ID_1)
                 .build(SWITCH_1.getFeatures());
         assertPreIngressCommand(preIngressCommand, SWITCH_2, preIngressCookie, Priority.FLOW_PRIORITY,
-                expectedPreIngressMatch,  newArrayList(new PopVlanAction()), mapMetadata(preIngressMetadata));
+                expectedPreIngressMatch, newArrayList(new PopVlanAction()), mapMetadata(preIngressMetadata));
 
         assertInputCustomerCommand(inputCustomerCommand, SWITCH_2,
                 new PortColourCookie(MULTI_TABLE_INGRESS_RULES, PORT_NUMBER_1),
                 newHashSet(FieldMatch.builder().field(Field.IN_PORT).value(PORT_NUMBER_1).build()));
 
-        assertEquals(Lists.newArrayList(meterCommand.getUuid(), groupCommand.getUuid()), ingressCommand.getDependsOn());
+        assertEquals(newArrayList(meterCommand.getUuid(), groupCommand.getUuid()), ingressCommand.getDependsOn());
         assertMeterCommand(meterCommand);
     }
 
@@ -752,44 +752,54 @@ public class YPointForwardIngressHaRuleGeneratorTest extends HaRuleGeneratorBase
         RoutingMetadata preIngressMetadata = RoutingMetadata.builder().outerVlanId(OUTER_VLAN_ID_1)
                 .build(SWITCH_1.getFeatures());
         assertPreIngressCommand(preIngressCommand, SWITCH_2, preIngressCookie, Priority.FLOW_PRIORITY,
-                expectedPreIngressMatch,  newArrayList(new PopVlanAction()), mapMetadata(preIngressMetadata));
+                expectedPreIngressMatch, newArrayList(new PopVlanAction()), mapMetadata(preIngressMetadata));
 
-        assertEquals(Lists.newArrayList(meterCommand.getUuid(), groupCommand.getUuid()), ingressCommand.getDependsOn());
+        assertEquals(newArrayList(meterCommand.getUuid(), groupCommand.getUuid()), ingressCommand.getDependsOn());
         assertMeterCommand(meterCommand);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void nullSubPathsTest() {
-        HaFlow haFlow = buildHaFlow(SWITCH_2, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
-        buildGenerator(haFlow, null).generateCommands(SWITCH_2);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            HaFlow haFlow = buildHaFlow(SWITCH_2, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
+            buildGenerator(haFlow, null).generateCommands(SWITCH_2);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void emptySubPathsTest() {
-        HaFlow haFlow = buildHaFlow(SWITCH_2, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
-        buildGenerator(haFlow, new ArrayList<>()).generateCommands(SWITCH_2);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            HaFlow haFlow = buildHaFlow(SWITCH_2, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
+            buildGenerator(haFlow, new ArrayList<>()).generateCommands(SWITCH_2);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void oneSubFlowTest() {
-        FlowPath subPath1 = buildSubPath(PATH_ID_1, SWITCH_2, SWITCH_3, FORWARD_COOKIE, null);
-        HaFlow haFlow = buildHaFlow(SWITCH_2, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
-        buildGenerator(haFlow, Lists.newArrayList(subPath1)).generateCommands(SWITCH_2);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            FlowPath subPath1 = buildSubPath(PATH_ID_1, SWITCH_2, SWITCH_3, FORWARD_COOKIE, null);
+            HaFlow haFlow = buildHaFlow(SWITCH_2, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
+            buildGenerator(haFlow, Lists.newArrayList(subPath1)).generateCommands(SWITCH_2);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void incorrectSwitchTest() {
-        FlowPath subPath1 = buildSubPath(PATH_ID_1, SWITCH_2, SWITCH_2, FORWARD_COOKIE, null);
-        HaFlow haFlow = buildHaFlow(SWITCH_1, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
-        buildGenerator(haFlow, Lists.newArrayList(subPath1)).generateCommands(SWITCH_2);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            FlowPath subPath1 = buildSubPath(PATH_ID_1, SWITCH_2, SWITCH_2, FORWARD_COOKIE, null);
+            HaFlow haFlow = buildHaFlow(SWITCH_1, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
+            buildGenerator(haFlow, Lists.newArrayList(subPath1)).generateCommands(SWITCH_2);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void reverseSubPathTest() {
-        FlowPath subPath1 = buildSubPath(PATH_ID_1, SWITCH_2, SWITCH_3, FORWARD_COOKIE, null);
-        FlowPath subPath2 = buildSubPath(PATH_ID_1, SWITCH_2, SWITCH_2, REVERSE_COOKIE, null);
-        HaFlow haFlow = buildHaFlow(SWITCH_2, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
-        buildGenerator(haFlow, Lists.newArrayList(subPath1, subPath2)).generateCommands(SWITCH_2);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            FlowPath subPath1 = buildSubPath(PATH_ID_1, SWITCH_2, SWITCH_3, FORWARD_COOKIE, null);
+            FlowPath subPath2 = buildSubPath(PATH_ID_1, SWITCH_2, SWITCH_2, REVERSE_COOKIE, null);
+            HaFlow haFlow = buildHaFlow(SWITCH_2, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
+            buildGenerator(haFlow, Lists.newArrayList(subPath1, subPath2)).generateCommands(SWITCH_2);
+        });
     }
 
     private void assertGroup(GroupSpeakerData group, Set<Action> firstBucketActions,
@@ -826,7 +836,7 @@ public class YPointForwardIngressHaRuleGeneratorTest extends HaRuleGeneratorBase
                 .build();
         assertEquals(expectedInstructions, command.getInstructions());
         assertEquals(newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
-        assertEquals(Lists.newArrayList(expectedGroupUuid), command.getDependsOn());
+        assertEquals(newArrayList(expectedGroupUuid), command.getDependsOn());
     }
 
     private void assertPreIngressCommand(
@@ -837,7 +847,7 @@ public class YPointForwardIngressHaRuleGeneratorTest extends HaRuleGeneratorBase
         assertEquals(cookie, command.getCookie());
         assertEquals(OfTable.PRE_INGRESS, command.getTable());
         assertEquals(expectedPriority, command.getPriority());
-        assertTrue(command.getDependsOn().isEmpty());
+        Assertions.assertTrue(command.getDependsOn().isEmpty());
         assertEqualsMatch(expectedMatch, command.getMatch());
 
         Instructions expectedInstructions = Instructions.builder()
@@ -846,7 +856,7 @@ public class YPointForwardIngressHaRuleGeneratorTest extends HaRuleGeneratorBase
                 .goToTable(OfTable.INGRESS)
                 .build();
         assertEquals(expectedInstructions, command.getInstructions());
-        assertTrue(command.getFlags().isEmpty());
+        Assertions.assertTrue(command.getFlags().isEmpty());
     }
 
     private void assertInputCustomerCommand(
@@ -856,7 +866,7 @@ public class YPointForwardIngressHaRuleGeneratorTest extends HaRuleGeneratorBase
         assertEquals(cookie, command.getCookie());
         assertEquals(OfTable.INPUT, command.getTable());
         assertEquals(Priority.INGRESS_CUSTOMER_PORT_RULE_PRIORITY_MULTITABLE, command.getPriority());
-        assertTrue(command.getDependsOn().isEmpty());
+        Assertions.assertTrue(command.getDependsOn().isEmpty());
 
         assertEqualsMatch(expectedMatch, command.getMatch());
 
@@ -864,7 +874,7 @@ public class YPointForwardIngressHaRuleGeneratorTest extends HaRuleGeneratorBase
                 .goToTable(OfTable.PRE_INGRESS)
                 .build();
         assertEquals(expectedInstructions, command.getInstructions());
-        assertTrue(command.getFlags().isEmpty());
+        Assertions.assertTrue(command.getFlags().isEmpty());
     }
 
     private void assertMeterCommand(MeterSpeakerData command) {
@@ -874,7 +884,7 @@ public class YPointForwardIngressHaRuleGeneratorTest extends HaRuleGeneratorBase
         assertEquals(newHashSet(MeterFlag.BURST, MeterFlag.KBPS, MeterFlag.STATS), command.getFlags());
         assertEquals(BANDWIDTH, command.getRate());
         assertEquals(Math.round(BANDWIDTH * BURST_COEFFICIENT), command.getBurst());
-        assertTrue(command.getDependsOn().isEmpty());
+        Assertions.assertTrue(command.getDependsOn().isEmpty());
 
     }
 

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/haflow/YPointForwardTransitHaRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/haflow/YPointForwardTransitHaRuleGeneratorTest.java
@@ -16,7 +16,6 @@
 package org.openkilda.rulemanager.factory.generator.flow.haflow;
 
 import static com.google.common.collect.Sets.newHashSet;
-import static org.junit.Assert.assertEquals;
 import static org.openkilda.rulemanager.Utils.assertEqualsMatch;
 import static org.openkilda.rulemanager.Utils.getCommand;
 
@@ -56,7 +55,8 @@ import org.openkilda.rulemanager.group.WatchPort;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -79,7 +79,7 @@ public class YPointForwardTransitHaRuleGeneratorTest extends HaRuleGeneratorBase
                 SWITCH_2, SWITCH_3, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -97,7 +97,7 @@ public class YPointForwardTransitHaRuleGeneratorTest extends HaRuleGeneratorBase
                 SWITCH_2, SWITCH_3, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -122,7 +122,7 @@ public class YPointForwardTransitHaRuleGeneratorTest extends HaRuleGeneratorBase
                 SWITCH_2, SWITCH_3, OUTER_VLAN_ID_1, 0);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -142,7 +142,7 @@ public class YPointForwardTransitHaRuleGeneratorTest extends HaRuleGeneratorBase
                 SWITCH_2, SWITCH_3, 0, 0);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -163,7 +163,7 @@ public class YPointForwardTransitHaRuleGeneratorTest extends HaRuleGeneratorBase
                 SWITCH_2, SWITCH_3, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -185,7 +185,7 @@ public class YPointForwardTransitHaRuleGeneratorTest extends HaRuleGeneratorBase
                 SWITCH_2, SWITCH_3, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -216,7 +216,7 @@ public class YPointForwardTransitHaRuleGeneratorTest extends HaRuleGeneratorBase
                 SWITCH_2, SWITCH_3, OUTER_VLAN_ID_2, 0);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -240,7 +240,7 @@ public class YPointForwardTransitHaRuleGeneratorTest extends HaRuleGeneratorBase
                 SWITCH_2, SWITCH_3, 0, 0);
 
         List<SpeakerData> commands = generator.generateCommands(SWITCH_2);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
         FlowSpeakerData flowCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
 
@@ -256,35 +256,45 @@ public class YPointForwardTransitHaRuleGeneratorTest extends HaRuleGeneratorBase
         assertGroup(groupCommand, SWITCH_2, firstExpectedActions, secondExpectedActions);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void nullSubPathsTest() {
-        buildGenerator(null).generateCommands(SWITCH_1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            buildGenerator(null).generateCommands(SWITCH_1);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void emptySubPathsTest() {
-        buildGenerator(new ArrayList<>()).generateCommands(SWITCH_1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            buildGenerator(new ArrayList<>()).generateCommands(SWITCH_1);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void equalDestinationSubPathsTest() {
-        FlowPath subPath1 = buildSubPath(PATH_ID_1, SWITCH_1, SWITCH_2, FORWARD_COOKIE, null);
-        FlowPath subPath2 = buildSubPath(PATH_ID_2, SWITCH_1, SWITCH_2, FORWARD_COOKIE_2, null);
-        buildGenerator(Lists.newArrayList(subPath1, subPath2)).generateCommands(SWITCH_2);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            FlowPath subPath1 = buildSubPath(PATH_ID_1, SWITCH_1, SWITCH_2, FORWARD_COOKIE, null);
+            FlowPath subPath2 = buildSubPath(PATH_ID_2, SWITCH_1, SWITCH_2, FORWARD_COOKIE_2, null);
+            buildGenerator(Lists.newArrayList(subPath1, subPath2)).generateCommands(SWITCH_2);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void oneSwitchSubPathsTest() {
-        FlowPath subPath1 = buildSubPath(PATH_ID_1, SWITCH_1, SWITCH_2, FORWARD_COOKIE, null);
-        FlowPath subPath2 = buildSubPath(PATH_ID_2, SWITCH_3, SWITCH_3, FORWARD_COOKIE_2, null);
-        buildGenerator(Lists.newArrayList(subPath1, subPath2)).generateCommands(SWITCH_2);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            FlowPath subPath1 = buildSubPath(PATH_ID_1, SWITCH_1, SWITCH_2, FORWARD_COOKIE, null);
+            FlowPath subPath2 = buildSubPath(PATH_ID_2, SWITCH_3, SWITCH_3, FORWARD_COOKIE_2, null);
+            buildGenerator(Lists.newArrayList(subPath1, subPath2)).generateCommands(SWITCH_2);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void reverseSubPathTest() {
-        FlowPath subPath1 = buildSubPath(PATH_ID_1, SWITCH_1, SWITCH_2, REVERSE_COOKIE, null);
-        FlowPath subPath2 = buildSubPath(PATH_ID_2, SWITCH_1, SWITCH_3, FORWARD_COOKIE_2, null);
-        buildGenerator(Lists.newArrayList(subPath1, subPath2)).generateCommands(SWITCH_2);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            FlowPath subPath1 = buildSubPath(PATH_ID_1, SWITCH_1, SWITCH_2, REVERSE_COOKIE, null);
+            FlowPath subPath2 = buildSubPath(PATH_ID_2, SWITCH_1, SWITCH_3, FORWARD_COOKIE_2, null);
+            buildGenerator(Lists.newArrayList(subPath1, subPath2)).generateCommands(SWITCH_2);
+        });
     }
 
     private static Set<FieldMatch> buildExpectedVlanMatch() {
@@ -304,34 +314,34 @@ public class YPointForwardTransitHaRuleGeneratorTest extends HaRuleGeneratorBase
 
     private void assertGroup(GroupSpeakerData group, Switch expectedSwitch, Set<Action> firstBucketActions,
                              Set<Action> secondBucketActions) {
-        assertEquals(GROUP_ID, group.getGroupId());
-        assertEquals(expectedSwitch.getSwitchId(), group.getSwitchId());
-        assertEquals(expectedSwitch.getOfVersion(), group.getOfVersion().toString());
-        assertEquals(GroupType.ALL, group.getType());
-        assertEquals(0, group.getDependsOn().size());
-        assertEquals(2, group.getBuckets().size());
+        Assertions.assertEquals(GROUP_ID, group.getGroupId());
+        Assertions.assertEquals(expectedSwitch.getSwitchId(), group.getSwitchId());
+        Assertions.assertEquals(expectedSwitch.getOfVersion(), group.getOfVersion().toString());
+        Assertions.assertEquals(GroupType.ALL, group.getType());
+        Assertions.assertEquals(0, group.getDependsOn().size());
+        Assertions.assertEquals(2, group.getBuckets().size());
         for (Bucket bucket : group.getBuckets()) {
-            assertEquals(WatchGroup.ANY, bucket.getWatchGroup());
-            assertEquals(WatchPort.ANY, bucket.getWatchPort());
+            Assertions.assertEquals(WatchGroup.ANY, bucket.getWatchGroup());
+            Assertions.assertEquals(WatchPort.ANY, bucket.getWatchPort());
         }
-        assertEquals(firstBucketActions, group.getBuckets().get(0).getWriteActions());
-        assertEquals(secondBucketActions, group.getBuckets().get(1).getWriteActions());
+        Assertions.assertEquals(firstBucketActions, group.getBuckets().get(0).getWriteActions());
+        Assertions.assertEquals(secondBucketActions, group.getBuckets().get(1).getWriteActions());
     }
 
     private void assertCommand(
             FlowSpeakerData command, Switch expectedSwitch, Set<FieldMatch> expectedMatch,
             List<Action> expectedApplyActions, UUID expectedGroupUuid) {
-        assertEquals(expectedSwitch.getSwitchId(), command.getSwitchId());
-        assertEquals(expectedSwitch.getOfVersion(), command.getOfVersion().toString());
-        assertEquals(HA_FLOW_PATH.getCookie(), command.getCookie());
-        assertEquals(OfTable.TRANSIT, command.getTable());
-        assertEquals(Priority.FLOW_PRIORITY, command.getPriority());
-        assertEquals(newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
+        Assertions.assertEquals(expectedSwitch.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(expectedSwitch.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(HA_FLOW_PATH.getCookie(), command.getCookie());
+        Assertions.assertEquals(OfTable.TRANSIT, command.getTable());
+        Assertions.assertEquals(Priority.FLOW_PRIORITY, command.getPriority());
+        Assertions.assertEquals(newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
         assertEqualsMatch(expectedMatch, command.getMatch());
 
         Instructions expectedInstructions = Instructions.builder().applyActions(expectedApplyActions).build();
-        assertEquals(expectedInstructions, command.getInstructions());
-        assertEquals(Lists.newArrayList(expectedGroupUuid), command.getDependsOn());
+        Assertions.assertEquals(expectedInstructions, command.getInstructions());
+        Assertions.assertEquals(Lists.newArrayList(expectedGroupUuid), command.getDependsOn());
     }
 
 

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/loop/FlowLoopIngressRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/loop/FlowLoopIngressRuleGeneratorTest.java
@@ -17,8 +17,6 @@ package org.openkilda.rulemanager.factory.generator.flow.loop;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.model.SwitchFeature.RESET_COUNTS_FLAG;
 import static org.openkilda.rulemanager.Utils.assertEqualsMatch;
 import static org.openkilda.rulemanager.Utils.buildSwitch;
@@ -46,7 +44,8 @@ import org.openkilda.rulemanager.action.SetFieldAction;
 import org.openkilda.rulemanager.match.FieldMatch;
 import org.openkilda.rulemanager.utils.RoutingMetadata;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.List;
@@ -138,7 +137,7 @@ public class FlowLoopIngressRuleGeneratorTest {
         Flow flow = buildFlow(PATH, 0, 0, 0, 0);
         flow.setLoopSwitchId(null);
         List<SpeakerData> commands = buildGenerator(flow, false).generateCommands(SWITCH_1);
-        assertEquals(0, commands.size());
+        Assertions.assertEquals(0, commands.size());
     }
 
     private FieldMatch buildMetadataMatch(int outerVlan) {
@@ -148,22 +147,22 @@ public class FlowLoopIngressRuleGeneratorTest {
 
     private void assertIngressCommands(List<SpeakerData> commands, OfTable table, int priority,
                                        Set<FieldMatch> expectedMatch, List<Action> expectedApplyActions) {
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(SWITCH_1.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(LOOP_COOKIE, flowCommandData.getCookie());
-        assertEquals(table, flowCommandData.getTable());
-        assertEquals(priority, flowCommandData.getPriority());
+        Assertions.assertEquals(LOOP_COOKIE, flowCommandData.getCookie());
+        Assertions.assertEquals(table, flowCommandData.getTable());
+        Assertions.assertEquals(priority, flowCommandData.getPriority());
 
         assertEqualsMatch(expectedMatch, flowCommandData.getMatch());
 
         Instructions expectedInstructions = Instructions.builder().applyActions(expectedApplyActions).build();
-        assertEquals(expectedInstructions, flowCommandData.getInstructions());
-        assertTrue(flowCommandData.getFlags().isEmpty());
+        Assertions.assertEquals(expectedInstructions, flowCommandData.getInstructions());
+        Assertions.assertTrue(flowCommandData.getFlags().isEmpty());
     }
 
     private Flow buildFlow(FlowPath path, int srcOuterVlan, int srcInnerVlan, int dstOuterVlan, int dstInnerVlan) {

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/loop/FlowLoopTransitRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/loop/FlowLoopTransitRuleGeneratorTest.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.flow.loop;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.model.SwitchFeature.NOVIFLOW_PUSH_POP_VXLAN;
 import static org.openkilda.model.SwitchFeature.RESET_COUNTS_FLAG;
 import static org.openkilda.rulemanager.Utils.assertEqualsMatch;
@@ -49,7 +47,8 @@ import org.openkilda.rulemanager.action.SetFieldAction;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Sets;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -66,7 +65,7 @@ public class FlowLoopTransitRuleGeneratorTest {
     public static final Switch SWITCH_1 = buildSwitch(SWITCH_ID_1, Sets.newHashSet(
             RESET_COUNTS_FLAG, NOVIFLOW_PUSH_POP_VXLAN));
     public static final Switch SWITCH_2 = buildSwitch(SWITCH_ID_2, Sets.newHashSet(
-            RESET_COUNTS_FLAG, NOVIFLOW_PUSH_POP_VXLAN));   
+            RESET_COUNTS_FLAG, NOVIFLOW_PUSH_POP_VXLAN));
     public static final Switch SWITCH_3 = buildSwitch(SWITCH_ID_3, Sets.newHashSet(
             RESET_COUNTS_FLAG, NOVIFLOW_PUSH_POP_VXLAN));
     public static final int VLAN = 5;
@@ -158,7 +157,7 @@ public class FlowLoopTransitRuleGeneratorTest {
                 .multiTable(true)
                 .encapsulation(VLAN_ENCAPSULATION)
                 .build();
-        assertEquals(0, generator.generateCommands(SWITCH_1).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_1).size());
     }
 
     @Test
@@ -173,21 +172,21 @@ public class FlowLoopTransitRuleGeneratorTest {
                 .multiTable(true)
                 .encapsulation(VLAN_ENCAPSULATION)
                 .build();
-        assertEquals(0, generator.generateCommands(SWITCH_1).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_1).size());
     }
 
     private void assertTransitCommands(List<SpeakerData> commands, OfTable table,
                                        FlowTransitEncapsulation encapsulation) {
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(SWITCH_2.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(SWITCH_2.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(SWITCH_2.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(SWITCH_2.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(LOOP_COOKIE, flowCommandData.getCookie());
-        assertEquals(table, flowCommandData.getTable());
-        assertEquals(Priority.LOOP_FLOW_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(LOOP_COOKIE, flowCommandData.getCookie());
+        Assertions.assertEquals(table, flowCommandData.getTable());
+        Assertions.assertEquals(Priority.LOOP_FLOW_PRIORITY, flowCommandData.getPriority());
 
         Set<FieldMatch> expectedMatch;
         List<Action> expectedApplyActions = new ArrayList<>();
@@ -202,8 +201,8 @@ public class FlowLoopTransitRuleGeneratorTest {
 
         expectedApplyActions.add(new PortOutAction(new PortNumber(SpecialPortType.IN_PORT)));
         Instructions expectedInstructions = Instructions.builder().applyActions(expectedApplyActions).build();
-        assertEquals(expectedInstructions, flowCommandData.getInstructions());
-        assertTrue(flowCommandData.getFlags().isEmpty());
+        Assertions.assertEquals(expectedInstructions, flowCommandData.getInstructions());
+        Assertions.assertTrue(flowCommandData.getFlags().isEmpty());
     }
 
     private Set<FieldMatch> buildExpectedVlanMatch(int port, int vlanId) {

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/mirror/EgressMirrorRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/mirror/EgressMirrorRuleGeneratorTest.java
@@ -16,8 +16,7 @@
 package org.openkilda.rulemanager.factory.generator.flow.mirror;
 
 import static com.google.common.collect.Sets.newHashSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openkilda.model.SwitchFeature.NOVIFLOW_PUSH_POP_VXLAN;
 import static org.openkilda.model.SwitchFeature.RESET_COUNTS_FLAG;
 import static org.openkilda.rulemanager.Utils.assertEqualsMatch;
@@ -66,7 +65,8 @@ import org.openkilda.rulemanager.group.WatchPort;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -121,7 +121,7 @@ public class EgressMirrorRuleGeneratorTest {
                 groupCommand.getUuid());
         assertGroupCommand(groupCommand);
     }
-    
+
     @Test
     public void buildVlanMultiTableOuterVlanEgressMirrorRuleTest() {
         FlowPath path = buildPathWithMirror(true);
@@ -132,7 +132,7 @@ public class EgressMirrorRuleGeneratorTest {
         assertEquals(2, commands.size());
         FlowSpeakerData egressCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
-        
+
         ArrayList<Action> expectedApplyActions = Lists.newArrayList(
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID).build(),
                 new GroupAction(GROUP_ID));
@@ -360,7 +360,7 @@ public class EgressMirrorRuleGeneratorTest {
 
     @Test
     public void oneSwitchFlowEgressMirrorRuleTest() {
-        FlowPath path =  FlowPath.builder()
+        FlowPath path = FlowPath.builder()
                 .pathId(PATH_ID)
                 .srcSwitch(SWITCH_1)
                 .destSwitch(SWITCH_1)
@@ -372,7 +372,7 @@ public class EgressMirrorRuleGeneratorTest {
 
     @Test
     public void pathWithoutSegmentsFlowEgressMirrorRuleTest() {
-        FlowPath path =  FlowPath.builder()
+        FlowPath path = FlowPath.builder()
                 .pathId(PATH_ID)
                 .srcSwitch(SWITCH_1)
                 .destSwitch(SWITCH_2)
@@ -422,7 +422,7 @@ public class EgressMirrorRuleGeneratorTest {
 
         Instructions expectedInstructions = Instructions.builder().applyActions(expectedApplyActions).build();
         assertEquals(expectedInstructions, command.getInstructions());
-        assertTrue(command.getFlags().isEmpty());
+        Assertions.assertTrue(command.getFlags().isEmpty());
     }
 
     private void assertGroupCommand(GroupSpeakerData command) {
@@ -430,7 +430,7 @@ public class EgressMirrorRuleGeneratorTest {
         assertEquals(SWITCH_2.getSwitchId(), command.getSwitchId());
         assertEquals(SWITCH_2.getOfVersion(), command.getOfVersion().toString());
         assertEquals(GroupType.ALL, command.getType());
-        assertTrue(command.getDependsOn().isEmpty());
+        Assertions.assertTrue(command.getDependsOn().isEmpty());
 
         assertEquals(2, command.getBuckets().size());
         Bucket flowBucket = command.getBuckets().get(0);
@@ -522,11 +522,11 @@ public class EgressMirrorRuleGeneratorTest {
                         .build())
                 .build();
         mirrorPoints.addPaths(FlowMirrorPath.builder()
-                        .mirrorSwitch(SWITCH_2)
-                        .egressSwitch(SWITCH_2)
-                        .pathId(PATH_ID)
-                        .egressPort(MIRROR_PORT)
-                        .egressOuterVlan(MIRROR_VLAN)
+                .mirrorSwitch(SWITCH_2)
+                .egressSwitch(SWITCH_2)
+                .pathId(PATH_ID)
+                .egressPort(MIRROR_PORT)
+                .egressOuterVlan(MIRROR_VLAN)
                 .build());
         return mirrorPoints;
     }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/mirror/IngressMirrorRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/flow/mirror/IngressMirrorRuleGeneratorTest.java
@@ -17,8 +17,6 @@ package org.openkilda.rulemanager.factory.generator.flow.mirror;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.SwitchFeature.METERS;
@@ -78,8 +76,9 @@ import org.openkilda.rulemanager.match.FieldMatch;
 import org.openkilda.rulemanager.utils.RoutingMetadata;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -126,7 +125,7 @@ public class IngressMirrorRuleGeneratorTest {
 
     RuleManagerConfig config;
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = mock(RuleManagerConfig.class);
         when(config.getFlowMeterBurstCoefficient()).thenReturn(BURST_COEFFICIENT);
@@ -139,7 +138,7 @@ public class IngressMirrorRuleGeneratorTest {
         IngressMirrorRuleGenerator generator = buildGenerator(MULTI_TABLE_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildIngressActions(getEndpoint(flow), GROUP_ID);
         List<Action> expectedActions = newArrayList(new PopVlanAction(), new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -148,7 +147,7 @@ public class IngressMirrorRuleGeneratorTest {
         IngressMirrorRuleGenerator generator = buildGenerator(MULTI_TABLE_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildIngressActions(getEndpoint(flow), GROUP_ID);
         List<Action> expectedActions = newArrayList(new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -157,7 +156,7 @@ public class IngressMirrorRuleGeneratorTest {
         IngressMirrorRuleGenerator generator = buildGenerator(MULTI_TABLE_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildIngressActions(getEndpoint(flow), GROUP_ID);
         List<Action> expectedActions = newArrayList(new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -166,7 +165,7 @@ public class IngressMirrorRuleGeneratorTest {
         IngressMirrorRuleGenerator generator = buildGenerator(MULTI_TABLE_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildIngressActions(getEndpoint(flow), GROUP_ID);
         List<Action> expectedActions = newArrayList(new PopVlanAction(), new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
 
@@ -176,7 +175,7 @@ public class IngressMirrorRuleGeneratorTest {
         IngressMirrorRuleGenerator generator = buildGenerator(MULTI_TABLE_PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildIngressActions(getEndpoint(flow), GROUP_ID);
         List<Action> expectedActions = newArrayList(new PopVlanAction(), new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -185,7 +184,7 @@ public class IngressMirrorRuleGeneratorTest {
         IngressMirrorRuleGenerator generator = buildGenerator(MULTI_TABLE_PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildIngressActions(getEndpoint(flow), GROUP_ID);
         List<Action> expectedActions = newArrayList(new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -194,7 +193,7 @@ public class IngressMirrorRuleGeneratorTest {
         IngressMirrorRuleGenerator generator = buildGenerator(MULTI_TABLE_PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildIngressActions(getEndpoint(flow), GROUP_ID);
         List<Action> expectedActions = newArrayList(new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -203,7 +202,7 @@ public class IngressMirrorRuleGeneratorTest {
         IngressMirrorRuleGenerator generator = buildGenerator(SINGLE_TABLE_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildIngressActions(getEndpoint(flow), GROUP_ID);
         List<Action> expectedActions = newArrayList(new PopVlanAction(), new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -212,7 +211,7 @@ public class IngressMirrorRuleGeneratorTest {
         IngressMirrorRuleGenerator generator = buildGenerator(SINGLE_TABLE_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildIngressActions(getEndpoint(flow), GROUP_ID);
         List<Action> expectedActions = newArrayList(new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -221,7 +220,7 @@ public class IngressMirrorRuleGeneratorTest {
         IngressMirrorRuleGenerator generator = buildGenerator(SINGLE_TABLE_PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildIngressActions(getEndpoint(flow), GROUP_ID);
         List<Action> expectedActions = newArrayList(new PopVlanAction(), new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -230,7 +229,7 @@ public class IngressMirrorRuleGeneratorTest {
         IngressMirrorRuleGenerator generator = buildGenerator(SINGLE_TABLE_PATH, flow, VXLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildIngressActions(getEndpoint(flow), GROUP_ID);
         List<Action> expectedActions = newArrayList(new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -244,7 +243,7 @@ public class IngressMirrorRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build(),
                 new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -255,7 +254,7 @@ public class IngressMirrorRuleGeneratorTest {
         List<Action> expectedActions = newArrayList(
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build(),
                 new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -264,7 +263,7 @@ public class IngressMirrorRuleGeneratorTest {
         IngressMirrorRuleGenerator generator = buildGenerator(MULTI_TABLE_ONE_SWITCH_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildIngressActions(getEndpoint(flow), GROUP_ID);
         List<Action> expectedActions = newArrayList(new PopVlanAction(), new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -278,7 +277,7 @@ public class IngressMirrorRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build(),
                 new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -290,7 +289,7 @@ public class IngressMirrorRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build(),
                 new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -299,7 +298,7 @@ public class IngressMirrorRuleGeneratorTest {
         IngressMirrorRuleGenerator generator = buildGenerator(MULTI_TABLE_ONE_SWITCH_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildIngressActions(getEndpoint(flow), GROUP_ID);
         List<Action> expectedActions = newArrayList(new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -313,7 +312,7 @@ public class IngressMirrorRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build(),
                 new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -325,7 +324,7 @@ public class IngressMirrorRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build(),
                 new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -334,7 +333,7 @@ public class IngressMirrorRuleGeneratorTest {
         IngressMirrorRuleGenerator generator = buildGenerator(MULTI_TABLE_ONE_SWITCH_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildIngressActions(getEndpoint(flow), GROUP_ID);
         List<Action> expectedActions = newArrayList(new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     ///////
@@ -347,7 +346,7 @@ public class IngressMirrorRuleGeneratorTest {
         List<Action> expectedActions = newArrayList(
                 SetFieldAction.builder().field(Field.VLAN_VID).value((short) OUTER_VLAN_ID_2).build(),
                 new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -356,7 +355,7 @@ public class IngressMirrorRuleGeneratorTest {
         IngressMirrorRuleGenerator generator = buildGenerator(SINGLE_TABLE_ONE_SWITCH_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildIngressActions(getEndpoint(flow), GROUP_ID);
         List<Action> expectedActions = newArrayList(new PopVlanAction(), new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -368,7 +367,7 @@ public class IngressMirrorRuleGeneratorTest {
                 new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(OUTER_VLAN_ID_2).build(),
                 new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -377,7 +376,7 @@ public class IngressMirrorRuleGeneratorTest {
         IngressMirrorRuleGenerator generator = buildGenerator(SINGLE_TABLE_ONE_SWITCH_PATH, flow, VLAN_ENCAPSULATION);
         List<Action> transformActions = generator.buildIngressActions(getEndpoint(flow), GROUP_ID);
         List<Action> expectedActions = newArrayList(new GroupAction(GROUP_ID));
-        assertEquals(expectedActions, transformActions);
+        Assertions.assertEquals(expectedActions, transformActions);
     }
 
     @Test
@@ -385,7 +384,7 @@ public class IngressMirrorRuleGeneratorTest {
         Flow flow = buildFlow(MULTI_TABLE_ONE_SWITCH_PATH, 0, 0, OUTER_VLAN_ID_2, 0);
         IngressMirrorRuleGenerator generator = buildGenerator(MULTI_TABLE_ONE_SWITCH_PATH, flow, VLAN_ENCAPSULATION);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
 
         FlowSpeakerData ingressCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
@@ -408,7 +407,7 @@ public class IngressMirrorRuleGeneratorTest {
         Flow flow = buildFlow(MULTI_TABLE_PATH, OUTER_VLAN_ID_1, INNER_VLAN_ID_1);
         IngressMirrorRuleGenerator generator = buildGenerator(MULTI_TABLE_PATH, flow, VXLAN_ENCAPSULATION);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
 
         FlowSpeakerData ingressCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
@@ -435,7 +434,7 @@ public class IngressMirrorRuleGeneratorTest {
         Flow flow = buildFlow(SINGLE_TABLE_PATH, OUTER_VLAN_ID_1, 0);
         IngressMirrorRuleGenerator generator = buildGenerator(SINGLE_TABLE_PATH, flow, VLAN_ENCAPSULATION);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
 
         FlowSpeakerData ingressCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
@@ -459,7 +458,7 @@ public class IngressMirrorRuleGeneratorTest {
         Flow flow = buildFlow(SINGLE_TABLE_ONE_SWITCH_PATH, 0, 0, 0, 0);
         IngressMirrorRuleGenerator generator = buildGenerator(SINGLE_TABLE_ONE_SWITCH_PATH, flow, VXLAN_ENCAPSULATION);
         List<SpeakerData> commands = generator.generateCommands(SWITCH_1);
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
 
         FlowSpeakerData ingressCommand = getCommand(FlowSpeakerData.class, commands);
         GroupSpeakerData groupCommand = getCommand(GroupSpeakerData.class, commands);
@@ -479,7 +478,7 @@ public class IngressMirrorRuleGeneratorTest {
         FlowPath path = buildPath(true);
         Flow flow = buildFlow(path, 0, 0);
         IngressMirrorRuleGenerator generator = buildGenerator(path, flow, VXLAN_ENCAPSULATION);
-        assertEquals(0, generator.generateCommands(SWITCH_1).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_1).size());
     }
 
     @Test
@@ -488,42 +487,42 @@ public class IngressMirrorRuleGeneratorTest {
         path.addFlowMirrorPoints(buildMirrorPoints(SWITCH_2));
         Flow flow = buildFlow(path, 0, 0);
         IngressMirrorRuleGenerator generator = buildGenerator(path, flow, VXLAN_ENCAPSULATION);
-        assertEquals(0, generator.generateCommands(SWITCH_1).size());
+        Assertions.assertEquals(0, generator.generateCommands(SWITCH_1).size());
     }
 
     private void assertGroupCommand(GroupSpeakerData command, Set<Action> flowActions) {
-        assertEquals(GROUP_ID, command.getGroupId());
-        assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
-        assertEquals(GroupType.ALL, command.getType());
-        assertTrue(command.getDependsOn().isEmpty());
+        Assertions.assertEquals(GROUP_ID, command.getGroupId());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(GroupType.ALL, command.getType());
+        Assertions.assertTrue(command.getDependsOn().isEmpty());
 
-        assertEquals(2, command.getBuckets().size());
+        Assertions.assertEquals(2, command.getBuckets().size());
         Bucket flowBucket = command.getBuckets().get(0);
         assertBucketCommon(flowBucket);
-        assertEquals(flowActions, flowBucket.getWriteActions());
+        Assertions.assertEquals(flowActions, flowBucket.getWriteActions());
 
         Bucket mirrorBucket = command.getBuckets().get(1);
         assertBucketCommon(mirrorBucket);
-        assertEquals(newHashSet(new PushVlanAction(),
+        Assertions.assertEquals(newHashSet(new PushVlanAction(),
                 SetFieldAction.builder().field(Field.VLAN_VID).value(MIRROR_VLAN).build(),
                 new PortOutAction(new PortNumber(MIRROR_PORT))), mirrorBucket.getWriteActions());
     }
 
     private void assertBucketCommon(Bucket bucket) {
-        assertEquals(WatchGroup.ANY, bucket.getWatchGroup());
-        assertEquals(WatchPort.ANY, bucket.getWatchPort());
+        Assertions.assertEquals(WatchGroup.ANY, bucket.getWatchGroup());
+        Assertions.assertEquals(WatchPort.ANY, bucket.getWatchPort());
     }
 
     private void assertIngressCommand(
             FlowSpeakerData command, int expectedPriority, OfTable expectedTable, Set<FieldMatch> expectedMatch,
             List<Action> expectedApplyActions, MeterId expectedMeter, UUID groupCommandUuid) {
-        assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
-        assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
+        Assertions.assertEquals(SWITCH_1.getSwitchId(), command.getSwitchId());
+        Assertions.assertEquals(SWITCH_1.getOfVersion(), command.getOfVersion().toString());
 
-        assertEquals(MIRROR_COOKIE, command.getCookie());
-        assertEquals(expectedTable, command.getTable());
-        assertEquals(expectedPriority, command.getPriority());
+        Assertions.assertEquals(MIRROR_COOKIE, command.getCookie());
+        Assertions.assertEquals(expectedTable, command.getTable());
+        Assertions.assertEquals(expectedPriority, command.getPriority());
 
         assertEqualsMatch(expectedMatch, command.getMatch());
 
@@ -531,9 +530,9 @@ public class IngressMirrorRuleGeneratorTest {
                 .applyActions(expectedApplyActions)
                 .goToMeter(expectedMeter)
                 .build();
-        assertEquals(expectedInstructions, command.getInstructions());
-        assertEquals(Sets.newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
-        assertEquals(newArrayList(groupCommandUuid), new ArrayList<>(command.getDependsOn()));
+        Assertions.assertEquals(expectedInstructions, command.getInstructions());
+        Assertions.assertEquals(newHashSet(OfFlowFlag.RESET_COUNTERS), command.getFlags());
+        Assertions.assertEquals(newArrayList(groupCommandUuid), new ArrayList<>(command.getDependsOn()));
     }
 
     private IngressMirrorRuleGenerator buildGenerator(

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/BfdCatchRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/BfdCatchRuleGeneratorTest.java
@@ -15,9 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.model.SwitchFeature.BFD;
 import static org.openkilda.model.cookie.Cookie.CATCH_BFD_RULE_COOKIE;
 import static org.openkilda.rulemanager.Constants.Priority.CATCH_BFD_RULE_PRIORITY;
@@ -41,7 +38,8 @@ import org.openkilda.rulemanager.action.PortOutAction;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Sets;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -54,39 +52,39 @@ public class BfdCatchRuleGeneratorTest {
         BfdCatchRuleGenerator generator = new BfdCatchRuleGenerator();
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(new Cookie(CATCH_BFD_RULE_COOKIE), flowCommandData.getCookie());
-        assertEquals(OfTable.INPUT, flowCommandData.getTable());
-        assertEquals(CATCH_BFD_RULE_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(new Cookie(CATCH_BFD_RULE_COOKIE), flowCommandData.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, flowCommandData.getTable());
+        Assertions.assertEquals(CATCH_BFD_RULE_PRIORITY, flowCommandData.getPriority());
 
         FieldMatch ethDstMatch = getMatchByField(Field.ETH_DST, flowCommandData.getMatch());
-        assertEquals(sw.getSwitchId().toLong(), ethDstMatch.getValue());
-        assertFalse(ethDstMatch.isMasked());
+        Assertions.assertEquals(sw.getSwitchId().toLong(), ethDstMatch.getValue());
+        Assertions.assertFalse(ethDstMatch.isMasked());
 
         FieldMatch ethTypeMatch = getMatchByField(Field.ETH_TYPE, flowCommandData.getMatch());
-        assertEquals(EthType.IPv4, ethTypeMatch.getValue());
-        assertFalse(ethTypeMatch.isMasked());
+        Assertions.assertEquals(EthType.IPv4, ethTypeMatch.getValue());
+        Assertions.assertFalse(ethTypeMatch.isMasked());
 
         FieldMatch ipProtoMatch = getMatchByField(Field.IP_PROTO, flowCommandData.getMatch());
-        assertEquals(IpProto.UDP, ipProtoMatch.getValue());
-        assertFalse(ipProtoMatch.isMasked());
+        Assertions.assertEquals(IpProto.UDP, ipProtoMatch.getValue());
+        Assertions.assertFalse(ipProtoMatch.isMasked());
 
         FieldMatch udpDstMatch = getMatchByField(Field.UDP_DST, flowCommandData.getMatch());
-        assertEquals(Constants.BDF_DEFAULT_PORT, udpDstMatch.getValue());
-        assertFalse(udpDstMatch.isMasked());
+        Assertions.assertEquals(Constants.BDF_DEFAULT_PORT, udpDstMatch.getValue());
+        Assertions.assertFalse(udpDstMatch.isMasked());
 
         Instructions instructions = flowCommandData.getInstructions();
-        assertEquals(1, instructions.getApplyActions().size());
+        Assertions.assertEquals(1, instructions.getApplyActions().size());
         Action action = instructions.getApplyActions().get(0);
-        assertTrue(action instanceof PortOutAction);
+        Assertions.assertTrue(action instanceof PortOutAction);
         PortOutAction portOutAction = (PortOutAction) action;
-        assertEquals(SpecialPortType.LOCAL, portOutAction.getPortNumber().getPortType());
+        Assertions.assertEquals(SpecialPortType.LOCAL, portOutAction.getPortNumber().getPortType());
     }
 
     @Test
@@ -95,6 +93,6 @@ public class BfdCatchRuleGeneratorTest {
         BfdCatchRuleGenerator generator = new BfdCatchRuleGenerator();
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertTrue(commands.isEmpty());
+        Assertions.assertTrue(commands.isEmpty());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/BroadCastDiscoveryRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/BroadCastDiscoveryRuleGeneratorTest.java
@@ -15,10 +15,7 @@
 
 package org.openkilda.rulemanager.factory.generator.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.MeterId.createMeterIdForDefaultRule;
@@ -64,8 +61,9 @@ import org.openkilda.rulemanager.group.GroupType;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
@@ -77,7 +75,7 @@ public class BroadCastDiscoveryRuleGeneratorTest {
     private BroadCastDiscoveryRuleGenerator generator;
     private Switch sw;
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = mock(RuleManagerConfig.class);
         when(config.getBroadcastRateLimit()).thenReturn(200);
@@ -104,8 +102,8 @@ public class BroadCastDiscoveryRuleGeneratorTest {
         GroupSpeakerData groupCommandData = getCommand(GroupSpeakerData.class, commands);
 
         assertEquals(2, flowCommandData.getDependsOn().size());
-        assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
-        assertTrue(flowCommandData.getDependsOn().contains(groupCommandData.getUuid()));
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(groupCommandData.getUuid()));
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -139,8 +137,8 @@ public class BroadCastDiscoveryRuleGeneratorTest {
         GroupSpeakerData groupCommandData = getCommand(GroupSpeakerData.class, commands);
 
         assertEquals(2, flowCommandData.getDependsOn().size());
-        assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
-        assertTrue(flowCommandData.getDependsOn().contains(groupCommandData.getUuid()));
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(groupCommandData.getUuid()));
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -154,13 +152,13 @@ public class BroadCastDiscoveryRuleGeneratorTest {
         Instructions instructions = flowCommandData.getInstructions();
         assertEquals(2, instructions.getApplyActions().size());
         Action first = instructions.getApplyActions().get(0);
-        assertTrue(first instanceof MeterAction);
+        Assertions.assertTrue(first instanceof MeterAction);
         MeterAction meterAction = (MeterAction) first;
         assertEquals(meterCommandData.getMeterId(), meterAction.getMeterId());
         checkGroupAction(instructions.getApplyActions().get(1), groupCommandData.getGroupId());
-        assertNull(instructions.getWriteActions());
-        assertNull(instructions.getGoToMeter());
-        assertNull(instructions.getGoToTable());
+        Assertions.assertNull(instructions.getWriteActions());
+        Assertions.assertNull(instructions.getGoToMeter());
+        Assertions.assertNull(instructions.getGoToTable());
 
         // Check meter command
         checkMeterCommand(meterCommandData);
@@ -183,7 +181,7 @@ public class BroadCastDiscoveryRuleGeneratorTest {
         MeterSpeakerData meterCommandData = getCommand(MeterSpeakerData.class, commands);
 
         assertEquals(1, flowCommandData.getDependsOn().size());
-        assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -196,12 +194,12 @@ public class BroadCastDiscoveryRuleGeneratorTest {
         Instructions instructions = flowCommandData.getInstructions();
         assertEquals(1, instructions.getApplyActions().size());
         Action first = instructions.getApplyActions().get(0);
-        assertTrue(first instanceof PortOutAction);
+        Assertions.assertTrue(first instanceof PortOutAction);
         PortOutAction portOutAction = (PortOutAction) first;
         assertEquals(SpecialPortType.CONTROLLER, portOutAction.getPortNumber().getPortType());
-        assertNull(instructions.getWriteActions());
+        Assertions.assertNull(instructions.getWriteActions());
         assertEquals(meterCommandData.getMeterId(), instructions.getGoToMeter());
-        assertNull(instructions.getGoToTable());
+        Assertions.assertNull(instructions.getGoToTable());
 
         // Check meter command
         checkMeterCommand(meterCommandData);
@@ -221,7 +219,7 @@ public class BroadCastDiscoveryRuleGeneratorTest {
         GroupSpeakerData groupCommandData = getCommand(GroupSpeakerData.class, commands);
 
         assertEquals(1, flowCommandData.getDependsOn().size());
-        assertTrue(flowCommandData.getDependsOn().contains(groupCommandData.getUuid()));
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(groupCommandData.getUuid()));
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -236,9 +234,9 @@ public class BroadCastDiscoveryRuleGeneratorTest {
         Action action = instructions.getApplyActions().get(0);
         checkGroupAction(action, groupCommandData.getGroupId());
 
-        assertNull(instructions.getWriteActions());
-        assertNull(instructions.getGoToMeter());
-        assertNull(instructions.getGoToTable());
+        Assertions.assertNull(instructions.getWriteActions());
+        Assertions.assertNull(instructions.getGoToMeter());
+        Assertions.assertNull(instructions.getGoToTable());
 
         // Check group command
         checkGroupCommand(groupCommandData);
@@ -255,7 +253,7 @@ public class BroadCastDiscoveryRuleGeneratorTest {
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
 
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -269,12 +267,12 @@ public class BroadCastDiscoveryRuleGeneratorTest {
         Instructions instructions = flowCommandData.getInstructions();
         assertEquals(1, instructions.getApplyActions().size());
         Action first = instructions.getApplyActions().get(0);
-        assertTrue(first instanceof PortOutAction);
+        Assertions.assertTrue(first instanceof PortOutAction);
         PortOutAction portOutAction = (PortOutAction) first;
         assertEquals(SpecialPortType.CONTROLLER, portOutAction.getPortNumber().getPortType());
-        assertNull(instructions.getWriteActions());
-        assertNull(instructions.getGoToMeter());
-        assertNull(instructions.getGoToTable());
+        Assertions.assertNull(instructions.getWriteActions());
+        Assertions.assertNull(instructions.getGoToMeter());
+        Assertions.assertNull(instructions.getGoToTable());
     }
 
     @Test
@@ -291,8 +289,8 @@ public class BroadCastDiscoveryRuleGeneratorTest {
         GroupSpeakerData groupCommandData = getCommand(GroupSpeakerData.class, commands);
 
         assertEquals(2, flowCommandData.getDependsOn().size());
-        assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
-        assertTrue(flowCommandData.getDependsOn().contains(groupCommandData.getUuid()));
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(groupCommandData.getUuid()));
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -326,8 +324,8 @@ public class BroadCastDiscoveryRuleGeneratorTest {
         GroupSpeakerData groupCommandData = getCommand(GroupSpeakerData.class, commands);
 
         assertEquals(2, flowCommandData.getDependsOn().size());
-        assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
-        assertTrue(flowCommandData.getDependsOn().contains(groupCommandData.getUuid()));
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(groupCommandData.getUuid()));
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -348,7 +346,7 @@ public class BroadCastDiscoveryRuleGeneratorTest {
                 config.getDiscoPacketSize());
         assertEquals(expectedBurst, meterCommandData.getBurst());
         assertEquals(3, meterCommandData.getFlags().size());
-        assertTrue(Sets.newHashSet(MeterFlag.BURST, MeterFlag.STATS, MeterFlag.KBPS)
+        Assertions.assertTrue(Sets.newHashSet(MeterFlag.BURST, MeterFlag.STATS, MeterFlag.KBPS)
                 .containsAll(meterCommandData.getFlags()));
 
         // Check group command
@@ -364,22 +362,22 @@ public class BroadCastDiscoveryRuleGeneratorTest {
     private void checkEthDstMatch(Set<FieldMatch> match) {
         FieldMatch ethDstMatch = getMatchByField(Field.ETH_DST, match);
         assertEquals(new SwitchId(config.getDiscoveryBcastPacketDst()).toLong(), ethDstMatch.getValue());
-        assertTrue(ethDstMatch.isMasked());
+        Assertions.assertTrue(ethDstMatch.isMasked());
         assertEquals(Mask.NO_MASK, ethDstMatch.getMask().longValue());
     }
 
     private void checkUpdDstMatch(Set<FieldMatch> match) {
         FieldMatch ipProtoMatch = getMatchByField(Field.IP_PROTO, match);
         assertEquals(IpProto.UDP, ipProtoMatch.getValue());
-        assertFalse(ipProtoMatch.isMasked());
+        Assertions.assertFalse(ipProtoMatch.isMasked());
 
         FieldMatch ethTypeMatch = getMatchByField(Field.ETH_TYPE, match);
         assertEquals(EthType.IPv4, ethTypeMatch.getValue());
-        assertFalse(ethTypeMatch.isMasked());
+        Assertions.assertFalse(ethTypeMatch.isMasked());
 
         FieldMatch updDestMatch = getMatchByField(Field.UDP_DST, match);
         assertEquals(DISCOVERY_PACKET_UDP_PORT, updDestMatch.getValue());
-        assertFalse(updDestMatch.isMasked());
+        Assertions.assertFalse(updDestMatch.isMasked());
     }
 
     private void checkGroupInstructions(Instructions instructions, MeterId meterId, GroupId groupId) {
@@ -387,13 +385,13 @@ public class BroadCastDiscoveryRuleGeneratorTest {
         Action action = instructions.getApplyActions().get(0);
         checkGroupAction(action, groupId);
 
-        assertNull(instructions.getWriteActions());
+        Assertions.assertNull(instructions.getWriteActions());
         assertEquals(instructions.getGoToMeter(), meterId);
-        assertNull(instructions.getGoToTable());
+        Assertions.assertNull(instructions.getGoToTable());
     }
 
     private void checkGroupAction(Action action, GroupId groupId) {
-        assertTrue(action instanceof GroupAction);
+        Assertions.assertTrue(action instanceof GroupAction);
         GroupAction groupAction = (GroupAction) action;
         assertEquals(groupAction.getGroupId(), groupId);
     }
@@ -403,7 +401,7 @@ public class BroadCastDiscoveryRuleGeneratorTest {
         assertEquals(config.getBroadcastRateLimit(), meterCommandData.getRate());
         assertEquals(config.getSystemMeterBurstSizeInPackets(), meterCommandData.getBurst());
         assertEquals(3, meterCommandData.getFlags().size());
-        assertTrue(Sets.newHashSet(MeterFlag.BURST, MeterFlag.STATS, MeterFlag.PKTPS)
+        Assertions.assertTrue(Sets.newHashSet(MeterFlag.BURST, MeterFlag.STATS, MeterFlag.PKTPS)
                 .containsAll(meterCommandData.getFlags()));
     }
 

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/ConnectedDevicesRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/ConnectedDevicesRuleGeneratorTest.java
@@ -15,9 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.model.SwitchFeature.METERS;
 import static org.openkilda.model.SwitchFeature.PKTPS_FLAG;
 import static org.openkilda.rulemanager.Utils.buildSwitch;
@@ -40,7 +37,8 @@ import org.openkilda.rulemanager.action.PortOutAction;
 import org.openkilda.rulemanager.factory.RuleGenerator;
 import org.openkilda.rulemanager.match.FieldMatch;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
@@ -61,16 +59,16 @@ public abstract class ConnectedDevicesRuleGeneratorTest {
         sw = buildSwitch("OF_13", expectedFeatures);
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(2, commands.size());
-        commands.forEach(c -> assertEquals(sw.getSwitchId(), c.getSwitchId()));
-        commands.forEach(c -> assertEquals(sw.getOfVersion(), c.getOfVersion().toString()));
+        Assertions.assertEquals(2, commands.size());
+        commands.forEach(c -> Assertions.assertEquals(sw.getSwitchId(), c.getSwitchId()));
+        commands.forEach(c -> Assertions.assertEquals(sw.getOfVersion(), c.getOfVersion().toString()));
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
         MeterSpeakerData meterCommandData = getCommand(MeterSpeakerData.class, commands);
 
-        assertEquals(1, flowCommandData.getDependsOn().size());
-        assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
-        assertTrue(meterCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(1, flowCommandData.getDependsOn().size());
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
+        Assertions.assertTrue(meterCommandData.getDependsOn().isEmpty());
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -88,16 +86,16 @@ public abstract class ConnectedDevicesRuleGeneratorTest {
         sw = buildSwitch("OF_15", expectedFeatures);
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(2, commands.size());
-        commands.forEach(c -> assertEquals(sw.getSwitchId(), c.getSwitchId()));
-        commands.forEach(c -> assertEquals(sw.getOfVersion(), c.getOfVersion().toString()));
+        Assertions.assertEquals(2, commands.size());
+        commands.forEach(c -> Assertions.assertEquals(sw.getSwitchId(), c.getSwitchId()));
+        commands.forEach(c -> Assertions.assertEquals(sw.getOfVersion(), c.getOfVersion().toString()));
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
         MeterSpeakerData meterCommandData = getCommand(MeterSpeakerData.class, commands);
 
-        assertEquals(1, flowCommandData.getDependsOn().size());
-        assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
-        assertTrue(meterCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(1, flowCommandData.getDependsOn().size());
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
+        Assertions.assertTrue(meterCommandData.getDependsOn().isEmpty());
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -117,13 +115,13 @@ public abstract class ConnectedDevicesRuleGeneratorTest {
         sw = buildSwitch("OF_13", expectedFeatures);
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(1, commands.size());
-        commands.forEach(c -> assertEquals(sw.getSwitchId(), c.getSwitchId()));
-        commands.forEach(c -> assertEquals(sw.getOfVersion(), c.getOfVersion().toString()));
+        Assertions.assertEquals(1, commands.size());
+        commands.forEach(c -> Assertions.assertEquals(sw.getSwitchId(), c.getSwitchId()));
+        commands.forEach(c -> Assertions.assertEquals(sw.getOfVersion(), c.getOfVersion().toString()));
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
 
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -139,16 +137,16 @@ public abstract class ConnectedDevicesRuleGeneratorTest {
         sw = buildSwitch("OF_13", expectedFeatures);
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(2, commands.size());
-        commands.forEach(c -> assertEquals(sw.getSwitchId(), c.getSwitchId()));
-        commands.forEach(c -> assertEquals(sw.getOfVersion(), c.getOfVersion().toString()));
+        Assertions.assertEquals(2, commands.size());
+        commands.forEach(c -> Assertions.assertEquals(sw.getSwitchId(), c.getSwitchId()));
+        commands.forEach(c -> Assertions.assertEquals(sw.getOfVersion(), c.getOfVersion().toString()));
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
         MeterSpeakerData meterCommandData = getCommand(MeterSpeakerData.class, commands);
 
-        assertEquals(1, flowCommandData.getDependsOn().size());
-        assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
-        assertTrue(meterCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(1, flowCommandData.getDependsOn().size());
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
+        Assertions.assertTrue(meterCommandData.getDependsOn().isEmpty());
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -162,40 +160,40 @@ public abstract class ConnectedDevicesRuleGeneratorTest {
     }
 
     protected void checkFlowCommandBaseProperties(FlowSpeakerData flowCommandData) {
-        assertEquals(cookie, flowCommandData.getCookie());
-        assertEquals(table, flowCommandData.getTable());
-        assertEquals(priority, flowCommandData.getPriority());
+        Assertions.assertEquals(cookie, flowCommandData.getCookie());
+        Assertions.assertEquals(table, flowCommandData.getTable());
+        Assertions.assertEquals(priority, flowCommandData.getPriority());
     }
 
     protected abstract void checkMatch(Set<FieldMatch> match);
 
     protected void checkInstructions(Instructions instructions, MeterId meterId) {
-        assertEquals(1, instructions.getApplyActions().size());
+        Assertions.assertEquals(1, instructions.getApplyActions().size());
         Action action = instructions.getApplyActions().get(0);
-        assertTrue(action instanceof PortOutAction);
+        Assertions.assertTrue(action instanceof PortOutAction);
         PortOutAction portOutAction = (PortOutAction) action;
-        assertEquals(SpecialPortType.CONTROLLER, portOutAction.getPortNumber().getPortType());
+        Assertions.assertEquals(SpecialPortType.CONTROLLER, portOutAction.getPortNumber().getPortType());
 
-        assertNull(instructions.getWriteActions());
-        assertEquals(instructions.getGoToMeter(), meterId);
-        assertNull(instructions.getGoToTable());
+        Assertions.assertNull(instructions.getWriteActions());
+        Assertions.assertEquals(instructions.getGoToMeter(), meterId);
+        Assertions.assertNull(instructions.getGoToTable());
     }
 
     protected void checkInstructionsOf15(Instructions instructions, MeterId meterId) {
-        assertEquals(2, instructions.getApplyActions().size());
+        Assertions.assertEquals(2, instructions.getApplyActions().size());
         Action first = instructions.getApplyActions().get(0);
-        assertTrue(first instanceof PortOutAction);
+        Assertions.assertTrue(first instanceof PortOutAction);
         PortOutAction portOutAction = (PortOutAction) first;
-        assertEquals(SpecialPortType.CONTROLLER, portOutAction.getPortNumber().getPortType());
+        Assertions.assertEquals(SpecialPortType.CONTROLLER, portOutAction.getPortNumber().getPortType());
 
         Action second = instructions.getApplyActions().get(1);
-        assertTrue(second instanceof MeterAction);
+        Assertions.assertTrue(second instanceof MeterAction);
         MeterAction meterAction = (MeterAction) second;
-        assertEquals(meterId, meterAction.getMeterId());
+        Assertions.assertEquals(meterId, meterAction.getMeterId());
 
-        assertNull(instructions.getWriteActions());
-        assertNull(instructions.getGoToMeter());
-        assertNull(instructions.getGoToTable());
+        Assertions.assertNull(instructions.getWriteActions());
+        Assertions.assertNull(instructions.getGoToMeter());
+        Assertions.assertNull(instructions.getGoToTable());
     }
 
     protected abstract void checkMeterCommand(MeterSpeakerData meterCommandData);

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/DropDiscoveryLoopRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/DropDiscoveryLoopRuleGeneratorTest.java
@@ -15,10 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.cookie.Cookie.DROP_VERIFICATION_LOOP_RULE_COOKIE;
@@ -37,8 +33,9 @@ import org.openkilda.rulemanager.RuleManagerConfig;
 import org.openkilda.rulemanager.SpeakerData;
 import org.openkilda.rulemanager.match.FieldMatch;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -49,7 +46,7 @@ public class DropDiscoveryLoopRuleGeneratorTest {
 
     private DropDiscoveryLoopRuleGenerator generator;
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = mock(RuleManagerConfig.class);
         when(config.getDiscoveryBcastPacketDst()).thenReturn("00:26:E1:FF:FF:FF");
@@ -64,30 +61,30 @@ public class DropDiscoveryLoopRuleGeneratorTest {
         Switch sw = buildSwitch("OF_13", Collections.emptySet());
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(new Cookie(DROP_VERIFICATION_LOOP_RULE_COOKIE), flowCommandData.getCookie());
-        assertEquals(OfTable.INPUT, flowCommandData.getTable());
-        assertEquals(DROP_DISCOVERY_LOOP_RULE_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(new Cookie(DROP_VERIFICATION_LOOP_RULE_COOKIE), flowCommandData.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, flowCommandData.getTable());
+        Assertions.assertEquals(DROP_DISCOVERY_LOOP_RULE_PRIORITY, flowCommandData.getPriority());
 
         FieldMatch ethDstMatch = getMatchByField(Field.ETH_DST, flowCommandData.getMatch());
-        assertEquals(new SwitchId(config.getDiscoveryBcastPacketDst()).toLong(), ethDstMatch.getValue());
-        assertFalse(ethDstMatch.isMasked());
+        Assertions.assertEquals(new SwitchId(config.getDiscoveryBcastPacketDst()).toLong(), ethDstMatch.getValue());
+        Assertions.assertFalse(ethDstMatch.isMasked());
 
         FieldMatch ethSrcMatch = getMatchByField(Field.ETH_SRC, flowCommandData.getMatch());
-        assertEquals(sw.getSwitchId().toLong(), ethSrcMatch.getValue());
-        assertFalse(ethSrcMatch.isMasked());
+        Assertions.assertEquals(sw.getSwitchId().toLong(), ethSrcMatch.getValue());
+        Assertions.assertFalse(ethSrcMatch.isMasked());
 
-        assertNull(flowCommandData.getInstructions().getApplyActions());
-        assertNull(flowCommandData.getInstructions().getGoToMeter());
-        assertNull(flowCommandData.getInstructions().getGoToTable());
-        assertNull(flowCommandData.getInstructions().getWriteMetadata());
-        assertNull(flowCommandData.getInstructions().getWriteActions());
+        Assertions.assertNull(flowCommandData.getInstructions().getApplyActions());
+        Assertions.assertNull(flowCommandData.getInstructions().getGoToMeter());
+        Assertions.assertNull(flowCommandData.getInstructions().getGoToTable());
+        Assertions.assertNull(flowCommandData.getInstructions().getWriteMetadata());
+        Assertions.assertNull(flowCommandData.getInstructions().getWriteActions());
     }
 
     @Test
@@ -95,6 +92,6 @@ public class DropDiscoveryLoopRuleGeneratorTest {
         Switch sw = buildSwitch("OF_12", Collections.emptySet());
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertTrue(commands.isEmpty());
+        Assertions.assertTrue(commands.isEmpty());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/RoundTripLatencyRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/RoundTripLatencyRuleGeneratorTest.java
@@ -15,9 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.SwitchFeature.NOVIFLOW_COPY_FIELD;
@@ -51,8 +48,9 @@ import org.openkilda.rulemanager.factory.generator.service.noviflow.RoundTripLat
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -61,7 +59,7 @@ public class RoundTripLatencyRuleGeneratorTest {
 
     private RuleManagerConfig config;
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = mock(RuleManagerConfig.class);
         when(config.getDiscoveryBcastPacketDst()).thenReturn("00:26:E1:FF:FF:FF");
@@ -75,52 +73,52 @@ public class RoundTripLatencyRuleGeneratorTest {
                 .build();
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(new Cookie(ROUND_TRIP_LATENCY_RULE_COOKIE), flowCommandData.getCookie());
-        assertEquals(OfTable.INPUT, flowCommandData.getTable());
-        assertEquals(ROUND_TRIP_LATENCY_RULE_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(new Cookie(ROUND_TRIP_LATENCY_RULE_COOKIE), flowCommandData.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, flowCommandData.getTable());
+        Assertions.assertEquals(ROUND_TRIP_LATENCY_RULE_PRIORITY, flowCommandData.getPriority());
 
         FieldMatch ethSrcMatch = getMatchByField(Field.ETH_SRC, flowCommandData.getMatch());
-        assertEquals(sw.getSwitchId().toLong(), ethSrcMatch.getValue());
-        assertFalse(ethSrcMatch.isMasked());
+        Assertions.assertEquals(sw.getSwitchId().toLong(), ethSrcMatch.getValue());
+        Assertions.assertFalse(ethSrcMatch.isMasked());
 
         FieldMatch ethDstMatch = getMatchByField(Field.ETH_DST, flowCommandData.getMatch());
-        assertEquals(new SwitchId(config.getDiscoveryBcastPacketDst()).toLong(), ethDstMatch.getValue());
-        assertFalse(ethDstMatch.isMasked());
+        Assertions.assertEquals(new SwitchId(config.getDiscoveryBcastPacketDst()).toLong(), ethDstMatch.getValue());
+        Assertions.assertFalse(ethDstMatch.isMasked());
 
         FieldMatch ethTypeMatch = getMatchByField(Field.ETH_TYPE, flowCommandData.getMatch());
-        assertEquals(EthType.IPv4, ethTypeMatch.getValue());
-        assertFalse(ethTypeMatch.isMasked());
+        Assertions.assertEquals(EthType.IPv4, ethTypeMatch.getValue());
+        Assertions.assertFalse(ethTypeMatch.isMasked());
 
         FieldMatch ipProtoMatch = getMatchByField(Field.IP_PROTO, flowCommandData.getMatch());
-        assertEquals(IpProto.UDP, ipProtoMatch.getValue());
-        assertFalse(ipProtoMatch.isMasked());
+        Assertions.assertEquals(IpProto.UDP, ipProtoMatch.getValue());
+        Assertions.assertFalse(ipProtoMatch.isMasked());
 
         FieldMatch udpDstMatch = getMatchByField(Field.UDP_DST, flowCommandData.getMatch());
-        assertEquals(Constants.LATENCY_PACKET_UDP_PORT, udpDstMatch.getValue());
-        assertFalse(udpDstMatch.isMasked());
+        Assertions.assertEquals(Constants.LATENCY_PACKET_UDP_PORT, udpDstMatch.getValue());
+        Assertions.assertFalse(udpDstMatch.isMasked());
 
         Instructions instructions = flowCommandData.getInstructions();
-        assertEquals(2, instructions.getApplyActions().size());
+        Assertions.assertEquals(2, instructions.getApplyActions().size());
         Action first = instructions.getApplyActions().get(0);
-        assertTrue(first instanceof CopyFieldAction);
+        Assertions.assertTrue(first instanceof CopyFieldAction);
         CopyFieldAction copyFieldAction = (CopyFieldAction) first;
-        assertEquals(ROUND_TRIP_LATENCY_TIMESTAMP_SIZE, copyFieldAction.getNumberOfBits());
-        assertEquals(0, copyFieldAction.getSrcOffset());
-        assertEquals(ROUND_TRIP_LATENCY_T1_OFFSET, copyFieldAction.getDstOffset());
-        assertEquals(NOVIFLOW_RX_TIMESTAMP, copyFieldAction.getOxmSrcHeader());
-        assertEquals(NOVIFLOW_PACKET_OFFSET, copyFieldAction.getOxmDstHeader());
+        Assertions.assertEquals(ROUND_TRIP_LATENCY_TIMESTAMP_SIZE, copyFieldAction.getNumberOfBits());
+        Assertions.assertEquals(0, copyFieldAction.getSrcOffset());
+        Assertions.assertEquals(ROUND_TRIP_LATENCY_T1_OFFSET, copyFieldAction.getDstOffset());
+        Assertions.assertEquals(NOVIFLOW_RX_TIMESTAMP, copyFieldAction.getOxmSrcHeader());
+        Assertions.assertEquals(NOVIFLOW_PACKET_OFFSET, copyFieldAction.getOxmDstHeader());
 
         Action second = instructions.getApplyActions().get(1);
-        assertTrue(second instanceof PortOutAction);
+        Assertions.assertTrue(second instanceof PortOutAction);
         PortOutAction portOutAction = (PortOutAction) second;
-        assertEquals(SpecialPortType.CONTROLLER, portOutAction.getPortNumber().getPortType());
+        Assertions.assertEquals(SpecialPortType.CONTROLLER, portOutAction.getPortNumber().getPortType());
     }
 
     @Test
@@ -129,6 +127,6 @@ public class RoundTripLatencyRuleGeneratorTest {
         BfdCatchRuleGenerator generator = new BfdCatchRuleGenerator();
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertTrue(commands.isEmpty());
+        Assertions.assertTrue(commands.isEmpty());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/TableDefaultRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/TableDefaultRuleGeneratorTest.java
@@ -15,9 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.model.cookie.Cookie.DROP_RULE_COOKIE;
 import static org.openkilda.rulemanager.Constants.Priority.MINIMAL_POSITIVE_PRIORITY;
 import static org.openkilda.rulemanager.Utils.buildSwitch;
@@ -29,7 +26,8 @@ import org.openkilda.rulemanager.FlowSpeakerData;
 import org.openkilda.rulemanager.OfTable;
 import org.openkilda.rulemanager.SpeakerData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -45,22 +43,22 @@ public class TableDefaultRuleGeneratorTest {
                 .build();
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(new Cookie(DROP_RULE_COOKIE), flowCommandData.getCookie());
-        assertEquals(OfTable.INPUT, flowCommandData.getTable());
-        assertEquals(MINIMAL_POSITIVE_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(new Cookie(DROP_RULE_COOKIE), flowCommandData.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, flowCommandData.getTable());
+        Assertions.assertEquals(MINIMAL_POSITIVE_PRIORITY, flowCommandData.getPriority());
 
-        assertTrue(flowCommandData.getMatch().isEmpty());
-        assertNull(flowCommandData.getInstructions().getApplyActions());
-        assertNull(flowCommandData.getInstructions().getGoToTable());
-        assertNull(flowCommandData.getInstructions().getGoToMeter());
-        assertNull(flowCommandData.getInstructions().getWriteActions());
-        assertNull(flowCommandData.getInstructions().getWriteMetadata());
+        Assertions.assertTrue(flowCommandData.getMatch().isEmpty());
+        Assertions.assertNull(flowCommandData.getInstructions().getApplyActions());
+        Assertions.assertNull(flowCommandData.getInstructions().getGoToTable());
+        Assertions.assertNull(flowCommandData.getInstructions().getGoToMeter());
+        Assertions.assertNull(flowCommandData.getInstructions().getWriteActions());
+        Assertions.assertNull(flowCommandData.getInstructions().getWriteMetadata());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/TablePassThroughDefaultRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/TablePassThroughDefaultRuleGeneratorTest.java
@@ -15,9 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.model.cookie.Cookie.MULTITABLE_EGRESS_PASS_THROUGH_COOKIE;
 import static org.openkilda.rulemanager.Constants.Priority.MINIMAL_POSITIVE_PRIORITY;
 import static org.openkilda.rulemanager.Utils.buildSwitch;
@@ -30,7 +27,8 @@ import org.openkilda.rulemanager.Instructions;
 import org.openkilda.rulemanager.OfTable;
 import org.openkilda.rulemanager.SpeakerData;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -47,23 +45,23 @@ public class TablePassThroughDefaultRuleGeneratorTest {
                 .build();
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(new Cookie(MULTITABLE_EGRESS_PASS_THROUGH_COOKIE), flowCommandData.getCookie());
-        assertEquals(OfTable.EGRESS, flowCommandData.getTable());
-        assertEquals(MINIMAL_POSITIVE_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(new Cookie(MULTITABLE_EGRESS_PASS_THROUGH_COOKIE), flowCommandData.getCookie());
+        Assertions.assertEquals(OfTable.EGRESS, flowCommandData.getTable());
+        Assertions.assertEquals(MINIMAL_POSITIVE_PRIORITY, flowCommandData.getPriority());
 
-        assertTrue(flowCommandData.getMatch().isEmpty());
+        Assertions.assertTrue(flowCommandData.getMatch().isEmpty());
 
         Instructions instructions = flowCommandData.getInstructions();
-        assertNull(instructions.getApplyActions());
-        assertNull(instructions.getWriteActions());
-        assertNull(instructions.getGoToMeter());
-        assertEquals(OfTable.TRANSIT, instructions.getGoToTable());
+        Assertions.assertNull(instructions.getApplyActions());
+        Assertions.assertNull(instructions.getWriteActions());
+        Assertions.assertNull(instructions.getGoToMeter());
+        Assertions.assertEquals(OfTable.TRANSIT, instructions.getGoToTable());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/UniCastDiscoveryRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/UniCastDiscoveryRuleGeneratorTest.java
@@ -15,9 +15,7 @@
 
 package org.openkilda.rulemanager.factory.generator.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.MeterId.createMeterIdForDefaultRule;
@@ -51,8 +49,9 @@ import org.openkilda.rulemanager.action.SetFieldAction;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -65,7 +64,7 @@ public class UniCastDiscoveryRuleGeneratorTest {
     private UniCastDiscoveryRuleGenerator generator;
     private Switch sw;
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = mock(RuleManagerConfig.class);
         when(config.getBroadcastRateLimit()).thenReturn(200);
@@ -91,7 +90,7 @@ public class UniCastDiscoveryRuleGeneratorTest {
         MeterSpeakerData meterCommandData = getCommand(MeterSpeakerData.class, commands);
 
         assertEquals(1, flowCommandData.getDependsOn().size());
-        assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -111,7 +110,7 @@ public class UniCastDiscoveryRuleGeneratorTest {
         sw = buildSwitch("OF_12", Sets.newHashSet(METERS, PKTPS_FLAG));
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertTrue(commands.isEmpty());
+        Assertions.assertTrue(commands.isEmpty());
     }
 
     @Test
@@ -127,7 +126,7 @@ public class UniCastDiscoveryRuleGeneratorTest {
         MeterSpeakerData meterCommandData = getCommand(MeterSpeakerData.class, commands);
 
         assertEquals(1, flowCommandData.getDependsOn().size());
-        assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -140,14 +139,14 @@ public class UniCastDiscoveryRuleGeneratorTest {
         Instructions instructions = flowCommandData.getInstructions();
         assertEquals(3, instructions.getApplyActions().size());
         Action first = instructions.getApplyActions().get(0);
-        assertTrue(first instanceof MeterAction);
+        Assertions.assertTrue(first instanceof MeterAction);
         MeterAction meterAction = (MeterAction) first;
         assertEquals(meterCommandData.getMeterId(), meterAction.getMeterId());
         checkPortOutAction(instructions.getApplyActions().get(1));
         checkSetFieldAction(instructions.getApplyActions().get(2));
-        assertNull(instructions.getWriteActions());
-        assertNull(instructions.getGoToMeter());
-        assertNull(instructions.getGoToTable());
+        Assertions.assertNull(instructions.getWriteActions());
+        Assertions.assertNull(instructions.getGoToMeter());
+        Assertions.assertNull(instructions.getGoToTable());
 
         // Check meter command
         checkMeterCommand(meterCommandData);
@@ -164,7 +163,7 @@ public class UniCastDiscoveryRuleGeneratorTest {
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
 
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -177,9 +176,9 @@ public class UniCastDiscoveryRuleGeneratorTest {
         assertEquals(2, instructions.getApplyActions().size());
         checkPortOutAction(instructions.getApplyActions().get(0));
         checkSetFieldAction(instructions.getApplyActions().get(1));
-        assertNull(instructions.getWriteActions());
-        assertNull(instructions.getGoToMeter());
-        assertNull(instructions.getGoToTable());
+        Assertions.assertNull(instructions.getWriteActions());
+        Assertions.assertNull(instructions.getGoToMeter());
+        Assertions.assertNull(instructions.getGoToTable());
     }
 
     @Test
@@ -195,7 +194,7 @@ public class UniCastDiscoveryRuleGeneratorTest {
         MeterSpeakerData meterCommandData = getCommand(MeterSpeakerData.class, commands);
 
         assertEquals(1, flowCommandData.getDependsOn().size());
-        assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -214,7 +213,7 @@ public class UniCastDiscoveryRuleGeneratorTest {
                 config.getDiscoPacketSize());
         assertEquals(expectedBurst, meterCommandData.getBurst());
         assertEquals(3, meterCommandData.getFlags().size());
-        assertTrue(Sets.newHashSet(MeterFlag.BURST, MeterFlag.STATS, MeterFlag.KBPS)
+        Assertions.assertTrue(Sets.newHashSet(MeterFlag.BURST, MeterFlag.STATS, MeterFlag.KBPS)
                 .containsAll(meterCommandData.getFlags()));
     }
 
@@ -227,12 +226,12 @@ public class UniCastDiscoveryRuleGeneratorTest {
     private void checkMatch(Set<FieldMatch> match) {
         FieldMatch ethSrcMatch = getMatchByField(Field.ETH_SRC, match);
         assertEquals(new SwitchId(config.getFlowPingMagicSrcMacAddress()).toLong(), ethSrcMatch.getValue());
-        assertTrue(ethSrcMatch.isMasked());
+        Assertions.assertTrue(ethSrcMatch.isMasked());
         assertEquals(Mask.NO_MASK, ethSrcMatch.getMask().longValue());
 
         FieldMatch ethDstMatch = getMatchByField(Field.ETH_DST, match);
         assertEquals(sw.getSwitchId().toLong(), ethDstMatch.getValue());
-        assertTrue(ethDstMatch.isMasked());
+        Assertions.assertTrue(ethDstMatch.isMasked());
         assertEquals(Mask.NO_MASK, ethDstMatch.getMask().longValue());
     }
 
@@ -240,19 +239,19 @@ public class UniCastDiscoveryRuleGeneratorTest {
         assertEquals(2, instructions.getApplyActions().size());
         checkPortOutAction(instructions.getApplyActions().get(0));
         checkSetFieldAction(instructions.getApplyActions().get(1));
-        assertNull(instructions.getWriteActions());
+        Assertions.assertNull(instructions.getWriteActions());
         assertEquals(instructions.getGoToMeter(), meterId);
-        assertNull(instructions.getGoToTable());
+        Assertions.assertNull(instructions.getGoToTable());
     }
 
     private void checkPortOutAction(Action action) {
-        assertTrue(action instanceof PortOutAction);
+        Assertions.assertTrue(action instanceof PortOutAction);
         PortOutAction portOutAction = (PortOutAction) action;
         assertEquals(SpecialPortType.CONTROLLER, portOutAction.getPortNumber().getPortType());
     }
 
     private void checkSetFieldAction(Action action) {
-        assertTrue(action instanceof SetFieldAction);
+        Assertions.assertTrue(action instanceof SetFieldAction);
         SetFieldAction setFieldAction = (SetFieldAction) action;
         assertEquals(Field.ETH_DST, setFieldAction.getField());
         assertEquals(sw.getSwitchId().toLong(), setFieldAction.getValue());
@@ -263,7 +262,7 @@ public class UniCastDiscoveryRuleGeneratorTest {
         assertEquals(config.getUnicastRateLimit(), meterCommandData.getRate());
         assertEquals(config.getSystemMeterBurstSizeInPackets(), meterCommandData.getBurst());
         assertEquals(3, meterCommandData.getFlags().size());
-        assertTrue(Sets.newHashSet(MeterFlag.BURST, MeterFlag.STATS, MeterFlag.PKTPS)
+        Assertions.assertTrue(Sets.newHashSet(MeterFlag.BURST, MeterFlag.STATS, MeterFlag.PKTPS)
                 .containsAll(meterCommandData.getFlags()));
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/UnicastVerificationVxlanRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/UnicastVerificationVxlanRuleGeneratorTest.java
@@ -15,10 +15,7 @@
 
 package org.openkilda.rulemanager.factory.generator.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.MeterId.createMeterIdForDefaultRule;
@@ -58,8 +55,9 @@ import org.openkilda.rulemanager.action.PortOutAction;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
@@ -70,7 +68,7 @@ public class UnicastVerificationVxlanRuleGeneratorTest {
     private UnicastVerificationVxlanRuleGenerator generator;
     private Switch sw;
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = mock(RuleManagerConfig.class);
         when(config.getUnicastRateLimit()).thenReturn(200);
@@ -96,7 +94,7 @@ public class UnicastVerificationVxlanRuleGeneratorTest {
         MeterSpeakerData meterCommandData = getCommand(MeterSpeakerData.class, commands);
 
         assertEquals(1, flowCommandData.getDependsOn().size());
-        assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -120,7 +118,7 @@ public class UnicastVerificationVxlanRuleGeneratorTest {
         MeterSpeakerData meterCommandData = getCommand(MeterSpeakerData.class, commands);
 
         assertEquals(1, flowCommandData.getDependsOn().size());
-        assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -128,18 +126,18 @@ public class UnicastVerificationVxlanRuleGeneratorTest {
         Instructions instructions = flowCommandData.getInstructions();
         assertEquals(3, instructions.getApplyActions().size());
         Action first = instructions.getApplyActions().get(0);
-        assertTrue(first instanceof PopVxlanAction);
+        Assertions.assertTrue(first instanceof PopVxlanAction);
         PopVxlanAction popVxlanAction = (PopVxlanAction) first;
         assertEquals(ActionType.POP_VXLAN_OVS, popVxlanAction.getType());
 
         Action second = instructions.getApplyActions().get(1);
-        assertTrue(second instanceof PortOutAction);
+        Assertions.assertTrue(second instanceof PortOutAction);
         PortOutAction sendToControllerAction = (PortOutAction) second;
         assertEquals(SpecialPortType.CONTROLLER, sendToControllerAction.getPortNumber().getPortType());
 
-        assertNull(instructions.getWriteActions());
+        Assertions.assertNull(instructions.getWriteActions());
         assertEquals(instructions.getGoToMeter(), meterCommandData.getMeterId());
-        assertNull(instructions.getGoToTable());
+        Assertions.assertNull(instructions.getGoToTable());
 
         // Check meter command
         checkMeterCommand(meterCommandData);
@@ -158,7 +156,7 @@ public class UnicastVerificationVxlanRuleGeneratorTest {
         MeterSpeakerData meterCommandData = getCommand(MeterSpeakerData.class, commands);
 
         assertEquals(1, flowCommandData.getDependsOn().size());
-        assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -168,23 +166,23 @@ public class UnicastVerificationVxlanRuleGeneratorTest {
         Instructions instructions = flowCommandData.getInstructions();
         assertEquals(4, instructions.getApplyActions().size());
         Action first = instructions.getApplyActions().get(0);
-        assertTrue(first instanceof PopVxlanAction);
+        Assertions.assertTrue(first instanceof PopVxlanAction);
         PopVxlanAction popVxlanAction = (PopVxlanAction) first;
         assertEquals(ActionType.POP_VXLAN_NOVIFLOW, popVxlanAction.getType());
 
         Action second = instructions.getApplyActions().get(1);
-        assertTrue(second instanceof PortOutAction);
+        Assertions.assertTrue(second instanceof PortOutAction);
         PortOutAction sendToControllerAction = (PortOutAction) second;
         assertEquals(SpecialPortType.CONTROLLER, sendToControllerAction.getPortNumber().getPortType());
 
         Action third = instructions.getApplyActions().get(3);
-        assertTrue(third instanceof MeterAction);
+        Assertions.assertTrue(third instanceof MeterAction);
         MeterAction meterAction = (MeterAction) third;
         assertEquals(meterCommandData.getMeterId(), meterAction.getMeterId());
 
-        assertNull(instructions.getWriteActions());
-        assertNull(instructions.getGoToMeter());
-        assertNull(instructions.getGoToTable());
+        Assertions.assertNull(instructions.getWriteActions());
+        Assertions.assertNull(instructions.getGoToMeter());
+        Assertions.assertNull(instructions.getGoToTable());
 
         // Check meter command
         checkMeterCommand(meterCommandData);
@@ -201,7 +199,7 @@ public class UnicastVerificationVxlanRuleGeneratorTest {
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
 
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -211,18 +209,18 @@ public class UnicastVerificationVxlanRuleGeneratorTest {
         Instructions instructions = flowCommandData.getInstructions();
         assertEquals(3, instructions.getApplyActions().size());
         Action first = instructions.getApplyActions().get(0);
-        assertTrue(first instanceof PopVxlanAction);
+        Assertions.assertTrue(first instanceof PopVxlanAction);
         PopVxlanAction popVxlanAction = (PopVxlanAction) first;
         assertEquals(ActionType.POP_VXLAN_NOVIFLOW, popVxlanAction.getType());
 
         Action second = instructions.getApplyActions().get(1);
-        assertTrue(second instanceof PortOutAction);
+        Assertions.assertTrue(second instanceof PortOutAction);
         PortOutAction sendToControllerAction = (PortOutAction) second;
         assertEquals(SpecialPortType.CONTROLLER, sendToControllerAction.getPortNumber().getPortType());
 
-        assertNull(instructions.getWriteActions());
-        assertNull(instructions.getGoToMeter());
-        assertNull(instructions.getGoToTable());
+        Assertions.assertNull(instructions.getWriteActions());
+        Assertions.assertNull(instructions.getGoToMeter());
+        Assertions.assertNull(instructions.getGoToTable());
     }
 
     @Test
@@ -238,7 +236,7 @@ public class UnicastVerificationVxlanRuleGeneratorTest {
         MeterSpeakerData meterCommandData = getCommand(MeterSpeakerData.class, commands);
 
         assertEquals(1, flowCommandData.getDependsOn().size());
-        assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
+        Assertions.assertTrue(flowCommandData.getDependsOn().contains(meterCommandData.getUuid()));
 
         // Check flow command
         checkFlowCommandBaseProperties(flowCommandData);
@@ -254,7 +252,7 @@ public class UnicastVerificationVxlanRuleGeneratorTest {
                 config.getDiscoPacketSize());
         assertEquals(expectedBurst, meterCommandData.getBurst());
         assertEquals(3, meterCommandData.getFlags().size());
-        assertTrue(Sets.newHashSet(MeterFlag.BURST, MeterFlag.STATS, MeterFlag.KBPS)
+        Assertions.assertTrue(Sets.newHashSet(MeterFlag.BURST, MeterFlag.STATS, MeterFlag.KBPS)
                 .containsAll(meterCommandData.getFlags()));
     }
 
@@ -263,7 +261,7 @@ public class UnicastVerificationVxlanRuleGeneratorTest {
         sw = buildSwitch("OF_13", Sets.newHashSet(METERS));
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertTrue(commands.isEmpty());
+        Assertions.assertTrue(commands.isEmpty());
     }
 
     private void checkFlowCommandBaseProperties(FlowSpeakerData flowCommandData) {
@@ -277,42 +275,42 @@ public class UnicastVerificationVxlanRuleGeneratorTest {
 
         FieldMatch ethSrcMatch = getMatchByField(Field.ETH_SRC, match);
         assertEquals(new SwitchId(config.getFlowPingMagicSrcMacAddress()).toLong(), ethSrcMatch.getValue());
-        assertTrue(ethSrcMatch.isMasked());
+        Assertions.assertTrue(ethSrcMatch.isMasked());
         assertEquals(Mask.NO_MASK, ethSrcMatch.getMask().longValue());
 
         FieldMatch ethDstMatch = getMatchByField(Field.ETH_DST, match);
         assertEquals(sw.getSwitchId().toLong(), ethDstMatch.getValue());
-        assertTrue(ethDstMatch.isMasked());
+        Assertions.assertTrue(ethDstMatch.isMasked());
         assertEquals(Mask.NO_MASK, ethDstMatch.getMask().longValue());
 
         FieldMatch ipProtoMatch = getMatchByField(Field.IP_PROTO, match);
         assertEquals(IpProto.UDP, ipProtoMatch.getValue());
-        assertFalse(ipProtoMatch.isMasked());
+        Assertions.assertFalse(ipProtoMatch.isMasked());
 
         FieldMatch ethTypeMatch = getMatchByField(Field.ETH_TYPE, match);
         assertEquals(EthType.IPv4, ethTypeMatch.getValue());
-        assertFalse(ethTypeMatch.isMasked());
+        Assertions.assertFalse(ethTypeMatch.isMasked());
 
         FieldMatch updDestMatch = getMatchByField(Field.UDP_SRC, match);
         assertEquals(STUB_VXLAN_UDP_SRC, updDestMatch.getValue());
-        assertFalse(updDestMatch.isMasked());
+        Assertions.assertFalse(updDestMatch.isMasked());
     }
 
     private void checkInstructions(Instructions instructions, MeterId meterId) {
         assertEquals(3, instructions.getApplyActions().size());
         Action first = instructions.getApplyActions().get(0);
-        assertTrue(first instanceof PopVxlanAction);
+        Assertions.assertTrue(first instanceof PopVxlanAction);
         PopVxlanAction popVxlanAction = (PopVxlanAction) first;
         assertEquals(ActionType.POP_VXLAN_NOVIFLOW, popVxlanAction.getType());
 
         Action second = instructions.getApplyActions().get(1);
-        assertTrue(second instanceof PortOutAction);
+        Assertions.assertTrue(second instanceof PortOutAction);
         PortOutAction sendToControllerAction = (PortOutAction) second;
         assertEquals(SpecialPortType.CONTROLLER, sendToControllerAction.getPortNumber().getPortType());
 
-        assertNull(instructions.getWriteActions());
+        Assertions.assertNull(instructions.getWriteActions());
         assertEquals(instructions.getGoToMeter(), meterId);
-        assertNull(instructions.getGoToTable());
+        Assertions.assertNull(instructions.getGoToTable());
     }
 
     private void checkMeterCommand(MeterSpeakerData meterCommandData) {
@@ -321,7 +319,7 @@ public class UnicastVerificationVxlanRuleGeneratorTest {
         assertEquals(config.getUnicastRateLimit(), meterCommandData.getRate());
         assertEquals(config.getSystemMeterBurstSizeInPackets(), meterCommandData.getBurst());
         assertEquals(3, meterCommandData.getFlags().size());
-        assertTrue(Sets.newHashSet(MeterFlag.BURST, MeterFlag.STATS, MeterFlag.PKTPS)
+        Assertions.assertTrue(Sets.newHashSet(MeterFlag.BURST, MeterFlag.STATS, MeterFlag.PKTPS)
                 .containsAll(meterCommandData.getFlags()));
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/arp/ArpIngressRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/arp/ArpIngressRuleGeneratorTest.java
@@ -15,8 +15,8 @@
 
 package org.openkilda.rulemanager.factory.generator.service.arp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openkilda.model.SwitchFeature.METERS;
 import static org.openkilda.model.SwitchFeature.PKTPS_FLAG;
 import static org.openkilda.model.cookie.Cookie.ARP_INGRESS_COOKIE;
@@ -30,13 +30,13 @@ import org.openkilda.rulemanager.match.FieldMatch;
 import org.openkilda.rulemanager.utils.RoutingMetadata;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.Set;
 
 public class ArpIngressRuleGeneratorTest extends ArpRuleGeneratorTest {
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = prepareConfig();
 

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/arp/ArpInputPreDropRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/arp/ArpInputPreDropRuleGeneratorTest.java
@@ -15,8 +15,8 @@
 
 package org.openkilda.rulemanager.factory.generator.service.arp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.openkilda.model.SwitchFeature.METERS;
 import static org.openkilda.model.SwitchFeature.PKTPS_FLAG;
 import static org.openkilda.model.cookie.Cookie.ARP_INPUT_PRE_DROP_COOKIE;
@@ -30,13 +30,13 @@ import org.openkilda.rulemanager.ProtoConstants.EthType;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.Set;
 
 public class ArpInputPreDropRuleGeneratorTest extends ArpRuleGeneratorTest {
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = prepareConfig();
 

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/arp/ArpPostIngressOneSwitchRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/arp/ArpPostIngressOneSwitchRuleGeneratorTest.java
@@ -15,8 +15,8 @@
 
 package org.openkilda.rulemanager.factory.generator.service.arp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openkilda.model.SwitchFeature.METERS;
 import static org.openkilda.model.SwitchFeature.PKTPS_FLAG;
 import static org.openkilda.model.cookie.Cookie.ARP_POST_INGRESS_ONE_SWITCH_COOKIE;
@@ -30,20 +30,20 @@ import org.openkilda.rulemanager.match.FieldMatch;
 import org.openkilda.rulemanager.utils.RoutingMetadata;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.Set;
 
 public class ArpPostIngressOneSwitchRuleGeneratorTest extends ArpRuleGeneratorTest {
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = prepareConfig();
 
         generator = ArpPostIngressOneSwitchRuleGenerator.builder()
                 .config(config)
                 .build();
-        
+
         cookie = new Cookie(ARP_POST_INGRESS_ONE_SWITCH_COOKIE);
         table = OfTable.POST_INGRESS;
         priority = Priority.ARP_POST_INGRESS_ONE_SWITCH_PRIORITY;

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/arp/ArpPostIngressRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/arp/ArpPostIngressRuleGeneratorTest.java
@@ -15,8 +15,8 @@
 
 package org.openkilda.rulemanager.factory.generator.service.arp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openkilda.model.SwitchFeature.METERS;
 import static org.openkilda.model.SwitchFeature.PKTPS_FLAG;
 import static org.openkilda.model.cookie.Cookie.ARP_POST_INGRESS_COOKIE;
@@ -30,13 +30,13 @@ import org.openkilda.rulemanager.match.FieldMatch;
 import org.openkilda.rulemanager.utils.RoutingMetadata;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.Set;
 
 public class ArpPostIngressRuleGeneratorTest extends ArpRuleGeneratorTest {
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = prepareConfig();
 

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/arp/ArpPostIngressVxlanRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/arp/ArpPostIngressVxlanRuleGeneratorTest.java
@@ -15,10 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.service.arp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.model.SwitchFeature.METERS;
 import static org.openkilda.model.SwitchFeature.NOVIFLOW_PUSH_POP_VXLAN;
 import static org.openkilda.model.SwitchFeature.PKTPS_FLAG;
@@ -46,15 +42,16 @@ import org.openkilda.rulemanager.match.FieldMatch;
 import org.openkilda.rulemanager.utils.RoutingMetadata;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
 
 public class ArpPostIngressVxlanRuleGeneratorTest extends ArpRuleGeneratorTest {
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = prepareConfig();
 
@@ -75,69 +72,69 @@ public class ArpPostIngressVxlanRuleGeneratorTest extends ArpRuleGeneratorTest {
         sw = buildSwitch("OF_13", expectedFeatures);
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertTrue(commands.isEmpty());
+        Assertions.assertTrue(commands.isEmpty());
     }
 
     @Override
     protected void checkMatch(Set<FieldMatch> match) {
-        assertEquals(4, match.size());
+        Assertions.assertEquals(4, match.size());
         FieldMatch metadataMatch = getMatchByField(Field.METADATA, match);
         RoutingMetadata expectedMetadata = RoutingMetadata.builder().arpFlag(true).build(sw.getFeatures());
-        assertEquals(expectedMetadata.getValue(), metadataMatch.getValue());
-        assertTrue(metadataMatch.isMasked());
-        assertEquals(expectedMetadata.getMask(), metadataMatch.getMask().longValue());
+        Assertions.assertEquals(expectedMetadata.getValue(), metadataMatch.getValue());
+        Assertions.assertTrue(metadataMatch.isMasked());
+        Assertions.assertEquals(expectedMetadata.getMask(), metadataMatch.getMask().longValue());
 
         FieldMatch ipProtoMatch = getMatchByField(Field.IP_PROTO, match);
-        assertEquals(IpProto.UDP, ipProtoMatch.getValue());
-        assertFalse(ipProtoMatch.isMasked());
+        Assertions.assertEquals(IpProto.UDP, ipProtoMatch.getValue());
+        Assertions.assertFalse(ipProtoMatch.isMasked());
 
         FieldMatch udpSrcMatch = getMatchByField(Field.UDP_SRC, match);
-        assertEquals(ARP_VXLAN_UDP_SRC, udpSrcMatch.getValue());
-        assertFalse(udpSrcMatch.isMasked());
+        Assertions.assertEquals(ARP_VXLAN_UDP_SRC, udpSrcMatch.getValue());
+        Assertions.assertFalse(udpSrcMatch.isMasked());
 
         FieldMatch updDestMatch = getMatchByField(Field.UDP_DST, match);
-        assertEquals(VXLAN_UDP_DST, updDestMatch.getValue());
-        assertFalse(updDestMatch.isMasked());
+        Assertions.assertEquals(VXLAN_UDP_DST, updDestMatch.getValue());
+        Assertions.assertFalse(updDestMatch.isMasked());
     }
 
     @Override
     protected void checkInstructions(Instructions instructions, MeterId meterId) {
-        assertEquals(2, instructions.getApplyActions().size());
+        Assertions.assertEquals(2, instructions.getApplyActions().size());
         Action first = instructions.getApplyActions().get(0);
-        assertTrue(first instanceof PopVxlanAction);
+        Assertions.assertTrue(first instanceof PopVxlanAction);
         PopVxlanAction popVxlanAction = (PopVxlanAction) first;
-        assertEquals(ActionType.POP_VXLAN_NOVIFLOW, popVxlanAction.getType());
+        Assertions.assertEquals(ActionType.POP_VXLAN_NOVIFLOW, popVxlanAction.getType());
 
         Action second = instructions.getApplyActions().get(1);
-        assertTrue(second instanceof PortOutAction);
+        Assertions.assertTrue(second instanceof PortOutAction);
         PortOutAction portOutAction = (PortOutAction) second;
-        assertEquals(SpecialPortType.CONTROLLER, portOutAction.getPortNumber().getPortType());
+        Assertions.assertEquals(SpecialPortType.CONTROLLER, portOutAction.getPortNumber().getPortType());
 
-        assertNull(instructions.getWriteActions());
-        assertEquals(instructions.getGoToMeter(), meterId);
-        assertNull(instructions.getGoToTable());
+        Assertions.assertNull(instructions.getWriteActions());
+        Assertions.assertEquals(instructions.getGoToMeter(), meterId);
+        Assertions.assertNull(instructions.getGoToTable());
     }
 
     @Override
     protected void checkInstructionsOf15(Instructions instructions, MeterId meterId) {
-        assertEquals(3, instructions.getApplyActions().size());
+        Assertions.assertEquals(3, instructions.getApplyActions().size());
         Action first = instructions.getApplyActions().get(0);
-        assertTrue(first instanceof PopVxlanAction);
+        Assertions.assertTrue(first instanceof PopVxlanAction);
         PopVxlanAction popVxlanAction = (PopVxlanAction) first;
-        assertEquals(ActionType.POP_VXLAN_NOVIFLOW, popVxlanAction.getType());
+        Assertions.assertEquals(ActionType.POP_VXLAN_NOVIFLOW, popVxlanAction.getType());
 
         Action second = instructions.getApplyActions().get(1);
-        assertTrue(second instanceof PortOutAction);
+        Assertions.assertTrue(second instanceof PortOutAction);
         PortOutAction portOutAction = (PortOutAction) second;
-        assertEquals(SpecialPortType.CONTROLLER, portOutAction.getPortNumber().getPortType());
+        Assertions.assertEquals(SpecialPortType.CONTROLLER, portOutAction.getPortNumber().getPortType());
 
         Action third = instructions.getApplyActions().get(2);
-        assertTrue(third instanceof MeterAction);
+        Assertions.assertTrue(third instanceof MeterAction);
         MeterAction meterAction = (MeterAction) third;
-        assertEquals(meterId, meterAction.getMeterId());
+        Assertions.assertEquals(meterId, meterAction.getMeterId());
 
-        assertNull(instructions.getWriteActions());
-        assertNull(instructions.getGoToMeter());
-        assertNull(instructions.getGoToTable());
+        Assertions.assertNull(instructions.getWriteActions());
+        Assertions.assertNull(instructions.getGoToMeter());
+        Assertions.assertNull(instructions.getGoToTable());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/arp/ArpRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/arp/ArpRuleGeneratorTest.java
@@ -15,8 +15,8 @@
 
 package org.openkilda.rulemanager.factory.generator.service.arp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.MeterId.createMeterIdForDefaultRule;

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/arp/ArpTransitRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/arp/ArpTransitRuleGeneratorTest.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.service.arp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.openkilda.model.SwitchFeature.METERS;
 import static org.openkilda.model.SwitchFeature.PKTPS_FLAG;
 import static org.openkilda.model.cookie.Cookie.ARP_TRANSIT_COOKIE;
@@ -30,13 +28,14 @@ import org.openkilda.rulemanager.ProtoConstants.EthType;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.Set;
 
 public class ArpTransitRuleGeneratorTest extends ArpRuleGeneratorTest {
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = prepareConfig();
 
@@ -53,9 +52,9 @@ public class ArpTransitRuleGeneratorTest extends ArpRuleGeneratorTest {
 
     @Override
     protected void checkMatch(Set<FieldMatch> match) {
-        assertEquals(1, match.size());
+        Assertions.assertEquals(1, match.size());
         FieldMatch ethTypeMatch = getMatchByField(Field.ETH_TYPE, match);
-        assertEquals(EthType.ARP, ethTypeMatch.getValue());
-        assertFalse(ethTypeMatch.isMasked());
+        Assertions.assertEquals(EthType.ARP, ethTypeMatch.getValue());
+        Assertions.assertFalse(ethTypeMatch.isMasked());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/isl/EgressIslVlanRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/isl/EgressIslVlanRuleGeneratorTest.java
@@ -15,9 +15,9 @@
 
 package org.openkilda.rulemanager.factory.generator.service.isl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openkilda.rulemanager.Constants.Priority.ISL_EGRESS_VLAN_RULE_PRIORITY_MULTITABLE;
 import static org.openkilda.rulemanager.Utils.buildSwitch;
 import static org.openkilda.rulemanager.Utils.getCommand;
@@ -33,8 +33,8 @@ import org.openkilda.rulemanager.OfTable;
 import org.openkilda.rulemanager.SpeakerData;
 import org.openkilda.rulemanager.match.FieldMatch;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -45,7 +45,7 @@ public class EgressIslVlanRuleGeneratorTest {
 
     private EgressIslVlanRuleGenerator generator;
 
-    @Before
+    @BeforeEach
     public void setup() {
         generator = EgressIslVlanRuleGenerator.builder()
                 .islPort(ISL_PORT)

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/isl/EgressIslVxlanRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/isl/EgressIslVxlanRuleGeneratorTest.java
@@ -15,9 +15,7 @@
 
 package org.openkilda.rulemanager.factory.generator.service.isl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openkilda.model.SwitchFeature.KILDA_OVS_PUSH_POP_MATCH_VXLAN;
 import static org.openkilda.rulemanager.Constants.Priority.ISL_EGRESS_VXLAN_RULE_PRIORITY_MULTITABLE;
 import static org.openkilda.rulemanager.Constants.STUB_VXLAN_UDP_SRC;
@@ -41,8 +39,9 @@ import org.openkilda.rulemanager.SpeakerData;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -54,7 +53,7 @@ public class EgressIslVxlanRuleGeneratorTest {
 
     private EgressIslVxlanRuleGenerator generator;
 
-    @Before
+    @BeforeEach
     public void setup() {
         generator = EgressIslVxlanRuleGenerator.builder()
                 .islPort(ISL_PORT)
@@ -71,7 +70,7 @@ public class EgressIslVxlanRuleGeneratorTest {
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
         assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
         assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
         assertEquals(new PortColourCookie(CookieType.MULTI_TABLE_ISL_VXLAN_EGRESS_RULES, ISL_PORT),
                 flowCommandData.getCookie());
@@ -96,7 +95,7 @@ public class EgressIslVxlanRuleGeneratorTest {
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
         assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
         assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
         assertEquals(new PortColourCookie(CookieType.MULTI_TABLE_ISL_VXLAN_EGRESS_RULES, ISL_PORT),
                 flowCommandData.getCookie());
@@ -109,7 +108,7 @@ public class EgressIslVxlanRuleGeneratorTest {
 
         FieldMatch ethTypeMatch = getMatchByField(Field.ETH_TYPE, match);
         assertEquals(EthType.IPv4, ethTypeMatch.getValue());
-        assertFalse(ethTypeMatch.isMasked());
+        Assertions.assertFalse(ethTypeMatch.isMasked());
 
         Instructions instructions = flowCommandData.getInstructions();
         assertEquals(OfTable.EGRESS, instructions.getGoToTable());
@@ -120,32 +119,32 @@ public class EgressIslVxlanRuleGeneratorTest {
         Switch sw = buildSwitch("OF_13", Collections.emptySet());
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertTrue(commands.isEmpty());
+        Assertions.assertTrue(commands.isEmpty());
     }
 
     private void checkMatch(Set<FieldMatch> match, SwitchId switchId) {
         FieldMatch ethDstMatch = getMatchByField(Field.ETH_DST, match);
         assertEquals(switchId.toLong(), ethDstMatch.getValue());
-        assertFalse(ethDstMatch.isMasked());
+        Assertions.assertFalse(ethDstMatch.isMasked());
 
         FieldMatch ethTypeMatch = getMatchByField(Field.ETH_TYPE, match);
         assertEquals(EthType.IPv4, ethTypeMatch.getValue());
-        assertFalse(ethTypeMatch.isMasked());
+        Assertions.assertFalse(ethTypeMatch.isMasked());
 
         FieldMatch ipProtoMatch = getMatchByField(Field.IP_PROTO, match);
         assertEquals(IpProto.UDP, ipProtoMatch.getValue());
-        assertFalse(ipProtoMatch.isMasked());
+        Assertions.assertFalse(ipProtoMatch.isMasked());
 
         FieldMatch inPortMatch = getMatchByField(Field.IN_PORT, match);
         assertEquals(ISL_PORT, inPortMatch.getValue());
-        assertFalse(inPortMatch.isMasked());
+        Assertions.assertFalse(inPortMatch.isMasked());
 
         FieldMatch udpSrcMatch = getMatchByField(Field.UDP_SRC, match);
         assertEquals(STUB_VXLAN_UDP_SRC, udpSrcMatch.getValue());
-        assertFalse(udpSrcMatch.isMasked());
+        Assertions.assertFalse(udpSrcMatch.isMasked());
 
         FieldMatch udpDstMatch = getMatchByField(Field.UDP_DST, match);
         assertEquals(VXLAN_UDP_DST, udpDstMatch.getValue());
-        assertFalse(udpDstMatch.isMasked());
+        Assertions.assertFalse(udpDstMatch.isMasked());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/isl/InputPingRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/isl/InputPingRuleGeneratorTest.java
@@ -15,10 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.service.isl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.rulemanager.Constants.Priority.PING_INPUT_PRIORITY;
 import static org.openkilda.rulemanager.Utils.buildSwitch;
 import static org.openkilda.rulemanager.Utils.getCommand;
@@ -35,8 +31,9 @@ import org.openkilda.rulemanager.SpeakerData;
 import org.openkilda.rulemanager.factory.RuleGenerator;
 import org.openkilda.rulemanager.match.FieldMatch;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -47,12 +44,12 @@ public class InputPingRuleGeneratorTest {
     private static final int ISL_PORT = 1;
     private static final String FLOW_PING_MAGIC_SRC_MAC_ADDRESS = "00:00:00:00:00:01";
 
-    @Before
+    @BeforeEach
     public void setup() {
         generator = InputPingRuleGenerator.builder()
-                            .islPort(ISL_PORT)
-                            .flowPingMagicSrcMacAddress(FLOW_PING_MAGIC_SRC_MAC_ADDRESS)
-                            .build();
+                .islPort(ISL_PORT)
+                .flowPingMagicSrcMacAddress(FLOW_PING_MAGIC_SRC_MAC_ADDRESS)
+                .build();
     }
 
     @Test
@@ -60,31 +57,31 @@ public class InputPingRuleGeneratorTest {
         Switch sw = buildSwitch("OF_13", Collections.emptySet());
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(new PortColourCookie(CookieType.PING_INPUT, ISL_PORT), flowCommandData.getCookie());
-        assertEquals(OfTable.INPUT, flowCommandData.getTable());
-        assertEquals(PING_INPUT_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(new PortColourCookie(CookieType.PING_INPUT, ISL_PORT), flowCommandData.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, flowCommandData.getTable());
+        Assertions.assertEquals(PING_INPUT_PRIORITY, flowCommandData.getPriority());
 
         FieldMatch ethSrcMatch = getMatchByField(Field.ETH_SRC, flowCommandData.getMatch());
-        assertEquals(new SwitchId(FLOW_PING_MAGIC_SRC_MAC_ADDRESS).toLong(), ethSrcMatch.getValue());
-        assertFalse(ethSrcMatch.isMasked());
+        Assertions.assertEquals(new SwitchId(FLOW_PING_MAGIC_SRC_MAC_ADDRESS).toLong(), ethSrcMatch.getValue());
+        Assertions.assertFalse(ethSrcMatch.isMasked());
 
         FieldMatch inPortMatch = getMatchByField(Field.IN_PORT, flowCommandData.getMatch());
-        assertEquals(ISL_PORT, inPortMatch.getValue());
-        assertFalse(inPortMatch.isMasked());
+        Assertions.assertEquals(ISL_PORT, inPortMatch.getValue());
+        Assertions.assertFalse(inPortMatch.isMasked());
 
-        assertEquals(flowCommandData.getInstructions().getGoToTable(), OfTable.TRANSIT);
+        Assertions.assertEquals(flowCommandData.getInstructions().getGoToTable(), OfTable.TRANSIT);
 
-        assertNull(flowCommandData.getInstructions().getWriteMetadata());
-        assertNull(flowCommandData.getInstructions().getGoToMeter());
-        assertNull(flowCommandData.getInstructions().getApplyActions());
-        assertNull(flowCommandData.getInstructions().getWriteActions());
+        Assertions.assertNull(flowCommandData.getInstructions().getWriteMetadata());
+        Assertions.assertNull(flowCommandData.getInstructions().getGoToMeter());
+        Assertions.assertNull(flowCommandData.getInstructions().getApplyActions());
+        Assertions.assertNull(flowCommandData.getInstructions().getWriteActions());
     }
 
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/isl/TransitIslVxlanRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/isl/TransitIslVxlanRuleGeneratorTest.java
@@ -15,9 +15,8 @@
 
 package org.openkilda.rulemanager.factory.generator.service.isl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openkilda.model.SwitchFeature.KILDA_OVS_PUSH_POP_MATCH_VXLAN;
 import static org.openkilda.rulemanager.Constants.Priority.ISL_TRANSIT_VXLAN_RULE_PRIORITY_MULTITABLE;
 import static org.openkilda.rulemanager.Constants.STUB_VXLAN_UDP_SRC;
@@ -40,8 +39,9 @@ import org.openkilda.rulemanager.SpeakerData;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -53,7 +53,7 @@ public class TransitIslVxlanRuleGeneratorTest {
 
     private TransitIslVxlanRuleGenerator generator;
 
-    @Before
+    @BeforeEach
     public void setup() {
         generator = TransitIslVxlanRuleGenerator.builder()
                 .islPort(ISL_PORT)
@@ -108,7 +108,7 @@ public class TransitIslVxlanRuleGeneratorTest {
 
         FieldMatch ethTypeMatch = getMatchByField(Field.ETH_TYPE, match);
         assertEquals(EthType.IPv4, ethTypeMatch.getValue());
-        assertFalse(ethTypeMatch.isMasked());
+        Assertions.assertFalse(ethTypeMatch.isMasked());
 
         Instructions instructions = flowCommandData.getInstructions();
         assertEquals(OfTable.TRANSIT, instructions.getGoToTable());
@@ -125,22 +125,22 @@ public class TransitIslVxlanRuleGeneratorTest {
     private void checkMatch(Set<FieldMatch> match) {
         FieldMatch ethTypeMatch = getMatchByField(Field.ETH_TYPE, match);
         assertEquals(EthType.IPv4, ethTypeMatch.getValue());
-        assertFalse(ethTypeMatch.isMasked());
+        Assertions.assertFalse(ethTypeMatch.isMasked());
 
         FieldMatch ipProtoMatch = getMatchByField(Field.IP_PROTO, match);
         assertEquals(IpProto.UDP, ipProtoMatch.getValue());
-        assertFalse(ipProtoMatch.isMasked());
+        Assertions.assertFalse(ipProtoMatch.isMasked());
 
         FieldMatch inPortMatch = getMatchByField(Field.IN_PORT, match);
         assertEquals(ISL_PORT, inPortMatch.getValue());
-        assertFalse(inPortMatch.isMasked());
+        Assertions.assertFalse(inPortMatch.isMasked());
 
         FieldMatch udpSrcMatch = getMatchByField(Field.UDP_SRC, match);
         assertEquals(STUB_VXLAN_UDP_SRC, udpSrcMatch.getValue());
-        assertFalse(udpSrcMatch.isMasked());
+        Assertions.assertFalse(udpSrcMatch.isMasked());
 
         FieldMatch udpDstMatch = getMatchByField(Field.UDP_DST, match);
         assertEquals(VXLAN_UDP_DST, udpDstMatch.getValue());
-        assertFalse(udpDstMatch.isMasked());
+        Assertions.assertFalse(udpDstMatch.isMasked());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/lacp/DropSlowProtocolsLoopRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/lacp/DropSlowProtocolsLoopRuleGeneratorTest.java
@@ -15,8 +15,7 @@
 
 package org.openkilda.rulemanager.factory.generator.service.lacp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openkilda.rulemanager.Constants.Priority.DROP_LOOP_SLOW_PROTOCOLS_PRIORITY;
 import static org.openkilda.rulemanager.Utils.assertEqualsMatch;
 import static org.openkilda.rulemanager.Utils.buildSwitch;
@@ -35,8 +34,9 @@ import org.openkilda.rulemanager.SpeakerData;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -45,7 +45,7 @@ import java.util.Set;
 public class DropSlowProtocolsLoopRuleGeneratorTest {
     private DropSlowProtocolsLoopRuleGenerator generator;
 
-    @Before
+    @BeforeEach
     public void setup() {
         generator = DropSlowProtocolsLoopRuleGenerator.builder().build();
     }
@@ -60,7 +60,7 @@ public class DropSlowProtocolsLoopRuleGeneratorTest {
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
         assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
         assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
         assertEquals(new ServiceCookie(ServiceCookieTag.DROP_SLOW_PROTOCOLS_LOOP_COOKIE), flowCommandData.getCookie());
         assertEquals(OfTable.INPUT, flowCommandData.getTable());

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/lacp/LacpReplyRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/lacp/LacpReplyRuleGeneratorTest.java
@@ -16,8 +16,6 @@
 package org.openkilda.rulemanager.factory.generator.service.lacp;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.SwitchFeature.METERS;
@@ -47,8 +45,9 @@ import org.openkilda.rulemanager.action.PortOutAction;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Sets;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -59,7 +58,7 @@ public class LacpReplyRuleGeneratorTest {
     public static final int LOGICAL_PORT = 1234;
     private static RuleManagerConfig config;
 
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         config = mock(RuleManagerConfig.class);
         when(config.getLacpPacketSize()).thenReturn(150);
@@ -73,21 +72,21 @@ public class LacpReplyRuleGeneratorTest {
         Switch sw = buildSwitch("OF_13", Sets.newHashSet(METERS, PKTPS_FLAG));
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(2, commands.size());
+        Assertions.assertEquals(2, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
         MeterSpeakerData meterCommandData = getCommand(MeterSpeakerData.class, commands);
 
         assertLacpReplyFlow(sw, flowCommandData, newArrayList(meterCommandData.getUuid()));
 
-        assertEquals(sw.getSwitchId(), meterCommandData.getSwitchId());
-        assertEquals(MeterId.LACP_REPLY_METER_ID, meterCommandData.getMeterId());
-        assertEquals(config.getLacpRateLimit(), meterCommandData.getRate());
-        assertEquals(config.getLacpMeterBurstSizeInPackets(), meterCommandData.getBurst());
-        assertEquals(3, meterCommandData.getFlags().size());
-        assertTrue(Sets.newHashSet(MeterFlag.BURST, MeterFlag.STATS, MeterFlag.PKTPS)
+        Assertions.assertEquals(sw.getSwitchId(), meterCommandData.getSwitchId());
+        Assertions.assertEquals(MeterId.LACP_REPLY_METER_ID, meterCommandData.getMeterId());
+        Assertions.assertEquals(config.getLacpRateLimit(), meterCommandData.getRate());
+        Assertions.assertEquals(config.getLacpMeterBurstSizeInPackets(), meterCommandData.getBurst());
+        Assertions.assertEquals(3, meterCommandData.getFlags().size());
+        Assertions.assertTrue(Sets.newHashSet(MeterFlag.BURST, MeterFlag.STATS, MeterFlag.PKTPS)
                 .containsAll(meterCommandData.getFlags()));
-        assertTrue(meterCommandData.getDependsOn().isEmpty());
+        Assertions.assertTrue(meterCommandData.getDependsOn().isEmpty());
     }
 
     @Test
@@ -96,26 +95,27 @@ public class LacpReplyRuleGeneratorTest {
         Switch sw = buildSwitch("OF_13", Sets.newHashSet(METERS, PKTPS_FLAG));
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
         assertLacpReplyFlow(sw, flowCommandData, newArrayList());
     }
 
     private static void assertLacpReplyFlow(Switch sw, FlowSpeakerData flowCommandData, List<UUID> expectedDependsOn) {
-        assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertEquals(expectedDependsOn, new ArrayList<>(flowCommandData.getDependsOn()));
+        Assertions.assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertEquals(expectedDependsOn, new ArrayList<>(flowCommandData.getDependsOn()));
 
-        assertEquals(new PortColourCookie(CookieType.LACP_REPLY_INPUT, LOGICAL_PORT), flowCommandData.getCookie());
-        assertEquals(OfTable.INPUT, flowCommandData.getTable());
-        assertEquals(LACP_RULE_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(new PortColourCookie(CookieType.LACP_REPLY_INPUT, LOGICAL_PORT),
+                flowCommandData.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, flowCommandData.getTable());
+        Assertions.assertEquals(LACP_RULE_PRIORITY, flowCommandData.getPriority());
 
         Instructions expectedInstructions = Instructions.builder()
                 .goToMeter(MeterId.LACP_REPLY_METER_ID)
                 .applyActions(newArrayList(new PortOutAction(new PortNumber(SpecialPortType.CONTROLLER))))
                 .build();
-        assertEquals(expectedInstructions, flowCommandData.getInstructions());
+        Assertions.assertEquals(expectedInstructions, flowCommandData.getInstructions());
 
         Set<FieldMatch> expectedMatch = Sets.newHashSet(
                 FieldMatch.builder().field(Field.IN_PORT).value(LOGICAL_PORT).build(),

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/lldp/LldpIngressRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/lldp/LldpIngressRuleGeneratorTest.java
@@ -15,8 +15,8 @@
 
 package org.openkilda.rulemanager.factory.generator.service.lldp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openkilda.model.SwitchFeature.METERS;
 import static org.openkilda.model.SwitchFeature.PKTPS_FLAG;
 import static org.openkilda.model.cookie.Cookie.LLDP_INGRESS_COOKIE;
@@ -30,13 +30,13 @@ import org.openkilda.rulemanager.match.FieldMatch;
 import org.openkilda.rulemanager.utils.RoutingMetadata;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.Set;
 
 public class LldpIngressRuleGeneratorTest extends LldpRuleGeneratorTest {
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = prepareConfig();
 

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/lldp/LldpInputPreDropRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/lldp/LldpInputPreDropRuleGeneratorTest.java
@@ -15,8 +15,9 @@
 
 package org.openkilda.rulemanager.factory.generator.service.lldp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.openkilda.model.SwitchFeature.METERS;
 import static org.openkilda.model.SwitchFeature.PKTPS_FLAG;
 import static org.openkilda.model.cookie.Cookie.LLDP_INPUT_PRE_DROP_COOKIE;
@@ -30,13 +31,13 @@ import org.openkilda.rulemanager.ProtoConstants.EthType;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.Set;
 
 public class LldpInputPreDropRuleGeneratorTest extends LldpRuleGeneratorTest {
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = prepareConfig();
 

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/lldp/LldpPostIngressOneSwitchRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/lldp/LldpPostIngressOneSwitchRuleGeneratorTest.java
@@ -15,8 +15,8 @@
 
 package org.openkilda.rulemanager.factory.generator.service.lldp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openkilda.model.SwitchFeature.METERS;
 import static org.openkilda.model.SwitchFeature.PKTPS_FLAG;
 import static org.openkilda.model.cookie.Cookie.LLDP_POST_INGRESS_ONE_SWITCH_COOKIE;
@@ -30,13 +30,13 @@ import org.openkilda.rulemanager.match.FieldMatch;
 import org.openkilda.rulemanager.utils.RoutingMetadata;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.Set;
 
 public class LldpPostIngressOneSwitchRuleGeneratorTest extends LldpRuleGeneratorTest {
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = prepareConfig();
 

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/lldp/LldpPostIngressRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/lldp/LldpPostIngressRuleGeneratorTest.java
@@ -15,8 +15,8 @@
 
 package org.openkilda.rulemanager.factory.generator.service.lldp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openkilda.model.SwitchFeature.METERS;
 import static org.openkilda.model.SwitchFeature.PKTPS_FLAG;
 import static org.openkilda.model.cookie.Cookie.LLDP_POST_INGRESS_COOKIE;
@@ -30,13 +30,13 @@ import org.openkilda.rulemanager.match.FieldMatch;
 import org.openkilda.rulemanager.utils.RoutingMetadata;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.Set;
 
 public class LldpPostIngressRuleGeneratorTest extends LldpRuleGeneratorTest {
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = prepareConfig();
 

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/lldp/LldpPostIngressVxlanRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/lldp/LldpPostIngressVxlanRuleGeneratorTest.java
@@ -15,10 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.service.lldp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.model.SwitchFeature.METERS;
 import static org.openkilda.model.SwitchFeature.NOVIFLOW_PUSH_POP_VXLAN;
 import static org.openkilda.model.SwitchFeature.PKTPS_FLAG;
@@ -46,15 +42,16 @@ import org.openkilda.rulemanager.match.FieldMatch;
 import org.openkilda.rulemanager.utils.RoutingMetadata;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
 
 public class LldpPostIngressVxlanRuleGeneratorTest extends LldpRuleGeneratorTest {
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = prepareConfig();
 
@@ -75,69 +72,69 @@ public class LldpPostIngressVxlanRuleGeneratorTest extends LldpRuleGeneratorTest
         sw = buildSwitch("OF_13", expectedFeatures);
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertTrue(commands.isEmpty());
+        Assertions.assertTrue(commands.isEmpty());
     }
 
     @Override
     protected void checkMatch(Set<FieldMatch> match) {
-        assertEquals(4, match.size());
+        Assertions.assertEquals(4, match.size());
         FieldMatch metadataMatch = getMatchByField(Field.METADATA, match);
         RoutingMetadata expectedMetadata = RoutingMetadata.builder().lldpFlag(true).build(sw.getFeatures());
-        assertEquals(expectedMetadata.getValue(), metadataMatch.getValue());
-        assertTrue(metadataMatch.isMasked());
-        assertEquals(expectedMetadata.getMask(), metadataMatch.getMask().longValue());
+        Assertions.assertEquals(expectedMetadata.getValue(), metadataMatch.getValue());
+        Assertions.assertTrue(metadataMatch.isMasked());
+        Assertions.assertEquals(expectedMetadata.getMask(), metadataMatch.getMask().longValue());
 
         FieldMatch ipProtoMatch = getMatchByField(Field.IP_PROTO, match);
-        assertEquals(IpProto.UDP, ipProtoMatch.getValue());
-        assertFalse(ipProtoMatch.isMasked());
+        Assertions.assertEquals(IpProto.UDP, ipProtoMatch.getValue());
+        Assertions.assertFalse(ipProtoMatch.isMasked());
 
         FieldMatch udpSrcMatch = getMatchByField(Field.UDP_SRC, match);
-        assertEquals(STUB_VXLAN_UDP_SRC, udpSrcMatch.getValue());
-        assertFalse(udpSrcMatch.isMasked());
+        Assertions.assertEquals(STUB_VXLAN_UDP_SRC, udpSrcMatch.getValue());
+        Assertions.assertFalse(udpSrcMatch.isMasked());
 
         FieldMatch updDestMatch = getMatchByField(Field.UDP_DST, match);
-        assertEquals(VXLAN_UDP_DST, updDestMatch.getValue());
-        assertFalse(updDestMatch.isMasked());
+        Assertions.assertEquals(VXLAN_UDP_DST, updDestMatch.getValue());
+        Assertions.assertFalse(updDestMatch.isMasked());
     }
 
     @Override
     protected void checkInstructions(Instructions instructions, MeterId meterId) {
-        assertEquals(2, instructions.getApplyActions().size());
+        Assertions.assertEquals(2, instructions.getApplyActions().size());
         Action first = instructions.getApplyActions().get(0);
-        assertTrue(first instanceof PopVxlanAction);
+        Assertions.assertTrue(first instanceof PopVxlanAction);
         PopVxlanAction popVxlanAction = (PopVxlanAction) first;
-        assertEquals(ActionType.POP_VXLAN_NOVIFLOW, popVxlanAction.getType());
+        Assertions.assertEquals(ActionType.POP_VXLAN_NOVIFLOW, popVxlanAction.getType());
 
         Action second = instructions.getApplyActions().get(1);
-        assertTrue(second instanceof PortOutAction);
+        Assertions.assertTrue(second instanceof PortOutAction);
         PortOutAction portOutAction = (PortOutAction) second;
-        assertEquals(SpecialPortType.CONTROLLER, portOutAction.getPortNumber().getPortType());
+        Assertions.assertEquals(SpecialPortType.CONTROLLER, portOutAction.getPortNumber().getPortType());
 
-        assertNull(instructions.getWriteActions());
-        assertEquals(instructions.getGoToMeter(), meterId);
-        assertNull(instructions.getGoToTable());
+        Assertions.assertNull(instructions.getWriteActions());
+        Assertions.assertEquals(instructions.getGoToMeter(), meterId);
+        Assertions.assertNull(instructions.getGoToTable());
     }
 
     @Override
     protected void checkInstructionsOf15(Instructions instructions, MeterId meterId) {
-        assertEquals(3, instructions.getApplyActions().size());
+        Assertions.assertEquals(3, instructions.getApplyActions().size());
         Action first = instructions.getApplyActions().get(0);
-        assertTrue(first instanceof PopVxlanAction);
+        Assertions.assertTrue(first instanceof PopVxlanAction);
         PopVxlanAction popVxlanAction = (PopVxlanAction) first;
-        assertEquals(ActionType.POP_VXLAN_NOVIFLOW, popVxlanAction.getType());
+        Assertions.assertEquals(ActionType.POP_VXLAN_NOVIFLOW, popVxlanAction.getType());
 
         Action second = instructions.getApplyActions().get(1);
-        assertTrue(second instanceof PortOutAction);
+        Assertions.assertTrue(second instanceof PortOutAction);
         PortOutAction portOutAction = (PortOutAction) second;
-        assertEquals(SpecialPortType.CONTROLLER, portOutAction.getPortNumber().getPortType());
+        Assertions.assertEquals(SpecialPortType.CONTROLLER, portOutAction.getPortNumber().getPortType());
 
         Action third = instructions.getApplyActions().get(2);
-        assertTrue(third instanceof MeterAction);
+        Assertions.assertTrue(third instanceof MeterAction);
         MeterAction meterAction = (MeterAction) third;
-        assertEquals(meterId, meterAction.getMeterId());
+        Assertions.assertEquals(meterId, meterAction.getMeterId());
 
-        assertNull(instructions.getWriteActions());
-        assertNull(instructions.getGoToMeter());
-        assertNull(instructions.getGoToTable());
+        Assertions.assertNull(instructions.getWriteActions());
+        Assertions.assertNull(instructions.getGoToMeter());
+        Assertions.assertNull(instructions.getGoToTable());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/lldp/LldpRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/lldp/LldpRuleGeneratorTest.java
@@ -15,8 +15,8 @@
 
 package org.openkilda.rulemanager.factory.generator.service.lldp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.MeterId.createMeterIdForDefaultRule;

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/lldp/LldpTransitRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/lldp/LldpTransitRuleGeneratorTest.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.service.lldp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.openkilda.model.SwitchFeature.METERS;
 import static org.openkilda.model.SwitchFeature.PKTPS_FLAG;
 import static org.openkilda.model.cookie.Cookie.LLDP_TRANSIT_COOKIE;
@@ -30,13 +28,14 @@ import org.openkilda.rulemanager.ProtoConstants.EthType;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.Set;
 
 public class LldpTransitRuleGeneratorTest extends LldpRuleGeneratorTest {
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = prepareConfig();
 
@@ -53,9 +52,9 @@ public class LldpTransitRuleGeneratorTest extends LldpRuleGeneratorTest {
 
     @Override
     protected void checkMatch(Set<FieldMatch> match) {
-        assertEquals(1, match.size());
+        Assertions.assertEquals(1, match.size());
         FieldMatch ethTypeMatch = getMatchByField(Field.ETH_TYPE, match);
-        assertEquals(EthType.LLDP, ethTypeMatch.getValue());
-        assertFalse(ethTypeMatch.isMasked());
+        Assertions.assertEquals(EthType.LLDP, ethTypeMatch.getValue());
+        Assertions.assertFalse(ethTypeMatch.isMasked());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/server42/Server42FlowRttOutputVlanRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/server42/Server42FlowRttOutputVlanRuleGeneratorTest.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.service.server42;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.model.SwitchFeature.NOVIFLOW_COPY_FIELD;
 import static org.openkilda.model.cookie.Cookie.SERVER_42_FLOW_RTT_OUTPUT_VLAN_COOKIE;
 import static org.openkilda.rulemanager.Constants.NOVIFLOW_TIMESTAMP_SIZE_IN_BITS;
@@ -47,8 +45,9 @@ import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
@@ -56,7 +55,7 @@ import java.util.Set;
 public class Server42FlowRttOutputVlanRuleGeneratorTest {
     private Server42FlowRttOutputVlanRuleGenerator generator;
 
-    @Before
+    @BeforeEach
     public void setup() {
         generator = Server42FlowRttOutputVlanRuleGenerator.builder()
                 .server42Port(Utils.SERVER_42_PORT)
@@ -70,16 +69,16 @@ public class Server42FlowRttOutputVlanRuleGeneratorTest {
         Switch sw = buildSwitch("OF_13", Sets.newHashSet(NOVIFLOW_COPY_FIELD));
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(new Cookie(SERVER_42_FLOW_RTT_OUTPUT_VLAN_COOKIE), flowCommandData.getCookie());
-        assertEquals(OfTable.INPUT, flowCommandData.getTable());
-        assertEquals(SERVER_42_FLOW_RTT_OUTPUT_VLAN_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(new Cookie(SERVER_42_FLOW_RTT_OUTPUT_VLAN_COOKIE), flowCommandData.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, flowCommandData.getTable());
+        Assertions.assertEquals(SERVER_42_FLOW_RTT_OUTPUT_VLAN_PRIORITY, flowCommandData.getPriority());
 
         Set<FieldMatch> expectedMatch = Sets.newHashSet(
                 FieldMatch.builder().field(Field.ETH_DST).value(sw.getSwitchId().toMacAddressAsLong()).build(),
@@ -87,7 +86,7 @@ public class Server42FlowRttOutputVlanRuleGeneratorTest {
                 FieldMatch.builder().field(Field.IP_PROTO).value(IpProto.UDP).build(),
                 FieldMatch.builder().field(Field.UDP_SRC).value(SERVER_42_FLOW_RTT_REVERSE_UDP_PORT).build(),
                 FieldMatch.builder().field(Field.UDP_DST).value(SERVER_42_FLOW_RTT_FORWARD_UDP_PORT).build());
-        assertEquals(expectedMatch, flowCommandData.getMatch());
+        Assertions.assertEquals(expectedMatch, flowCommandData.getMatch());
 
         List<Action> expectedApplyActions = Lists.newArrayList(
                 new PushVlanAction(),
@@ -104,6 +103,6 @@ public class Server42FlowRttOutputVlanRuleGeneratorTest {
                 new PortOutAction(new PortNumber(Utils.SERVER_42_PORT)));
 
         Instructions expectedInstructions = Instructions.builder().applyActions(expectedApplyActions).build();
-        assertEquals(expectedInstructions, flowCommandData.getInstructions());
+        Assertions.assertEquals(expectedInstructions, flowCommandData.getInstructions());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/server42/Server42FlowRttOutputVxlanRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/server42/Server42FlowRttOutputVxlanRuleGeneratorTest.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.service.server42;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.model.SwitchFeature.KILDA_OVS_PUSH_POP_MATCH_VXLAN;
 import static org.openkilda.model.SwitchFeature.NOVIFLOW_COPY_FIELD;
 import static org.openkilda.model.SwitchFeature.NOVIFLOW_PUSH_POP_VXLAN;
@@ -52,8 +50,9 @@ import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
@@ -61,7 +60,7 @@ import java.util.Set;
 public class Server42FlowRttOutputVxlanRuleGeneratorTest {
     private Server42FlowRttOutputVxlanRuleGenerator generator;
 
-    @Before
+    @BeforeEach
     public void setup() {
         generator = Server42FlowRttOutputVxlanRuleGenerator.builder()
                 .server42Port(Utils.SERVER_42_PORT)
@@ -85,16 +84,16 @@ public class Server42FlowRttOutputVxlanRuleGeneratorTest {
     private void testOutputRule(Switch sw, Action expectedPopVxlan, boolean copyField) {
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(new Cookie(SERVER_42_FLOW_RTT_OUTPUT_VXLAN_COOKIE), flowCommandData.getCookie());
-        assertEquals(OfTable.INPUT, flowCommandData.getTable());
-        assertEquals(SERVER_42_FLOW_RTT_OUTPUT_VXLAN_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(new Cookie(SERVER_42_FLOW_RTT_OUTPUT_VXLAN_COOKIE), flowCommandData.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, flowCommandData.getTable());
+        Assertions.assertEquals(SERVER_42_FLOW_RTT_OUTPUT_VXLAN_PRIORITY, flowCommandData.getPriority());
 
         Set<FieldMatch> expectedMatch = Sets.newHashSet(
                 FieldMatch.builder().field(Field.ETH_DST).value(sw.getSwitchId().toMacAddressAsLong()).build(),
@@ -102,7 +101,7 @@ public class Server42FlowRttOutputVxlanRuleGeneratorTest {
                 FieldMatch.builder().field(Field.IP_PROTO).value(IpProto.UDP).build(),
                 FieldMatch.builder().field(Field.UDP_SRC).value(SERVER_42_FLOW_RTT_REVERSE_UDP_VXLAN_PORT).build(),
                 FieldMatch.builder().field(Field.UDP_DST).value(VXLAN_UDP_DST).build());
-        assertEquals(expectedMatch, flowCommandData.getMatch());
+        Assertions.assertEquals(expectedMatch, flowCommandData.getMatch());
 
         List<Action> expectedApplyActions = Lists.newArrayList(
                 expectedPopVxlan,
@@ -123,6 +122,6 @@ public class Server42FlowRttOutputVxlanRuleGeneratorTest {
         }
         expectedApplyActions.add(new PortOutAction(new PortNumber(Utils.SERVER_42_PORT)));
         Instructions expectedInstructions = Instructions.builder().applyActions(expectedApplyActions).build();
-        assertEquals(expectedInstructions, flowCommandData.getInstructions());
+        Assertions.assertEquals(expectedInstructions, flowCommandData.getInstructions());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/server42/Server42FlowRttTurningRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/server42/Server42FlowRttTurningRuleGeneratorTest.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.service.server42;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.model.SwitchFeature.KILDA_OVS_SWAP_FIELD;
 import static org.openkilda.model.SwitchFeature.NOVIFLOW_SWAP_ETH_SRC_ETH_DST;
 import static org.openkilda.model.cookie.Cookie.SERVER_42_FLOW_RTT_TURNING_COOKIE;
@@ -48,8 +46,9 @@ import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
@@ -57,7 +56,7 @@ import java.util.Set;
 public class Server42FlowRttTurningRuleGeneratorTest {
     private Server42FlowRttTurningRuleGenerator generator;
 
-    @Before
+    @BeforeEach
     public void setup() {
         generator = new Server42FlowRttTurningRuleGenerator();
     }
@@ -77,23 +76,23 @@ public class Server42FlowRttTurningRuleGeneratorTest {
     private void testOutputRule(Switch sw, ActionType expectedSwapFieldType) {
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(new Cookie(SERVER_42_FLOW_RTT_TURNING_COOKIE), flowCommandData.getCookie());
-        assertEquals(OfTable.INPUT, flowCommandData.getTable());
-        assertEquals(SERVER_42_FLOW_RTT_TURNING_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(new Cookie(SERVER_42_FLOW_RTT_TURNING_COOKIE), flowCommandData.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, flowCommandData.getTable());
+        Assertions.assertEquals(SERVER_42_FLOW_RTT_TURNING_PRIORITY, flowCommandData.getPriority());
 
         Set<FieldMatch> expectedMatch = Sets.newHashSet(
                 FieldMatch.builder().field(Field.ETH_DST).value(sw.getSwitchId().toMacAddressAsLong()).build(),
                 FieldMatch.builder().field(Field.ETH_TYPE).value(EthType.IPv4).build(),
                 FieldMatch.builder().field(Field.IP_PROTO).value(IpProto.UDP).build(),
                 FieldMatch.builder().field(Field.UDP_SRC).value(SERVER_42_FLOW_RTT_FORWARD_UDP_PORT).build());
-        assertEquals(expectedMatch, flowCommandData.getMatch());
+        Assertions.assertEquals(expectedMatch, flowCommandData.getMatch());
 
         List<Action> expectedApplyActions = Lists.newArrayList(
                 SetFieldAction.builder().field(Field.UDP_SRC).value(SERVER_42_FLOW_RTT_REVERSE_UDP_PORT).build(),
@@ -108,6 +107,6 @@ public class Server42FlowRttTurningRuleGeneratorTest {
                 new PortOutAction(new PortNumber(SpecialPortType.IN_PORT)));
 
         Instructions expectedInstructions = Instructions.builder().applyActions(expectedApplyActions).build();
-        assertEquals(expectedInstructions, flowCommandData.getInstructions());
+        Assertions.assertEquals(expectedInstructions, flowCommandData.getInstructions());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/server42/Server42FlowRttVxlanTurningRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/server42/Server42FlowRttVxlanTurningRuleGeneratorTest.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.service.server42;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.openkilda.model.SwitchFeature.KILDA_OVS_SWAP_FIELD;
 import static org.openkilda.model.SwitchFeature.NOVIFLOW_SWAP_ETH_SRC_ETH_DST;
 import static org.openkilda.model.cookie.Cookie.SERVER_42_FLOW_RTT_VXLAN_TURNING_COOKIE;
@@ -49,8 +47,9 @@ import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
@@ -58,7 +57,7 @@ import java.util.Set;
 public class Server42FlowRttVxlanTurningRuleGeneratorTest {
     private Server42FlowRttVxlanTurningRuleGenerator generator;
 
-    @Before
+    @BeforeEach
     public void setup() {
         generator = new Server42FlowRttVxlanTurningRuleGenerator();
     }
@@ -78,16 +77,16 @@ public class Server42FlowRttVxlanTurningRuleGeneratorTest {
     private void testOutputRule(Switch sw, ActionType expectedSwapFieldType) {
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(new Cookie(SERVER_42_FLOW_RTT_VXLAN_TURNING_COOKIE), flowCommandData.getCookie());
-        assertEquals(OfTable.INPUT, flowCommandData.getTable());
-        assertEquals(SERVER_42_FLOW_RTT_VXLAN_TURNING_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(new Cookie(SERVER_42_FLOW_RTT_VXLAN_TURNING_COOKIE), flowCommandData.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, flowCommandData.getTable());
+        Assertions.assertEquals(SERVER_42_FLOW_RTT_VXLAN_TURNING_PRIORITY, flowCommandData.getPriority());
 
         Set<FieldMatch> expectedMatch = Sets.newHashSet(
                 FieldMatch.builder().field(Field.ETH_DST).value(sw.getSwitchId().toMacAddressAsLong()).build(),
@@ -95,7 +94,7 @@ public class Server42FlowRttVxlanTurningRuleGeneratorTest {
                 FieldMatch.builder().field(Field.IP_PROTO).value(IpProto.UDP).build(),
                 FieldMatch.builder().field(Field.UDP_SRC).value(SERVER_42_FLOW_RTT_FORWARD_UDP_PORT).build(),
                 FieldMatch.builder().field(Field.UDP_DST).value(VXLAN_UDP_DST).build());
-        assertEquals(expectedMatch, flowCommandData.getMatch());
+        Assertions.assertEquals(expectedMatch, flowCommandData.getMatch());
 
         List<Action> expectedApplyActions = Lists.newArrayList(
                 SetFieldAction.builder().field(Field.UDP_SRC).value(SERVER_42_FLOW_RTT_REVERSE_UDP_VXLAN_PORT).build(),
@@ -110,6 +109,6 @@ public class Server42FlowRttVxlanTurningRuleGeneratorTest {
                 new PortOutAction(new PortNumber(SpecialPortType.IN_PORT)));
 
         Instructions expectedInstructions = Instructions.builder().applyActions(expectedApplyActions).build();
-        assertEquals(expectedInstructions, flowCommandData.getInstructions());
+        Assertions.assertEquals(expectedInstructions, flowCommandData.getInstructions());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/server42/Server42IslRttInputRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/server42/Server42IslRttInputRuleGeneratorTest.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.service.server42;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.SwitchFeature.NOVIFLOW_COPY_FIELD;
@@ -46,8 +44,9 @@ import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
@@ -59,7 +58,7 @@ public class Server42IslRttInputRuleGeneratorTest {
 
     private Server42IslRttInputRuleGenerator generator;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RuleManagerConfig config = mock(RuleManagerConfig.class);
         when(config.getServer42IslRttMagicMacAddress()).thenReturn(MAC_ADDRESS.toString());
@@ -77,16 +76,17 @@ public class Server42IslRttInputRuleGeneratorTest {
         Switch sw = buildSwitch("OF_13", Sets.newHashSet(NOVIFLOW_COPY_FIELD));
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(new PortColourCookie(CookieType.SERVER_42_ISL_RTT_INPUT, ISL_PORT), flowCommandData.getCookie());
-        assertEquals(OfTable.INPUT, flowCommandData.getTable());
-        assertEquals(SERVER_42_ISL_RTT_INPUT_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(new PortColourCookie(CookieType.SERVER_42_ISL_RTT_INPUT, ISL_PORT),
+                flowCommandData.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, flowCommandData.getTable());
+        Assertions.assertEquals(SERVER_42_ISL_RTT_INPUT_PRIORITY, flowCommandData.getPriority());
 
         Set<FieldMatch> expectedMatch = Sets.newHashSet(
                 FieldMatch.builder().field(Field.IN_PORT).value(Utils.SERVER_42_PORT).build(),
@@ -94,7 +94,7 @@ public class Server42IslRttInputRuleGeneratorTest {
                 FieldMatch.builder().field(Field.ETH_TYPE).value(EthType.IPv4).build(),
                 FieldMatch.builder().field(Field.IP_PROTO).value(IpProto.UDP).build(),
                 FieldMatch.builder().field(Field.UDP_SRC).value(OFFSET + ISL_PORT).build());
-        assertEquals(expectedMatch, flowCommandData.getMatch());
+        Assertions.assertEquals(expectedMatch, flowCommandData.getMatch());
 
         List<Action> expectedApplyActions = Lists.newArrayList(
                 SetFieldAction.builder().field(Field.UDP_SRC).value(SERVER_42_ISL_RTT_FORWARD_UDP_PORT).build(),
@@ -102,6 +102,6 @@ public class Server42IslRttInputRuleGeneratorTest {
                 new PortOutAction(new PortNumber(ISL_PORT)));
 
         Instructions expectedInstructions = Instructions.builder().applyActions(expectedApplyActions).build();
-        assertEquals(expectedInstructions, flowCommandData.getInstructions());
+        Assertions.assertEquals(expectedInstructions, flowCommandData.getInstructions());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/server42/Server42IslRttOutputRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/server42/Server42IslRttOutputRuleGeneratorTest.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.service.server42;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.SwitchFeature.NOVIFLOW_COPY_FIELD;
@@ -47,8 +45,9 @@ import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
@@ -58,7 +57,7 @@ public class Server42IslRttOutputRuleGeneratorTest {
 
     private Server42IslRttOutputRuleGenerator generator;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RuleManagerConfig config = mock(RuleManagerConfig.class);
         when(config.getServer42IslRttMagicMacAddress()).thenReturn(MAC_ADDRESS.toString());
@@ -76,23 +75,23 @@ public class Server42IslRttOutputRuleGeneratorTest {
         Switch sw = buildSwitch("OF_13", Sets.newHashSet(NOVIFLOW_COPY_FIELD));
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(new Cookie(SERVER_42_ISL_RTT_OUTPUT_COOKIE), flowCommandData.getCookie());
-        assertEquals(OfTable.INPUT, flowCommandData.getTable());
-        assertEquals(SERVER_42_ISL_RTT_OUTPUT_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(new Cookie(SERVER_42_ISL_RTT_OUTPUT_COOKIE), flowCommandData.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, flowCommandData.getTable());
+        Assertions.assertEquals(SERVER_42_ISL_RTT_OUTPUT_PRIORITY, flowCommandData.getPriority());
 
         Set<FieldMatch> expectedMatch = Sets.newHashSet(
                 FieldMatch.builder().field(Field.ETH_DST).value(MAC_ADDRESS.toLong()).build(),
                 FieldMatch.builder().field(Field.ETH_TYPE).value(EthType.IPv4).build(),
                 FieldMatch.builder().field(Field.IP_PROTO).value(IpProto.UDP).build(),
                 FieldMatch.builder().field(Field.UDP_SRC).value(SERVER_42_ISL_RTT_REVERSE_UDP_PORT).build());
-        assertEquals(expectedMatch, flowCommandData.getMatch());
+        Assertions.assertEquals(expectedMatch, flowCommandData.getMatch());
 
         List<Action> expectedApplyActions = Lists.newArrayList(
                 new PushVlanAction(),
@@ -102,6 +101,6 @@ public class Server42IslRttOutputRuleGeneratorTest {
                 new PortOutAction(new PortNumber(Utils.SERVER_42_PORT)));
 
         Instructions expectedInstructions = Instructions.builder().applyActions(expectedApplyActions).build();
-        assertEquals(expectedInstructions, flowCommandData.getInstructions());
+        Assertions.assertEquals(expectedInstructions, flowCommandData.getInstructions());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/server42/Server42IslRttTurningRuleGeneratorTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/factory/generator/service/server42/Server42IslRttTurningRuleGeneratorTest.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.rulemanager.factory.generator.service.server42;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openkilda.model.SwitchFeature.NOVIFLOW_COPY_FIELD;
@@ -47,8 +45,9 @@ import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Set;
@@ -58,7 +57,7 @@ public class Server42IslRttTurningRuleGeneratorTest {
 
     private Server42IslRttTurningRuleGenerator generator;
 
-    @Before
+    @BeforeEach
     public void setup() {
         RuleManagerConfig config = mock(RuleManagerConfig.class);
         when(config.getServer42IslRttMagicMacAddress()).thenReturn(MAC_ADDRESS.toString());
@@ -73,29 +72,29 @@ public class Server42IslRttTurningRuleGeneratorTest {
         Switch sw = buildSwitch("OF_13", Sets.newHashSet(NOVIFLOW_COPY_FIELD));
         List<SpeakerData> commands = generator.generateCommands(sw);
 
-        assertEquals(1, commands.size());
+        Assertions.assertEquals(1, commands.size());
 
         FlowSpeakerData flowCommandData = getCommand(FlowSpeakerData.class, commands);
-        assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
-        assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
-        assertTrue(flowCommandData.getDependsOn().isEmpty());
+        Assertions.assertEquals(sw.getSwitchId(), flowCommandData.getSwitchId());
+        Assertions.assertEquals(sw.getOfVersion(), flowCommandData.getOfVersion().toString());
+        Assertions.assertTrue(flowCommandData.getDependsOn().isEmpty());
 
-        assertEquals(new Cookie(SERVER_42_ISL_RTT_TURNING_COOKIE), flowCommandData.getCookie());
-        assertEquals(OfTable.INPUT, flowCommandData.getTable());
-        assertEquals(SERVER_42_ISL_RTT_TURNING_PRIORITY, flowCommandData.getPriority());
+        Assertions.assertEquals(new Cookie(SERVER_42_ISL_RTT_TURNING_COOKIE), flowCommandData.getCookie());
+        Assertions.assertEquals(OfTable.INPUT, flowCommandData.getTable());
+        Assertions.assertEquals(SERVER_42_ISL_RTT_TURNING_PRIORITY, flowCommandData.getPriority());
 
         Set<FieldMatch> expectedMatch = Sets.newHashSet(
                 FieldMatch.builder().field(Field.ETH_DST).value(MAC_ADDRESS.toLong()).build(),
                 FieldMatch.builder().field(Field.ETH_TYPE).value(EthType.IPv4).build(),
                 FieldMatch.builder().field(Field.IP_PROTO).value(IpProto.UDP).build(),
                 FieldMatch.builder().field(Field.UDP_SRC).value(SERVER_42_ISL_RTT_FORWARD_UDP_PORT).build());
-        assertEquals(expectedMatch, flowCommandData.getMatch());
+        Assertions.assertEquals(expectedMatch, flowCommandData.getMatch());
 
         List<Action> expectedApplyActions = Lists.newArrayList(
                 SetFieldAction.builder().field(Field.UDP_SRC).value(SERVER_42_ISL_RTT_REVERSE_UDP_PORT).build(),
                 new PortOutAction(new PortNumber(SpecialPortType.IN_PORT)));
 
         Instructions expectedInstructions = Instructions.builder().applyActions(expectedApplyActions).build();
-        assertEquals(expectedInstructions, flowCommandData.getInstructions());
+        Assertions.assertEquals(expectedInstructions, flowCommandData.getInstructions());
     }
 }

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/utils/RuleManagerHelperTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/utils/RuleManagerHelperTest.java
@@ -17,8 +17,9 @@ package org.openkilda.rulemanager.utils;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openkilda.rulemanager.utils.RuleManagerHelper.checkCircularDependencies;
 import static org.openkilda.rulemanager.utils.RuleManagerHelper.groupCommandsByDependenciesAndSort;
 import static org.openkilda.rulemanager.utils.RuleManagerHelper.removeDuplicateCommands;
@@ -62,7 +63,7 @@ import org.openkilda.rulemanager.group.WatchPort;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Sets;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -165,34 +166,42 @@ public class RuleManagerHelperTest {
         // if there are no exceptions - test passed
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void checkCircularDependenciesUnknownDependsOnTest() {
-        FlowSpeakerData command = buildFullFlowSpeakerCommandData(METER_ID_1, UUID.randomUUID());
-        checkCircularDependencies(newArrayList(command));
+        assertThrows(IllegalStateException.class, () -> {
+            FlowSpeakerData command = buildFullFlowSpeakerCommandData(METER_ID_1, UUID.randomUUID());
+            checkCircularDependencies(newArrayList(command));
+        });
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void checkCircularDependenciesLoopTest() {
-        FlowSpeakerData command = buildFullFlowSpeakerCommandData(METER_ID_1, null);
-        command.getDependsOn().add(command.getUuid());
-        checkCircularDependencies(newArrayList(command));
+        assertThrows(IllegalStateException.class, () -> {
+            FlowSpeakerData command = buildFullFlowSpeakerCommandData(METER_ID_1, null);
+            command.getDependsOn().add(command.getUuid());
+            checkCircularDependencies(newArrayList(command));
+        });
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void checkCircularDependenciesCycle3Test() {
-        FlowSpeakerData command1 = buildFullFlowSpeakerCommandData(METER_ID_1, null);
-        FlowSpeakerData command2 = buildFullFlowSpeakerCommandData(METER_ID_1, command1.getUuid());
-        FlowSpeakerData command3 = buildFullFlowSpeakerCommandData(METER_ID_2, command2.getUuid());
-        command1.getDependsOn().add(command3.getUuid());
-        checkCircularDependencies(newArrayList(command1, command2, command3));
+        assertThrows(IllegalStateException.class, () -> {
+            FlowSpeakerData command1 = buildFullFlowSpeakerCommandData(METER_ID_1, null);
+            FlowSpeakerData command2 = buildFullFlowSpeakerCommandData(METER_ID_1, command1.getUuid());
+            FlowSpeakerData command3 = buildFullFlowSpeakerCommandData(METER_ID_2, command2.getUuid());
+            command1.getDependsOn().add(command3.getUuid());
+            checkCircularDependencies(newArrayList(command1, command2, command3));
+        });
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void checkCircularDependenciesCycle2Test() {
-        FlowSpeakerData command1 = buildFullFlowSpeakerCommandData(METER_ID_1, null);
-        FlowSpeakerData command2 = buildFullFlowSpeakerCommandData(METER_ID_1, command1.getUuid());
-        command1.getDependsOn().add(command2.getUuid());
-        checkCircularDependencies(newArrayList(command1, command2));
+        assertThrows(IllegalStateException.class, () -> {
+            FlowSpeakerData command1 = buildFullFlowSpeakerCommandData(METER_ID_1, null);
+            FlowSpeakerData command2 = buildFullFlowSpeakerCommandData(METER_ID_1, command1.getUuid());
+            command1.getDependsOn().add(command2.getUuid());
+            checkCircularDependencies(newArrayList(command1, command2));
+        });
     }
 
     @Test

--- a/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/utils/UtilsTest.java
+++ b/src-java/rule-manager/rule-manager-implementation/src/test/java/org/openkilda/rulemanager/utils/UtilsTest.java
@@ -16,9 +16,10 @@
 package org.openkilda.rulemanager.utils;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openkilda.model.SwitchFeature.KILDA_OVS_PUSH_POP_MATCH_VXLAN;
 import static org.openkilda.model.SwitchFeature.METERS;
 import static org.openkilda.model.SwitchFeature.NOVIFLOW_PUSH_POP_VXLAN;
@@ -41,7 +42,7 @@ import org.openkilda.rulemanager.action.ActionType;
 import org.openkilda.rulemanager.action.PushVxlanAction;
 
 import com.google.common.collect.Sets;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UtilsTest {
     public static final PathId PATH_ID = new PathId("path_id");
@@ -87,15 +88,17 @@ public class UtilsTest {
         assertEquals(PORT_NUMBER_2, Utils.getOutPort(PATH, null).getPortNumber());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void multiSwitchPathWithoutSegmentsOutPortTest() {
-        FlowPath path = FlowPath.builder()
-                .pathId(PATH_ID)
-                .srcSwitch(SWITCH_1)
-                .destSwitch(SWITCH_2)
-                .segments(newArrayList())
-                .build();
-        Utils.getOutPort(path, null);
+        assertThrows(IllegalStateException.class, () -> {
+            FlowPath path = FlowPath.builder()
+                    .pathId(PATH_ID)
+                    .srcSwitch(SWITCH_1)
+                    .destSwitch(SWITCH_2)
+                    .segments(newArrayList())
+                    .build();
+            Utils.getOutPort(path, null);
+        });
     }
 
     @Test
@@ -118,9 +121,10 @@ public class UtilsTest {
         assertPushVxlan(ActionType.PUSH_VXLAN_OVS, pushVxlan);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void buildInvalidPushVxlanTest() {
-        Utils.buildPushVxlan(VNI, SWITCH_ID_1, SWITCH_ID_2, VXLAN_UDP_SRC, Sets.newHashSet());
+        assertThrows(IllegalArgumentException.class,
+                () -> Utils.buildPushVxlan(VNI, SWITCH_ID_1, SWITCH_ID_2, VXLAN_UDP_SRC, Sets.newHashSet()));
     }
 
     private void assertPushVxlan(ActionType actionType, PushVxlanAction pushVxlanAction) {

--- a/src-java/testing/test-library/build.gradle
+++ b/src-java/testing/test-library/build.gradle
@@ -55,11 +55,15 @@ dependencies {
     annotationProcessor 'org.mapstruct:mapstruct-processor'
 
     api 'org.junit.jupiter:junit-jupiter-api'
-    api 'org.junit.vintage:junit-vintage-engine'
+    api 'org.junit.jupiter:junit-jupiter-engine'
     api 'com.github.javafaker:javafaker:1.0.2'
     implementation 'com.nitorcreations:matchers'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding'
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/testing/test-library/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/testing/test-library/src/checkstyle/checkstyle-suppressions.xml
@@ -4,4 +4,5 @@
         "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
 
 <suppressions>
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
 </suppressions>

--- a/src-java/testing/test-library/src/test/java/org/openkilda/testing/service/traffexam/networkpool/Inet4NetworkTest.java
+++ b/src-java/testing/test-library/src/test/java/org/openkilda/testing/service/traffexam/networkpool/Inet4NetworkTest.java
@@ -15,10 +15,10 @@
 
 package org.openkilda.testing.service.traffexam.networkpool;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.Inet4Address;
 import java.net.InetAddress;
@@ -42,10 +42,8 @@ public class Inet4NetworkTest {
             raises = true;
         }
 
-        assertTrue(
-                String.format(
-                        "Here must be %s exception", Inet4ValueException.class),
-                raises);
+        assertTrue(raises, String.format(
+                "Here must be %s exception", Inet4ValueException.class));
     }
 
     @Test
@@ -65,9 +63,7 @@ public class Inet4NetworkTest {
         } catch (Inet4ValueException e) {
             raises = true;
         }
-        assertTrue(
-                String.format(
-                        "Here must be %s exception", Inet4ValueException.class),
-                raises);
+        assertTrue(raises, String.format(
+                "Here must be %s exception", Inet4ValueException.class));
     }
 }


### PR DESCRIPTION
This PR contains the Junit4->Junit5 migration for the following modules:

- [ ] stats-topology
- [ ] base-topology
- [ ] blue-green
- [ ] connecteddevices-topology
- [ ] kilda-persistence-tinkerpop
- [ ] isllatency-topology
- [ ] opentsdb-topology
- [ ] ping-topology
- [ ] flowhs-topology
- [ ] flowmonitoring-topology
- [ ] nbworker-topology
- [ ] kilda-pce
- [ ] floodlight-service
- [ ] floodlightrouter-topology
- [ ] grpc-speaker
- [ ] kilda-configuration
- [ ] kilda-model
- [ ] kilda-persistence-api
- [ ] network-topology
- [ ] northbound-service
- [x] testing
- [x] reroute-topology
- [x] rule-manager
- [ ] server42
- [ ] swmanager-topology


closes #5242