### PR TITLE
open-kilda-5393 Missed cache for mirror groups bug

### DIFF
--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/NotifyFlowStatsOnNewPathsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/NotifyFlowStatsOnNewPathsAction.java
@@ -45,7 +45,8 @@ public class NotifyFlowStatsOnNewPathsAction<T extends FlowPathSwappingFsm<T, S,
                     Flow flow = flowPath.getFlow();
                     UpdateFlowPathInfo pathInfo = new UpdateFlowPathInfo(
                             flow.getFlowId(), flow.getYFlowId(), flow.getYPointSwitchId(), flowPath.getCookie(),
-                            flowPath.getMeterId(), FlowPathMapper.INSTANCE.mapToPathNodes(flow, flowPath),
+                            flowPath.getMeterId(), null,
+                            FlowPathMapper.INSTANCE.mapToPathNodes(flow, flowPath),
                             flow.getVlanStatistics(), flowPath.hasIngressMirror(), flowPath.hasEgressMirror());
                     carrier.sendNotifyFlowStats(pathInfo);
                 });

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/NotifyFlowStatsOnRemovedPathsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/NotifyFlowStatsOnRemovedPathsAction.java
@@ -48,7 +48,8 @@ public class NotifyFlowStatsOnRemovedPathsAction<T extends FlowPathSwappingFsm<T
                     Flow flow = flowPath.getFlow();
                     RemoveFlowPathInfo pathInfo = new RemoveFlowPathInfo(
                             flow.getFlowId(), flow.getYFlowId(), flow.getYPointSwitchId(), flowPath.getCookie(),
-                            flowPath.getMeterId(), FlowPathMapper.INSTANCE.mapToPathNodes(originalFlow, flowPath),
+                            flowPath.getMeterId(), null,
+                            FlowPathMapper.INSTANCE.mapToPathNodes(originalFlow, flowPath),
                             flow.getVlanStatistics(), flowPath.hasIngressMirror(), flowPath.hasEgressMirror());
                     carrier.sendNotifyFlowStats(pathInfo);
                 });

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/create/actions/NotifyFlowStatsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/create/actions/NotifyFlowStatsAction.java
@@ -42,7 +42,7 @@ public class NotifyFlowStatsAction extends
             Flow flow = flowPath.getFlow();
             UpdateFlowPathInfo pathInfo = new UpdateFlowPathInfo(
                     flow.getFlowId(), flow.getYFlowId(), flow.getYPointSwitchId(), flowPath.getCookie(),
-                    flowPath.getMeterId(), FlowPathMapper.INSTANCE.mapToPathNodes(flow, flowPath),
+                    flowPath.getMeterId(), null, FlowPathMapper.INSTANCE.mapToPathNodes(flow, flowPath),
                     flow.getVlanStatistics(), flowPath.hasIngressMirror(), flowPath.hasEgressMirror());
             carrier.sendNotifyFlowStats(pathInfo);
         });

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/delete/actions/NotifyFlowStatsAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/delete/actions/NotifyFlowStatsAction.java
@@ -42,7 +42,8 @@ public class NotifyFlowStatsAction extends
             Flow flow = flowPath.getFlow();
             RemoveFlowPathInfo pathInfo = new RemoveFlowPathInfo(
                     flow.getFlowId(), flow.getYFlowId(), flow.getYPointSwitchId(), flowPath.getCookie(),
-                    flowPath.getMeterId(), FlowPathMapper.INSTANCE.mapToPathNodes(flow, flowPath),
+                    flowPath.getMeterId(), null,
+                    FlowPathMapper.INSTANCE.mapToPathNodes(flow, flowPath),
                     flow.getVlanStatistics(), flowPath.hasIngressMirror(), flowPath.hasEgressMirror());
             carrier.sendNotifyFlowStats(pathInfo);
         });

