### PR TITLE
#5390: [TEST] Attempt to fix several flaky tests increasing waiting intervals

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/HealthCheckSpecification.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/HealthCheckSpecification.groovy
@@ -21,7 +21,7 @@ import org.springframework.beans.factory.annotation.Value
 @Slf4j
 class HealthCheckSpecification extends HealthCheckBaseSpecification {
 
-    private static final int WAIT_FOR_LAB_TO_BE_OPERATIONAL = 120 //sec
+    private static final int WAIT_FOR_LAB_TO_BE_OPERATIONAL = 210 //sec
     static Throwable healthCheckError
     static boolean healthCheckRan = false
     @Value('${health_check.verifier:true}')

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/server42/Server42IslRttSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/server42/Server42IslRttSpec.groovy
@@ -2,6 +2,7 @@ package org.openkilda.functionaltests.spec.server42
 
 import org.openkilda.functionaltests.model.stats.IslStats
 import org.springframework.beans.factory.annotation.Autowired
+import spock.lang.Unroll
 
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs
 import static groovyx.gpars.GParsPool.withPool
@@ -58,7 +59,8 @@ class Server42IslRttSpec extends HealthCheckSpecification {
     int statsWaitSeconds = 4
 
     @Tags([LOW_PRIORITY])
-    def "ISL RTT stats are #testLabel available only if both global and switch toggles are 'on'"() {
+    @Unroll
+    def "ISL RTT stats are available only if both global and switch toggles are 'on'"() {
         given: "An active ISL with both switches having server42"
         def server42switchesDpIds = topology.getActiveServer42Switches()*.dpId
         def isl = topology.islsForActiveSwitches.find {
@@ -658,7 +660,7 @@ class Server42IslRttSpec extends HealthCheckSpecification {
 
     void checkIslRttStats(Isl isl, Date checkpointTime, Boolean statExist) {
         //wait till near real-time stats arrive to TSDB
-        sleep(statsWaitSeconds * 1000)
+        sleep((statsWaitSeconds + 1) * 1000)
         def stats = islStats.of(isl).get(ISL_RTT, SERVER_42)
         if (statExist) {
             assert stats.hasNonZeroValuesAfter(checkpointTime.getTime())

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/FlowStatSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/FlowStatSpec.groovy
@@ -97,7 +97,7 @@ class FlowStatSpec extends HealthCheckSpecification {
         }
 
         and: "Wait till stats from old main path are collected"
-        Wrappers.wait(WAIT_OFFSET, 3) {
+        Wrappers.wait(statsRouterRequestInterval, 3) {
             statsHelper."force kilda to collect stats"()
             def newStats = flowStats.of(flow.getFlowId())
             assert newStats.get(FLOW_RAW_BYTES, srcSwitchId, mainForwardCookie).getNewestTimeStamp() ==

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/StormLcmSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/StormLcmSpec.groovy
@@ -140,7 +140,7 @@ class StormLcmSpec extends HealthCheckSpecification {
         !networkDeployed && wfmManipulator.deployTopology("network")
         srcBlockData && lockKeeper.reviveSwitch(islUnderTest.srcSwitch, srcBlockData)
         dstBlockData && lockKeeper.reviveSwitch(islUnderTest.dstSwitch, dstBlockData)
-        Wrappers.wait(WAIT_OFFSET + discoveryInterval) {
+        Wrappers.wait(WAIT_OFFSET + discoveryTimeout) {
             assert database.getIsls(topology.getIsls()).every {it.status == IslStatus.ACTIVE}
             assert northbound.getAllLinks().every {it.state == IslChangeType.DISCOVERED}
         }


### PR DESCRIPTION
Implements #5390

* ISL RTT stats test gives more time for last stats collected before turning stats off
* Flow stats test gives more time for last stats collected after swapping the path
* Storm restart spec now waits longer for links discovery in post-test
* Whole run now waits longer for lab to be operational