### PR TITLE
Change health check test for the MySQL container. Update docs.

### DIFF
--- a/confd/templates/docker-compose/docker-compose.tmpl
+++ b/confd/templates/docker-compose/docker-compose.tmpl
@@ -140,7 +140,7 @@ services:
     ports:
       - 8101:3306
     healthcheck:
-      test: "mysql -u kilda -pkilda -e 'use kilda; select count(user());'"
+      test: "mysql -u kilda -pkilda --protocol=tcp -e 'use kilda; select count(user());'"
       interval: 3s
       timeout: 3s
       retries: 5

--- a/confd/templates/docker-compose/docker-compose.tmpl
+++ b/confd/templates/docker-compose/docker-compose.tmpl
@@ -140,7 +140,11 @@ services:
     ports:
       - 8101:3306
     healthcheck:
-      test: "mysqladmin -u kilda -pkilda ping"
+      test: "mysql -u kilda -pkilda -e 'use kilda; select count(user());'"
+      interval: 3s
+      timeout: 3s
+      retries: 5
+      start_period: 20s
     networks:
       default:
         aliases:

--- a/docker/db-mysql-migration/migrations/README.md
+++ b/docker/db-mysql-migration/migrations/README.md
@@ -47,7 +47,7 @@ changeSet:
 To start DB update manually you need to compose a migration image and execute a migration script. Optionally, you
 can execute liquibase with arbitrary parameters.
 
-To create an image, navigate to (TODO) 
+To create an image, navigate to the root of the OpenKilda project and execute:
 ```shell script
 docker-compose build db_mysql_migration
 ```


### PR DESCRIPTION
This change is an attempt to improve health checking for the MySQL container. It's difficult to say for sure, if there is only one problem, but probably, the previous test command could report that the container is healthy, however it doesn't yet accept connections (mysqladmin doesn't say that the DB is created and ready). Also, I suspect, that the health checking could report false information because of starting and stopping a temporary server during the initialization stage: this container starts a service, creates a DB called `kilda` then stops the temporary server, then starts the actual service. 


I added the command to select DB and run some query afterwards. Together, it says that selecting a DB is successful and therefore it's been created during the init stage. A select statement says that the server can execute queries.
Start period 

closes #5459 