### PR TITLE
#5390: [TEST] Use helper methods to create flow

### DIFF
--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/FlowHelper.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/FlowHelper.groovy
@@ -1,6 +1,7 @@
 package org.openkilda.functionaltests.helpers
 
 import org.openkilda.messaging.payload.flow.PathNodePayload
+import org.openkilda.messaging.payload.history.FlowHistoryEntry
 import org.openkilda.model.SwitchId
 
 import static groovyx.gpars.GParsPool.withPool
@@ -167,6 +168,33 @@ class FlowHelper {
         def response = northbound.updateFlow(flowId, flow)
         Wrappers.wait(FLOW_CRUD_TIMEOUT) { assert northbound.getFlowStatus(flowId).status == FlowState.UP }
         return response
+    }
+
+    /**
+     * Returns last (the freshest) flow history entry
+     * @param flowId
+     * @return
+     */
+    FlowHistoryEntry getLatestHistoryEntry(String flowId) {
+        return northbound.getFlowHistory(flowId).last()
+    }
+
+    /**
+     * Returns the number of entries in flow history
+     * @param flowId
+     * @return
+     */
+    int getHistorySize(String flowId) {
+        return northbound.getFlowHistory(flowId).size()
+    }
+
+    //TODO: Switch to enum for action
+    List<FlowHistoryEntry> getHistoryEntriesByAction(String flowId, String action) {
+        return northbound.getFlowHistory(flowId).findAll {it.getAction() == action}
+    }
+
+    FlowHistoryEntry getEarliestHistoryEntryByAction(String flowId, String action) {
+        return getHistoryEntriesByAction(flowId, action).first()
     }
 
     /**

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/configuration/ConfigurationSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/configuration/ConfigurationSpec.groovy
@@ -43,7 +43,7 @@ class ConfigurationSpec extends HealthCheckSpecification {
         assumeTrue(switchPair != null, "Unable to find required switch pair in topology")
         def flow1 = flowHelperV2.randomFlow(switchPair)
         flow1.encapsulationType = null
-        northboundV2.addFlow(flow1)
+        flowHelperV2.addFlow(flow1)
 
         then: "Flow is created with current default encapsulation type(transit_vlan)"
         northboundV2.getFlow(flow1.flowId).encapsulationType == defaultEncapsulationType.toString().toLowerCase()
@@ -62,7 +62,7 @@ class ConfigurationSpec extends HealthCheckSpecification {
         when: "Create a flow without encapsulation type"
         def flow2 = flowHelperV2.randomFlow(switchPair, false, [flow1])
         flow2.encapsulationType = null
-        northboundV2.addFlow(flow2)
+        flowHelperV2.addFlow(flow2)
 
         then: "Flow is created with new default encapsulation type(vxlan)"
         northboundV2.getFlow(flow2.flowId).encapsulationType == newFlowEncapsulationType.toString().toLowerCase()

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/BandwidthSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/BandwidthSpec.groovy
@@ -298,9 +298,8 @@ class BandwidthSpec extends HealthCheckSpecification {
             }
         }
 
-        def flow = flowHelper.randomFlow(switchPair)
-        flow.maximumBandwidth = involvedBandwidths.max() + 1
-        northbound.addFlow(flow)
+        def flow = flowHelper.randomFlow(switchPair).tap {it.maximumBandwidth = involvedBandwidths.max() + 1}
+        flowHelper.addFlow(flow)
 
         then: "The flow is not created because flow path should not be found"
         def exc = thrown(HttpClientErrorException)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV1Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV1Spec.groovy
@@ -378,7 +378,7 @@ class FlowCrudV1Spec extends HealthCheckSpecification {
         flow.destination.vlanId = flow.source.vlanId
 
         when: "Try creating such flow"
-        northbound.addFlow(flow)
+        flowHelper.addFlow(flow)
 
         then: "Error is returned, stating a readable reason"
         def error = thrown(HttpClientErrorException)
@@ -403,7 +403,7 @@ class FlowCrudV1Spec extends HealthCheckSpecification {
         flowHelper.addFlow(flow)
 
         and: "Try creating the second flow which conflicts"
-        northbound.addFlow(conflictingFlow)
+        flowHelper.addFlow(conflictingFlow)
 
         then: "Error is returned, stating a readable reason of conflict"
         def error = thrown(HttpClientErrorException)
@@ -508,7 +508,7 @@ class FlowCrudV1Spec extends HealthCheckSpecification {
         }
 
         when: "Try building a flow using the isolated switch"
-        northbound.addFlow(flow)
+        flowHelper.addFlow(flow)
 
         then: "Error is returned, stating that there is no path found for such flow"
         def error = thrown(HttpClientErrorException)
@@ -789,7 +789,7 @@ Failed to find path with requested bandwidth=$flow.maximumBandwidth/).matches(er
 
         when: "Create a flow"
         def flow = flowHelper.singleSwitchFlow(sw)
-        northbound.addFlow(flow)
+        flowHelper.addFlow(flow)
 
         then: "Human readable error is returned"
         def exc = thrown(HttpClientErrorException)
@@ -832,7 +832,7 @@ are not connected to the controller/).matches(exc)
         def amountOfFlows = 5
         amountOfFlows.times {
             def flow = flowHelper.singleSwitchFlow(sw)
-            northbound.addFlow(flow)
+            flowHelper.addFlow(flow)
             flows << flow.id
         }
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowDiversitySpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowDiversitySpec.groovy
@@ -75,7 +75,7 @@ class FlowDiversitySpec extends HealthCheckSpecification {
 
         and: "Flows' histories contain 'diverseGroupId' information"
         [flow2, flow3].each {//flow1 had no diversity at the time of creation
-            assert northbound.getFlowHistory(it.flowId).find { it.action == CREATE_ACTION }.dumps
+            assert flowHelper.getEarliestHistoryEntryByAction(it.flowId, CREATE_ACTION).dumps
                     .find { it.type == "stateAfter" }?.diverseGroupId
         }
 
@@ -85,13 +85,13 @@ class FlowDiversitySpec extends HealthCheckSpecification {
 
         then: "Flows' histories contain 'diverseGroupId' information in 'delete' operation"
         [flow1, flow2].each {
-            verifyAll(northbound.getFlowHistory(it.flowId).find { it.action == DELETE_ACTION }.dumps) {
+            verifyAll(flowHelper.getEarliestHistoryEntryByAction(it.flowId, DELETE_ACTION).dumps) {
                 it.find { it.type == "stateBefore" }?.diverseGroupId
                 !it.find { it.type == "stateAfter" }?.diverseGroupId
             }
         }
         //except flow3, because after deletion of flow1/flow2 flow3 is no longer in the diversity group
-        verifyAll(northbound.getFlowHistory(flow3.flowId).find { it.action == DELETE_ACTION }.dumps) {
+        verifyAll(flowHelper.getEarliestHistoryEntryByAction(flow3.flowId, DELETE_ACTION).dumps) {
             !it.find { it.type == "stateBefore" }?.diverseGroupId
             !it.find { it.type == "stateAfter" }?.diverseGroupId
         }
@@ -120,7 +120,7 @@ class FlowDiversitySpec extends HealthCheckSpecification {
                                                                 flow2.tap { it.diverseFlowId = flow1.flowId })
 
         and: "Second flow's history contains 'groupId' information"
-        verifyAll(northbound.getFlowHistory(flow2.flowId).find { it.action == UPDATE_ACTION }.dumps) {
+        verifyAll(flowHelper.getEarliestHistoryEntryByAction(flow2.flowId, UPDATE_ACTION).dumps) {
             !it.find { it.type == "stateBefore" }?.diverseGroupId
             it.find { it.type == "stateAfter" }?.diverseGroupId
         }
@@ -186,7 +186,7 @@ class FlowDiversitySpec extends HealthCheckSpecification {
         !northboundV2.getFlow(flow2.flowId).diverseWith
 
         and: "The flow's history reflects the change of 'groupId' field"
-        verifyAll(northbound.getFlowHistory(flow2.flowId).find { it.action == UPDATE_ACTION }.dumps) {
+        verifyAll(flowHelper.getEarliestHistoryEntryByAction(flow2.flowId, UPDATE_ACTION).dumps) {
             //https://github.com/telstra/open-kilda/issues/3807
 //            it.find { it.type == "stateBefore" }.groupId
             !it.find { it.type == "stateAfter" }.diverseGroupId

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowHistorySpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowHistorySpec.groovy
@@ -371,7 +371,7 @@ class FlowHistorySpec extends HealthCheckSpecification {
 
         and: "The root cause('Switch is not active') is registered in flow history"
         Wrappers.wait(WAIT_OFFSET) {
-            def flowHistory = northbound.getFlowHistory(flow.flowId).find { it.action == REROUTE_ACTION }
+            def flowHistory = flowHelper.getEarliestHistoryEntryByAction(flow.flowId, REROUTE_ACTION)
             assert flowHistory.payload[0].action == "Started flow validation"
             assert flowHistory.payload[1].action == "ValidateFlowAction failed: Flow's $flow.flowId src switch is not active"
             assert flowHistory.payload[2].action == REROUTE_FAIL

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowLoopSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowLoopSpec.groovy
@@ -261,7 +261,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
 
         and: "Flow history contains info about flowLoop"
         Wrappers.wait(WAIT_OFFSET / 2) {
-            def flowHistory = northbound.getFlowHistory(flow.flowId).last()
+            def flowHistory = flowHelper.getLatestHistoryEntry(flow.flowId)
             assert !flowHistory.dumps.find { it.type == "stateBefore" }.loopSwitchId
             assert flowHistory.dumps.find { it.type == "stateAfter" }.loopSwitchId == switchPair.dst.dpId
         }
@@ -463,7 +463,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
         northboundV2.createFlowLoop(flow.flowId, new FlowLoopPayload(switchPair.src.dpId))
         Wrappers.wait(WAIT_OFFSET) {
             assert northboundV2.getFlowStatus(flow.flowId).status == FlowState.UP
-            assert northbound.getFlowHistory(flow.flowId).last().payload.last().action == UPDATE_SUCCESS
+            assert flowHelper.getLatestHistoryEntry(flow.flowId).payload.last().action == UPDATE_SUCCESS
         }
 
         when: "Break ISL on the main path (bring port down) to init auto swap"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowMonitoringSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowMonitoringSpec.groovy
@@ -122,7 +122,7 @@ class FlowMonitoringSpec extends HealthCheckSpecification {
          * and then reroute the flow.
          */
         wait(flowSlaCheckIntervalSeconds * 2 + flowLatencySlaTimeoutSeconds + WAIT_OFFSET) {
-            def history = northbound.getFlowHistory(flow.flowId).last()
+            def history = flowHelper.getLatestHistoryEntry(flow.flowId)
             // Flow sync or flow reroute with reason "Flow latency become unhealthy"
             assert history.getAction() == "Flow paths sync"
                 || (history.details.contains("healthy") &&
@@ -177,7 +177,7 @@ and flowLatencyMonitoringReactions is disabled in featureToggle"() {
 
         then: "Flow is not rerouted because flowLatencyMonitoringReactions is disabled in featureToggle"
         sleep((flowSlaCheckIntervalSeconds * 2 + flowLatencySlaTimeoutSeconds) * 1000)
-        northbound.getFlowHistory(flow.flowId).findAll { it.action == REROUTE_ACTION }.empty
+        flowHelper.getHistoryEntriesByAction(flow.flowId, REROUTE_ACTION).isEmpty()
 
         and: "Flow path is not changed"
         pathHelper.convert(northbound.getFlowPath(flow.flowId)) == mainPath

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MirrorEndpointsSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MirrorEndpointsSpec.groovy
@@ -8,7 +8,6 @@ import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE_SWITCHES
 import static org.openkilda.functionaltests.extension.tags.Tag.TOPOLOGY_DEPENDENT
-import static org.openkilda.functionaltests.model.stats.Direction.FORWARD
 import static org.openkilda.functionaltests.model.stats.FlowStatsMetric.FLOW_RAW_BYTES
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 import static spock.util.matcher.HamcrestSupport.expect
@@ -102,7 +101,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
 
         and: "Flow history reports a successful mirror creation"
         Wrappers.wait(WAIT_OFFSET) {
-            with(northbound.getFlowHistory(flow.flowId).last()) {
+            with(flowHelper.getLatestHistoryEntry(flow.getFlowId())) {
                 action == FlowHistoryConstants.CREATE_MIRROR_ACTION
                 it.payload.last().action == FlowHistoryConstants.CREATE_MIRROR_SUCCESS
             }
@@ -183,7 +182,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
 
         then: "'Mirror point delete' operation is present in flow history"
         Wrappers.wait(WAIT_OFFSET) {
-            with(northbound.getFlowHistory(flow.flowId).last()) {
+            with(flowHelper.getLatestHistoryEntry(flow.flowId)) {
                 action == FlowHistoryConstants.DELETE_MIRROR_ACTION
                 payload.last().action == FlowHistoryConstants.DELETE_MIRROR_SUCCESS
             }
@@ -873,7 +872,7 @@ with these parameters./)
             it.destination.portNumber = mirrorPoint.sinkEndpoint.portNumber
             it.destination.vlanId = mirrorPoint.sinkEndpoint.vlanId
         }
-        northboundV2.addFlow(otherFlow)
+        flowHelperV2.addFlow(otherFlow)
 
         then: "Error is returned, cannot create flow that conflicts with mirror point"
         def error = thrown(HttpClientErrorException)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
@@ -940,7 +940,7 @@ doesn't have links with enough bandwidth, Failed to find path with requested ban
                 status == FlowState.DEGRADED.toString()
                 statusInfo == StatusInfo.OVERLAPPING_PROTECTED_PATH
             }
-            assert northbound.getFlowHistory(flow.flowId).last().payload.find { it.action == REROUTE_FAIL }
+            assert flowHelper.getLatestHistoryEntry(flow.flowId).payload.find { it.action == REROUTE_FAIL }
             assert northboundV2.getFlowHistoryStatuses(flow.flowId, 1).historyStatuses*.statusBecome == ["DEGRADED"]
         }
 
@@ -1323,8 +1323,8 @@ doesn't have links with enough bandwidth, Failed to find path with requested ban
         then: "Flow state is changed to DOWN"
         Wrappers.wait(WAIT_OFFSET) {
             assert northboundV2.getFlowStatus(flow.flowId).status == FlowState.DOWN
-            assert northbound.getFlowHistory(flow.flowId).find {
-                it.action == REROUTE_ACTION && it.taskId =~ (/.+ : retry #1 ignore_bw true/)
+            assert flowHelper.getHistoryEntriesByAction(flow.flowId, REROUTE_ACTION).find{
+                it.taskId =~ (/.+ : retry #1 ignore_bw true/)
             }?.payload?.last()?.action == REROUTE_FAIL
         }
         verifyAll(northboundV2.getFlow(flow.flowId).statusDetails) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathV1Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathV1Spec.groovy
@@ -514,8 +514,8 @@ class ProtectedPathV1Spec extends HealthCheckSpecification {
         then: "Flow state is changed to DOWN"
         Wrappers.wait(WAIT_OFFSET) {
             assert northbound.getFlowStatus(flow.id).status == FlowState.DOWN
-            assert northbound.getFlowHistory(flow.id).find {
-                it.action == REROUTE_ACTION && it.taskId =~ (/.+ : retry #1 ignore_bw true/)
+            assert flowHelper.getHistoryEntriesByAction(flow.id, REROUTE_ACTION).find {
+                it.taskId =~ (/.+ : retry #1 ignore_bw true/)
             }?.payload?.last()?.action == REROUTE_FAIL
         }
         verifyAll(northbound.getFlow(flow.id).flowStatusDetails) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/QinQFlowSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/QinQFlowSpec.groovy
@@ -180,14 +180,14 @@ class QinQFlowSpec extends HealthCheckSpecification {
         }
 
         and: "Flow history shows actual info into stateBefore and stateAfter sections"
-        def flowHistory = northbound.getFlowHistory(qinqFlow.flowId)
-        with(flowHistory.last().dumps.find { it.type == "stateBefore" }){
+        def flowHistoryEntry = flowHelper.getLatestHistoryEntry(qinqFlow.flowId)
+        with(flowHistoryEntry.dumps.find { it.type == "stateBefore" }){
             it.sourceVlan == srcVlanId
             it.sourceInnerVlan == srcInnerVlanId
             it.destinationVlan == dstVlanId
             it.destinationInnerVlan ==  dstInnerVlanId
         }
-        with(flowHistory.last().dumps.find { it.type == "stateAfter" }){
+        with(flowHistoryEntry.dumps.find { it.type == "stateAfter" }){
             it.sourceVlan == vlanFlow.source.vlanId
             it.sourceInnerVlan == vlanFlow.destination.vlanId
             it.destinationVlan == vlanFlow.destination.vlanId
@@ -327,7 +327,7 @@ class QinQFlowSpec extends HealthCheckSpecification {
         def flow = flowHelperV2.randomFlow(swP)
         flow.source.innerVlanId = srcInnerVlanId
         flow.destination.innerVlanId = dstInnerVlanId
-        northboundV2.addFlow(flow)
+        flowHelperV2.addFlow(flow)
 
         then: "Human readable error is returned"
         def exc = thrown(HttpClientErrorException)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
@@ -1060,8 +1060,8 @@ switches"() {
                 it.state == IslChangeType.FAILED
             }.size() == broughtDownPorts.size() * 2
             assert northbound.getFlowStatus(flow1.id).status == FlowState.DOWN
-            assert northbound.getFlowHistory(flow1.id).find {
-                it.action == REROUTE_ACTION && it.taskId =~ (/.+ : retry #1 ignore_bw true/)
+            assert flowHelper.getHistoryEntriesByAction(flow1.id, REROUTE_ACTION).find {
+                it.taskId =~ (/.+ : retry #1 ignore_bw true/)
             }?.payload?.last()?.action == REROUTE_FAIL
         }
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/SubFlowSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/SubFlowSpec.groovy
@@ -67,7 +67,7 @@ class SubFlowSpec extends HealthCheckSpecification {
 
         and: "Flow history doesn't contain info about illegal action"
         //create action only
-        northbound.getFlowHistory(yFlow.YFlowId).last().payload.last().action == CREATE_SUCCESS_Y
+        flowHelper.getLatestHistoryEntry(yFlow.YFlowId).payload.last().action == CREATE_SUCCESS_Y
 
         and: "Sub flow is pingable"
         verifyAll(northbound.pingFlow(subFlow.flowId, new PingInput())) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowCreateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowCreateSpec.groovy
@@ -70,9 +70,9 @@ class YFlowCreateSpec extends HealthCheckSpecification {
         northboundV2.getAllFlows()*.flowId.sort() == yFlow.subFlows*.flowId.sort()
 
         and: "History has relevant entries about y-flow creation"
-        Wrappers.wait(FLOW_CRUD_TIMEOUT) { northbound.getFlowHistory(yFlow.YFlowId).last().payload.last().action == CREATE_SUCCESS_Y }
+        Wrappers.wait(FLOW_CRUD_TIMEOUT) { flowHelper.getLatestHistoryEntry(yFlow.YFlowId).payload.last().action == CREATE_SUCCESS_Y }
         yFlow.subFlows.each { sf ->
-            Wrappers.wait(FLOW_CRUD_TIMEOUT) { assert northbound.getFlowHistory(sf.flowId).last().payload.last().action == CREATE_SUCCESS }
+            Wrappers.wait(FLOW_CRUD_TIMEOUT) { assert flowHelper.getLatestHistoryEntry(sf.flowId).payload.last().action == CREATE_SUCCESS }
         }
 
         and: "User is able to view y-flow paths"
@@ -182,10 +182,10 @@ class YFlowCreateSpec extends HealthCheckSpecification {
         }
 
         and: "History has relevant entries about y-flow deletion"
-        Wrappers.wait(FLOW_CRUD_TIMEOUT) { northbound.getFlowHistory(yFlow.YFlowId).last().payload.last().action == DELETE_SUCCESS_Y }
+        Wrappers.wait(FLOW_CRUD_TIMEOUT) { flowHelper.getLatestHistoryEntry(yFlow.YFlowId).payload.last().action == DELETE_SUCCESS_Y }
         yFlow.subFlows.each { sf ->
             Wrappers.wait(FLOW_CRUD_TIMEOUT) {
-                assert northbound.getFlowHistory(sf.flowId).last().payload.last().action == DELETE_SUCCESS
+                assert flowHelper.getLatestHistoryEntry(sf.flowId).payload.last().action == DELETE_SUCCESS
             }
         }
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowDiversitySpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowDiversitySpec.groovy
@@ -68,7 +68,7 @@ class YFlowDiversitySpec extends HealthCheckSpecification {
 
         and: "YFlows histories contains 'diverse?' information"
         [yFlow2.subFlows[0], yFlow3.subFlows[0]].each {//flow1 had no diversity at the time of creation
-            assert northbound.getFlowHistory(it.flowId).find { it.action == CREATE_ACTION }.dumps
+            assert flowHelper.getEarliestHistoryEntryByAction(it.flowId, CREATE_ACTION).dumps
                     .find { it.type == "stateAfter" }?.diverseGroupId
         }
 
@@ -80,7 +80,7 @@ class YFlowDiversitySpec extends HealthCheckSpecification {
         def yFlowsAreDeleted = true
 
         then: "YFlows' histories contain 'diverseGroupId' information in 'delete' operation"
-        verifyAll(northbound.getFlowHistory(yFlow1.subFlows[0].flowId).find { it.action == DELETE_ACTION }.dumps) {
+        verifyAll(flowHelper.getEarliestHistoryEntryByAction(yFlow1.subFlows[0].flowId, DELETE_ACTION).dumps) {
             it.find { it.type == "stateBefore" }?.diverseGroupId
             !it.find { it.type == "stateAfter" }?.diverseGroupId
         }
@@ -134,7 +134,7 @@ class YFlowDiversitySpec extends HealthCheckSpecification {
         assert involvedIslSubFlowAfterUpdate != involvedIslSimpleFlow
 
         and: "First sub flow history contains 'groupId' information"
-        verifyAll(northbound.getFlowHistory(subFlow.flowId).find { it.action == UPDATE_ACTION }.dumps) {
+        verifyAll(flowHelper.getEarliestHistoryEntryByAction(subFlow.flowId, UPDATE_ACTION).dumps) {
             !it.find { it.type == "stateBefore" }?.diverseGroupId
             it.find { it.type == "stateAfter" }?.diverseGroupId
         }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowRerouteSpec.groovy
@@ -87,10 +87,10 @@ class YFlowRerouteSpec extends HealthCheckSpecification {
         then: "The flow was rerouted after reroute delay"
         and: "History has relevant entries about y-flow reroute"
         wait(FLOW_CRUD_TIMEOUT) {
-            assert northbound.getFlowHistory(yFlow.YFlowId).last().payload.last().action == REROUTE_SUCCESS_Y
+            assert flowHelper.getLatestHistoryEntry(yFlow.getYFlowId()).payload.last().action == REROUTE_SUCCESS_Y
         }
         yFlow.subFlows.each { sf ->
-            assert northbound.getFlowHistory(sf.flowId).last().payload.last().action == REROUTE_SUCCESS
+            assert flowHelper.getLatestHistoryEntry(sf.flowId).payload.last().action == REROUTE_SUCCESS
         }
         wait(rerouteDelay + WAIT_OFFSET) {
             yFlow = northboundV2.getYFlow(yFlow.YFlowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
@@ -163,9 +163,9 @@ class SwitchesSpec extends HealthCheckSpecification {
         and: "Get all flows going through the src switch"
         Wrappers.wait(WAIT_OFFSET * 2) {
             assert northboundV2.getFlowStatus(protectedFlow.flowId).status == FlowState.DOWN
-            assert northbound.getFlowHistory(protectedFlow.flowId).last().payload.find { it.action == REROUTE_FAIL }
+            assert flowHelper.getLatestHistoryEntry(protectedFlow.flowId).payload.find { it.action == REROUTE_FAIL }
             assert northboundV2.getFlowStatus(defaultFlow.flowId).status == FlowState.DOWN
-            def defaultFlowHistory = northbound.getFlowHistory(defaultFlow.flowId).findAll { it.action == REROUTE_ACTION }
+            def defaultFlowHistory = flowHelper.getHistoryEntriesByAction(defaultFlow.flowId, REROUTE_ACTION)
             assert defaultFlowHistory.last().payload.find { it.action == REROUTE_FAIL }
         }
         def getSwitchFlowsResponse6 = northbound.getSwitchFlows(switchPair.src.dpId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/toggles/FeatureTogglesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/toggles/FeatureTogglesSpec.groovy
@@ -35,7 +35,7 @@ class FeatureTogglesSpec extends HealthCheckSpecification {
         def disableFlowCreation = northbound.toggleFeature(FeatureTogglesDto.builder().createFlowEnabled(false).build())
 
         and: "Try to create a new flow"
-        northbound.addFlow(flowHelper.randomFlow(topology.activeSwitches[0], topology.activeSwitches[1]))
+        flowHelper.addFlow(flowHelper.randomFlow(topology.activeSwitches[0], topology.activeSwitches[1]))
 
         then: "Error response is returned, explaining that feature toggle doesn't allow such operation"
         def e = thrown(HttpClientErrorException)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/ChaosSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/ChaosSpec.groovy
@@ -40,7 +40,7 @@ class ChaosSpec extends HealthCheckSpecification {
         List<FlowRequestV2> flows = []
         flowsAmount.times {
             def flow = flowHelperV2.randomFlow(*topologyHelper.randomSwitchPair, false, flows)
-            northboundV2.addFlow(flow)
+            flowHelperV2.addFlow(flow)
             flows << flow
         }
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/FloodlightKafkaConnectionSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/FloodlightKafkaConnectionSpec.groovy
@@ -105,7 +105,7 @@ class FloodlightKafkaConnectionSpec extends HealthCheckSpecification {
                     updatedRegions[pair.src.dpId] != updatedRegions[pair.dst.dpId]
         }
         def flow = flowHelperV2.randomFlow(swPair)
-        northboundV2.addFlow(flow)
+        flowHelperV2.attemptToAddFlow(flow)
         wait(WAIT_OFFSET * 2) { //FL may be a bit laggy right after comming up, so this may take a bit longer than usual
             assert northboundV2.getFlowStatus(flow.flowId).status == FlowState.UP }
         northbound.validateFlow(flow.flowId).each { assert it.asExpected }


### PR DESCRIPTION
Implements #5390

* Replaced direct Northbound calls to create flows with helper method (for safety) where
possible
* Method FlowHelperV2.addFlow() now accepts expected flow state as an optional parameter
* Added several FlowHelper methods to retrieve history entries easier