### PR TITLE
skip haYPoint=endpoint when update periodic pings

### DIFF
--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/TopologyHelper.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/TopologyHelper.groovy
@@ -207,6 +207,18 @@ class TopologyHelper {
         }
     }
 
+    SwitchTriplet findSwitchTripletWithSharedEpInTheMiddleOfTheChain() {
+        def pairSharedEpAndEp1 = getAllSwitchPairs().neighbouring().random()
+        //shared endpoint should be in the middle of the switches chain to deploy ha-flow without shared path
+        def pairEp1AndEp2 = getAllSwitchPairs().neighbouring().excludePairs([pairSharedEpAndEp1]).includeSwitch(pairSharedEpAndEp1.src).random()
+        Switch thirdSwitch = pairSharedEpAndEp1.src == pairEp1AndEp2.dst ? pairEp1AndEp2.src : pairEp1AndEp2.dst
+        return switchTriplets.find {
+                    it.shared.dpId == pairSharedEpAndEp1.src.dpId
+                            && ((it.ep1.dpId == pairSharedEpAndEp1.dst.dpId && it.ep2.dpId == thirdSwitch.dpId)
+                            || (it.ep1.dpId == thirdSwitch.dpId && it.ep2.dpId == pairSharedEpAndEp1.dst.dpId))
+                }
+    }
+
     SwitchTriplet findSwitchTripletForHaFlowWithProtectedPaths() {
         return switchTriplets.find {
             if (!SwitchTriplet.ALL_ENDPOINTS_DIFFERENT(it)) {


### PR DESCRIPTION
HA flow periodic ping is sending a packet out when the Ypoint = Endpoint when periodic ping is activated. This PR skip this kind of haFlow during the periodic ping update and log a warning. 

This functionality must be removed in https://github.com/telstra/open-kilda/issues/5224