### PR TITLE
#5240: [TEST] VLAN ID 4095 should be allowed

### DIFF
--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/FlowHelper.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/FlowHelper.groovy
@@ -51,8 +51,7 @@ class FlowHelper {
     def random = new Random()
     def faker = new Faker()
     //Kilda allows user to pass reserved VLAN IDs 1 and 4095 if they want.
-    //VLAN 4095 is not allowed at the moment because of https://github.com/telstra/open-kilda/issues/5230
-    static final IntRange KILDA_ALLOWED_VLANS = 1..4094
+    static final IntRange KILDA_ALLOWED_VLANS = 1..4095
 
     /**
      * Creates a FlowCreatePayload instance with random vlan and flow id. Will try to build over traffgen ports or use

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
@@ -76,7 +76,7 @@ class FlowCrudSpec extends HealthCheckSpecification {
     final static Integer IMPOSSIBLY_LOW_LATENCY = 1
     final static Long IMPOSSIBLY_HIGH_BANDWIDTH = Long.MAX_VALUE
     final static FlowStatistics FLOW_STATISTICS_CAUSING_ERROR =
-            new FlowStatistics([[4095, 0].shuffled().first(), 2001] as Set)
+            new FlowStatistics([[4096, 0].shuffled().first(), 2001] as Set)
     @Autowired
     @Shared
     Provider<TraffExamService> traffExamProvider
@@ -652,16 +652,16 @@ class FlowCrudSpec extends HealthCheckSpecification {
                 new FlowNotUpdatedWithMissingPathExpectedError(~/Not enough bandwidth or no path found. \
 Switch .* doesn't have links with enough bandwidth, \
 Failed to find path with requested bandwidth=${IMPOSSIBLY_HIGH_BANDWIDTH}/)
-        "vlan id is above 4094" |
+        "vlan id is above 4095" |
                 {FlowResponseV2 flowResponseV2 -> flowResponseV2.source =
                         flowResponseV2.getSource().tap {it.vlanId = 4096}}|
-        new FlowNotUpdatedExpectedError(~/Errors: VlanId must be less than 4095/)
+        new FlowNotUpdatedExpectedError(~/Errors: VlanId must be less than 4096/)
 
     }
 
     @Tidy
     @Tags([LOW_PRIORITY])
-    def "Unable to partially update to a flow with statistics vlan set to 0 or above 4094"() {
+    def "Unable to partially update to a flow with statistics vlan set to 0 or above 4095"() {
         given: "A flow"
         def (Switch srcSwitch, Switch dstSwitch) = topology.activeSwitches
         def flowRequest = flowHelperV2.randomFlow(srcSwitch, dstSwitch)
@@ -675,7 +675,7 @@ Failed to find path with requested bandwidth=${IMPOSSIBLY_HIGH_BANDWIDTH}/)
 
         then: "Flow is not updated"
         def actualException = thrown(HttpClientErrorException)
-        new FlowNotUpdatedExpectedError(~/To collect vlan statistics, the vlan IDs must be from 1 up to 4094/)
+        new FlowNotUpdatedExpectedError(~/To collect vlan statistics, the vlan IDs must be from 1 up to 4095/)
                 .matches(actualException)
 
         cleanup: "Remove the flow"


### PR DESCRIPTION
* Tests now use VLAN ID 4095 as correct value