### PR TITLE
Adding an ability to use a default implementation for sending history.

### DIFF
--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/AbstractBolt.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/AbstractBolt.java
@@ -66,10 +66,10 @@ public abstract class AbstractBolt extends BaseRichBolt {
     @Getter(AccessLevel.PROTECTED)
     private transient Integer taskId;
 
-    @Getter(AccessLevel.PROTECTED)
+    @Getter(AccessLevel.PUBLIC)
     private transient Tuple currentTuple;
 
-    @Getter(AccessLevel.PROTECTED)
+    @Getter(AccessLevel.PUBLIC)
     @Setter(AccessLevel.PROTECTED)
     private transient CommandContext commandContext;
 
@@ -137,7 +137,14 @@ public abstract class AbstractBolt extends BaseRichBolt {
         output.emit(stream, payload);
     }
 
-    protected void emitWithContext(String stream, Tuple input, Values payload) {
+    /**
+     * Emitting (sending a message) the given payload with the anchor based on the tuple to the given stream.
+     * This guarantees that the message will be eventually processed by Storm even in cases of the target bolt failure.
+     * @param stream Storm stream to send the message to
+     * @param input current tuple; will be used as an anchor
+     * @param payload the message payload
+     */
+    public void emitWithContext(String stream, Tuple input, Values payload) {
         payload.add(getCommandContext());
         log.debug("emit tuple into {} stream: {}", stream, payload);
         getOutput().emit(stream, input, payload);

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/ContextEmittable.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/ContextEmittable.java
@@ -1,0 +1,29 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm;
+
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.Values;
+
+/**
+ * This interface represents something that has CommandContext and
+ * knows how to emit the payload via a given Storm stream.
+ */
+public interface ContextEmittable {
+    CommandContext getCommandContext();
+
+    void emitWithContext(String stream, Tuple input, Values payload);
+}

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/DefaultHistoryUpdateCarrier.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/DefaultHistoryUpdateCarrier.java
@@ -1,0 +1,40 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm;
+
+import lombok.NonNull;
+import org.openkilda.messaging.info.InfoMessage;
+import org.openkilda.wfm.share.history.model.FlowHistoryHolder;
+
+import org.apache.storm.tuple.Values;
+
+/**
+ * This bold adds support for sending history updates that are accessible later via HistoryService.
+ * A topology that uses this bolt must register a path to history bolt. That is, in a topology that extends
+ * AbstractTopology, declare a Kafka bolt and specify a component ID that is a source of history updates
+ * in the fields grouping and declare a stream.
+ * TODO add a readme.md with the details and example.
+ */
+public interface DefaultHistoryUpdateCarrier extends HistoryUpdateCarrier, TupleIdentifiable, ContextEmittable {
+
+    @Override
+    default void sendHistoryUpdate(@NonNull FlowHistoryHolder historyHolder) {
+        InfoMessage message = new InfoMessage(historyHolder, getCommandContext().getCreateTime(),
+                getCommandContext().getCorrelationId());
+        emitWithContext(getHistoryStreamName(), getCurrentTuple(),
+                new Values(historyHolder.getTaskId(), message));
+    }
+}

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/HistoryUpdateCarrier.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/HistoryUpdateCarrier.java
@@ -1,0 +1,32 @@
+/* Copyright 2019 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm;
+
+import org.openkilda.wfm.share.history.model.FlowHistoryHolder;
+
+/**
+ * Defines a base carrier for processing history updates.
+ */
+public interface HistoryUpdateCarrier {
+    /**
+     * Sends main events to history bolt.
+     */
+    void sendHistoryUpdate(FlowHistoryHolder historyHolder);
+
+    default String getHistoryStreamName() {
+        return "HUB_TO_HISTORY_TOPOLOGY_SENDER";
+    }
+}

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/TupleIdentifiable.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/TupleIdentifiable.java
@@ -1,4 +1,4 @@
-/* Copyright 2019 Telstra Open Source
+/* Copyright 2023 Telstra Open Source
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -13,16 +13,13 @@
  *   limitations under the License.
  */
 
-package org.openkilda.wfm.topology.flowhs.service.common;
+package org.openkilda.wfm;
 
-import org.openkilda.wfm.share.history.model.FlowHistoryHolder;
+import org.apache.storm.tuple.Tuple;
 
 /**
- * Defines a base carrier for processing history updates.
+ * This interface represents something that has a distinct tuple that can be used as an anchor in Storm.
  */
-public interface HistoryUpdateCarrier {
-    /**
-     * Sends main events to history bolt.
-     */
-    void sendHistoryUpdate(FlowHistoryHolder historyHolder);
+public interface TupleIdentifiable {
+    Tuple getCurrentTuple();
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/FlowCreateHubBolt.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/bolts/FlowCreateHubBolt.java
@@ -41,10 +41,10 @@ import org.openkilda.pce.PathComputerConfig;
 import org.openkilda.pce.PathComputerFactory;
 import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.server42.control.messaging.flowrtt.ActivateFlowMonitoringInfoData;
+import org.openkilda.wfm.DefaultHistoryUpdateCarrier;
 import org.openkilda.wfm.error.PipelineException;
 import org.openkilda.wfm.share.flow.resources.FlowResourcesConfig;
 import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
-import org.openkilda.wfm.share.history.model.FlowHistoryHolder;
 import org.openkilda.wfm.share.hubandspoke.HubBolt;
 import org.openkilda.wfm.share.utils.KeyProvider;
 import org.openkilda.wfm.share.zk.ZkStreams;
@@ -66,7 +66,7 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 
-public class FlowCreateHubBolt extends HubBolt implements FlowGenericCarrier {
+public class FlowCreateHubBolt extends HubBolt implements FlowGenericCarrier, DefaultHistoryUpdateCarrier {
     private final FlowCreateConfig config;
     private final PathComputerConfig pathComputerConfig;
     private final FlowResourcesConfig flowResourcesConfig;
@@ -159,14 +159,6 @@ public class FlowCreateHubBolt extends HubBolt implements FlowGenericCarrier {
     @Override
     public void sendNorthboundResponse(@NonNull Message message) {
         emitWithContext(Stream.HUB_TO_NB_RESPONSE_SENDER.name(), getCurrentTuple(), new Values(currentKey, message));
-    }
-
-    @Override
-    public void sendHistoryUpdate(@NonNull FlowHistoryHolder historyHolder) {
-        InfoMessage message = new InfoMessage(historyHolder, getCommandContext().getCreateTime(),
-                getCommandContext().getCorrelationId());
-        emitWithContext(Stream.HUB_TO_HISTORY_TOPOLOGY_SENDER.name(), getCurrentTuple(),
-                new Values(historyHolder.getTaskId(), message));
     }
 
     @Override

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowPathSwappingFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowPathSwappingFsm.java
@@ -26,10 +26,10 @@ import org.openkilda.model.FlowPathStatus;
 import org.openkilda.model.PathId;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.CommandContext;
+import org.openkilda.wfm.HistoryUpdateCarrier;
 import org.openkilda.wfm.share.flow.resources.FlowResources;
 import org.openkilda.wfm.topology.flowhs.model.RequestedFlow;
 import org.openkilda.wfm.topology.flowhs.service.FlowProcessingEventListener;
-import org.openkilda.wfm.topology.flowhs.service.common.HistoryUpdateCarrier;
 import org.openkilda.wfm.topology.flowhs.service.common.NorthboundResponseCarrier;
 
 import lombok.Getter;

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowProcessingWithHistorySupportFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowProcessingWithHistorySupportFsm.java
@@ -18,13 +18,13 @@ package org.openkilda.wfm.topology.flowhs.fsm.common;
 import static java.util.Collections.emptyList;
 
 import org.openkilda.wfm.CommandContext;
+import org.openkilda.wfm.HistoryUpdateCarrier;
 import org.openkilda.wfm.share.history.model.FlowDumpData;
 import org.openkilda.wfm.share.history.model.FlowEventData;
 import org.openkilda.wfm.share.history.model.FlowHistoryData;
 import org.openkilda.wfm.share.history.model.FlowHistoryHolder;
 import org.openkilda.wfm.share.utils.KeyProvider;
 import org.openkilda.wfm.topology.flowhs.service.common.FlowHistoryCarrier;
-import org.openkilda.wfm.topology.flowhs.service.common.HistoryUpdateCarrier;
 import org.openkilda.wfm.topology.flowhs.service.common.NorthboundResponseCarrier;
 import org.openkilda.wfm.topology.flowhs.service.common.ProcessingEventListener;
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowProcessingWithSpeakerCommandsFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowProcessingWithSpeakerCommandsFsm.java
@@ -21,8 +21,8 @@ import org.openkilda.floodlight.api.request.rulemanager.BaseSpeakerCommandsReque
 import org.openkilda.floodlight.api.response.rulemanager.SpeakerCommandResponse;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.CommandContext;
+import org.openkilda.wfm.HistoryUpdateCarrier;
 import org.openkilda.wfm.topology.flowhs.service.FlowProcessingEventListener;
-import org.openkilda.wfm.topology.flowhs.service.common.HistoryUpdateCarrier;
 import org.openkilda.wfm.topology.flowhs.service.common.NorthboundResponseCarrier;
 
 import lombok.Getter;

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/HaFlowPathSwappingFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/HaFlowPathSwappingFsm.java
@@ -31,12 +31,12 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.pce.GetHaPathsResult;
 import org.openkilda.pce.HaPath;
 import org.openkilda.wfm.CommandContext;
+import org.openkilda.wfm.HistoryUpdateCarrier;
 import org.openkilda.wfm.share.flow.resources.HaFlowResources;
 import org.openkilda.wfm.share.flow.resources.HaPathIdsPair;
 import org.openkilda.wfm.share.flow.resources.HaPathIdsPair.HaFlowPathIds;
 import org.openkilda.wfm.topology.flowhs.fsm.common.context.SpeakerResponseContext;
 import org.openkilda.wfm.topology.flowhs.service.FlowProcessingEventListener;
-import org.openkilda.wfm.topology.flowhs.service.common.HistoryUpdateCarrier;
 import org.openkilda.wfm.topology.flowhs.service.common.NorthboundResponseCarrier;
 
 import lombok.Getter;

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/haflow/BaseHaFlowPathRemovalAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/haflow/BaseHaFlowPathRemovalAction.java
@@ -20,10 +20,10 @@ import org.openkilda.model.HaFlowPath;
 import org.openkilda.model.PathId;
 import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.persistence.repositories.HaFlowPathRepository;
+import org.openkilda.wfm.HistoryUpdateCarrier;
 import org.openkilda.wfm.share.flow.resources.HaPathIdsPair;
 import org.openkilda.wfm.topology.flowhs.fsm.common.FlowProcessingWithHistorySupportFsm;
 import org.openkilda.wfm.topology.flowhs.fsm.common.actions.BaseFlowPathRemovalAction;
-import org.openkilda.wfm.topology.flowhs.service.common.HistoryUpdateCarrier;
 import org.openkilda.wfm.topology.flowhs.service.haflow.history.HaFlowHistory;
 import org.openkilda.wfm.topology.flowhs.service.haflow.history.HaFlowHistoryService;
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/haflow/RevertResourceAllocationAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/haflow/RevertResourceAllocationAction.java
@@ -19,11 +19,11 @@ import static java.lang.String.format;
 
 import org.openkilda.model.HaFlow;
 import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.wfm.HistoryUpdateCarrier;
 import org.openkilda.wfm.share.flow.resources.FlowResourcesManager;
 import org.openkilda.wfm.share.flow.resources.HaFlowResources;
 import org.openkilda.wfm.topology.flowhs.fsm.common.HaFlowPathSwappingFsm;
 import org.openkilda.wfm.topology.flowhs.fsm.common.context.SpeakerResponseContext;
-import org.openkilda.wfm.topology.flowhs.service.common.HistoryUpdateCarrier;
 import org.openkilda.wfm.topology.flowhs.service.haflow.history.HaFlowHistory;
 import org.openkilda.wfm.topology.flowhs.service.haflow.history.HaFlowHistoryService;
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/reroute/actions/CompleteFlowPathRemovalAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/reroute/actions/CompleteFlowPathRemovalAction.java
@@ -16,13 +16,13 @@
 package org.openkilda.wfm.topology.flowhs.fsm.haflow.reroute.actions;
 
 import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.wfm.HistoryUpdateCarrier;
 import org.openkilda.wfm.share.metrics.TimedExecution;
 import org.openkilda.wfm.topology.flowhs.fsm.common.actions.haflow.BaseHaFlowPathRemovalAction;
 import org.openkilda.wfm.topology.flowhs.fsm.haflow.reroute.HaFlowRerouteContext;
 import org.openkilda.wfm.topology.flowhs.fsm.haflow.reroute.HaFlowRerouteFsm;
 import org.openkilda.wfm.topology.flowhs.fsm.haflow.reroute.HaFlowRerouteFsm.Event;
 import org.openkilda.wfm.topology.flowhs.fsm.haflow.reroute.HaFlowRerouteFsm.State;
-import org.openkilda.wfm.topology.flowhs.service.common.HistoryUpdateCarrier;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/update/actions/CompleteFlowPathRemovalAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/update/actions/CompleteFlowPathRemovalAction.java
@@ -16,12 +16,12 @@
 package org.openkilda.wfm.topology.flowhs.fsm.haflow.update.actions;
 
 import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.wfm.HistoryUpdateCarrier;
 import org.openkilda.wfm.topology.flowhs.fsm.common.actions.haflow.BaseHaFlowPathRemovalAction;
 import org.openkilda.wfm.topology.flowhs.fsm.haflow.update.HaFlowUpdateContext;
 import org.openkilda.wfm.topology.flowhs.fsm.haflow.update.HaFlowUpdateFsm;
 import org.openkilda.wfm.topology.flowhs.fsm.haflow.update.HaFlowUpdateFsm.Event;
 import org.openkilda.wfm.topology.flowhs.fsm.haflow.update.HaFlowUpdateFsm.State;
-import org.openkilda.wfm.topology.flowhs.service.common.HistoryUpdateCarrier;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowGenericCarrier.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/FlowGenericCarrier.java
@@ -21,8 +21,8 @@ import org.openkilda.messaging.info.stats.RemoveFlowPathInfo;
 import org.openkilda.messaging.info.stats.StatsNotification;
 import org.openkilda.messaging.info.stats.UpdateFlowPathInfo;
 import org.openkilda.model.SwitchId;
+import org.openkilda.wfm.HistoryUpdateCarrier;
 import org.openkilda.wfm.topology.flowhs.model.RequestedFlow;
-import org.openkilda.wfm.topology.flowhs.service.common.HistoryUpdateCarrier;
 import org.openkilda.wfm.topology.flowhs.service.common.LifecycleEventCarrier;
 import org.openkilda.wfm.topology.flowhs.service.common.NorthboundResponseCarrier;
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/haflow/history/HaFlowHistoryService.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/haflow/history/HaFlowHistoryService.java
@@ -15,10 +15,10 @@
 
 package org.openkilda.wfm.topology.flowhs.service.haflow.history;
 
+import org.openkilda.wfm.HistoryUpdateCarrier;
 import org.openkilda.wfm.share.history.model.FlowHistoryHolder;
 import org.openkilda.wfm.share.history.model.HaFlowEventData;
 import org.openkilda.wfm.share.history.model.HaFlowHistoryData;
-import org.openkilda.wfm.topology.flowhs.service.common.HistoryUpdateCarrier;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/haflow/history/HaFlowHistoryServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/haflow/history/HaFlowHistoryServiceTest.java
@@ -28,7 +28,7 @@ import org.openkilda.wfm.share.history.model.HaFlowDumpData;
 import org.openkilda.wfm.share.history.model.HaFlowEventData;
 import org.openkilda.wfm.share.history.model.HaFlowEventData.Event;
 import org.openkilda.wfm.share.history.model.HaFlowEventData.Initiator;
-import org.openkilda.wfm.topology.flowhs.service.common.HistoryUpdateCarrier;
+import org.openkilda.wfm.HistoryUpdateCarrier;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
I extracted interfaces from AbstractBolt, this allows to have an interface with the default implementation for sending history. I chose it to an interface and not a class in the hierarchy of bolts, so that we can opt-in or opt-out the default implementation more easily. Also it was needed to move classes to another module, up in the dependency structure.
I added the usage to one bolt to show how it is going to look like.

Although is solves code duplication problem, but there are some downsides:
- this interface cannot enforce a topology to declare what is needed to be declared.
- the access modifiers for some methods changed to be public (I actually don't know why and don't really see the need for it, the class that extends one of the abstract bolts is not inherited and used only in topologies. This is not super clear point. Bolts could be final to resolve this).
- there is a need to unify the naming of streams and bolts for history.