### PR TITLE
5424 GUI: enable to get flow path if flow name contains a dot

### DIFF
--- a/src-gui/src/main/java/org/openkilda/controller/ContractController.java
+++ b/src-gui/src/main/java/org/openkilda/controller/ContractController.java
@@ -63,7 +63,7 @@ public class ContractController {
     /**
      * Returns delete contract exists in the system.
      */
-    @RequestMapping(value = "/delete/{flowId}/{contractid:.+}", method = RequestMethod.DELETE)
+    @RequestMapping(value = "/delete/{flowId:.+}/{contractid:.+}", method = RequestMethod.DELETE)
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
     public boolean deleteContract(@PathVariable(name = "flowId", required = false) String flowId,

--- a/src-gui/src/main/java/org/openkilda/controller/FlowController.java
+++ b/src-gui/src/main/java/org/openkilda/controller/FlowController.java
@@ -109,7 +109,7 @@ public class FlowController extends BaseController {
      *            id of flow path requested.
      * @return flow path with all nodes/switches exists in provided flow
      */
-    @RequestMapping(value = "/path/{flowId}", method = RequestMethod.GET)
+    @RequestMapping(value = "/path/{flowId:.+}", method = RequestMethod.GET)
     @ResponseStatus(HttpStatus.OK)
     public @ResponseBody FlowPayload getFlowPath(@PathVariable final String flowId) {
         LOGGER.info("Get flow path. Flow id: '" + flowId + "'");
@@ -124,7 +124,7 @@ public class FlowController extends BaseController {
      *            id of reroute requested.
      * @return reroute flow of new flow path with all nodes/switches exist
      */
-    @RequestMapping(value = "/{flowId}/reroute", method = RequestMethod.GET)
+    @RequestMapping(value = "/{flowId:.+}/reroute", method = RequestMethod.GET)
     @ResponseStatus(HttpStatus.OK)
     public @ResponseBody FlowPath rerouteFlow(@PathVariable final String flowId) {
         activityLogger.log(ActivityType.FLOW_REROUTE, flowId);
@@ -139,7 +139,7 @@ public class FlowController extends BaseController {
      *            id of validate flow requested.
      * @return validate flow
      */
-    @RequestMapping(value = "/{flowId}/validate", method = RequestMethod.GET)
+    @RequestMapping(value = "/{flowId:.+}/validate", method = RequestMethod.GET)
     @ResponseStatus(HttpStatus.OK)
     public @ResponseBody String validateFlow(@PathVariable final String flowId) {
         activityLogger.log(ActivityType.FLOW_VALIDATE, flowId);
@@ -155,7 +155,7 @@ public class FlowController extends BaseController {
      * @return flowInfo
      * @throws AccessDeniedException the access denied exception
      */
-    @RequestMapping(value = "/{flowId}", method = RequestMethod.GET)
+    @RequestMapping(value = "/{flowId:.+}", method = RequestMethod.GET)
     @ResponseStatus(HttpStatus.OK)
     @Permissions(values = { IConstants.Permission.MENU_FLOWS })
     public @ResponseBody FlowInfo getFlowById(@PathVariable final String flowId,
@@ -172,7 +172,7 @@ public class FlowController extends BaseController {
      *            id of flow requested.
      * @return flow
      */
-    @RequestMapping(value = "/{flowId}/status", method = RequestMethod.GET)
+    @RequestMapping(value = "/{flowId:.+}/status", method = RequestMethod.GET)
     @ResponseStatus(HttpStatus.OK)
     public @ResponseBody FlowStatus getFlowStatusById(@PathVariable final String flowId) {
         LOGGER.info("Get flow status by id. Flow id: '" + flowId + "'");
@@ -203,7 +203,7 @@ public class FlowController extends BaseController {
      *            the flow
      * @return the flow
      */
-    @RequestMapping(value = "/{flowId}", method = RequestMethod.PUT)
+    @RequestMapping(value = "/{flowId:.+}", method = RequestMethod.PUT)
     @ResponseStatus(HttpStatus.CREATED)
     @Permissions(values = { IConstants.Permission.FW_FLOW_UPDATE })
     public @ResponseBody FlowV2 updateFlow(@PathVariable("flowId") final String flowId, 
@@ -221,7 +221,7 @@ public class FlowController extends BaseController {
      *            the flow id
      * @return the flow
      */
-    @RequestMapping(value = "/{flowId}", method = RequestMethod.DELETE)
+    @RequestMapping(value = "/{flowId:.+}", method = RequestMethod.DELETE)
     @ResponseStatus(HttpStatus.OK)
     @Permissions(values = { IConstants.Permission.FW_FLOW_DELETE })
     @ResponseBody
@@ -240,7 +240,7 @@ public class FlowController extends BaseController {
      *            id of validate flow requested.
      * @return validate flow
      */
-    @RequestMapping(value = "/{flowId}/sync", method = RequestMethod.PATCH)
+    @RequestMapping(value = "/{flowId:.+}/sync", method = RequestMethod.PATCH)
     @ResponseStatus(HttpStatus.OK)
     @Permissions(values = { IConstants.Permission.FW_FLOW_RESYNC })
     public @ResponseBody String resyncFlow(@PathVariable final String flowId) {
@@ -277,7 +277,7 @@ public class FlowController extends BaseController {
      * @param flow the flow
      * @return the string
      */
-    @RequestMapping(value = "/{flowId}/ping", method = RequestMethod.PUT)
+    @RequestMapping(value = "/{flowId:.+}/ping", method = RequestMethod.PUT)
     @ResponseStatus(HttpStatus.OK)
     @Permissions(values = { IConstants.Permission.FW_FLOW_PING })
     public @ResponseBody String flowPing(@PathVariable final String flowId, @RequestBody final FlowV2 flow) {
@@ -291,7 +291,7 @@ public class FlowController extends BaseController {
      *
      * @return the flow history.
      */
-    @RequestMapping(value = "/all/history/{flowId}", method = RequestMethod.GET)
+    @RequestMapping(value = "/all/history/{flowId:.+}", method = RequestMethod.GET)
     @ResponseStatus(HttpStatus.OK)
     @Permissions(values = { IConstants.Permission.FW_FLOW_HISTORY })
     public @ResponseBody List<FlowHistory> getFlowHistory(@PathVariable final String flowId,
@@ -306,7 +306,7 @@ public class FlowController extends BaseController {
      *            id of flow.
      * @return FlowConnectedDevice
      */
-    @RequestMapping(value = "/connected/devices/{flowId}", method = RequestMethod.GET)
+    @RequestMapping(value = "/connected/devices/{flowId:.+}", method = RequestMethod.GET)
     @ResponseStatus(HttpStatus.OK)
     public @ResponseBody FlowConnectedDevice getFlowConnectedDevice(@PathVariable final String flowId,
             @RequestParam(name = "since", required = false) String timeLastSeen) {

--- a/src-gui/src/main/java/org/openkilda/controller/StatsController.java
+++ b/src-gui/src/main/java/org/openkilda/controller/StatsController.java
@@ -144,7 +144,7 @@ public class StatsController {
      * @param downsample the downsample
      * @return the flow stats
      */
-    @RequestMapping(value = "flowid/{flowid}/{startDate}/{endDate}/{downsample}/{metric}",
+    @RequestMapping(value = "flowid/{flowid:.+}/{startDate}/{endDate}/{downsample}/{metric}",
             method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     @Permissions(values = {IConstants.Permission.MENU_FLOWS})
@@ -263,7 +263,7 @@ public class StatsController {
      * @param direction  the direction
      * @return the flow loss packet stats
      */
-    @RequestMapping(value = "flow/losspackets/{flowid}/{startDate}/{endDate}/{downsample}/{direction}",
+    @RequestMapping(value = "flow/losspackets/{flowid:.+}/{startDate}/{endDate}/{downsample}/{direction}",
             method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     @Permissions(values = {IConstants.Permission.MENU_FLOWS})
@@ -325,7 +325,7 @@ public class StatsController {
      * @param metric     the metric
      * @return the meter stats
      */
-    @RequestMapping(value = "meter/{flowid}/{startDate}/{endDate}/{downsample}/{metric}/{direction}",
+    @RequestMapping(value = "meter/{flowid:.+}/{startDate}/{endDate}/{downsample}/{metric}/{direction}",
             method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     @Permissions(values = {IConstants.Permission.MENU_FLOWS})


### PR DESCRIPTION
added the regex to  @requestMapping annotation in order to match flowId pathVars with dots characters for all existed bff endpoints.

with this fix the flows that contains dot character "." in their id should be correctly working.

To test:
create flow so that id contains a dot character, example:

```
{
  "flow_id": "flow.1",
  "source": {
    "detect_connected_devices": {
      "arp": true,
      "lldp": true
    },
    "inner_vlan_id": 100,
    "port_number": 101,
    "switch_id": "1",
    "vlan_id": 102
  },
  "destination": {
    "detect_connected_devices": {
      "arp": true,
      "lldp": true
    },
    "inner_vlan_id": 103,
    "port_number": 104,
    "switch_id": "3",
    "vlan_id": 105
  },
  "maximum_bandwidth": 100
}
```

got to the flow details page for created flow., click on PATH tab:

<img width="1254" alt="image" src="https://github.com/telstra/open-kilda/assets/9297385/5d24875b-678f-4a2b-9570-6bda9721539a">


The flow path is represented correctly. 

Closes #5424 