### PR TITLE
Improve usages of time range params and time formatting in the response

### DIFF
--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/history/FlowHistoryEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/history/FlowHistoryEntry.java
@@ -17,66 +17,31 @@ package org.openkilda.messaging.payload.history;
 
 import org.openkilda.messaging.info.InfoData;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.time.Instant;
 import java.util.List;
 
 @JsonSerialize
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Data
 @EqualsAndHashCode(callSuper = false)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class FlowHistoryEntry extends InfoData {
-    @JsonProperty("flow_id")
     private String flowId;
-
-    @JsonProperty("timestamp")
     private long timestamp;
-
-    @JsonProperty("timestamp_iso")
-    private String timestampIso;
-
-    @JsonProperty("actor")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
+    private Instant timestampIso;
     private String actor;
-
-    @JsonProperty("action")
     private String action;
-
-    @JsonProperty("task_id")
     private String taskId;
-
-    @JsonProperty("details")
     private String details;
-
-    @JsonProperty("payload")
     private List<FlowHistoryPayload> payload;
-
-    @JsonProperty("dumps")
     private List<FlowDumpPayload> dumps;
-
-    @Builder
-    public FlowHistoryEntry(
-            @JsonProperty("flow_id") String flowId,
-            @JsonProperty("timestamp") long timestamp,
-            @JsonProperty("timestamp_iso") String timestampIso,
-            @JsonProperty("actor") String actor,
-            @JsonProperty("action") String action,
-            @JsonProperty("task_id") String taskId,
-            @JsonProperty("details") String details,
-            @JsonProperty("payload") List<FlowHistoryPayload> payload,
-            @JsonProperty("dumps") List<FlowDumpPayload> dumps) {
-        this.flowId = flowId;
-        this.timestamp = timestamp;
-        this.timestampIso = timestampIso;
-        this.actor = actor;
-        this.action = action;
-        this.taskId = taskId;
-        this.details = details;
-        this.payload = payload;
-        this.dumps = dumps;
-    }
 }

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/mappers/HistoryMapper.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/mappers/HistoryMapper.java
@@ -64,8 +64,7 @@ public abstract class HistoryMapper {
 
     @Mapping(target = "payload", source = "payload")
     @Mapping(target = "dumps", source = "dumps")
-    @Mapping(target = "timestampIso",
-             expression = "java(flowEvent.getTimestamp().atOffset(ZoneOffset.UTC).toString())")
+    @Mapping(target = "timestampIso", source = "flowEvent.timestamp")
     public abstract FlowHistoryEntry map(
             FlowEvent flowEvent, List<FlowHistoryPayload> payload, List<FlowDumpPayload> dumps);
 

--- a/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/mappers/HistoryMapperTest.java
+++ b/src-java/base-topology/base-storm-topology/src/test/java/org/openkilda/wfm/share/mappers/HistoryMapperTest.java
@@ -203,8 +203,8 @@ public class HistoryMapperTest {
         assertEquals(entry.getActor(), event.getActor());
         assertEquals(entry.getDumps(), flowDumpPayloads);
         assertEquals(entry.getPayload(), flowHistoryPayloads);
-        assertEquals(entry.getTimestampIso(), event.getTimestamp().atOffset(ZoneOffset.UTC).toString());
-        assertEquals(entry.getTimestampIso(), "2021-02-09T19:28:45Z");
+        assertEquals(entry.getTimestampIso(), event.getTimestamp());
+        assertEquals(entry.getTimestampIso().toString(), "2021-02-09T19:28:45Z");
         assertEquals(entry.getTaskId(), event.getTaskId());
     }
 

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetFlowHistoryRequest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetFlowHistoryRequest.java
@@ -17,35 +17,22 @@ package org.openkilda.messaging.nbtopology.request;
 
 import org.openkilda.messaging.nbtopology.annotations.ReadRequest;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+
+import java.time.Instant;
 
 @ReadRequest
 @Value
 @Builder
 @EqualsAndHashCode(callSuper = false)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class GetFlowHistoryRequest extends HistoryRequest {
-    @JsonProperty("flow_id")
     String flowId;
-
-    @JsonProperty("timestamp_from")
-    long timestampFrom;
-
-    @JsonProperty("timestamp_to")
-    long timestampTo;
-
-    @JsonProperty("max_count")
     int maxCount;
-
-    public GetFlowHistoryRequest(@JsonProperty("flow_id") String flowId,
-                                 @JsonProperty("timestamp_from") long timestampFrom,
-                                 @JsonProperty("timestamp_to") long timestampTo,
-                                 @JsonProperty("max_count") int maxCount) {
-        this.flowId = flowId;
-        this.timestampFrom = timestampFrom;
-        this.timestampTo = timestampTo;
-        this.maxCount = maxCount;
-    }
+    Instant timeFrom;
+    Instant timeTo;
 }

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/HistoryOperationsBolt.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/HistoryOperationsBolt.java
@@ -67,10 +67,8 @@ public class HistoryOperationsBolt extends PersistenceOperationsBolt {
 
     @TimedExecution("get_flow_history")
     private List<InfoData> getFlowHistory(GetFlowHistoryRequest request) {
-        Instant timeFrom = Instant.ofEpochSecond(request.getTimestampFrom());
-        Instant timeTo = Instant.ofEpochSecond(request.getTimestampTo() + 1).minusMillis(1);
         return historyService.listFlowEvents(
-                request.getFlowId(), timeFrom, timeTo, request.getMaxCount()).stream()
+                request.getFlowId(), request.getTimeFrom(), request.getTimeTo(), request.getMaxCount()).stream()
                 .map(entry -> {
                     List<FlowHistoryPayload> payload = listFlowHistories(entry);
                     List<FlowDumpPayload> dumps = listFlowDumps(entry);

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/converter/LongToInstantConverter.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/converter/LongToInstantConverter.java
@@ -1,0 +1,43 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.northbound.converter;
+
+import java.time.Instant;
+
+/**
+ * This class converts Linux epoch seconds or milliseconds to an Instant object.
+ */
+public final class LongToInstantConverter {
+    private LongToInstantConverter() {
+    }
+
+    /**
+     * Converts Linux epoch seconds or milliseconds to an Instant object.
+     * @param timeAsLong non-null value that represents a Linux epoch time in seconds or milliseconds
+     * @return an Instant object
+     */
+    public static Instant convert(Long timeAsLong) {
+        if (timeAsLong == null) {
+            throw new IllegalArgumentException();
+        }
+
+        if (Math.log10(Math.abs(timeAsLong)) < 10) {
+            return Instant.ofEpochSecond(timeAsLong);
+        } else {
+            return Instant.ofEpochMilli(timeAsLong);
+        }
+    }
+}

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/FlowService.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/FlowService.java
@@ -239,8 +239,8 @@ public interface FlowService {
     CompletableFuture<FlowMeterEntries> modifyMeter(String flowId);
 
     CompletableFuture<List<FlowHistoryEntry>> listFlowEvents(String flowId,
-                                                             long timestampFrom,
-                                                             long timestampTo, int maxCount);
+                                                             Instant timestampFrom,
+                                                             Instant timestampTo, int maxCount);
 
     CompletableFuture<FlowHistoryStatusesResponse> getFlowStatuses(String flowId,
                                                                    long timestampFrom,

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/impl/FlowServiceImpl.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/service/impl/FlowServiceImpl.java
@@ -668,10 +668,10 @@ public class FlowServiceImpl implements FlowService {
 
     @Override
     public CompletableFuture<List<FlowHistoryEntry>> listFlowEvents(String flowId,
-                                                                    long timestampFrom,
-                                                                    long timestampTo, int maxCount) {
-        log.info("API request: List flow events: flowId {}, timestampFrom {}, timestampTo {}, maxCount {}",
-                flowId, timestampFrom, timestampTo, maxCount);
+                                                                    Instant timeFrom,
+                                                                    Instant timeTo, int maxCount) {
+        log.info("API request: List flow events: flowId {}, timeFrom {}, timeTo {}, maxCount {}",
+                flowId, timeFrom, timeTo, maxCount);
         if (maxCount < 1) {
             throw new MessageException(RequestCorrelationId.getId(), System.currentTimeMillis(),
                     ErrorType.PARAMETERS_INVALID, format("Invalid `max_count` argument '%s'.", maxCount),
@@ -680,8 +680,8 @@ public class FlowServiceImpl implements FlowService {
         String correlationId = RequestCorrelationId.getId();
         GetFlowHistoryRequest request = GetFlowHistoryRequest.builder()
                 .flowId(flowId)
-                .timestampFrom(timestampFrom)
-                .timestampTo(timestampTo)
+                .timeFrom(timeFrom)
+                .timeTo(timeTo)
                 .maxCount(maxCount)
                 .build();
         CommandMessage command = new CommandMessage(request, System.currentTimeMillis(), correlationId);


### PR DESCRIPTION
This is a draft demonstrating an approach to not use any time conversions, except in the controller to validate the input and format the response. There is also a validation in the HA-flow history branch, so it would make sense to continue with this issue after HA-flow history is merged.