### PR TITLE
HA-flow history: add dumps, fix task IDs for saving an action to history

### DIFF
--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/history/HaFlowHistory.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/history/HaFlowHistory.java
@@ -40,6 +40,21 @@ public final class HaFlowHistory {
         this.taskId = taskId;
     }
 
+    /**
+     * This method creates an object that holds history fields. The current history implementation
+     * expects the parameter to be the taskId (history actions are grouped by this parameter).
+     * Usage:<p>
+     * <pre>
+     * HaFlowHistory.of(correlationId)
+     *     .withAction("An action title goes here")
+     *     .withDescription("Optionally, a more detailed description could be added")
+     *     .withHaFlowId(haFlowId)
+     *     .withDumpBefore(haFlowDumpData);
+     * </pre>
+     * </p>
+     * @param taskId a string containing correlation ID of the operation that saves a history record
+     * @return an HaFlowHistory object that is supposed to be filled with history parameters.
+     */
     public static HaFlowHistory of(String taskId) {
         return new HaFlowHistory(taskId);
     }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/HaFlowProcessingFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/HaFlowProcessingFsm.java
@@ -19,9 +19,13 @@ import org.openkilda.floodlight.api.request.rulemanager.BaseSpeakerCommandsReque
 import org.openkilda.floodlight.api.response.rulemanager.SpeakerCommandResponse;
 import org.openkilda.model.SwitchId;
 import org.openkilda.wfm.CommandContext;
+import org.openkilda.wfm.share.history.model.FlowDumpData;
+import org.openkilda.wfm.share.history.model.FlowEventData;
 import org.openkilda.wfm.topology.flowhs.service.common.HistoryUpdateCarrier;
 import org.openkilda.wfm.topology.flowhs.service.common.NorthboundResponseCarrier;
 import org.openkilda.wfm.topology.flowhs.service.common.ProcessingEventListener;
+import org.openkilda.wfm.topology.flowhs.service.history.FlowHistoryService;
+import org.openkilda.wfm.topology.flowhs.service.history.HaFlowHistory;
 
 import lombok.Getter;
 import lombok.NonNull;
@@ -103,4 +107,87 @@ public abstract class HaFlowProcessingFsm<T extends AbstractStateMachine<T, S, E
     public void clearSpeakerCommands() {
         speakerCommands.clear();
     }
+
+    //region Simple Flow history methods
+    @Override
+    public void saveErrorToHistory(String action, String errorMessage) {
+        logFlowHistoryInHaFlowFsmError();
+        FlowHistoryService.using(getCarrier()).saveError(HaFlowHistory.of(getCommandContext().getCorrelationId())
+                .withHaFlowId(getHaFlowId())
+                .withAction(action)
+                .withDescription(errorMessage));
+    }
+
+    @Override
+    public void saveErrorToHistory(String errorMessage) {
+        logFlowHistoryInHaFlowFsmError();
+        FlowHistoryService.using(getCarrier()).saveError(HaFlowHistory.of(getCommandContext().getCorrelationId())
+                .withHaFlowId(getHaFlowId())
+                .withAction(errorMessage));
+    }
+
+    @Override
+    public void saveErrorToHistory(String errorMessage, Exception ex) {
+        logFlowHistoryInHaFlowFsmError();
+        FlowHistoryService.using(getCarrier()).saveError(HaFlowHistory.of(getCommandContext().getCorrelationId())
+                .withHaFlowId(getHaFlowId())
+                .withAction(errorMessage)
+                .withDescription(ex.getMessage()));
+    }
+
+    @Override
+    public void saveActionToHistory(String action) {
+        logFlowHistoryInHaFlowFsmError();
+    }
+
+    @Override
+    public void saveActionToHistory(String action, String description) {
+        logFlowHistoryInHaFlowFsmError();
+    }
+
+    @Override
+    public void saveFlowActionToHistory(String flowId, String action) {
+        logFlowHistoryInHaFlowFsmError();
+    }
+
+    @Override
+    public void saveFlowActionToHistory(String flowId, String action, String description) {
+        logFlowHistoryInHaFlowFsmError();
+    }
+
+    @Override
+    public void saveNewEventToHistory(String action, FlowEventData.Event event) {
+        logFlowHistoryInHaFlowFsmError();
+    }
+
+    @Override
+    public void saveNewEventToHistory(String flowId, String action, FlowEventData.Event event) {
+        logFlowHistoryInHaFlowFsmError();
+    }
+
+    @Override
+    public void saveNewEventToHistory(String action,
+                                      FlowEventData.Event event, FlowEventData.Initiator initiator, String details) {
+        logFlowHistoryInHaFlowFsmError();
+    }
+
+    @Override
+    public void saveNewEventToHistory(String flowId, String action, FlowEventData.Event event,
+                                      FlowEventData.Initiator initiator, String details, String taskId) {
+        logFlowHistoryInHaFlowFsmError();
+    }
+
+    @Override
+    public void saveActionWithDumpToHistory(String action, String description, FlowDumpData flowDumpData) {
+        logFlowHistoryInHaFlowFsmError();
+    }
+
+    private void logFlowHistoryInHaFlowFsmError() {
+        //TODO remove usages of base classes and interfaces dedicated for simple flow and remove all methods
+        //that are not applicable to HA-flow. Then all methods in this region could be removed as well.
+        RuntimeException exception = new RuntimeException("Dummy Exception");
+        log.warn("Storing simple flow history is invoked from an HA-flow FSM. Trace: {}",
+                (Object) exception.getStackTrace());
+    }
+    //endregion
 }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/CompleteHaFlowPathRemovalAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/CompleteHaFlowPathRemovalAction.java
