### PR TITLE
Change MySQL docker image version to 8.0.34

### DIFF
--- a/confd/templates/docker-compose/docker-compose.tmpl
+++ b/confd/templates/docker-compose/docker-compose.tmpl
@@ -126,7 +126,7 @@ services:
 
   mysql_db:
     hostname: mysql.pendev
-    image: mysql:5.7.34
+    image: mysql:8.0.34
     command: --default-authentication-plugin=mysql_native_password
     volumes:
       - ./docker/mysql/setup_data:/docker-entrypoint-initdb.d

--- a/confd/vars/main.yaml
+++ b/confd/vars/main.yaml
@@ -10,7 +10,7 @@ kilda_orientdb_password: "kilda"
 kilda_orientdb_database: "kilda"
 
 kilda_persistence_default_implementation: "orientdb"
-kilda_persistence_history_implementation: "orientdb"
+kilda_persistence_history_implementation: "hibernate"
 
 kilda_kafka_hosts: "kafka.pendev:9092"
 kilda_zookeeper_hosts: "zookeeper.pendev"


### PR DESCRIPTION
This change upgrades a version of MySQL to version 8 and makes MySQL a default storage for history. 