### PR TITLE
update spring gui repository

### DIFF
--- a/src-gui/build.gradle
+++ b/src-gui/build.gradle
@@ -9,7 +9,7 @@ plugins {
 repositories {
     mavenCentral()
     maven {
-        url 'https://repo.spring.io/libs-milestone'
+        url 'https://repo.spring.io/milestone'
     }
 }
 


### PR DESCRIPTION
The repository was outdated and it was failing with 401 responses.

[*]https://spring.io/blog/2022/12/14/notice-of-permissions-changes-to-repo-spring-io-january-2023

Closes #5311 