@@ -63,6 +63,7 @@ public class CompleteHaFlowPathRemovalAction extends
 
         Set<PathId> pathIds = transactionManager.doInTransaction(() -> {
             HaFlow haFlow = getHaFlow(stateMachine.getHaFlowId());
+
             for (HaFlowPath haFlowPath : haFlow.getPaths()) {
                 for (FlowPath subPath : haFlowPath.getSubPaths()) {
                     // Flow path cascade remove will remove segments too

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/DeallocateResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/delete/actions/DeallocateResourcesAction.java
@@ -47,7 +47,7 @@ public class DeallocateResourcesAction extends
                     resourcesManager.deallocateHaFlowResources(resources));
 
             FlowHistoryService.using(stateMachine.getCarrier()).save(HaFlowHistory
-                    .of(stateMachine.getHaFlowId())
+                    .of(stateMachine.getCommandContext().getCorrelationId())
                     .withAction("Flow resources have been deallocated")
                     .withDescription(format("The ha-flow resources for %s / %s have been deallocated",
                             resources.getForward().getPathId(), resources.getReverse().getPathId()))

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/reroute/HaFlowRerouteFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/reroute/HaFlowRerouteFsm.java
@@ -371,7 +371,8 @@ public final class HaFlowRerouteFsm extends HaFlowPathSwappingFsm<HaFlowRerouteF
                     .perform(new NotifyHaFlowMonitorAction<>(persistenceManager, carrier));
 
             builder.defineFinalState(State.FINISHED)
-                    .addEntryAction(new OnFinishedAction(dashboardLogger, carrier));
+                    .addEntryAction(new OnFinishedAction(dashboardLogger, carrier,
+                            persistenceManager.getRepositoryFactory().createHaFlowRepository()));
             builder.defineFinalState(State.FINISHED_WITH_ERROR)
                     .addEntryAction(new OnFinishedWithErrorAction(dashboardLogger, carrier));
         }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/reroute/actions/ValidateHaFlowAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/haflow/reroute/actions/ValidateHaFlowAction.java
@@ -93,6 +93,12 @@ public class ValidateHaFlowAction extends
 
         HaFlow haFlow = transactionManager.doInTransaction(() -> {
             HaFlow foundHaFlow = getHaFlow(flowId);
+            FlowHistoryService.using(stateMachine.getCarrier()).save(HaFlowHistory
+                    .of(stateMachine.getCommandContext().getCorrelationId())
+                    .withAction("HA-flow validation started.")
+                    .withDescription("Saving a dump before.")
+                    .withHaFlowDumpBefore(foundHaFlow));
+
             if (foundHaFlow.getStatus() == FlowStatus.IN_PROGRESS) {
                 String message = format("HA-flow %s is in progress now", flowId);
                 stateMachine.setRerouteError(new FlowInProgressError(message));


### PR DESCRIPTION
- [x] After this fix, the action of de-allocating resources will be visible in the list of actions under the history event of deleting HA-flow on.
- [x]  fix also allows to use simple flow history methods in HA-flow FSMs (but arguably this is a temporary solution).
- [x] add dumps before and after to the HA flow reroute event.
- [x] add a dump before to the HA flow delete event.

closes #5425 