--- a/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/BaseFlowPathInfo.java
+++ b/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/BaseFlowPathInfo.java
@@ -26,6 +26,7 @@ import lombok.NonNull;
 import lombok.ToString;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -40,6 +41,7 @@ public abstract class BaseFlowPathInfo extends StatsNotification {
     SwitchId yPointSwitchId;
     @NonNull FlowSegmentCookie cookie;
     MeterId meterId;
+    Map<Long, SwitchId> switchIdByGroupId;
     @NonNull List<PathNodePayload> pathNodes;
     Set<Integer> statVlans;
     boolean ingressMirror;

--- a/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/HaFlowStatsInfoFactory.java
+++ b/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/HaFlowStatsInfoFactory.java
@@ -57,7 +57,8 @@ public class HaFlowStatsInfoFactory {
         List<UpdateFlowPathInfo> result = new ArrayList<>();
         for (SubFlowPathInfo path : subPaths) {
             result.add(new UpdateFlowPathInfo(path.flowId, blank.yFlowId, blank.yPointResources.getSwitchId(),
-                    path.cookie, path.meterId, path.pathNodes, path.statVlans, path.ingressMirror, path.egressMirror));
+                    path.cookie, path.meterId, null,
+                    path.pathNodes, path.statVlans, path.ingressMirror, path.egressMirror));
         }
         return result;
     }

--- a/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/RemoveFlowPathInfo.java
+++ b/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/RemoveFlowPathInfo.java
@@ -29,6 +29,7 @@ import lombok.NonNull;
 import lombok.Value;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -46,10 +47,12 @@ public class RemoveFlowPathInfo extends BaseFlowPathInfo {
                               @JsonProperty("ypoint_switch_id") SwitchId yPointSwitchId,
                               @NonNull @JsonProperty("cookie") FlowSegmentCookie cookie,
                               @JsonProperty("meter_id") MeterId meterId,
+                              @JsonProperty("switch_id_by_group_id") Map<Long, SwitchId> switchIdByGroupId,
                               @NonNull @JsonProperty("path_nodes") List<PathNodePayload> pathNodes,
                               @JsonProperty("stat_vlans") Set<Integer> statVlans,
                               @JsonProperty("ingress_mirror") boolean ingressMirror,
                               @JsonProperty("egress_mirror") boolean egressMirror) {
-        super(flowId, yFlowId, yPointSwitchId, cookie, meterId, pathNodes, statVlans, ingressMirror, egressMirror);
+        super(flowId, yFlowId, yPointSwitchId, cookie, meterId, switchIdByGroupId,
+                pathNodes, statVlans, ingressMirror, egressMirror);
     }
 }

--- a/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/UpdateFlowPathInfo.java
+++ b/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/UpdateFlowPathInfo.java
@@ -30,6 +30,7 @@ import lombok.ToString;
 import lombok.Value;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -48,10 +49,12 @@ public class UpdateFlowPathInfo extends BaseFlowPathInfo {
                               @JsonProperty("ypoint_switch_id") SwitchId yPointSwitchId,
                               @NonNull @JsonProperty("cookie") FlowSegmentCookie cookie,
                               @JsonProperty("meter_id") MeterId meterId,
+                              @JsonProperty("switch_id_by_group_id") Map<Long, SwitchId> switchIdByGroupId,
                               @NonNull @JsonProperty("path_nodes") List<PathNodePayload> pathNodes,
                               @JsonProperty("stat_vlans") Set<Integer> statVlans,
                               @JsonProperty("ingress_mirror") boolean ingressMirror,
                               @JsonProperty("egress_mirror") boolean egressMirror) {
-        super(flowId, yFlowId, yPointSwitchId, cookie, meterId, pathNodes, statVlans, ingressMirror, egressMirror);
+        super(flowId, yFlowId, yPointSwitchId, cookie, meterId, switchIdByGroupId,
+                pathNodes, statVlans, ingressMirror, egressMirror);
     }
 }

--- a/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/YFlowStatsInfoFactory.java
+++ b/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/YFlowStatsInfoFactory.java
@@ -57,7 +57,8 @@ public class YFlowStatsInfoFactory {
         List<UpdateFlowPathInfo> result = new ArrayList<>();
         for (SubFlowPathInfo path : subPaths) {
             result.add(new UpdateFlowPathInfo(path.flowId, blank.yFlowId, blank.yPointResources.getSwitchId(),
-                    path.cookie, path.meterId, path.pathNodes, path.statVlans, path.ingressMirror, path.egressMirror));
+                    path.cookie, path.meterId, null,
+                    path.pathNodes, path.statVlans, path.ingressMirror, path.egressMirror));
         }
         return result;
     }

--- a/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/model/KildaEntryDescriptorHandler.java
+++ b/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/model/KildaEntryDescriptorHandler.java
@@ -37,4 +37,6 @@ public interface KildaEntryDescriptorHandler {
     void handleStatsEntry(DummyMeterDescriptor descriptor);
 
     void handleStatsEntry(DummyGroupDescriptor descriptor);
+
+    void handleStatsEntry(MirrorGroupDescriptor descriptor);
 }

