### PR TITLE
Bugfix/5303 reroute yflow correct response if already on best path

### DIFF
--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/error/ErrorType.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/error/ErrorType.java
@@ -101,7 +101,12 @@ public enum ErrorType {
     /**
      * The request cannot be processed.
      */
-    UNPROCESSABLE_REQUEST("The request cannot be processed");
+    UNPROCESSABLE_REQUEST("The request cannot be processed"),
+
+    /**
+     * The error message for Y-Flow subflow that can not be rerouted since already on the best path.
+     */
+    ALREADY_ON_BEST_PATH("The flow already on the best path");
 
     /**
      * The text type value.

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/PostResourceAllocationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/reroute/actions/PostResourceAllocationAction.java
@@ -62,10 +62,12 @@ public class PostResourceAllocationAction extends
             currentForwardId = flow.getForwardPathId();
         }
         FlowPath currentForwardPath = currentForwardId != null ? getFlowPath(currentForwardId) : null;
-
+        Message rerouteResponse = buildRerouteResponseMessage(currentForwardPath, newForwardPath,
+                stateMachine.getCommandContext());
         if (stateMachine.getNewPrimaryForwardPath() == null && stateMachine.getNewPrimaryReversePath() == null
                 && stateMachine.getNewProtectedForwardPath() == null
                 && stateMachine.getNewProtectedReversePath() == null) {
+            stateMachine.setOperationResultMessage(rerouteResponse);
             stateMachine.fireRerouteIsSkipped("Reroute is unsuccessful. Couldn't find new path(s)");
         } else {
             if (stateMachine.isEffectivelyDown()) {
@@ -78,8 +80,7 @@ public class PostResourceAllocationAction extends
             stateMachine.notifyEventListeners(listener -> listener.onResourcesAllocated(flowId));
         }
 
-        return Optional.of(buildRerouteResponseMessage(currentForwardPath, newForwardPath,
-                stateMachine.getCommandContext()));
+        return Optional.of(rerouteResponse);
     }
 
     private Message buildRerouteResponseMessage(FlowPath currentForward, FlowPath newForward,

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/reroute/actions/CompleteYFlowReroutingAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/reroute/actions/CompleteYFlowReroutingAction.java
@@ -54,7 +54,8 @@ public class CompleteYFlowReroutingAction extends
         dashboardLogger.onYFlowStatusUpdate(yFlowId, flowStatus);
         stateMachine.saveActionToHistory(format("The y-flow status was set to %s", flowStatus));
 
-        if (stateMachine.getErrorReason() == null) {
+        if (stateMachine.getErrorReason() == null
+                || (stateMachine.getFailedSubFlows().size() == 1 && stateMachine.getSubFlows().size() > 1)) {
             stateMachine.fire(Event.NEXT);
         } else {
             stateMachine.fire(Event.ERROR);

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/reroute/actions/HandleNotReroutedSubFlowAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/reroute/actions/HandleNotReroutedSubFlowAction.java
@@ -16,24 +16,38 @@
 package org.openkilda.wfm.topology.flowhs.fsm.yflow.reroute.actions;
 
 import static java.lang.String.format;
+import static org.apache.commons.collections4.CollectionUtils.isEmpty;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
 import org.openkilda.messaging.Message;
+import org.openkilda.messaging.command.flow.FlowRerouteRequest;
 import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.wfm.CommandContext;
 import org.openkilda.wfm.topology.flowhs.fsm.common.actions.NbTrackableWithHistorySupportAction;
 import org.openkilda.wfm.topology.flowhs.fsm.yflow.reroute.YFlowRerouteContext;
 import org.openkilda.wfm.topology.flowhs.fsm.yflow.reroute.YFlowRerouteFsm;
 import org.openkilda.wfm.topology.flowhs.fsm.yflow.reroute.YFlowRerouteFsm.Event;
 import org.openkilda.wfm.topology.flowhs.fsm.yflow.reroute.YFlowRerouteFsm.State;
+import org.openkilda.wfm.topology.flowhs.service.FlowRerouteService;
+import org.openkilda.wfm.topology.flowhs.utils.YFlowUtils;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
 @Slf4j
 public class HandleNotReroutedSubFlowAction
         extends NbTrackableWithHistorySupportAction<YFlowRerouteFsm, State, Event, YFlowRerouteContext> {
-    public HandleNotReroutedSubFlowAction(PersistenceManager persistenceManager) {
+
+    private final YFlowUtils utils;
+    private final FlowRerouteService flowRerouteService;
+
+    public HandleNotReroutedSubFlowAction(PersistenceManager persistenceManager,
+                                          FlowRerouteService flowRerouteService) {
         super(persistenceManager);
+        utils = new YFlowUtils(persistenceManager);
+        this.flowRerouteService = flowRerouteService;
     }
 
     @Override
@@ -63,6 +77,14 @@ public class HandleNotReroutedSubFlowAction
         stateMachine.notifyEventListeners(listener ->
                 listener.onSubFlowProcessingFinished(stateMachine.getYFlowId(), subFlowId));
 
+        stateMachine.setMainErrorAndDescription(context.getErrorType(), context.getError());
+
+        FlowRerouteRequest secondRerouteRequest = getSecondRerouteRequestOrNull(stateMachine);
+
+        if (isForthcomingSubflowRequestLeft(isFirstError, secondRerouteRequest, subFlowId)) {
+            prepareAndSendSecondSubFlowRerouteRequest(secondRerouteRequest, stateMachine);
+        }
+
         if (stateMachine.getReroutingSubFlows().isEmpty()) {
             if (stateMachine.getFailedSubFlows().containsAll(stateMachine.getSubFlows())) {
                 stateMachine.fire(Event.YFLOW_REROUTE_SKIPPED);
@@ -75,13 +97,47 @@ public class HandleNotReroutedSubFlowAction
             }
         }
 
-        if (isFirstError) {
-            Message message = stateMachine.buildErrorMessage(context.getErrorType(), getGenericErrorMessage(),
-                    context.getError());
-            return Optional.of(message);
+        if (isNoSuccessAndNoMoreRequests(isFirstError, stateMachine)) {
+            return Optional.of(stateMachine.buildErrorMessage(stateMachine.getMainError(),
+                    getGenericErrorMessage(), stateMachine.getMainErrorDescription()));
+        }
+
+        if (isAnySuccessAndNoForthcomingRequests(stateMachine)) {
+            return Optional.of(utils.buildRerouteResponseMessage(stateMachine));
         }
 
         return Optional.empty();
+    }
+
+    private FlowRerouteRequest getSecondRerouteRequestOrNull(YFlowRerouteFsm stateMachine) {
+        return stateMachine.getRerouteRequests().size() == 2
+                ? ((ArrayList<FlowRerouteRequest>) stateMachine.getRerouteRequests()).get(1) : null;
+    }
+
+    private boolean isForthcomingSubflowRequestLeft(boolean isFirstError,
+                                                    FlowRerouteRequest secondRerouteRequest,
+                                                    String currentSubFlowId) {
+        return isFirstError && secondRerouteRequest != null
+                && !currentSubFlowId.equals(secondRerouteRequest.getFlowId());
+    }
+
+    private void prepareAndSendSecondSubFlowRerouteRequest(FlowRerouteRequest secondRerouteRequest,
+                                                           YFlowRerouteFsm stateMachine) {
+        secondRerouteRequest.getAffectedIsls().clear();
+        stateMachine.addReroutingSubFlow(secondRerouteRequest.getFlowId());
+        stateMachine.notifyEventListeners(listener -> listener.onSubFlowProcessingStart(stateMachine.getYFlowId(),
+                secondRerouteRequest.getFlowId()));
+        CommandContext flowContext = stateMachine.getCommandContext().fork(secondRerouteRequest.getFlowId());
+        flowRerouteService.startFlowRerouting(secondRerouteRequest, flowContext, stateMachine.getYFlowId());
+    }
+
+    private boolean isNoSuccessAndNoMoreRequests(boolean isFirstError, YFlowRerouteFsm stateMachine) {
+        return !isFirstError || (isEmpty(stateMachine.getAllocatedSubFlows())
+                && stateMachine.getReroutingSubFlows().isEmpty());
+    }
+
+    private boolean isAnySuccessAndNoForthcomingRequests(YFlowRerouteFsm stateMachine) {
+        return isNotEmpty(stateMachine.getAllocatedSubFlows()) && isEmpty(stateMachine.getReroutingSubFlows());
     }
 
     @Override

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/reroute/actions/OnSubFlowReroutedAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/yflow/reroute/actions/OnSubFlowReroutedAction.java
@@ -66,7 +66,7 @@ public class OnSubFlowReroutedAction extends
         }
 
         if (stateMachine.getReroutingSubFlows().isEmpty()) {
-            if (stateMachine.getFailedSubFlows().isEmpty()) {
+            if (stateMachine.getFailedSubFlows().isEmpty() || !stateMachine.getAllocatedSubFlows().isEmpty()) {
                 stateMachine.fire(Event.ALL_SUB_FLOWS_REROUTED);
             } else {
                 if (stateMachine.getFailedSubFlows().containsAll(stateMachine.getSubFlows())) {

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/AbstractYFlowTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/AbstractYFlowTest.java
@@ -110,6 +110,9 @@ public abstract class AbstractYFlowTest<T> extends InMemoryGraphBasedTest {
     protected final IslDirectionalReference islSharedToTransit = new IslDirectionalReference(
             new IslEndpoint(SWITCH_SHARED, 25),
             new IslEndpoint(SWITCH_TRANSIT, 25));
+    protected final IslDirectionalReference islTransitToSw5 = new IslDirectionalReference(
+            new IslEndpoint(SWITCH_TRANSIT, 25),
+            new IslEndpoint(SWITCH_ALT_TRANSIT, 25));
     protected final IslDirectionalReference islTransitToFirst = new IslDirectionalReference(
             new IslEndpoint(SWITCH_TRANSIT, 26),
             new IslEndpoint(SWITCH_FIRST_EP, 26));
@@ -192,10 +195,10 @@ public abstract class AbstractYFlowTest<T> extends InMemoryGraphBasedTest {
         dummyFactory.makeSwitch(SWITCH_NEW_FIRST_EP);
         dummyFactory.makeSwitch(SWITCH_NEW_SECOND_EP);
         for (IslDirectionalReference reference : new IslDirectionalReference[]{
-                islSharedToFirst, islSharedToSecond, islSharedToTransit, islTransitToFirst, islTransitToSecond,
-                islSharedToAltTransit, islAltTransitToFirst, islAltTransitToSecond, islTransitToNewFirst,
-                islTransitToNewSecond, islSharedToNewAltTransit, islNewAltTransitToFirst, islNewAltTransitToSecond,
-                islSharedToNewTransit, islNewTransitToFirst, islNewTransitToSecond}) {
+                islSharedToFirst, islSharedToSecond, islSharedToTransit, islTransitToSw5, islTransitToFirst,
+                islTransitToSecond, islSharedToAltTransit, islAltTransitToFirst, islAltTransitToSecond,
+                islTransitToNewFirst, islTransitToNewSecond, islSharedToNewAltTransit, islNewAltTransitToFirst,
+                islNewAltTransitToSecond, islSharedToNewTransit, islNewTransitToFirst, islNewTransitToSecond}) {
             dummyFactory.makeIsl(reference.getSourceEndpoint(), reference.getDestEndpoint());
             dummyFactory.makeIsl(reference.getDestEndpoint(), reference.getSourceEndpoint());
         }
@@ -610,6 +613,66 @@ public abstract class AbstractYFlowTest<T> extends InMemoryGraphBasedTest {
                         .build())
                 .reverse(Path.builder()
                         .srcSwitchId(SWITCH_FIRST_EP)
+                        .destSwitchId(SWITCH_SHARED)
+                        .segments(reverseSegments)
+                        .build())
+                .backUpPathComputationWayUsed(false)
+                .build();
+    }
+
+    /**
+     * Path with the following switches 1-4-5-2.
+     *
+     * @return GetPathsResult
+     */
+    protected GetPathsResult buildFirstSubFlowPathPairWithNewSwitch5Transit() {
+        List<Segment> forwardSegments = ImmutableList.of(
+                buildPathSegment(islSharedToTransit), //1-4
+                buildPathSegment(islTransitToSw5),  //4-5
+                buildPathSegment(islAltTransitToFirst)); // 5-2
+        List<Segment> reverseSegments = ImmutableList.of(
+                buildPathSegment(islAltTransitToFirst.makeOpposite()),
+                buildPathSegment(islTransitToSw5.makeOpposite()),
+                buildPathSegment(islSharedToTransit.makeOpposite()));
+
+        return GetPathsResult.builder()
+                .forward(Path.builder()
+                        .srcSwitchId(SWITCH_SHARED)
+                        .destSwitchId(SWITCH_FIRST_EP)
+                        .segments(forwardSegments)
+                        .build())
+                .reverse(Path.builder()
+                        .srcSwitchId(SWITCH_FIRST_EP)
+                        .destSwitchId(SWITCH_SHARED)
+                        .segments(reverseSegments)
+                        .build())
+                .backUpPathComputationWayUsed(false)
+                .build();
+    }
+
+    /**
+     * Path with the following switches 1-4-5-3.
+     *
+     * @return GetPathsResult
+     */
+    protected GetPathsResult buildSecondSubFlowPathPairWithNewSwitch5Transit() {
+        List<Segment> forwardSegments = ImmutableList.of(
+                buildPathSegment(islSharedToTransit), //1-4
+                buildPathSegment(islTransitToSw5),  //4-5
+                buildPathSegment(islAltTransitToSecond)); // 5-3
+        List<Segment> reverseSegments = ImmutableList.of(
+                buildPathSegment(islAltTransitToSecond.makeOpposite()),
+                buildPathSegment(islTransitToSw5.makeOpposite()),
+                buildPathSegment(islSharedToTransit.makeOpposite()));
+
+        return GetPathsResult.builder()
+                .forward(Path.builder()
+                        .srcSwitchId(SWITCH_SHARED)
+                        .destSwitchId(SWITCH_SECOND_EP)
+                        .segments(forwardSegments)
+                        .build())
+                .reverse(Path.builder()
+                        .srcSwitchId(SWITCH_SECOND_EP)
                         .destSwitchId(SWITCH_SHARED)
                         .segments(reverseSegments)
                         .build())

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/utils/NorthboundExceptionHandler.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/utils/NorthboundExceptionHandler.java
@@ -54,6 +54,7 @@ public class NorthboundExceptionHandler extends ResponseEntityExceptionHandler {
 
         switch (exception.getErrorType()) {
             case NOT_FOUND:
+            case ALREADY_ON_BEST_PATH:
                 status = HttpStatus.NOT_FOUND;
                 break;
             case DATA_INVALID:


### PR DESCRIPTION
Added the correct response for Y-Flow reroute API, for the case of "already on the best path".
Slightly changed the logic for Y-flow-reroute functionality for partly failure cases.

Here is the picture that represents the 6 cases covered in this fix.
Basically we have y-flow with the 9th switch as a y-point and shared switch.
3rd switch is a first endpoint, 8th switch as a second endpoint.
In the picture, for cases 1,2,3 and 4 we can see an existed possible path between switches that has less cost than the current one.
For the 3,4,5,6 cases we can see that there is no possible and any other paths with one of the endpoints.

<img width="1793" alt="image" src="https://github.com/telstra/open-kilda/assets/9297385/d11e5c19-e090-4e5a-91d8-c8a0e3c9ddb2">
From the picture above you can see that for only 5th case was a correct reroute response with appropriate behaviour. 
This PR fixes the rest of the cases.

What has been change in terms of a internal logic?

**BEFORE**: Y-flow reroute fsm launches the regular reroute fsm under the hood for each subflow. the problem was that if we face any error while rerouting the first subflow we will not try to reroute the second subflow, and as result we will fail the whole y-flow reroute process. 
Here is the description for each 6 case of an old behaviour:
Y-flow 9-3-8 ,     affinityGroup subflow9-3 

**1.** There is an alternate subpath 9-3, for 9-8 the same.  Response 500, ﻿ but reroute  9-3 happened.   This is wrong behaviour. The response body : 
```
{.  
  "correlation_id": "25fe7ce5-0254-4a8d-bcf3-1d61f6c2cce9 : reruote9-3-8",
  "timestamp": 1691066388920,
  "error-type": "Internal service error",
  "error-message": "Could not reroute y-flow",
  "error-description": "Reroute is unsuccessful. Couldn't find new path(s)"
}
```
**2.** There is an alternate subpath 9-8, for 9-3 the same.  Response 500. Reroute has not been happened . This is wrong behaviour.
**3.** There is an alternate subpath  9-3, for 9-8 no path, since 8 is unreachable(switch 8  all isl ports down [1, 7, 16, 47, 49]): X Got 404, but  9-3 has not been rerouted, This is wrong behaviour. The response body: 
```
 {
  "correlation_id": "14788401-8ab9-424a-842a-6b1714c4cfee : reruote9-3-8",
  "timestamp": 1691067035992,
  "error-type": "Object was not found",
  "error-message": "Could not reroute y-flow",
  "error-description": "Not enough bandwidth or no path found. Switch 00:00:00:00:00:00:00:08 doesn't have links with enough bandwidth, Failed to find path with requested bandwidth=100"
}
```
**4.** There is an alternate subpath 9-8, for 9-3 no path, since 3 is unreachable (switch 3 all isl ports down [1,2,4,5,6] ) :  Got 404:   nothing was rerouted. This is wrong behaviour. The response body:     
```
{
  "correlation_id": "6799435d-9c4b-4a03-b557-f288733c464d : reruote9-3-8",
  "timestamp": 1691068142508,
  "error-type": "Object was not found",
  "error-message": "Could not reroute y-flow",
  "error-description": "Not enough bandwidth or no path found. Switch 00:00:00:00:00:00:00:03 doesn't have links with enough bandwidth, Failed to find path with requested bandwidth=100"
}
```
**5.** No alternate paths for 9-8.  9-3 impossible, no path.  since 3 is unreachable.: Response 404:   Correct response with the correct response body:     
```
{
  "correlation_id": "59b9c4df-884f-48f5-9240-38f61ecfe466 : reruote9-3-8",
  "timestamp": 1691068808567,
  "error-type": "Object was not found",
  "error-message": "Could not reroute y-flow",
  "error-description": "Not enough bandwidth or no path found. Switch 00:00:00:00:00:00:00:03 doesn't have links with enough bandwidth, Failed to find path with requested bandwidth=100"
}
```
**6.** No alternate paths for 9-3, 9-8 impossible, no path. 8 unreachable. Response 500, Wrong response. Response body:     
```
 {
  "correlation_id": "5be8981a-aa81-44f0-a85a-94f02627848b : reruote9-3-8",
  "timestamp": 1691069310602,
  "error-type": "Internal service error",
  "error-message": "Could not reroute y-flow",
  "error-description": "Reroute is unsuccessful. Couldn't find new path(s)"
}
```


**AFTER**: 
+ Y-flow reroute fsm will not stop the attempt to reroute the second subflow in case of a first subflow reroute failure. 
+ added correct response bodies, replace 500 response code with 404.


To reproduce the behaviour we could use the following req:
`http://vm:8080/api/v2/y-flows`

```
{
  "y_flow_id": "yflow9-3-8",
  "shared_endpoint": {
    "port_number": 101,
    "switch_id": "9"
  },
  "maximum_bandwidth": 100,
  "path_computation_strategy": "cost",
  "sub_flows": [
    {
      "flow_id": "subflow9-3",
      "endpoint": {
        "detect_connected_devices": {
          "arp": true,
          "lldp": true
        },
        "inner_vlan_id": 108,
        "port_number": 103,
        "switch_id": "3",
        "vlan_id": 109
      },
      "shared_endpoint": {
        "inner_vlan_id": 110,
        "vlan_id": 111
      }
    },
{
      "flow_id": "subflow9-8",
      "endpoint": {
        "detect_connected_devices": {
          "arp": true,
          "lldp": true
        },
        "inner_vlan_id": 118,
        "port_number": 113,
        "switch_id": "8",
        "vlan_id": 120
      },
      "shared_endpoint": {
        "inner_vlan_id": 111,
        "vlan_id": 112
      }
    }
  ]
}
```

then we can alter the cost for the isl links between certain switches to reproduce 6 scenarios from the screenshot(or from the description list)


closes #5303 