### PR TITLE
open-kilda-5264 GUI: Add ability to reroute YFlow via UI

### DIFF
--- a/src-gui/src/checkstyle/checkstyle.xml
+++ b/src-gui/src/checkstyle/checkstyle.xml
@@ -124,12 +124,12 @@
                      value="Type name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="MemberName">
-            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <property name="format" value="^y[A-Z][a-zA-Z0-9]*$|^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
             <message key="name.invalidPattern"
                      value="Member name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="ParameterName">
-            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <property name="format" value="^aSwitch$|^y[A-Z][a-zA-Z0-9]*$|^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
             <message key="name.invalidPattern"
                      value="Parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>

--- a/src-gui/src/main/java/org/openkilda/constants/IConstants.java
+++ b/src-gui/src/main/java/org/openkilda/constants/IConstants.java
@@ -127,8 +127,10 @@ public abstract class IConstants {
         public static final String VERSION_TWO = "/v2";
         public static final String GET_FLOW = VERSION_ONE + "/flows";
         public static final String GET_FLOW_V2 = VERSION_TWO + "/flows";
+        public static final String GET_Y_FLOW_V2 = VERSION_TWO + "/y-flows";
         public static final String GET_FLOW_STATUS = GET_FLOW_V2 + "/status/";
         public static final String GET_FLOW_REROUTE = GET_FLOW_V2 + "/{flow_id}/reroute";
+        public static final String GET_Y_FLOW_REROUTE = GET_Y_FLOW_V2 + "/{y_flow_id}/reroute";
         public static final String GET_FLOW_VALIDATE = GET_FLOW + "/{flow_id}/validate";
         public static final String GET_PATH_FLOW = GET_FLOW + "/path";
         public static final String GET_SWITCHES = VERSION_ONE + "/switches";

--- a/src-gui/src/main/java/org/openkilda/controller/YFlowController.java
+++ b/src-gui/src/main/java/org/openkilda/controller/YFlowController.java
@@ -44,11 +44,11 @@ public class YFlowController extends BaseController {
     private ActivityLogger activityLogger;
 
     /**
-     * Re route the y-flow and returns shared path and sub-flow paths with all nodes/switches exists in
+     * Reroute the y-flow and returns the shared path and sub-flow paths with all nodes/switches exists in
      * provided y-flow.
      *
-     * @param yFlowId id of reroute requested.
-     * @return reroute flow of new flow path with all nodes/switches exist
+     * @param yFlowId ID of y-flow to be rerouted.
+     * @return the result of the rerouting operation.
      */
     @RequestMapping(value = "/{yFlowId}/reroute", method = RequestMethod.GET)
     @ResponseStatus(HttpStatus.OK)

--- a/src-gui/src/main/java/org/openkilda/controller/YFlowController.java
+++ b/src-gui/src/main/java/org/openkilda/controller/YFlowController.java
@@ -1,0 +1,60 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.controller;
+
+import org.openkilda.log.ActivityLogger;
+import org.openkilda.log.constants.ActivityType;
+import org.openkilda.model.YFlowRerouteResult;
+import org.openkilda.service.YFlowService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/y-flows")
+public class YFlowController extends BaseController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(YFlowController.class);
+
+    @Autowired
+    private YFlowService yFlowService;
+
+    @Autowired
+    private ActivityLogger activityLogger;
+
+    /**
+     * Re route the y-flow and returns shared path and sub-flow paths with all nodes/switches exists in
+     * provided y-flow.
+     *
+     * @param yFlowId id of reroute requested.
+     * @return reroute flow of new flow path with all nodes/switches exist
+     */
+    @RequestMapping(value = "/{yFlowId}/reroute", method = RequestMethod.GET)
+    @ResponseStatus(HttpStatus.OK)
+    public @ResponseBody YFlowRerouteResult rerouteFlow(@PathVariable final String yFlowId) {
+        activityLogger.log(ActivityType.FLOW_REROUTE, yFlowId);
+        LOGGER.info("Reroute y-flow. Y-Flow id: '" + yFlowId + "'");
+        return yFlowService.rerouteFlow(yFlowId);
+    }
+}

--- a/src-gui/src/main/java/org/openkilda/integration/converter/FlowConverter.java
+++ b/src-gui/src/main/java/org/openkilda/integration/converter/FlowConverter.java
@@ -242,6 +242,7 @@ public class FlowConverter {
     public FlowInfo toFlowV2Info(final FlowV2 flow, Map<String, String> csNames) {
         FlowInfo flowInfo = new FlowInfo();
         flowInfo.setFlowid(flow.getId());
+        flowInfo.setYFlowId(flow.getYFlowId());
         flowInfo.setMaximumBandwidth(flow.getMaximumBandwidth());
         flowInfo.setAllocateProtectedPath(flow.isAllocateProtectedPath());
         flowInfo.setDescription(flow.getDescription());

--- a/src-gui/src/main/java/org/openkilda/integration/model/FlowV2.java
+++ b/src-gui/src/main/java/org/openkilda/integration/model/FlowV2.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
 import lombok.Data;
 
 import java.util.List;
@@ -37,6 +36,9 @@ public class FlowV2 {
     @JsonProperty("flow_id")
     private String id;
 
+    @JsonProperty("y_flow_id")
+    private String yFlowId;
+
     @JsonProperty("source")
     private FlowV2Endpoint source;
 
@@ -45,7 +47,7 @@ public class FlowV2 {
 
     @JsonProperty("ignore_bandwidth")
     private boolean ignoreBandwidth;
-    
+
     @JsonProperty("maximum_bandwidth")
     private int maximumBandwidth;
 
@@ -54,56 +56,56 @@ public class FlowV2 {
 
     @JsonProperty("last_updated")
     private String lastUpdated;
-    
+
     @JsonProperty("status")
     private String status;
-    
+
     @JsonProperty("timeout")
     private int timeout;
-    
+
     @JsonProperty("diverse_flow_id")
     private String diverseFlowId;
-    
+
     @JsonProperty("allocate_protected_path")
     private boolean allocateProtectedPath;
-    
+
     @JsonProperty("pinned")
     private boolean pinned;
-    
+
     @JsonProperty("encapsulation_type")
     private String encapsulationType;
-    
+
     @JsonProperty("path_computation_strategy")
     private String pathComputationStrategy;
-    
+
     @JsonProperty("periodic_pings")
     private boolean periodicPings;
 
     @JsonProperty("created")
     private String created;
-    
+
     @JsonProperty("diverse_with")
     private List<String> diverseWith;
-    
+
     @JsonProperty("max_latency")
     private Long maxLatency;
-    
+
     @JsonProperty("max_latency_tier2")
     private Long maxLatencyTier2;
 
     @JsonProperty("priority")
     private int priority;
-    
+
     @JsonProperty("status_info")
     private String statusInfo;
-    
+
     @JsonProperty("target_path_computation_strategy")
     private String targetPathComputationStrategy;
-    
+
     @JsonProperty("status_details")
     private StatusDetail statusDetails;
-    
-    
+
+
     public String getId() {
         return id;
     }
@@ -163,16 +165,17 @@ public class FlowV2 {
     public int getTimeout() {
         return timeout;
     }
-    
+
 
     public void setTimeout(int timeout) {
         this.timeout = timeout;
     }
-    
+
 
     @Override
     public String toString() {
-        return "Flow [id=" + id + ", source=" + source + ", destination=" + destination
+        return "Flow [id=" + id + (yFlowId == null ? "" : "yflow=" + yFlowId) + ", source=" + source
+                + ", destination=" + destination
                 + ", maximumBandwidth=" + maximumBandwidth + ", description=" + description
                 + ", lastUpdated=" + lastUpdated + ", status=" + status + "]";
     }

--- a/src-gui/src/main/java/org/openkilda/integration/service/FlowsIntegrationService.java
+++ b/src-gui/src/main/java/org/openkilda/integration/service/FlowsIntegrationService.java
@@ -30,6 +30,7 @@ import org.openkilda.model.FlowConnectedDevice;
 import org.openkilda.model.FlowHistory;
 import org.openkilda.model.FlowInfo;
 import org.openkilda.model.FlowPath;
+import org.openkilda.model.YFlowRerouteResult;
 import org.openkilda.service.ApplicationService;
 import org.openkilda.utility.IoUtil;
 
@@ -196,6 +197,33 @@ public class FlowsIntegrationService {
             throw new IntegrationException(e);
         } catch (IOException e) {
             LOGGER.warn("Error occurred while rerouting flow by id:" + flowId, e);
+            throw new IntegrationException(e);
+        }
+    }
+
+    /**
+     * Reroute Y-flow.
+     *
+     * @param yFlowId y-flow id
+     * @return YFlowRerouteResult
+     */
+    public YFlowRerouteResult rerouteYFlow(String yFlowId) {
+        try {
+            HttpResponse response = restClientManager.invoke(
+                    applicationProperties.getNbBaseUrl() + IConstants.NorthBoundUrl.GET_Y_FLOW_REROUTE
+                            .replace("{y_flow_id}", UriUtils.encodePath(yFlowId, "UTF-8")),
+                    HttpMethod.POST, "", "", applicationService.getAuthHeader());
+            if (RestClientManager.isValidResponse(response)) {
+                return restClientManager.getResponse(response, YFlowRerouteResult.class);
+            } else {
+                String content = IoUtil.toString(response.getEntity().getContent());
+                throw new InvalidResponseException(response.getStatusLine().getStatusCode(), content);
+            }
+        } catch (InvalidResponseException e) {
+            LOGGER.error("Error occurred while rerouting flow by id:" + yFlowId, e);
+            throw new InvalidResponseException(e.getCode(), e.getResponse());
+        } catch (IOException e) {
+            LOGGER.warn("Error occurred while rerouting flow by id:" + yFlowId, e);
             throw new IntegrationException(e);
         }
     }

--- a/src-gui/src/main/java/org/openkilda/integration/service/FlowsIntegrationService.java
+++ b/src-gui/src/main/java/org/openkilda/integration/service/FlowsIntegrationService.java
@@ -48,6 +48,7 @@ import org.springframework.web.util.UriUtils;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.List;
+import javax.validation.constraints.NotNull;
 
 /**
  * The Class FlowsIntegrationService.
@@ -207,7 +208,7 @@ public class FlowsIntegrationService {
      * @param yFlowId y-flow id
      * @return YFlowRerouteResult
      */
-    public YFlowRerouteResult rerouteYFlow(String yFlowId) {
+    public YFlowRerouteResult rerouteYFlow(@NotNull String yFlowId) {
         try {
             HttpResponse response = restClientManager.invoke(
                     applicationProperties.getNbBaseUrl() + IConstants.NorthBoundUrl.GET_Y_FLOW_REROUTE

--- a/src-gui/src/main/java/org/openkilda/model/FlowInfo.java
+++ b/src-gui/src/main/java/org/openkilda/model/FlowInfo.java
@@ -19,7 +19,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.io.Serializable;
@@ -34,123 +35,61 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"flowid", "source_switch", "src_port", "src_vlan", "target_switch", "dst_port", "dst_vlan",
         "maximum_bandwidth", "status", "description", "diverse-flowid", "last-updated", "discrepancy"})
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Data
 public class FlowInfo implements Serializable {
+    private static final long serialVersionUID = -7015976328478701934L;
 
     @JsonProperty("flowid")
     private String flowid;
-
-    @JsonProperty("source_switch")
+    @JsonProperty("y_flow_id")
+    private String yFlowId;
     private String sourceSwitch;
-
-    @JsonProperty("src_port")
     private int srcPort;
-
-    @JsonProperty("src_vlan")
     private int srcVlan;
-    
-    @JsonProperty("src_inner_vlan")
     private int srcInnerVlan;
-
-    @JsonProperty("target_switch_name")
     private String targetSwitchName;
-
-    @JsonProperty("source_switch_name")
     private String sourceSwitchName;
-
-    @JsonProperty("target_switch")
     private String targetSwitch;
-
-    @JsonProperty("dst_port")
     private int dstPort;
-
-    @JsonProperty("dst_vlan")
     private int dstVlan;
-
-    @JsonProperty("dst_inner_vlan")
     private int dstInnerVlan;
-    
     @JsonProperty("diverse-flowid")
     private String diverseFlowid;
-
-    @JsonProperty("maximum_bandwidth")
     private int maximumBandwidth;
-    
-    @JsonProperty("allocate_protected_path")
     private boolean allocateProtectedPath;
-
-    @JsonProperty("status")
     private String status;
-
-    @JsonProperty("description")
     private String description;
-
     @JsonProperty("last-updated")
     private String lastUpdated;
-    
-    @JsonProperty("discrepancy")
     private FlowDiscrepancy discrepancy;
-
-    @JsonProperty("ignore_bandwidth")
     private boolean ignoreBandwidth;
-
-    @JsonProperty("state")
     private String state;
-    
     @JsonProperty("controller-flow")
     private boolean controllerFlow;
-    
     @JsonProperty("inventory-flow")
     private boolean inventoryFlow;
-    
-    @JsonProperty("pinned")
     private boolean pinned;
-    
     @JsonProperty("encapsulation-type")
     private String encapsulationType;
-    
     @JsonProperty("path-computation-strategy")
     private String pathComputationStrategy;
-    
     @JsonProperty("periodic-pings")
     private boolean periodicPings;
-
-    @JsonProperty("created")
     private String created;
-    
-    @JsonProperty("src_lldp")
     private boolean srcLldp;
-
-    @JsonProperty("src_arp")
     private boolean srcArp;
-
-    @JsonProperty("dst_lldp")
     private boolean dstLldp;
-
-    @JsonProperty("dst_arp")
     private boolean dstArp;
-    
-    @JsonProperty("diverse_with")
     private List<String> diverseWith;
-    
     @JsonProperty("max-latency")
     private Long maxLatency;
-
     @JsonProperty("max-latency-tier2")
     private Long maxLatencyTier2;
-    
-    @JsonProperty("priority")
     private int priority;
-    
-    @JsonProperty("status_info")
     private String statusInfo;
-    
     @JsonProperty("target-path-computation_strategy")
     private String targetPathComputationStrategy;
-    
     @JsonProperty("status-details")
     private StatusDetail statusDetails;
-
-    private static final long serialVersionUID = -7015976328478701934L;
-
 }

--- a/src-gui/src/main/java/org/openkilda/model/PathNodeV2.java
+++ b/src-gui/src/main/java/org/openkilda/model/PathNodeV2.java
@@ -1,0 +1,37 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.model;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(value = SnakeCaseStrategy.class)
+public class PathNodeV2 {
+    @NonNull
+    String switchId;
+    int portNo;
+    Long segmentLatency;
+}
+

--- a/src-gui/src/main/java/org/openkilda/model/YFlowRerouteResult.java
+++ b/src-gui/src/main/java/org/openkilda/model/YFlowRerouteResult.java
@@ -16,12 +16,14 @@
 package org.openkilda.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
 
 import java.io.Serializable;
 import java.util.List;
@@ -33,8 +35,9 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class YFlowRerouteResult implements Serializable {
 
     private static final long serialVersionUID = 3039165826298801296L;
@@ -47,7 +50,7 @@ public class YFlowRerouteResult implements Serializable {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class ReroutedSharedPath {
         List<PathNodeV2> nodes;
@@ -57,7 +60,7 @@ public class YFlowRerouteResult implements Serializable {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class ReroutedSubFlowPath {
         String flowId;

--- a/src-gui/src/main/java/org/openkilda/model/YFlowRerouteResult.java
+++ b/src-gui/src/main/java/org/openkilda/model/YFlowRerouteResult.java
@@ -1,0 +1,66 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * The Class YFlowRerouteResult.
+ */
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class YFlowRerouteResult implements Serializable {
+
+    private static final long serialVersionUID = 3039165826298801296L;
+
+    ReroutedSharedPath sharedPath;
+    List<ReroutedSubFlowPath> subFlowPaths;
+    boolean rerouted;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ReroutedSharedPath {
+        List<PathNodeV2> nodes;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ReroutedSubFlowPath {
+        String flowId;
+        List<PathNodeV2> nodes;
+    }
+}

--- a/src-gui/src/main/java/org/openkilda/service/YFlowService.java
+++ b/src-gui/src/main/java/org/openkilda/service/YFlowService.java
@@ -37,7 +37,7 @@ public class YFlowService {
      * @return flow path
      */
     public YFlowRerouteResult rerouteFlow(String yFlowId) {
-        LOGGER.info(String.format("Re-rote request for y-flow is in progress, for y-flow id: %s", yFlowId));
+        LOGGER.info(String.format("The re-routing request for y-flow is in progress, y-flow ID: %s", yFlowId));
         return flowsIntegrationService.rerouteYFlow(yFlowId);
     }
 

--- a/src-gui/src/main/java/org/openkilda/service/YFlowService.java
+++ b/src-gui/src/main/java/org/openkilda/service/YFlowService.java
@@ -1,0 +1,44 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.service;
+
+import org.openkilda.integration.service.FlowsIntegrationService;
+import org.openkilda.model.YFlowRerouteResult;
+
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class YFlowService {
+
+    private static final Logger LOGGER = Logger.getLogger(YFlowService.class);
+
+    @Autowired
+    private FlowsIntegrationService flowsIntegrationService;
+
+    /**
+     * Re-route Y-flow by Y-flow id.
+     *
+     * @param yFlowId the y-flow id
+     * @return flow path
+     */
+    public YFlowRerouteResult rerouteFlow(String yFlowId) {
+        LOGGER.info(String.format("Re-rote request for y-flow is in progress, for y-flow id: %s", yFlowId));
+        return flowsIntegrationService.rerouteYFlow(yFlowId);
+    }
+
+}

--- a/src-gui/ui/src/app/common/services/flows.service.ts
+++ b/src-gui/ui/src/app/common/services/flows.service.ts
@@ -79,6 +79,10 @@ export class FlowsService {
     return this.httpClient.get(`${environment.apiEndPoint}/flows/${flowId}/reroute`);
   }
 
+    getYFlowReRoutedPath(yFlowId): Observable<any> {
+        return this.httpClient.get(`${environment.apiEndPoint}/y-flows/${yFlowId}/reroute`);
+    }
+
   getFlowPathStats(jsonPayload): Observable<any> {
     return this.httpClient.post(`${environment.apiEndPoint}/stats/flowpath`, jsonPayload);
   }

--- a/src-gui/ui/src/app/modules/flows/flow-datatables/flow-datatables.component.html
+++ b/src-gui/ui/src/app/modules/flows/flow-datatables/flow-datatables.component.html
@@ -13,6 +13,13 @@
           <i class="fa fa-search" (click)="toggleSearch($event,'expandedFlowId')"></i>
           <input  class="heading_search_box" (click)="stopPropagationmethod($event)" (keydown.enter)="stopPropagationmethod($event)" type="search" placeholder="Search"  [hidden]="!expandedFlowId" id="expandedFlowId"/>
         </th>
+        <th class="">
+          <span title="Y-Flow ID">
+         Y-Flow ID
+        </span>
+          <i class="fa fa-search" (click)="toggleSearch($event,'expandedYFlowId')"></i>
+          <input  class="heading_search_box" (click)="stopPropagationmethod($event)" (keydown.enter)="stopPropagationmethod($event)" type="search" placeholder="Search"  [hidden]="!expandedYFlowId" id="expandedYFlowId"/>
+        </th>
         <th class="" >
           <span title="Source Switch">
             Src Switch
@@ -124,13 +131,21 @@
           <input [disabled]="row.status == 'UP' || row.status == 'IN PROGRESS' || (storeLinkSetting  && row.state) "  type="checkbox" class="large-checkbox" name="checkedFlow[row.flowid]" [checked]="checkedFlow[row.flowid]" (click) = "toggleSelection(row)" />
         </td>
         <td (click)="showFlow(row)" class="divTableCell" title="{{row.flowid }}" [contextMenu]="copyFLow"> 
-          {{row.flowid || "-"}} 
-          <context-menu #copyFLow>
+           {{row.flowid || "-"}} 
+           <context-menu #copyFLow>
               <ng-template contextMenuItem (execute)="copyToClip($event,'flowid',i);">
                 Copy to Clipboard
               </ng-template>
-            </context-menu>
+           </context-menu>
          </td>
+         <td (click)="showFlow(row)" class="divTableCell" title="{{row.y_flow_id }}" [contextMenu]="copyFLow">
+          {{row.y_flow_id || "-"}}
+          <context-menu #copyFLow>
+             <ng-template contextMenuItem (execute)="copyToClip($event,'y_flow_id',i);">
+               Copy to Clipboard
+             </ng-template>
+          </context-menu>
+        </td>
         <td (click)="showFlow(row)" title="{{row.source_switch_name}}" [contextMenu]="copySourceSwitch">
           {{row.source_switch_name || "-"}}
           <context-menu #copySourceSwitch>

--- a/src-gui/ui/src/app/modules/flows/flow-datatables/flow-datatables.component.ts
+++ b/src-gui/ui/src/app/modules/flows/flow-datatables/flow-datatables.component.ts
@@ -48,6 +48,7 @@ export class FlowDatatablesComponent implements OnInit, AfterViewInit, OnChanges
 
   expandedBandwidth = false;
   expandedFlowId = false;
+  expandedYFlowId = false;
   expandedState = false;
   expandedStatus = false;
   expandedDescription = false;
@@ -99,6 +100,7 @@ export class FlowDatatablesComponent implements OnInit, AfterViewInit, OnChanges
       'aoColumns': [
         { sWidth: '7%' , 'bSortable': false},
         { sWidth: '15%' },
+        { sWidth: '10%' },
         { sWidth:  '13%', 'sType': 'name', 'bSortable': true },
         { sWidth: '8%' },
         { sWidth: '8%' },
@@ -203,7 +205,7 @@ export class FlowDatatablesComponent implements OnInit, AfterViewInit, OnChanges
 
   toggleSearch(e, inputContainer) {
 
-    this[inputContainer] = this[inputContainer] ? false : true;
+    this[inputContainer] = !this[inputContainer];
     if (this[inputContainer]) {
       setTimeout(() => {
         this.renderer.selectRootElement('#' + inputContainer).focus();

--- a/src-gui/ui/src/app/modules/flows/flow-datatables/flow-datatables.component.ts
+++ b/src-gui/ui/src/app/modules/flows/flow-datatables/flow-datatables.component.ts
@@ -100,8 +100,8 @@ export class FlowDatatablesComponent implements OnInit, AfterViewInit, OnChanges
       'aoColumns': [
         { sWidth: '7%' , 'bSortable': false},
         { sWidth: '15%' },
-        { sWidth: '10%' },
-        { sWidth:  '13%', 'sType': 'name', 'bSortable': true },
+        { sWidth: '15%' },
+        { sWidth:  '13%',"sType": "name","bSortable": true },
         { sWidth: '8%' },
         { sWidth: '8%' },
         { sWidth: '9%' },

--- a/src-gui/ui/src/app/modules/flows/flow-datatables/flow-datatables.component.ts
+++ b/src-gui/ui/src/app/modules/flows/flow-datatables/flow-datatables.component.ts
@@ -101,7 +101,7 @@ export class FlowDatatablesComponent implements OnInit, AfterViewInit, OnChanges
         { sWidth: '7%' , 'bSortable': false},
         { sWidth: '15%' },
         { sWidth: '10%' },
-        { sWidth:  '13%',"sType": "name","bSortable": true },
+        { sWidth:  '13%', 'sType': 'name', 'bSortable': true },
         { sWidth: '8%' },
         { sWidth: '8%' },
         { sWidth: '9%' },

--- a/src-gui/ui/src/app/modules/flows/flow-datatables/flow-datatables.component.ts
+++ b/src-gui/ui/src/app/modules/flows/flow-datatables/flow-datatables.component.ts
@@ -100,7 +100,7 @@ export class FlowDatatablesComponent implements OnInit, AfterViewInit, OnChanges
       'aoColumns': [
         { sWidth: '7%' , 'bSortable': false},
         { sWidth: '15%' },
-        { sWidth: '15%' },
+        { sWidth: '10%' },
         { sWidth:  '13%',"sType": "name","bSortable": true },
         { sWidth: '8%' },
         { sWidth: '8%' },

--- a/src-gui/ui/src/app/modules/flows/flow-detail/flow-detail.component.html
+++ b/src-gui/ui/src/app/modules/flows/flow-detail/flow-detail.component.html
@@ -296,7 +296,7 @@
           <div class="tab-pane" *ngIf="openedTab == 'path'" [ngClass]="{'active': openedTab == 'path'}">
             <div class="text-right mb-2">
               <button *ngIf="commonService.hasPermission('fw_permission_reroute')" class="btn btn-dark btn-sm" (click)="reRouteFlow()">
-                Re-route {{ y_flow_id ? 'Y-Flow ' : 'Flow' }}</button>
+                Re-route {{isSubflowForYFlow()?'Y-Flow':'Flow'}}</button>
             </div>
             <app-flow-path *ngIf="!reRoutingInProgress"  [flowId]="flowDetail.flowid"></app-flow-path>
           </div>

--- a/src-gui/ui/src/app/modules/flows/flow-detail/flow-detail.component.html
+++ b/src-gui/ui/src/app/modules/flows/flow-detail/flow-detail.component.html
@@ -296,7 +296,7 @@
           <div class="tab-pane" *ngIf="openedTab == 'path'" [ngClass]="{'active': openedTab == 'path'}">
             <div class="text-right mb-2">
               <button *ngIf="commonService.hasPermission('fw_permission_reroute')" class="btn btn-dark btn-sm" (click)="reRouteFlow()">
-                Re-route {{isSubflowForYFlow()?'Y-Flow':'Flow'}}</button>
+                Re-route {{ y_flow_id ? 'Y-Flow ' : 'Flow' }}</button>
             </div>
             <app-flow-path *ngIf="!reRoutingInProgress"  [flowId]="flowDetail.flowid"></app-flow-path>
           </div>

--- a/src-gui/ui/src/app/modules/flows/flow-detail/flow-detail.component.html
+++ b/src-gui/ui/src/app/modules/flows/flow-detail/flow-detail.component.html
@@ -10,7 +10,7 @@
             <div class="clear clearfix"></div>
         </div>
       <p class="text-center flow-title" >Flow ID : <span [contextMenu]="copyFLow">{{flowDetail.flowid}}</span>
-      <a *ngIf="commonService.hasPermission('fw_flow_update') && (!storeLinkSetting || controllerFilter || (storeLinkSetting && flowDetail.hasOwnProperty('discrepancy') && flowDetail['discrepancy'].hasOwnProperty('controller-discrepancy') && !flowDetail['discrepancy']['controller-discrepancy']))" class="btn btn-dark btn-sm pull-right" role="button" aria-pressed="true" [routerLink]="['/flows/edit',flowDetail.flowid]">Edit</a>
+      <a *ngIf="!y_flow_id && commonService.hasPermission('fw_flow_update') && (!storeLinkSetting || controllerFilter || (storeLinkSetting && flowDetail.hasOwnProperty('discrepancy') && flowDetail['discrepancy'].hasOwnProperty('controller-discrepancy') && !flowDetail['discrepancy']['controller-discrepancy']))" class="btn btn-dark btn-sm pull-right" role="button" aria-pressed="true" [routerLink]="['/flows/edit',flowDetail.flowid]">Edit</a>
       </p>     
       </div>
     </div>
@@ -138,6 +138,12 @@
           <div class="row">
               <div class="col-sm-6">
                 <ul class="list-group list-group-no-border">
+                  <li *ngIf="y_flow_id" class="list-group-item">
+                    <div class="row">
+                      <div class="col-sm-4">Y-Flow ID:</div>
+                      <div class="col-sm-8">{{ y_flow_id }}</div>
+                    </div>
+                  </li>
                   <li class="list-group-item">
                     <div class="row">
                       <div class="col-sm-4">Status:</div>
@@ -289,8 +295,8 @@
           </div>
           <div class="tab-pane" *ngIf="openedTab == 'path'" [ngClass]="{'active': openedTab == 'path'}">
             <div class="text-right mb-2">
-              <button *ngIf="commonService.hasPermission('fw_permission_reroute')" class="btn btn-dark btn-sm" (click)="reRouteFlow()">Re-route
-                Flow</button>
+              <button *ngIf="commonService.hasPermission('fw_permission_reroute')" class="btn btn-dark btn-sm" (click)="reRouteFlow()">
+                Re-route {{ y_flow_id ? 'Y-Flow ' : 'Flow' }}</button>
             </div>
             <app-flow-path *ngIf="!reRoutingInProgress"  [flowId]="flowDetail.flowid"></app-flow-path>
           </div>

--- a/src-gui/ui/src/app/modules/flows/flow-detail/flow-detail.component.ts
+++ b/src-gui/ui/src/app/modules/flows/flow-detail/flow-detail.component.ts
@@ -795,8 +795,9 @@ export class FlowDetailComponent implements OnInit {
 
   processErrorResult(error: any) {
       this.loaderService.hide();
-      const { 'error-auxiliary-message': auxMessage, 'error-description': description } = error.error;
-      this.toaster.error(`${auxMessage} ${description}`, 'Error!');
+      const { 'error-auxiliary-message': auxMessage, 'error-description': description, 'error-message': message } = error.error;
+      this.toaster.error(`${auxMessage} ${description} ${message}`, 'Error!');
+      this.reRoutingInProgress = false;
   }
 
   addPingToLinks() {

--- a/src-gui/ui/src/app/modules/flows/flow-detail/flow-detail.component.ts
+++ b/src-gui/ui/src/app/modules/flows/flow-detail/flow-detail.component.ts
@@ -25,6 +25,7 @@ declare var moment: any;
 export class FlowDetailComponent implements OnInit {
   openedTab = 'graph';
   flowDetail: any;
+  y_flow_id: string;
   hasConnectedDevices = false;
   controllerFilter = false;
   graphOptions = {
@@ -52,12 +53,6 @@ export class FlowDetailComponent implements OnInit {
   forceSimulation: any;
   isDragMove: true;
   size: any;
-  min_zoom = 0.15;
-  max_zoom = 3;
-  zoomLevel = 0.15;
-  zoomStep = 0.15;
-  translateX = 0;
-  translateY = 0;
   validatedFlow: any = [];
   resyncedFlow: any = [];
   pingedFlow: any = [];
@@ -533,6 +528,9 @@ export class FlowDetailComponent implements OnInit {
        flowDetail['source_switch'] = this.convertSwitchPattern(flowDetail['source_switch']);
         flowDetail['target_switch'] = this.convertSwitchPattern(flowDetail['target_switch']);
         this.flowDetail = flowDetail;
+      if (this.isSubflowForYFlow(this.flowDetail)) {
+          this.y_flow_id = this.flowDetail.y_flow_id;
+      }
         this.hasConnectedDevices = (flowDetail.src_lldp || flowDetail.src_arp) || (flowDetail.dst_lldp || flowDetail.dst_arp);
         this.clipBoardItems = Object.assign(this.clipBoardItems, {
           flowName: flowDetail.flowid,
@@ -566,6 +564,9 @@ export class FlowDetailComponent implements OnInit {
         flow['source_switch'] = this.convertSwitchPattern(flow['source_switch']);
         flow['target_switch'] = this.convertSwitchPattern(flow['target_switch']);
         this.flowDetail = flow;
+          if (this.isSubflowForYFlow(this.flowDetail)) {
+              this.y_flow_id = this.flowDetail.y_flow_id;
+          }
         this.hasConnectedDevices = this.flowDetail.src_lldp || this.flowDetail.dst_lldp;
         this.clipBoardItems = Object.assign(this.clipBoardItems, {
           flowName: flow.flowid,
@@ -603,9 +604,6 @@ export class FlowDetailComponent implements OnInit {
       }
     );
   }
-
-
-
   }
 
   convertSwitchPattern(switchId) {
@@ -747,37 +745,56 @@ export class FlowDetailComponent implements OnInit {
   reRouteFlow() {
     this.reRoutingInProgress = true;
     this.loaderService.show(MessageObj.re_routing);
-    this.flowService.getReRoutedPath(this.flowDetail.flowid).subscribe(
-      data => {
-        this.loaderService.hide();
-        if (data && typeof(data.rerouted) !== 'undefined' && data.rerouted) {
+    if (this.isSubflowForYFlow(this.flowDetail)) {
+        this.flowService.getYFlowReRoutedPath(this.y_flow_id)
+            .subscribe(data => this.processRerouteResult(data),
+                error => {
+                    this.processErrorResult(error);
+                });
+    } else {
+        this.flowService.getReRoutedPath(this.flowDetail.flowid)
+            .subscribe(data => this.processRerouteResult(data),
+                error => {
+                    this.processErrorResult(error);
+                });
+    }
+  }
+
+  isSubflowForYFlow(flowDetail): boolean {
+      return typeof flowDetail.y_flow_id === 'string' && flowDetail.y_flow_id !== '';
+  }
+
+  processRerouteResult( data: any) {
+      this.loaderService.hide();
+      if (data && typeof(data.rerouted) !== 'undefined' && data.rerouted) {
           this.toaster.success('Flow : ' + this.flowDetail.flowid + ' successfully re-routed!', 'success');
-        } else {
+      } else {
           this.toaster.info('Flow : ' + this.flowDetail.flowid + ' already on best route!');
-        }
-        this.loaderService.show(MessageObj.reloading_status_and_flow_path);
-        /** Re-load flow path components */
-        setTimeout(() => {
+      }
+      this.loaderService.show(MessageObj.reloading_status_and_flow_path);
+      /** Re-load flow path components */
+      setTimeout(() => {
           this.reRoutingInProgress = false;
           this.loaderService.hide();
           this.flowService.getFlowStatus(this.flowDetail.flowid).subscribe(
-            flowStatus => {
-              this.flowDetail.status = (flowStatus && flowStatus.status) ?  flowStatus.status : this.flowDetail.status;
-            },
-            error => {
-              const errorMsg = error && error.error && error.error['error-auxiliary-message'] ? error.error['error-auxiliary-message'] : 'No Flow found';
-              // this.toaster.error(errorMsg, "Error");
-             }
+              flowStatus => {
+                  this.flowDetail.status = (flowStatus && flowStatus.status) ?  flowStatus.status : this.flowDetail.status;
+              },
+              error => {
+                  const errorMsg = error && error.error && error.error['error-auxiliary-message']
+                      ? error.error['error-auxiliary-message'] : 'No Flow found';
+                  console.log('error: ', errorMsg);
+              }
           );
-        }, 10000);
-      },
-      error => {
-        this.loaderService.hide();
-        this.toaster.error(error['error-auxiliary-message'], 'Error!');
-      }
-    );
-
+      }, 10000);
   }
+
+  processErrorResult(error: any) {
+      this.loaderService.hide();
+      const { 'error-auxiliary-message': auxMessage, 'error-description': description } = error.error;
+      this.toaster.error(`${auxMessage} ${description}`, 'Error!');
+  }
+
   addPingToLinks() {
     this.links.forEach(function(d, index) {
       $('#link' + index).addClass('flowline');

--- a/src-gui/ui/src/app/modules/flows/flow-detail/flow-detail.component.ts
+++ b/src-gui/ui/src/app/modules/flows/flow-detail/flow-detail.component.ts
@@ -604,7 +604,7 @@ export class FlowDetailComponent implements OnInit {
       }
     );
   }
-   if (this.isSubflowForYFlow()) {
+   if (this.isSubflowForYFlow(this.flowDetail)) {
        this.y_flow_id = this.flowDetail.y_flow_id;
    }
 

--- a/src-gui/ui/src/app/modules/flows/flow-detail/flow-detail.component.ts
+++ b/src-gui/ui/src/app/modules/flows/flow-detail/flow-detail.component.ts
@@ -604,6 +604,10 @@ export class FlowDetailComponent implements OnInit {
       }
     );
   }
+   if (this.isSubflowForYFlow()) {
+       this.y_flow_id = this.flowDetail.y_flow_id;
+   }
+
   }
 
   convertSwitchPattern(switchId) {


### PR DESCRIPTION
### This PR should be merged after the following one: (https://github.com/telstra/open-kilda/pull/5318)

UI:
- add y_flow_id to the flowDetail object that is stored in the localStorage.
- retrieve this y_flow_id when it is not null for particular flow, and call appropriate API for y-flow rerouting when needed.
- propagated the rerouting error from the northbound API.
- changed button name "Reroute Flow"->"Reroute Y-Flow" for Y-Flow subflows.
- added y-flow column to the flow-datables component.
- added Y-Flow ID list item to the Flow Details Page, flow details section for the subflow case.
- remove edit button for the Flow details page of the subflow case.

BFF:
  - add additional Controller,Service for Y-flow.

closes: #5264 






In order to test the ability to re-route Y-Flow we need to follow the next steps:

1) Create an Y-Flow using [y-flow-controller-v-2], bellow is the possible request body for creating Y-Flow.
```
{
  "y_flow_id": "yflow8-9-3",
  "shared_endpoint": {
    "port_number": 101,
    "switch_id": "8"
  },
  "maximum_bandwidth": 100,
  "path_computation_strategy": "cost",
  "sub_flows": [
    {
      "flow_id": "subflow8-9",
      "endpoint": {
        "detect_connected_devices": {
          "arp": true,
          "lldp": true
        },
        "inner_vlan_id": 108,
        "port_number": 103,
        "switch_id": "9",
        "vlan_id": 109
      },
      "shared_endpoint": {
        "inner_vlan_id": 110,
        "vlan_id": 111
      }
    },
{
      "flow_id": "subflow8-3",
      "endpoint": {
        "detect_connected_devices": {
          "arp": true,
          "lldp": true
        },
        "inner_vlan_id": 118,
        "port_number": 113,
        "switch_id": "3",
        "vlan_id": 120
      },
      "shared_endpoint": {
        "inner_vlan_id": 111,
        "vlan_id": 112
      }
    }
  ]
}
```

2) After successful creation of Y-Flow we need to reroute the flow, but just calling reroute 
API ([/v2/y-flows/{y_flow_id}/reroute]), it only gives us the error message with the following content:
```
{
  "correlation_id": "54234e83-0e52-4287-b7bc-55f14a512018 : CHUPIN_REROUTE",
  "timestamp": 1689864780401,
  "error-type": "Internal service error",
  "error-message": "Could not reroute y-flow",
  "error-description": "Reroute is unsuccessful. Couldn't find new path(s)"
}
```
This happens because of the existed paths are already best routed according to the internal logic of the flowhs-topology, despite the fact that an error message obviously misleading. **However we have already had a fix for this problem in the following PR**: 
https://github.com/telstra/open-kilda/pull/5318.
To trick this behaviour we need to change the cost of the existing links in our two paths, to do so as a one easy option we need to follow this link: (http://vm:2480/studio/index.html#/),  enter the credentials, 
follow the "GRAPH" tab and run the query:
<img width="1292" alt="image" src="https://github.com/telstra/open-kilda/assets/9297385/ce7e542b-d328-4269-a2f2-a668c8bf5e60">

change the cost for links between switches 8-3 and switches 8-9.
<img width="1210" alt="image" src="https://github.com/telstra/open-kilda/assets/9297385/e64ab065-f57e-4d3a-a9d6-4267adace521">
Setting the cost to 7000 for each link would be enough:
<img width="796" alt="image" src="https://github.com/telstra/open-kilda/assets/9297385/5e7a1164-b976-4a26-8fc5-b7428214148f">.

Then go to the UI
<img width="2289" alt="image" src="https://github.com/telstra/open-kilda/assets/9297385/4574b39b-b8b7-4e86-94c0-8fa4e57e45b5">
<img width="2559" alt="image" src="https://github.com/telstra/open-kilda/assets/9297385/f066930e-f054-4d7a-a599-02c369fcfeff">
Pressing the button should reroute all the subflows for the desired Y-Flow's subflow.


**Here are screenshots with the UI changes:**
<img width="2296" alt="image" src="https://github.com/telstra/open-kilda/assets/9297385/e6e79831-51e7-407f-9f4c-36a1f55bd1b2">
<img width="2294" alt="image" src="https://github.com/telstra/open-kilda/assets/9297385/8eee6116-fdb8-4d37-927b-ddb532922b8e">

1. We do not have the edit button for the Y-Flow subflows anymore.
2. Added the Y-Flow ID field with the value, for the Y-Flow subflows(there is no this field for regular flow)
3. Changed the label for the reroute flow button.
4. Added Y-Flow ID column with a search feature. 



### This PR should be merged after the following one: (https://github.com/telstra/open-kilda/pull/5318)
