### PR TITLE
Victoria metrics url fixes for multicluster victoria configuration.

### DIFF
--- a/confd/templates/gui/application.properties.tmpl
+++ b/confd/templates/gui/application.properties.tmpl
@@ -11,6 +11,15 @@ server.ssl.key-alias = kilda
 server.ssl.key-store = classpath:keystore-kilda.jks
 server.ssl.key-store-password = openkilda
 
+#SSL Victoria configuration. Configure the SSL keystore file for Victoria Metrics in Java with the certificate required
+#for the HTTPS schema. Provide this file to enable REST API calls over HTTPS to the Victoria DB.
+victoria.trust.store=file:./victoria-keystore-kilda.jks
+{{- if exists "/victoria_keystore_password" }}
+victoria.trust.store.password = {{ getv "/victoria_keystore_password" }}
+{{- else }}
+victoria.trust.store.password =
+{{- end }}
+
 #Derby database configuration (In Memory)
 spring.jpa.database=default
 spring.jpa.properties.hibernate.dialect={{ getv "/kilda_gui_db_dialect" }}
@@ -40,7 +49,7 @@ opentsdb.base.url=http://{{ getv "/kilda_opentsdb_hosts" }}:{{ getv "/kilda_open
 opentsdb.metric.prefix = {{ getv "/kilda_opentsdb_metric_prefix" }}
 
 #VICTORIA METRICS Base URL and metric prefix
-victoria.base.url=http://{{ getv "/kilda_victoriametrics_host" }}:{{ getv "/kilda_victoriametrics_read_port" }}/prometheus
+victoria.base.url={{ getv "/kilda_victoria_read_url_schema" }}://{{ getv "/kilda_victoriametrics_host" }}:{{ getv "/kilda_victoriametrics_read_port" }}{{ getv "/kilda_victoriametrics_read_path" }}/prometheus
 
 #Kilda username and password
 kilda.username = {{ getv "/kilda_northbound_username" }}

--- a/confd/vars/main.yaml
+++ b/confd/vars/main.yaml
@@ -24,6 +24,9 @@ kilda_victoriametrics_host: "victoriametrics.pendev"
 kilda_victoriametrics_write_port: "4242"
 kilda_victoriametrics_read_port: "8428"
 kilda_victoriametrics_path: ""
+kilda_victoriametrics_read_path: ""
+kilda_victoria_read_url_schema: "http"
+victoria_keystore_password: ""
 kilda_storm_numbus_hosts: "nimbus.pendev"
 
 kilda_hibernate_url: jdbc:mysql://mysql.pendev:3306/kilda

