### PR TITLE
modify topology.tmpl to not include the VictoriaMetrics

### DIFF
--- a/confd/templates/base-storm-topology/topology.properties.tmpl
+++ b/confd/templates/base-storm-topology/topology.properties.tmpl
@@ -55,7 +55,7 @@ persistence.implementation.default = {{ getv "/kilda_persistence_default_impleme
 persistence.implementation.area.history = {{ getv "/kilda_persistence_history_implementation" }}
 
 opentsdb.target.opentsdb = http://{{ getv "/kilda_opentsdb_hosts" }}:{{ getv "/kilda_opentsdb_port" }}
-{{if exists "/kilda_victoriametrics_host"}}
+{{if getv "/kilda_victoriametrics_host"}}
 opentsdb.target.victoriametrics = http://{{ getv "/kilda_victoriametrics_host" }}:{{ getv "/kilda_victoriametrics_port" }}{{ getv "/kilda_victoriametrics_path" }}
 {{end}}
 opentsdb.timeout = {{ getv "/kilda_opentsdb_timeout" }}

--- a/confd/vars/test-vars.yaml
+++ b/confd/vars/test-vars.yaml
@@ -33,4 +33,3 @@ kilda_logging_port_tests: 5006
 
 kilda_tests_grpc_endpoint: "http://localhost"
 kilda_tests_grpc_rest_port: "8091"
-

--- a/src-java/opentsdb-topology/opentsdb-storm-topology/src/test/java/org/openkilda/wfm/topology/opentsdb/OpenTsdbTopologyTest.java
+++ b/src-java/opentsdb-topology/opentsdb-storm-topology/src/test/java/org/openkilda/wfm/topology/opentsdb/OpenTsdbTopologyTest.java
@@ -15,6 +15,8 @@
 
 package org.openkilda.wfm.topology.opentsdb;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.openkilda.wfm.topology.opentsdb.OpenTsdbTopology.OTSDB_PARSE_BOLT_ID;
 
@@ -76,7 +78,7 @@ public class OpenTsdbTopologyTest extends StableAbstractStormTest {
     }
 
     @Test
-    public void shouldSuccessfulSendDatapoint() {
+    public void successfulSendDatapoint() {
         Datapoint datapoint = new Datapoint("metric", timestamp, Collections.emptyMap(), 123);
 
         MockedSources sources = new MockedSources();
@@ -101,7 +103,7 @@ public class OpenTsdbTopologyTest extends StableAbstractStormTest {
     }
 
     @Test
-    public void shouldSendDatapointRequestsOnlyOnce() throws Exception {
+    public void sendDatapointRequestsOnlyOnce() throws Exception {
         Datapoint datapoint = new Datapoint("metric", timestamp, Collections.emptyMap(), 123);
 
         MockedSources sources = new MockedSources();
@@ -126,7 +128,7 @@ public class OpenTsdbTopologyTest extends StableAbstractStormTest {
     }
 
     @Test
-    public void shouldSendDatapointRequestsTwice() throws Exception {
+    public void sendDatapointRequestsTwice() throws Exception {
         Datapoint datapoint1 = new Datapoint("metric", timestamp, Collections.emptyMap(), 123);
         Datapoint datapoint2 = new Datapoint("metric", timestamp, Collections.emptyMap(), 456);
 
@@ -155,6 +157,20 @@ public class OpenTsdbTopologyTest extends StableAbstractStormTest {
         });
         //verify that request is sent to OpenTSDB server once
         mockServer.verify(REQUEST, VerificationTimes.exactly(2));
+    }
+
+    @Test
+    public void isValidUrl() {
+        assertTrue(OpenTsdbTopology.isValidUrl("http://localhost:4243"));
+        assertTrue(OpenTsdbTopology.isValidUrl("http://localhost:4243/api/put"));
+    }
+
+    @Test
+    public void isValidUrlNoHost() {
+        assertFalse(OpenTsdbTopology.isValidUrl("http://:4243"));
+        assertFalse(OpenTsdbTopology.isValidUrl("http://localhost:"));
+        assertFalse(OpenTsdbTopology.isValidUrl("localhost:4242"));
+        assertFalse(OpenTsdbTopology.isValidUrl(""));
     }
 
     /**


### PR DESCRIPTION
* modify topology.tmpl not to include the VictoriaMetrics endpoint when the 'kilda_victoriametrics_host' variable is empty
* change the opentsdb bolt to check if the opentsdb/victoria URL is well formatted.

Closes #5306