### PR TITLE
[PART 5] open-kilda-5242 Migrate all unit tests from JUnit4 to JUnit5 v5

### DIFF
--- a/src-java/server42/server42-control-storm-topology/build.gradle
+++ b/src-java/server42/server42-control-storm-topology/build.gradle
@@ -29,8 +29,6 @@ dependencies {
     annotationProcessor 'org.mapstruct:mapstruct-processor'
     testAnnotationProcessor 'org.mapstruct:mapstruct-processor'
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
     testImplementation 'org.hamcrest:hamcrest-library'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testRuntimeOnly 'org.hibernate.validator:hibernate-validator'

--- a/src-java/server42/server42-control/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/server42/server42-control/src/checkstyle/checkstyle-suppressions.xml
@@ -5,4 +5,5 @@
 
 <suppressions>
     <suppress files="src/main/java/org/openkilda/server42/control/ControlApplication" checks="HideUtilityClassConstructor"/>
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
 </suppressions>

--- a/src-java/server42/server42-control/src/test/java/org/openkilda/server42/control/kafka/GateTest.java
+++ b/src-java/server42/server42-control/src/test/java/org/openkilda/server42/control/kafka/GateTest.java
@@ -49,8 +49,8 @@ import org.openkilda.server42.messaging.FlowDirection;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -59,12 +59,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.List;
 import java.util.Map;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {Gate.class})
 @ContextConfiguration(classes = SwitchToVlanMapping.class)
 @TestPropertySource("classpath:test.properties")

--- a/src-java/server42/server42-stats/build.gradle
+++ b/src-java/server42/server42-stats/build.gradle
@@ -71,3 +71,7 @@ bootJar {
 }
 
 bootJar.dependsOn generateVersionTxt
+
+test {
+    useJUnitPlatform()
+}

--- a/src-java/server42/server42-stats/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/server42/server42-stats/src/checkstyle/checkstyle-suppressions.xml
@@ -5,4 +5,5 @@
 
 <suppressions>
     <suppress files="src/main/java/org/openkilda/server42/stats/StatsApplication" checks="HideUtilityClassConstructor"/>
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
 </suppressions>