--- a/src-gui/src/main/java/org/openkilda/integration/service/StatsIntegrationService.java
+++ b/src-gui/src/main/java/org/openkilda/integration/service/StatsIntegrationService.java
@@ -77,14 +77,15 @@ public class StatsIntegrationService {
     private final RestClientManager restClientManager;
     private final ApplicationProperties appProps;
     private final ServerContext serverContext;
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
 
 
     public StatsIntegrationService(RestClientManager restClientManager, ApplicationProperties appProps,
-                                   ServerContext serverContext) {
+                                   ServerContext serverContext, RestTemplate restTemplate) {
         this.restClientManager = restClientManager;
         this.appProps = appProps;
         this.serverContext = serverContext;
+        this.restTemplate = restTemplate;
     }
 
     /**
@@ -103,20 +104,21 @@ public class StatsIntegrationService {
 
         HttpEntity<MultiValueMap<String, Object>> requestEntity
                 = getMultiValueMapHttpEntity(rangeQueryParamsRequest, headers);
+        String url = appProps.getVictoriaBaseUrl() + IConstants.VictoriaMetricsUrl.VICTORIA_RANGE_QUERY;
         try {
-            ResponseEntity<VictoriaDbRes> responseEntity = restTemplate.postForEntity(
-                    appProps.getVictoriaBaseUrl() + IConstants.VictoriaMetricsUrl.VICTORIA_RANGE_QUERY,
-                    requestEntity, VictoriaDbRes.class);
+            LOGGER.info("Request to Victoria DB with the following url: {}", url);
+            ResponseEntity<VictoriaDbRes> responseEntity
+                    = restTemplate.postForEntity(url, requestEntity, VictoriaDbRes.class);
             LOGGER.info("Received response from victoriaDb with the following http code: {}, status: {}, error: {}",
                     responseEntity.getStatusCodeValue(),
                     responseEntity.getBody().getStatus(),
                     responseEntity.getBody().getError());
             return responseEntity.getBody();
         } catch (ResourceAccessException e) {
+            LOGGER.error("Error while accessing VictoriaDB with the following URL: {}", url, e);
             return VictoriaDbRes.builder().status(Status.ERROR).errorType("500")
                     .error("Can not access stats at the moment, something wrong with the Victoria DB").build();
         }
-
     }
 
     private static HttpEntity<MultiValueMap<String, Object>> getMultiValueMapHttpEntity(

--- a/src-gui/src/main/java/org/openkilda/security/CustomRestTemplateConfiguration.java
+++ b/src-gui/src/main/java/org/openkilda/security/CustomRestTemplateConfiguration.java
@@ -1,0 +1,77 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.security;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import javax.net.ssl.SSLContext;
+
+
+@Configuration
+public class CustomRestTemplateConfiguration {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CustomRestTemplateConfiguration.class);
+
+    @Value("${victoria.trust.store}")
+    private Resource victoriaTrustStore;
+
+    @Value("${victoria.trust.store.password}")
+    private String trustStorePassword;
+
+    @Bean
+    public RestTemplate restTemplate() {
+        try {
+            LOGGER.info("Configuring restTemplate with the trustStore:{}", victoriaTrustStore.getURL());
+
+            if (!victoriaTrustStore.exists() || !victoriaTrustStore.isReadable()) {
+                LOGGER.error("Is resource exist? {}. Is resource readable? {}",
+                        victoriaTrustStore.exists(), victoriaTrustStore.isReadable());
+                throw new ResourceAccessException("CA certificate for victoriaDb has not been provided");
+            }
+            LOGGER.info("Resource content length: {}", victoriaTrustStore.contentLength());
+            SSLContext sslContext = new SSLContextBuilder()
+                    .loadTrustMaterial(victoriaTrustStore.getURL(),
+                            StringUtils.isBlank(trustStorePassword) ? null : trustStorePassword.toCharArray()).build();
+            LOGGER.debug("sslContext has been initialized");
+            SSLConnectionSocketFactory sslConFactory = new SSLConnectionSocketFactory(sslContext);
+            LOGGER.debug("sslConFactory has been initialized");
+            CloseableHttpClient httpClient = HttpClients.custom().setSSLSocketFactory(sslConFactory).build();
+            LOGGER.debug("httpClient has been initialized");
+            ClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
+            LOGGER.debug("requestFactory has been initialized");
+            RestTemplate restTemplate = new RestTemplate(requestFactory);
+            LOGGER.info("restTemplate has been initialized");
+            return restTemplate;
+        } catch (Exception e) {
+            LOGGER.error("Failed to initialize RestTemplate with SSL context. Using a simple RestTemplate.", e);
+            return new RestTemplate();
+        }
+
+    }
+}

--- a/src-gui/src/main/resources/application.properties.example
+++ b/src-gui/src/main/resources/application.properties.example
@@ -37,6 +37,9 @@ opentsdb.metric.prefix = kilda.
 #VICTORIA METRICS Base URL
 victoria.base.url=http://victoriametrics.pendev:8428/prometheus
 
+victoria.trust.store=file:./victoria-keystore-kilda.jks
+victoria.trust.store.password=openkilda
+
 #Kilda username and password
 kilda.username = kilda
 kilda.password = kilda


### PR DESCRIPTION
added new parameter
kilda_victoriametrics_read_path. 
On the **RIGEL/VEGA/PROD** environments the value for this parameter should be set to 
/select/0
Since we have multi cluster configuration for victoria Db on the rugel/vega/prod envs


This PR should be tested at least on the RIGEL env.
