### PR TITLE
Feature/path check structure

### DIFF
--- a/confd/templates/flowhs-topology/flowhs-topology.tmpl
+++ b/confd/templates/flowhs-topology/flowhs-topology.tmpl
@@ -62,7 +62,7 @@ bolts:
     parallelism: {{ getv "/kilda_storm_flow_hs_flow_delete_mirror_hub_parallelism" }}
   - id: "YFLOW_CREATE_HUB"
     parallelism: {{ getv "/kilda_storm_flow_hs_y_flow_create_hub_parallelism" }}
-  - id: "YFLOW_UPDATE_HUB
+  - id: "YFLOW_UPDATE_HUB"
     parallelism: {{ getv "/kilda_storm_flow_hs_y_flow_update_hub_parallelism" }}
     numTasks: {{ getv "/kilda_storm_flow_hs_num_tasks" }}
   - id: "YFLOW_DELETE_HUB"

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/network/PathValidationResult.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/network/PathValidationResult.java
@@ -32,7 +32,12 @@ import java.util.List;
 @JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class PathValidationResult extends InfoData {
     Boolean isValid;
-    @Singular
+
+    @Singular("addError")
     List<String> errors;
+
+    @Singular("addValidationMessage")
+    List<String> validationMessages;
+
     String pceResponse;
 }

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/main/java/org/openkilda/wfm/topology/nbworker/services/PathsService.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/main/java/org/openkilda/wfm/topology/nbworker/services/PathsService.java
@@ -332,7 +332,7 @@ public class PathsService {
         } catch (RuntimeException e) {
             return Collections.singletonList(PathValidationResult.builder()
                             .isValid(false)
-                            .error(format("Could not create path validation data from the request. %s", e))
+                            .addError(format("Could not create path validation data from the request. %s", e))
                             .build());
         }
 

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/PathValidateResponse.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/PathValidateResponse.java
@@ -33,5 +33,6 @@ import java.util.List;
 public class PathValidateResponse {
     Boolean isValid;
     List<String> errors;
+    List<String> validationMessages;
     String pceResponse;
 }

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundServiceImpl.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundServiceImpl.java
@@ -134,7 +134,7 @@ public class NorthboundServiceImpl implements NorthboundService {
             uriBuilder.queryParam("timeFrom", timeFrom);
         }
         if (timeTo != null) {
-            uriBuilder.queryParam("timeTo", timeTo);
+            uriBuilder.queryParam("timeTo", timeTo + 1 /* To not miss milliseconds*/);
         }
         if (maxCount != null) {
             uriBuilder.queryParam("max_count", maxCount);

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/tsdb/model/RawMetric.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/tsdb/model/RawMetric.java
@@ -66,10 +66,10 @@ public class RawMetric {
         map.put("type", this.type);
         map.put("cookieHex", this.cookieHex);
         map.put("origin", this.origin);
-        map.put("srcSwitch", this.srcSwitch);
-        map.put("dstSwitch", this.dstSwitch);
-        map.put("srcPort", this.srcPort);
-        map.put("dstPort", this.dstPort);
+        map.put("src_switch", this.srcSwitch);
+        map.put("dst_switch", this.dstSwitch);
+        map.put("src_port", this.srcPort);
+        map.put("dst_port", this.dstPort);
         map.put("inPort", this.inPort);
         map.put("outPort", this.outPort);
         map.put("tableid", this.tableid);


### PR DESCRIPTION
This change introduces a new field to the path check response called validationMessages. It contains messages from the validator; it gives information about what we know about the path. Errors is remained, but it contains errors if it is not possible to execute validations.
`isValid` in the path check response now returns true only if the PCE can compute the path.

It also contains a fix for a flow without diverse group issue: when a `diverse_with_flow` provided, but this flow doesn't contain a diverse group, only this flow in considered for the intersection checking (otherwise as before all flows from the diverse group are considered).

closes #5362 