--- a/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/model/MirrorGroupDescriptor.java
+++ b/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/model/MirrorGroupDescriptor.java
@@ -1,0 +1,42 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.stats.model;
+
+import org.openkilda.model.GroupId;
+import org.openkilda.model.SwitchId;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+
+@Getter
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class MirrorGroupDescriptor extends KildaEntryDescriptor {
+
+    GroupId mirrorGroupId;
+
+    public MirrorGroupDescriptor(@NonNull SwitchId switchId, GroupId mirrorGroupId) {
+        super(switchId, MeasurePoint.UNKNOWN);
+        this.mirrorGroupId = mirrorGroupId;
+    }
+
+    @Override
+    public void handle(KildaEntryDescriptorHandler handler) {
+        handler.handleStatsEntry(this);
+    }
+}

--- a/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/AnyFlowStatsEntryHandler.java
+++ b/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/AnyFlowStatsEntryHandler.java
@@ -30,6 +30,7 @@ import org.openkilda.wfm.topology.stats.model.DummyMeterDescriptor;
 import org.openkilda.wfm.topology.stats.model.EndpointFlowDescriptor;
 import org.openkilda.wfm.topology.stats.model.HaFlowDescriptor;
 import org.openkilda.wfm.topology.stats.model.KildaEntryDescriptor;
+import org.openkilda.wfm.topology.stats.model.MirrorGroupDescriptor;
 import org.openkilda.wfm.topology.stats.model.StatVlanDescriptor;
 import org.openkilda.wfm.topology.stats.model.YFlowDescriptor;
 import org.openkilda.wfm.topology.stats.model.YFlowSubDescriptor;
