### PR TITLE
Add an error reason when setting a degraded status on paths

### DIFF
--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/CompleteFlowPathInstallationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/CompleteFlowPathInstallationAction.java
@@ -47,6 +47,7 @@ public class CompleteFlowPathInstallationAction extends
             FlowPathStatus primaryPathStatus;
             if (stateMachine.isIgnoreBandwidth() || stateMachine.isBackUpPrimaryPathComputationWayUsed()) {
                 primaryPathStatus = FlowPathStatus.DEGRADED;
+                stateMachine.setErrorReason("The primary path status is " + FlowPathStatus.DEGRADED);
             } else {
                 primaryPathStatus = FlowPathStatus.ACTIVE;
             }
@@ -67,6 +68,7 @@ public class CompleteFlowPathInstallationAction extends
             FlowPathStatus protectedPathStatus;
             if (stateMachine.isIgnoreBandwidth() || stateMachine.isBackUpProtectedPathComputationWayUsed()) {
                 protectedPathStatus = FlowPathStatus.DEGRADED;
+                stateMachine.setErrorReason("The protected path status is " + FlowPathStatus.DEGRADED);
             } else {
                 protectedPathStatus = FlowPathStatus.ACTIVE;
             }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/OnFinishedAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/OnFinishedAction.java
@@ -47,7 +47,7 @@ public class OnFinishedAction extends HistoryRecordingAction<FlowRerouteFsm, Sta
             sendPeriodicPingNotification(stateMachine);
         } else {
             stateMachine.saveActionToHistory("Flow reroute completed",
-                    format("Flow reroute completed with status %s  and error %s", stateMachine.getNewFlowStatus(),
+                    format("Flow reroute completed with status %s and error: %s", stateMachine.getNewFlowStatus(),
                             stateMachine.getErrorReason()));
         }
         log.info("Flow {} reroute success", stateMachine.getFlowId());

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MaxLatencySpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MaxLatencySpec.groovy
@@ -240,7 +240,7 @@ class MaxLatencySpec extends HealthCheckSpecification {
             def flowHistory = northbound.getFlowHistory(flow.flowId).last()
             flowHistory.payload.last().action == REROUTE_SUCCESS
             // https://github.com/telstra/open-kilda/issues/4049
-            flowHistory.payload.last().details == "Flow reroute completed with status DEGRADED  and error null"
+            flowHistory.payload.last().details == "Flow reroute completed with status DEGRADED and error: The primary path status is DEGRADED"
             def flowInfo = northboundV2.getFlow(flow.flowId)
             assert flowInfo.status == FlowState.DEGRADED.toString()
             assert flowInfo.statusInfo == StatusInfo.BACK_UP_STRATEGY_USED


### PR DESCRIPTION
These changes add an error reason to the state machine that is used later to create a message for saving it in history. 
closes #4049 