### PR TITLE
Fix for gather group stats.

### DIFF
--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/statistics/StatisticsService.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/statistics/StatisticsService.java
@@ -251,7 +251,7 @@ public class StatisticsService implements IStatisticsService, IFloodlightModule 
         if (factory.getVersion().compareTo(OFVersion.OF_13) >= 0) {
             OFGroupStatsRequest groupStatsRequest = factory
                     .buildGroupStatsRequest()
-                    .setGroup(OFGroup.ANY)
+                    .setGroup(OFGroup.ALL)
                     .build();
 
             logger.info("Getting group stats for switch={} OF-xid:{}", iofSwitch.getId(), groupStatsRequest.getXid());

--- a/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/bolts/CacheBolt.java
+++ b/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/bolts/CacheBolt.java
@@ -124,10 +124,8 @@ public class CacheBolt extends AbstractBolt implements KildaEntryCacheCarrier {
         } else if (data instanceof RemoveYFlowStatsInfo) {
             cacheService.removeCached((RemoveYFlowStatsInfo) data);
         } else if (data instanceof UpdateHaFlowPathInfo) {
-            log.info("ICHUPIN CacheBolt addOrUpdateCacheHa");
             cacheService.addOrUpdateCacheHa((UpdateHaFlowPathInfo) data);
         } else if (data instanceof RemoveHaFlowPathInfo) {
-            log.info("ICHUPIN CacheBolt removeCachedHa");
             cacheService.removeCachedHa((RemoveHaFlowPathInfo) data);
         } else {
             unhandledInput(input);

--- a/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/GroupStatsHandler.java
+++ b/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/GroupStatsHandler.java
@@ -15,6 +15,8 @@
 
 package org.openkilda.wfm.topology.stats.service;
 
+import static org.openkilda.model.GroupId.ROUND_TRIP_LATENCY_GROUP_ID;
+
 import org.openkilda.messaging.info.stats.GroupStatsEntry;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.share.utils.MetricFormatter;
@@ -92,8 +94,9 @@ public final class GroupStatsHandler extends BaseStatsEntryHandler {
 
     @Override
     public void handleStatsEntry(DummyGroupDescriptor descriptor) {
-        log.error("Missed cache for switch '{}' groupId '{}'", switchId, statsEntry.getGroupId());
-        throw new IllegalArgumentException(formatUnexpectedDescriptorMessage(descriptor.getClass()));
+        if (ROUND_TRIP_LATENCY_GROUP_ID.getValue() != statsEntry.getGroupId()) {
+            log.warn("Missed cache for switch '{}' groupId '{}'", switchId, statsEntry.getGroupId());
+        }
     }
 
     @Override

--- a/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/KildaEntryCacheService.java
+++ b/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/KildaEntryCacheService.java
@@ -196,10 +196,6 @@ public class KildaEntryCacheService {
                 removePathInfo.getYPointGroupId(),
                 removePathInfo.getYPointMeterId(), removePathInfo.getHaSubFlowId(),
                 removePathInfo.getYPointSwitchId());
-
-        log.info("ICHUPIN CACHE_SERVICE after remove cookieToFlow cache :{}. \n cache: {}",
-                cookieToFlow.size(), cookieToFlow);
-        System.out.println("ICHUPIN after remove" + cookieToFlow.size());
     }
 
     /**
@@ -254,9 +250,6 @@ public class KildaEntryCacheService {
                 updatePathInfo.getYPointGroupId(),
                 updatePathInfo.getYPointMeterId(), updatePathInfo.getHaSubFlowId(),
                 updatePathInfo.getYPointSwitchId());
-        log.info("ICHUPIN CACHE_SERVICE after update cookieToFlow cache :{}. \n cache: {}",
-                cookieToFlow.size(), cookieToFlow);
-        System.out.println("ICHUPIN after update" + cookieToFlow.size());
     }
 
     private void updateCacheHa(KildaEntryDescriptorHandler cacheHandler,


### PR DESCRIPTION
This PR is a fix for the following PR: 
https://github.com/telstra/open-kilda/pull/5203 

It fixes the requests that is used for gathering the group stats.
Also it removes extra IllegalArgument exception in case of StatsTopology no-cache cases for groupStats. But leaves a warn comment for no-cache cases with all groupIds excepts the first one. 


We need to merge it into 142 upcoming release, so that it should end up in the develop branch since we merge release branches into develop after release.