@@ -105,6 +106,11 @@ public final class AnyFlowStatsEntryHandler extends BaseFlowStatsEntryHandler {
 
     @Override
     public void handleStatsEntry(DummyGroupDescriptor descriptor) {
+        throw new IllegalArgumentException(formatUnexpectedDescriptorMessage(descriptor.getClass()));
+    }
+
+    @Override
+    public void handleStatsEntry(MirrorGroupDescriptor descriptor) {
         throw new IllegalArgumentException(formatUnexpectedDescriptorMessage(descriptor.getClass()));
     }
 

--- a/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/BaseCacheChangeHandler.java
+++ b/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/BaseCacheChangeHandler.java
@@ -32,6 +32,7 @@ import org.openkilda.wfm.topology.stats.model.HaFlowDescriptor;
 import org.openkilda.wfm.topology.stats.model.KildaEntryDescriptor;
 import org.openkilda.wfm.topology.stats.model.KildaEntryDescriptorHandler;
 import org.openkilda.wfm.topology.stats.model.MeterCacheKey;
+import org.openkilda.wfm.topology.stats.model.MirrorGroupDescriptor;
 import org.openkilda.wfm.topology.stats.model.StatVlanDescriptor;
 import org.openkilda.wfm.topology.stats.model.YFlowDescriptor;
 import org.openkilda.wfm.topology.stats.model.YFlowSubDescriptor;
@@ -119,6 +120,11 @@ abstract class BaseCacheChangeHandler implements KildaEntryDescriptorHandler {
     @Override
     public void handleStatsEntry(DummyGroupDescriptor descriptor) {
         throw new IllegalArgumentException(formatUnexpectedArgumentMessage(descriptor.getClass()));
+    }
+
+    @Override
+    public void handleStatsEntry(MirrorGroupDescriptor descriptor) {
+        cacheAction(new GroupCacheKey(descriptor.getSwitchId(), descriptor.getMirrorGroupId().getValue()), descriptor);
     }
 
     private void handleHaFlowStatsEntry(SwitchId switchId, FlowSegmentCookie cookie, MeterId meterId,

--- a/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/FlowEndpointStatsEntryHandler.java
+++ b/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/FlowEndpointStatsEntryHandler.java
@@ -36,6 +36,7 @@ import org.openkilda.wfm.topology.stats.model.EndpointFlowDescriptor;
 import org.openkilda.wfm.topology.stats.model.HaFlowDescriptor;
 import org.openkilda.wfm.topology.stats.model.KildaEntryDescriptor;
 import org.openkilda.wfm.topology.stats.model.MeasurePoint;
+import org.openkilda.wfm.topology.stats.model.MirrorGroupDescriptor;
 import org.openkilda.wfm.topology.stats.model.StatVlanDescriptor;
 import org.openkilda.wfm.topology.stats.model.YFlowDescriptor;
 import org.openkilda.wfm.topology.stats.model.YFlowSubDescriptor;
@@ -135,6 +136,11 @@ public final class FlowEndpointStatsEntryHandler extends BaseFlowStatsEntryHandl
 
     @Override
     public void handleStatsEntry(DummyGroupDescriptor descriptor) {
+        throw new IllegalArgumentException(formatUnexpectedDescriptorMessage(descriptor.getClass()));
+    }
+
+    @Override
+    public void handleStatsEntry(MirrorGroupDescriptor descriptor) {
         throw new IllegalArgumentException(formatUnexpectedDescriptorMessage(descriptor.getClass()));
     }
 

--- a/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/GroupStatsHandler.java
+++ b/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/GroupStatsHandler.java
@@ -29,6 +29,7 @@ import org.openkilda.wfm.topology.stats.model.EndpointFlowDescriptor;
 import org.openkilda.wfm.topology.stats.model.HaFlowDescriptor;
 import org.openkilda.wfm.topology.stats.model.KildaEntryDescriptor;
 import org.openkilda.wfm.topology.stats.model.MeasurePoint;
+import org.openkilda.wfm.topology.stats.model.MirrorGroupDescriptor;
 import org.openkilda.wfm.topology.stats.model.StatVlanDescriptor;
 import org.openkilda.wfm.topology.stats.model.YFlowDescriptor;
 import org.openkilda.wfm.topology.stats.model.YFlowSubDescriptor;
@@ -90,6 +91,11 @@ public final class GroupStatsHandler extends BaseStatsEntryHandler {
     @Override
     public void handleStatsEntry(DummyMeterDescriptor descriptor) {
         throw new IllegalArgumentException(formatUnexpectedDescriptorMessage(descriptor.getClass()));
+    }
+
+    @Override
+    public void handleStatsEntry(MirrorGroupDescriptor descriptor) {
+        // nothing to do here, since do not need to write stats for now
     }
 
     @Override

--- a/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/MeterStatsHandler.java
+++ b/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/MeterStatsHandler.java
@@ -33,6 +33,7 @@ import org.openkilda.wfm.topology.stats.model.DummyMeterDescriptor;
 import org.openkilda.wfm.topology.stats.model.EndpointFlowDescriptor;
 import org.openkilda.wfm.topology.stats.model.HaFlowDescriptor;
 import org.openkilda.wfm.topology.stats.model.KildaEntryDescriptor;
+import org.openkilda.wfm.topology.stats.model.MirrorGroupDescriptor;
 import org.openkilda.wfm.topology.stats.model.StatVlanDescriptor;
 import org.openkilda.wfm.topology.stats.model.YFlowDescriptor;
 import org.openkilda.wfm.topology.stats.model.YFlowSubDescriptor;
@@ -123,6 +124,11 @@ public final class MeterStatsHandler extends BaseStatsEntryHandler {
 
     @Override
     public void handleStatsEntry(DummyGroupDescriptor descriptor) {
+        throw new IllegalArgumentException(formatUnexpectedDescriptorMessage(descriptor.getClass()));
+    }
+
+    @Override
+    public void handleStatsEntry(MirrorGroupDescriptor descriptor) {
         throw new IllegalArgumentException(formatUnexpectedDescriptorMessage(descriptor.getClass()));
     }
 

--- a/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java
+++ b/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/StatsTopologyTest.java
@@ -2637,7 +2637,7 @@ public class StatsTopologyTest extends AbstractStormTest {
             FlowPath flowPath, Set<Integer> vlanStatistics, boolean ingressMirror,
             boolean egressMirror, String yFlowId, SwitchId yPointSwitchId) {
         RemoveFlowPathInfo pathInfo = new RemoveFlowPathInfo(
-                flowPath.getFlowId(), yFlowId, yPointSwitchId, flowPath.getCookie(), flowPath.getMeterId(),
+                flowPath.getFlowId(), yFlowId, yPointSwitchId, flowPath.getCookie(), flowPath.getMeterId(), null,
                 FlowPathMapper.INSTANCE.mapToPathNodes(flowPath.getFlow(), flowPath), vlanStatistics, ingressMirror,
                 egressMirror);
         sendNotification(pathInfo);
@@ -2652,6 +2652,7 @@ public class StatsTopologyTest extends AbstractStormTest {
             FlowPath flowPath, Set<Integer> vlanStatistics, boolean ingressMirror, boolean egressMirror) {
         UpdateFlowPathInfo pathInfo = new UpdateFlowPathInfo(
                 flowPath.getFlowId(), null, null, flowPath.getCookie(), flowPath.getMeterId(),
+                null,
                 FlowPathMapper.INSTANCE.mapToPathNodes(flowPath.getFlow(), flowPath), vlanStatistics, ingressMirror,
                 egressMirror);
         sendNotification(pathInfo);
@@ -2681,7 +2682,8 @@ public class StatsTopologyTest extends AbstractStormTest {
     private void sendUpdateSubFlowPathInfo(FlowPath flowPath, Flow flow) {
         UpdateFlowPathInfo pathInfo = new UpdateFlowPathInfo(
                 flowPath.getFlowId(), flow.getYFlowId(), flow.getYPointSwitchId(), flowPath.getCookie(),
-                flowPath.getMeterId(), FlowPathMapper.INSTANCE.mapToPathNodes(flowPath.getFlow(), flowPath),
+                flowPath.getMeterId(), null,
+                FlowPathMapper.INSTANCE.mapToPathNodes(flowPath.getFlow(), flowPath),
                 flow.getVlanStatistics(), false, false);
         sendNotification(pathInfo);
     }

--- a/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/service/KildaEntryCacheServiceTest.java
+++ b/src-java/stats-topology/stats-storm-topology/src/test/java/org/openkilda/wfm/topology/stats/service/KildaEntryCacheServiceTest.java
@@ -589,7 +589,8 @@ public class KildaEntryCacheServiceTest {
         FlowPath forwardPath = flow.getForwardPath();
         UpdateFlowPathInfo pathInfo = new UpdateFlowPathInfo(
                 flow.getFlowId(), flow.getYFlowId(), flow.getYPointSwitchId(), forwardPath.getCookie(),
-                forwardPath.getMeterId(), FlowPathMapper.INSTANCE.mapToPathNodes(flow, forwardPath), STAT_VLANS,
+                forwardPath.getMeterId(), null,
+                FlowPathMapper.INSTANCE.mapToPathNodes(flow, forwardPath), STAT_VLANS,
                 false, false);
         service.addOrUpdateCache(pathInfo);
 
@@ -607,7 +608,8 @@ public class KildaEntryCacheServiceTest {
         FlowPath reversePath = flow.getReversePath();
         UpdateFlowPathInfo pathInfo2 = new UpdateFlowPathInfo(
                 flow.getFlowId(), flow.getYFlowId(), flow.getYPointSwitchId(), reversePath.getCookie(),
-                reversePath.getMeterId(), FlowPathMapper.INSTANCE.mapToPathNodes(flow, reversePath), STAT_VLANS,
+                reversePath.getMeterId(), null,
+                FlowPathMapper.INSTANCE.mapToPathNodes(flow, reversePath), STAT_VLANS,
                 false, false);
         service.addOrUpdateCache(pathInfo2);
 
@@ -629,7 +631,8 @@ public class KildaEntryCacheServiceTest {
         FlowPath protectedReversePath = flow.getProtectedReversePath();
         UpdateFlowPathInfo pathInfo3 = new UpdateFlowPathInfo(
                 flow.getFlowId(), flow.getYFlowId(), flow.getYPointSwitchId(), protectedReversePath.getCookie(),
-                protectedReversePath.getMeterId(), FlowPathMapper.INSTANCE.mapToPathNodes(flow, protectedReversePath),
+                protectedReversePath.getMeterId(), null,
+                FlowPathMapper.INSTANCE.mapToPathNodes(flow, protectedReversePath),
                 STAT_VLANS, false, false);
         service.addOrUpdateCache(pathInfo3);
 
@@ -668,7 +671,8 @@ public class KildaEntryCacheServiceTest {
         FlowPath forwardPath = flow.getForwardPath();
         UpdateFlowPathInfo pathInfo = new UpdateFlowPathInfo(
                 flow.getFlowId(), flow.getYFlowId(), flow.getYPointSwitchId(), forwardPath.getCookie(),
-                forwardPath.getMeterId(), FlowPathMapper.INSTANCE.mapToPathNodes(flow, forwardPath), STAT_VLANS,
+                forwardPath.getMeterId(), null,
+                FlowPathMapper.INSTANCE.mapToPathNodes(flow, forwardPath), STAT_VLANS,
                 false, false);
         service.addOrUpdateCache(pathInfo);
 
@@ -685,7 +689,8 @@ public class KildaEntryCacheServiceTest {
 
         RemoveFlowPathInfo pathInfo2 = new RemoveFlowPathInfo(
                 flow.getFlowId(), flow.getYFlowId(), flow.getYPointSwitchId(), forwardPath.getCookie(),
-                forwardPath.getMeterId(), FlowPathMapper.INSTANCE.mapToPathNodes(flow, forwardPath), STAT_VLANS,
+                forwardPath.getMeterId(), null,
+                FlowPathMapper.INSTANCE.mapToPathNodes(flow, forwardPath), STAT_VLANS,
                 false, false);
         service.removeCached(pathInfo2);
 
@@ -710,7 +715,8 @@ public class KildaEntryCacheServiceTest {
         FlowPath forwardPath = flow.getForwardPath();
         UpdateFlowPathInfo pathInfo = new UpdateFlowPathInfo(
                 flow.getFlowId(), flow.getYFlowId(), flow.getYPointSwitchId(), forwardPath.getCookie(),
-                forwardPath.getMeterId(), FlowPathMapper.INSTANCE.mapToPathNodes(flow, forwardPath), STAT_VLANS,
+                forwardPath.getMeterId(), null,
+                FlowPathMapper.INSTANCE.mapToPathNodes(flow, forwardPath), STAT_VLANS,
                 false, false);
         service.addOrUpdateCache(pathInfo);
 
@@ -728,7 +734,8 @@ public class KildaEntryCacheServiceTest {
         FlowPath protectedForwardPath = flow.getProtectedForwardPath();
         UpdateFlowPathInfo pathInfo2 = new UpdateFlowPathInfo(
                 flow.getFlowId(), flow.getYFlowId(), flow.getYPointSwitchId(), protectedForwardPath.getCookie(),
-                protectedForwardPath.getMeterId(), FlowPathMapper.INSTANCE.mapToPathNodes(flow, protectedForwardPath),
+                protectedForwardPath.getMeterId(), null,
+                FlowPathMapper.INSTANCE.mapToPathNodes(flow, protectedForwardPath),
                 STAT_VLANS, false, false);
         service.addOrUpdateCache(pathInfo2);
 
@@ -763,7 +770,8 @@ public class KildaEntryCacheServiceTest {
         FlowPath forwardPath = flow.getForwardPath();
         UpdateFlowPathInfo pathInfo = new UpdateFlowPathInfo(
                 flow.getFlowId(), flow.getYFlowId(), flow.getYPointSwitchId(), forwardPath.getCookie(),
-                forwardPath.getMeterId(), FlowPathMapper.INSTANCE.mapToPathNodes(flow, forwardPath), STAT_VLANS,
+                forwardPath.getMeterId(), null,
+                FlowPathMapper.INSTANCE.mapToPathNodes(flow, forwardPath), STAT_VLANS,
                 false, false);
         service.addOrUpdateCache(pathInfo);
 
@@ -780,7 +788,8 @@ public class KildaEntryCacheServiceTest {
 
         RemoveFlowPathInfo pathInfo2 = new RemoveFlowPathInfo(
                 flow.getFlowId(), flow.getYFlowId(), flow.getYPointSwitchId(), forwardPath.getCookie(),
-                forwardPath.getMeterId(), FlowPathMapper.INSTANCE.mapToPathNodes(flow, forwardPath), STAT_VLANS,
+                forwardPath.getMeterId(), null,
+                FlowPathMapper.INSTANCE.mapToPathNodes(flow, forwardPath), STAT_VLANS,
                 false, false);
         service.removeCached(pathInfo2);
 


### PR DESCRIPTION
In short now we will save group stats caches for mirror flows and remove it when the mirror flows will be removed.
Properly handle group stats records from floodlight. 
no missed cache spam fixes.


+ Added MirrorGroupDescriptor
+ mirror flow groupStats records will be correctly handled. i.e. updates group stats caches. 
+ No new stats records will be written, since we do not need to gather groupStats for mirror flow yet. But group stats records properly handled. 
+ fixed minor bug, when removing  mirror flow now also stats cache entries for that flow will be removed.

Closes #5393