--- a/src-java/server42/server42-stats/src/test/java/org/openkilda/server42/stats/zeromq/StatsCollectorTest.java
+++ b/src-java/server42/server42-stats/src/test/java/org/openkilda/server42/stats/zeromq/StatsCollectorTest.java
@@ -25,8 +25,8 @@ import org.openkilda.server42.stats.messaging.Statistics.FlowLatencyPacket;
 import org.openkilda.server42.stats.messaging.Statistics.LatencyPacketBucket;
 import org.openkilda.server42.stats.messaging.Statistics.LatencyPacketBucket.Builder;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,9 +34,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {StatsCollector.class})
 @TestPropertySource("classpath:test.properties")
 @MockBean(value = {
@@ -77,9 +77,9 @@ public class StatsCollectorTest {
         FlowRttStatsData statsPacket1 = (FlowRttStatsData) packet1Message.getData();
 
         assertThat(statsPacket1).extracting(
-                FlowRttStatsData::getFlowId,
-                FlowRttStatsData::getT0,
-                FlowRttStatsData::getT1)
+                        FlowRttStatsData::getFlowId,
+                        FlowRttStatsData::getT0,
+                        FlowRttStatsData::getT1)
                 .contains(packet1.getFlowId(), packet1.getT0(), packet1.getT1());
 
         assertThat(statsPacket1)
@@ -92,9 +92,9 @@ public class StatsCollectorTest {
         FlowRttStatsData statsPacket2 = (FlowRttStatsData) packet2Message.getData();
 
         assertThat(statsPacket2).extracting(
-                FlowRttStatsData::getFlowId,
-                FlowRttStatsData::getT0,
-                FlowRttStatsData::getT1)
+                        FlowRttStatsData::getFlowId,
+                        FlowRttStatsData::getT0,
+                        FlowRttStatsData::getT1)
                 .contains(packet2.getFlowId(), packet2.getT0(), packet2.getT1());
 
         assertThat(statsPacket2)

--- a/src-java/swmanager-topology/swmanager-messaging/build.gradle
+++ b/src-java/swmanager-topology/swmanager-messaging/build.gradle
@@ -15,8 +15,12 @@ dependencies {
     implementation 'com.google.guava:guava'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/swmanager-topology/swmanager-messaging/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/swmanager-topology/swmanager-messaging/src/checkstyle/checkstyle-suppressions.xml
@@ -4,4 +4,5 @@
         "http://checkstyle.sourceforge.net/dtds/suppressions_1_2.dtd">
 
 <suppressions>
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod"/>
 </suppressions>

--- a/src-java/swmanager-topology/swmanager-messaging/src/test/java/org/openkilda/messaging/swmanager/request/CreateLagPortRequestTest.java
+++ b/src-java/swmanager-topology/swmanager-messaging/src/test/java/org/openkilda/messaging/swmanager/request/CreateLagPortRequestTest.java
@@ -20,8 +20,8 @@ import org.openkilda.messaging.command.CommandMessage;
 import org.openkilda.model.SwitchId;
 
 import com.google.common.collect.Sets;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CreateLagPortRequestTest {
     StringSerializer serializer = new StringSerializer();
@@ -35,7 +35,7 @@ public class CreateLagPortRequestTest {
         CommandMessage reconstructedMessage = (CommandMessage) serializer.deserialize();
         CreateLagPortRequest reconstructed = (CreateLagPortRequest) reconstructedMessage.getData();
 
-        Assert.assertEquals(origin, reconstructed);
+        Assertions.assertEquals(origin, reconstructed);
     }
 
     public static CreateLagPortRequest makeRequest() {

--- a/src-java/swmanager-topology/swmanager-messaging/src/test/java/org/openkilda/messaging/swmanager/response/LagPortResponseTest.java
+++ b/src-java/swmanager-topology/swmanager-messaging/src/test/java/org/openkilda/messaging/swmanager/response/LagPortResponseTest.java
@@ -19,8 +19,8 @@ import org.openkilda.messaging.StringSerializer;
 import org.openkilda.messaging.info.InfoMessage;
 
 import com.google.common.collect.Sets;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LagPortResponseTest {
     StringSerializer serializer = new StringSerializer();
@@ -34,7 +34,7 @@ public class LagPortResponseTest {
         InfoMessage reconstructedMessage = (InfoMessage) serializer.deserialize();
         LagPortResponse reconstructed = (LagPortResponse) reconstructedMessage.getData();
 
-        Assert.assertEquals(origin, reconstructed);
+        Assertions.assertEquals(origin, reconstructed);
     }
 
     public static LagPortResponse makeResponse() {

--- a/src-java/swmanager-topology/swmanager-storm-topology/build.gradle
+++ b/src-java/swmanager-topology/swmanager-storm-topology/build.gradle
@@ -29,7 +29,8 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation 'org.mockito:mockito-junit-jupiter'
     testImplementation 'org.hamcrest:hamcrest-library'
     testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
@@ -62,4 +63,8 @@ shadowJar {
 
 artifacts {
     archives shadowJar
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/checkstyle/checkstyle-suppressions.xml
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/checkstyle/checkstyle-suppressions.xml
@@ -6,4 +6,5 @@
 <suppressions>
     <suppress files="src/main/.*Fsm\.java$" checks="JavadocMethod" />
     <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="VariableDeclarationUsageDistance" />
+    <suppress files="[/\\]src[/\\].*[Tt]est[/\\](java)[/\\]" checks="JavadocMethod" />
 </suppressions>

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/fsm/SwitchSyncFsmTest.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/fsm/SwitchSyncFsmTest.java
@@ -16,7 +16,6 @@
 package org.openkilda.wfm.topology.switchmanager.fsm;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.junit.Assert.assertEquals;
 
 import org.openkilda.floodlight.api.request.rulemanager.FlowCommand;
 import org.openkilda.floodlight.api.request.rulemanager.OfCommand;
@@ -26,7 +25,8 @@ import org.openkilda.rulemanager.FlowSpeakerData;
 import org.openkilda.wfm.topology.switchmanager.model.ValidationResult;
 import org.openkilda.wfm.topology.switchmanager.service.configs.SwitchSyncConfig;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -44,9 +44,9 @@ public class SwitchSyncFsmTest {
         List<List<OfCommand>> result = fsm.cleanupDependenciesAndBuildCommandBatches(
                 newArrayList(command1, command2, command3));
 
-        assertEquals(1, result.size());
-        assertEquals(3, result.get(0).size());
-        assertEquals(command3.getUuid(), ((FlowCommand) result.get(0).get(2)).getData().getUuid());
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals(3, result.get(0).size());
+        Assertions.assertEquals(command3.getUuid(), ((FlowCommand) result.get(0).get(2)).getData().getUuid());
     }
 
     @Test
@@ -63,9 +63,9 @@ public class SwitchSyncFsmTest {
         List<List<OfCommand>> result = fsm.cleanupDependenciesAndBuildCommandBatches(
                 newArrayList(command1, command2, command3, command4, command5, command6));
 
-        assertEquals(2, result.size());
-        assertEquals(5, result.get(0).size());
-        assertEquals(1, result.get(1).size());
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertEquals(5, result.get(0).size());
+        Assertions.assertEquals(1, result.get(1).size());
     }
 
     @Test
@@ -84,10 +84,10 @@ public class SwitchSyncFsmTest {
         List<List<OfCommand>> result = fsm.cleanupDependenciesAndBuildCommandBatches(
                 newArrayList(command1, command2, command3, command4, command5, command6, command7, command8));
 
-        assertEquals(3, result.size());
-        assertEquals(2, result.get(0).size());
-        assertEquals(2, result.get(1).size());
-        assertEquals(4, result.get(2).size());
+        Assertions.assertEquals(3, result.size());
+        Assertions.assertEquals(2, result.get(0).size());
+        Assertions.assertEquals(2, result.get(1).size());
+        Assertions.assertEquals(4, result.get(2).size());
     }
 
     private SwitchSyncFsm buildFsm(int batchSize) {

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/fsm/SwitchValidateFsmTest.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/fsm/SwitchValidateFsmTest.java
@@ -49,16 +49,16 @@ import org.openkilda.wfm.topology.switchmanager.service.SwitchManagerCarrier;
 import org.openkilda.wfm.topology.switchmanager.service.ValidationService;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 import java.util.Set;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SwitchValidateFsmTest {
 
     @Mock
@@ -92,7 +92,7 @@ public class SwitchValidateFsmTest {
             .requestCookie(null)
             .build();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.fsmExecutor = new FsmExecutor<>(SwitchValidateFsm.SwitchValidateEvent.NEXT);
 

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/mappers/FlowEntryConverterTest.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/mappers/FlowEntryConverterTest.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.wfm.topology.switchmanager.mappers;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 import static org.openkilda.wfm.topology.switchmanager.mappers.FlowEntryConverter.INSTANCE;
 
 import org.openkilda.messaging.info.rule.FlowApplyActions;
@@ -37,8 +35,9 @@ import org.openkilda.rulemanager.action.Action;
 import org.openkilda.rulemanager.action.SetFieldAction;
 import org.openkilda.rulemanager.match.FieldMatch;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -79,7 +78,7 @@ public class FlowEntryConverterTest {
     public static Instructions instructions;
     public static FlowSpeakerData data;
 
-    @BeforeClass
+    @BeforeAll
     public static void initializeData() {
 
         applyActions.add(SET_FIELD_ACTION);
@@ -117,44 +116,44 @@ public class FlowEntryConverterTest {
 
         FlowEntry entry = INSTANCE.toFlowEntry(data);
         // General asserts
-        assertEquals(COOKIE_VALUE, entry.getCookie());
-        assertEquals(DURATION_SECONDS, entry.getDurationSeconds());
-        assertEquals(DURATION_NANOSECONDS, entry.getDurationNanoSeconds());
-        assertEquals(OF_TABLE_FIELD.getTableId(), entry.getTableId());
-        assertEquals(PACKET_COUNT, entry.getPacketCount());
-        assertEquals(OF_VERSION.toString(), entry.getVersion());
-        assertEquals(PRIORITY, entry.getPriority());
-        assertEquals(IDLE_TIMEOUT, entry.getIdleTimeout());
-        assertEquals(HARD_TIMEOUT, entry.getHardTimeout());
-        assertEquals(BYTE_COUNT, entry.getByteCount());
+        Assertions.assertEquals(COOKIE_VALUE, entry.getCookie());
+        Assertions.assertEquals(DURATION_SECONDS, entry.getDurationSeconds());
+        Assertions.assertEquals(DURATION_NANOSECONDS, entry.getDurationNanoSeconds());
+        Assertions.assertEquals(OF_TABLE_FIELD.getTableId(), entry.getTableId());
+        Assertions.assertEquals(PACKET_COUNT, entry.getPacketCount());
+        Assertions.assertEquals(OF_VERSION.toString(), entry.getVersion());
+        Assertions.assertEquals(PRIORITY, entry.getPriority());
+        Assertions.assertEquals(IDLE_TIMEOUT, entry.getIdleTimeout());
+        Assertions.assertEquals(HARD_TIMEOUT, entry.getHardTimeout());
+        Assertions.assertEquals(BYTE_COUNT, entry.getByteCount());
 
         // Field match
         FlowMatchField entryMatchField = entry.getMatch();
         // Metadata field case
-        assertEquals(OF_METADATA_MASK.toString(), entryMatchField.getMetadataMask());
-        assertEquals(OF_METADATA_VALUE.toString(), entryMatchField.getMetadataValue());
+        Assertions.assertEquals(OF_METADATA_MASK.toString(), entryMatchField.getMetadataMask());
+        Assertions.assertEquals(OF_METADATA_VALUE.toString(), entryMatchField.getMetadataValue());
         // Other cases
-        assertEquals(Integer.toString(MATCH_VALUE), entryMatchField.getEthType());
-        assertEquals(Integer.toString(MATCH_VALUE), entryMatchField.getEthSrc());
-        assertEquals(Integer.toString(MATCH_VALUE), entryMatchField.getEthDst());
-        assertEquals(Integer.toString(MATCH_VALUE), entryMatchField.getInPort());
-        assertEquals(Integer.toString(MATCH_VALUE), entryMatchField.getIpProto());
-        assertEquals(Integer.toString(MATCH_VALUE), entryMatchField.getUdpSrc());
-        assertEquals(Integer.toString(MATCH_VALUE), entryMatchField.getUdpDst());
-        assertEquals(Integer.toString(MATCH_VALUE), entryMatchField.getVlanVid());
-        assertEquals(Integer.toString(MATCH_VALUE), entryMatchField.getTunnelId());
+        Assertions.assertEquals(Integer.toString(MATCH_VALUE), entryMatchField.getEthType());
+        Assertions.assertEquals(Integer.toString(MATCH_VALUE), entryMatchField.getEthSrc());
+        Assertions.assertEquals(Integer.toString(MATCH_VALUE), entryMatchField.getEthDst());
+        Assertions.assertEquals(Integer.toString(MATCH_VALUE), entryMatchField.getInPort());
+        Assertions.assertEquals(Integer.toString(MATCH_VALUE), entryMatchField.getIpProto());
+        Assertions.assertEquals(Integer.toString(MATCH_VALUE), entryMatchField.getUdpSrc());
+        Assertions.assertEquals(Integer.toString(MATCH_VALUE), entryMatchField.getUdpDst());
+        Assertions.assertEquals(Integer.toString(MATCH_VALUE), entryMatchField.getVlanVid());
+        Assertions.assertEquals(Integer.toString(MATCH_VALUE), entryMatchField.getTunnelId());
 
         // Instructions
         FlowInstructions instructions = entry.getInstructions();
-        assertEquals(METER_ID.getValue(), instructions.getGoToMeter().longValue());
-        assertEquals(OF_TABLE_FIELD.getTableId(), instructions.getGoToTable().longValue());
+        Assertions.assertEquals(METER_ID.getValue(), instructions.getGoToMeter().longValue());
+        Assertions.assertEquals(OF_TABLE_FIELD.getTableId(), instructions.getGoToTable().longValue());
         FlowApplyActions applyActions = instructions.getApplyActions();
         FlowSetFieldAction setFieldAction = applyActions.getSetFieldActions().get(0);
-        assertEquals(SET_FIELD_ACTION.getField().toString(), setFieldAction.getFieldName());
-        assertEquals(Long.toString(SET_FIELD_ACTION.getValue()), setFieldAction.getFieldValue());
+        Assertions.assertEquals(SET_FIELD_ACTION.getField().toString(), setFieldAction.getFieldName());
+        Assertions.assertEquals(Long.toString(SET_FIELD_ACTION.getValue()), setFieldAction.getFieldValue());
 
         // Flags
-        assertArrayEquals(flags.stream().map(OfFlowFlag::toString).toArray(), entry.getFlags());
+        Assertions.assertArrayEquals(flags.stream().map(OfFlowFlag::toString).toArray(), entry.getFlags());
 
     }
 

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/mappers/GroupEntryConverterTest.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/mappers/GroupEntryConverterTest.java
@@ -37,8 +37,8 @@ import org.openkilda.rulemanager.group.GroupType;
 import org.openkilda.rulemanager.group.WatchGroup;
 import org.openkilda.rulemanager.group.WatchPort;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -83,7 +83,7 @@ public class GroupEntryConverterTest {
     public static Set<Action> writeActions = new HashSet<>();
     public static List<Bucket> buckets = new LinkedList<>();
 
-    @BeforeClass
+    @BeforeAll
     public static void initializeData() {
         writeActions.add(SET_FIELD_ACTION);
         writeActions.add(PORT_OUT_ACTION);

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/mappers/LogicalPortMapperTest.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/mappers/LogicalPortMapperTest.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.wfm.topology.switchmanager.mappers;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openkilda.wfm.topology.switchmanager.mappers.LogicalPortMapper.INSTANCE;
 
 import org.openkilda.messaging.info.switches.v2.LogicalPortInfoEntryV2;
@@ -25,7 +25,7 @@ import org.openkilda.model.LagLogicalPort;
 import org.openkilda.model.SwitchId;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LogicalPortMapperTest {
     public static SwitchId SWITCH_ID = new SwitchId(1);

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/mappers/MeterEntryConverterTest.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/mappers/MeterEntryConverterTest.java
@@ -23,8 +23,8 @@ import org.openkilda.model.MeterId;
 import org.openkilda.rulemanager.MeterFlag;
 import org.openkilda.rulemanager.MeterSpeakerData;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -38,7 +38,7 @@ public class MeterEntryConverterTest {
 
     public static Set<MeterFlag> flags = new HashSet<>();
 
-    @BeforeClass
+    @BeforeAll
     public static void initializeData() {
         flags.add(MeterFlag.BURST);
 

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/mappers/RuleEntryConverterTest.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/mappers/RuleEntryConverterTest.java
@@ -15,8 +15,7 @@
 
 package org.openkilda.wfm.topology.switchmanager.mappers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openkilda.messaging.info.switches.v2.RuleInfoEntryV2;
 import org.openkilda.messaging.info.switches.v2.action.SetFieldActionEntry;
@@ -34,8 +33,9 @@ import org.openkilda.rulemanager.action.SetFieldAction;
 import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.google.common.collect.Lists;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -78,7 +78,7 @@ public class RuleEntryConverterTest {
     public static Instructions instructions;
     public static FlowSpeakerData data;
 
-    @BeforeClass
+    @BeforeAll
     public static void initializeData() {
 
         applyActions.add(SET_FIELD_ACTION);
@@ -126,7 +126,7 @@ public class RuleEntryConverterTest {
         data.getMatch().forEach(match -> {
             String fieldName = match.getField().name();
 
-            assertNotNull(entryMatchField.get(fieldName));
+            Assertions.assertNotNull(entryMatchField.get(fieldName));
             assertEquals(match.getValue(), entryMatchField.get(fieldName).getValue().intValue());
             assertEquals(match.getMask().intValue(), entryMatchField.get(fieldName).getMask().intValue());
         });
@@ -139,16 +139,14 @@ public class RuleEntryConverterTest {
         assertEquals(OF_METADATA.getMask(), instructions.getWriteMetadata().getMask().longValue());
 
         //actions
-        assertEquals(applyActions.get(0).getType().name(),
-                ((SetFieldActionEntry) instructions.getApplyActions().get(0)).getActionType());
+        assertEquals(applyActions.get(0).getType().name(), instructions.getApplyActions().get(0).getActionType());
         assertEquals(((SetFieldAction) applyActions.get(0)).getField().name(),
                 ((SetFieldActionEntry) instructions.getApplyActions().get(0)).getField());
         assertEquals(((SetFieldAction) applyActions.get(0)).getValue(),
                 ((SetFieldActionEntry) instructions.getApplyActions().get(0)).getValue());
 
         ArrayList<Action> writeActionsList = Lists.newArrayList(writeActions);
-        assertEquals(writeActionsList.get(0).getType().name(),
-                ((SetFieldActionEntry) instructions.getApplyActions().get(0)).getActionType());
+        assertEquals(writeActionsList.get(0).getType().name(), instructions.getApplyActions().get(0).getActionType());
         assertEquals(((SetFieldAction) writeActionsList.get(0)).getField().name(),
                 ((SetFieldActionEntry) instructions.getApplyActions().get(0)).getField());
         assertEquals(((SetFieldAction) writeActionsList.get(0)).getValue(),

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/mappers/ValidationMapperTest.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/mappers/ValidationMapperTest.java
@@ -15,8 +15,6 @@
 
 package org.openkilda.wfm.topology.switchmanager.mappers;
 
-import static org.junit.Assert.assertEquals;
-
 import org.openkilda.messaging.info.switches.v2.GroupInfoEntryV2;
 import org.openkilda.messaging.info.switches.v2.GroupsValidationEntryV2;
 import org.openkilda.messaging.info.switches.v2.LogicalPortInfoEntryV2;
@@ -62,8 +60,9 @@ import org.openkilda.wfm.topology.switchmanager.model.v2.ValidateMetersResultV2;
 import org.openkilda.wfm.topology.switchmanager.model.v2.ValidateRulesResultV2;
 
 import com.google.common.collect.Lists;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -234,7 +233,7 @@ public class ValidationMapperTest {
     private static ValidateMetersResultV2 metersResult;
     private static ValidateLogicalPortsResultV2 logicalPortsResult;
 
-    @BeforeClass
+    @BeforeAll
     public static void initializeData() {
         missingGroups.add(GroupEntryConverter.INSTANCE.toGroupEntry(initializeGroupSpeakerData(new SwitchId(1))));
         properGroups.add(GroupEntryConverter.INSTANCE.toGroupEntry(initializeGroupSpeakerData(new SwitchId(2))));
@@ -298,27 +297,27 @@ public class ValidationMapperTest {
         SwitchValidationResponseV2 response = ValidationMapper.INSTANCE.toSwitchResponse(context);
 
         GroupsValidationEntryV2 groupsEntry = response.getGroups();
-        assertEquals(missingGroups, groupsEntry.getMissing());
-        assertEquals(properGroups, groupsEntry.getProper());
-        assertEquals(excessGroups, groupsEntry.getExcess());
-        assertEquals(misconfiguredGroups, groupsEntry.getMisconfigured());
+        Assertions.assertEquals(missingGroups, groupsEntry.getMissing());
+        Assertions.assertEquals(properGroups, groupsEntry.getProper());
+        Assertions.assertEquals(excessGroups, groupsEntry.getExcess());
+        Assertions.assertEquals(misconfiguredGroups, groupsEntry.getMisconfigured());
 
         RulesValidationEntryV2 rulesEntry = response.getRules();
-        assertEquals(missingRules, rulesEntry.getMissing());
-        assertEquals(properRules, rulesEntry.getProper());
-        assertEquals(excessRules, rulesEntry.getExcess());
-        assertEquals(misconfiguredRules, rulesEntry.getMisconfigured());
+        Assertions.assertEquals(missingRules, rulesEntry.getMissing());
+        Assertions.assertEquals(properRules, rulesEntry.getProper());
+        Assertions.assertEquals(excessRules, rulesEntry.getExcess());
+        Assertions.assertEquals(misconfiguredRules, rulesEntry.getMisconfigured());
 
         LogicalPortsValidationEntryV2 portsEntry = response.getLogicalPorts();
-        assertEquals(missingPorts, portsEntry.getMissing());
-        assertEquals(properPorts, portsEntry.getProper());
-        assertEquals(excessPorts, portsEntry.getExcess());
-        assertEquals(misconfiguredPorts, portsEntry.getMisconfigured());
+        Assertions.assertEquals(missingPorts, portsEntry.getMissing());
+        Assertions.assertEquals(properPorts, portsEntry.getProper());
+        Assertions.assertEquals(excessPorts, portsEntry.getExcess());
+        Assertions.assertEquals(misconfiguredPorts, portsEntry.getMisconfigured());
 
         MetersValidationEntryV2 metersEntry = response.getMeters();
-        assertEquals(missingMeters, metersEntry.getMissing());
-        assertEquals(properMeters, metersEntry.getProper());
-        assertEquals(excessMeters, metersEntry.getExcess());
-        assertEquals(misconfiguredMeters, metersEntry.getMisconfigured());
+        Assertions.assertEquals(missingMeters, metersEntry.getMissing());
+        Assertions.assertEquals(properMeters, metersEntry.getProper());
+        Assertions.assertEquals(excessMeters, metersEntry.getExcess());
+        Assertions.assertEquals(misconfiguredMeters, metersEntry.getMisconfigured());
     }
 }

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/service/UpdateLagPortServiceTest.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/service/UpdateLagPortServiceTest.java
@@ -16,6 +16,7 @@
 package org.openkilda.wfm.topology.switchmanager.service;
 
 import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.openkilda.messaging.error.ErrorType;
 import org.openkilda.messaging.swmanager.request.UpdateLagPortRequest;
@@ -28,16 +29,16 @@ import org.openkilda.wfm.topology.switchmanager.service.configs.LagPortOperation
 import org.openkilda.wfm.topology.switchmanager.service.handler.LagPortUpdateHandler;
 
 import com.google.common.collect.Sets;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Set;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class UpdateLagPortServiceTest {
     @Mock
     private SwitchManagerCarrier carrier;
@@ -54,18 +55,18 @@ public class UpdateLagPortServiceTest {
         UpdateLagPortService subject = new UpdateLagPortService(carrier, operationService);
 
         String requestKey = "test-key";
-        Assert.assertFalse(subject.activeHandlers.containsKey(requestKey));
+        Assertions.assertFalse(subject.activeHandlers.containsKey(requestKey));
 
         UpdateLagPortRequest request = new UpdateLagPortRequest(
                 new SwitchId(1), (int) config.getPoolConfig().getIdMinimum(), Sets.newHashSet(1, 2, 3), true);
         subject.update(requestKey, request);
         LagPortUpdateHandler origin = subject.activeHandlers.get(requestKey);
-        Assert.assertNotNull(origin);
+        Assertions.assertNotNull(origin);
 
         UpdateLagPortRequest request2 = new UpdateLagPortRequest(
                 new SwitchId(2), (int) config.getPoolConfig().getIdMinimum(), Sets.newHashSet(1, 2, 3), true);
-        Assert.assertThrows(InconsistentDataException.class, () -> subject.update(requestKey, request2));
-        Assert.assertSame(origin, subject.activeHandlers.get(requestKey));
+        assertThrows(InconsistentDataException.class, () -> subject.update(requestKey, request2));
+        Assertions.assertSame(origin, subject.activeHandlers.get(requestKey));
     }
 
     @Test
@@ -82,7 +83,7 @@ public class UpdateLagPortServiceTest {
         subject.update(requestKey, request);
         Mockito.verify(carrier).errorResponse(
                 Mockito.eq(requestKey), Mockito.eq(ErrorType.NOT_FOUND), Mockito.anyString(), Mockito.anyString());
-        Assert.assertFalse(subject.activeHandlers.containsKey(requestKey));
+        Assertions.assertFalse(subject.activeHandlers.containsKey(requestKey));
     }
 
     @Test
@@ -103,7 +104,7 @@ public class UpdateLagPortServiceTest {
         subject.update(requestKey, request);
         Mockito.verify(carrier).errorResponse(
                 Mockito.eq(requestKey), Mockito.eq(ErrorType.DATA_INVALID), Mockito.anyString(), Mockito.anyString());
-        Assert.assertFalse(subject.activeHandlers.containsKey(requestKey));
+        Assertions.assertFalse(subject.activeHandlers.containsKey(requestKey));
     }
 
     private LagPortOperationConfig newConfig() {

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/service/handler/LagPortUpdateHandlerTest.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/service/handler/LagPortUpdateHandlerTest.java
@@ -15,6 +15,8 @@
 
 package org.openkilda.wfm.topology.switchmanager.service.handler;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.openkilda.messaging.MessageCookie;
 import org.openkilda.messaging.command.grpc.CreateOrUpdateLogicalPortRequest;
 import org.openkilda.messaging.error.ErrorData;
@@ -33,17 +35,17 @@ import org.openkilda.wfm.topology.switchmanager.service.SwitchManagerCarrier;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashSet;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class LagPortUpdateHandlerTest {
     @Mock
     private SwitchManagerCarrier carrier;
@@ -80,7 +82,7 @@ public class LagPortUpdateHandlerTest {
                         request.isLacpReply())));
         Mockito.verifyNoMoreInteractions(carrier);
 
-        Assert.assertTrue(subject.isCompleted());
+        Assertions.assertTrue(subject.isCompleted());
     }
 
     @Test
@@ -104,7 +106,7 @@ public class LagPortUpdateHandlerTest {
                 Mockito.eq(requestKey), Mockito.eq(error.getErrorType()), Mockito.anyString(), Mockito.anyString());
         Mockito.verifyNoMoreInteractions(carrier);
 
-        Assert.assertTrue(subject.isCompleted());
+        Assertions.assertTrue(subject.isCompleted());
     }
 
     @Test
@@ -128,7 +130,7 @@ public class LagPortUpdateHandlerTest {
                 Mockito.anyString(), Mockito.anyString());
         Mockito.verifyNoMoreInteractions(carrier);
 
-        Assert.assertTrue(subject.isCompleted());
+        Assertions.assertTrue(subject.isCompleted());
     }
 
     @Test
@@ -140,7 +142,7 @@ public class LagPortUpdateHandlerTest {
 
         Mockito.when(operationService.getSwitchIpAddress(request.getSwitchId())).thenThrow(
                 new SwitchNotFoundException(request.getSwitchId()));
-        Assert.assertThrows(SwitchManagerException.class, subject::start);
+        assertThrows(SwitchManagerException.class, subject::start);
     }
 
     private MessageCookie verifyStartHandler(
@@ -158,8 +160,8 @@ public class LagPortUpdateHandlerTest {
 
         // DB update and GRPC request
         subject.start();
-        Assert.assertFalse(subject.isCompleted());
-        Assert.assertEquals(existingTargets, subject.rollbackData);
+        Assertions.assertFalse(subject.isCompleted());
+        Assertions.assertEquals(existingTargets, subject.rollbackData);
 
         Mockito.verify(operationService).getSwitchIpAddress(Mockito.eq(request.getSwitchId()));
         Mockito.verify(operationService).updateLagPort(

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/service/impl/ValidationServiceImplTest.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/service/impl/ValidationServiceImplTest.java
@@ -19,11 +19,11 @@ import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -91,7 +91,7 @@ import org.openkilda.wfm.topology.switchmanager.service.ValidationService;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import java.util.ArrayList;
@@ -709,11 +709,11 @@ public class ValidationServiceImplTest {
         assertEquals(expected.getWriteMetadata().getMask(), actual.getWriteMetadata().getMask().longValue());
 
         assertEquals(expected.getApplyActions().stream().map(Action::getType).map(ActionType::name)
-                        .collect(Collectors.toList()),
-                actual.getApplyActions().stream().map(BaseAction::getActionType).collect(Collectors.toList()));
+                .collect(Collectors.toList()), actual.getApplyActions().stream().map(BaseAction::getActionType)
+                .collect(Collectors.toList()));
         assertEquals(expected.getWriteActions().stream().map(Action::getType).map(ActionType::name)
-                        .collect(Collectors.toList()),
-                actual.getWriteActions().stream().map(BaseAction::getActionType).collect(Collectors.toList()));
+                .collect(Collectors.toList()), actual.getWriteActions().stream().map(BaseAction::getActionType)
+                .collect(Collectors.toList()));
     }
 
     private void assertMeters(MeterInfoEntryV2 meterInfoEntry, long expectedId, long expectedRate,


### PR DESCRIPTION
This PR should be merged right after this one: https://github.com/telstra/open-kilda/pull/5260

- [ ] stats-topology
- [ ] base-topology
- [ ] blue-green
- [ ] connecteddevices-topology
- [ ] kilda-persistence-tinkerpop
- [ ] isllatency-topology
- [ ] opentsdb-topology
- [ ] ping-topology
- [ ] flowhs-topology
- [ ] flowmonitoring-topology
- [ ] nbworker-topology
- [ ] kilda-pce
- [ ] floodlight-service
- [ ] floodlightrouter-topology
- [ ] grpc-speaker
- [ ] kilda-configuration
- [ ] kilda-model
- [ ] kilda-persistence-api
- [ ] network-topology
- [ ] northbound-service
- [ ] testing
- [ ] reroute-topology
- [ ] rule-manager
- [x] server42
- [x] swmanager-topology

closes https://github.com/telstra/open-kilda/issues/5242