### PR TITLE
#5390: [TEST] Fix for flaky Server42 tests

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowPingSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowPingSpec.groovy
@@ -81,7 +81,7 @@ class HaFlowPingSpec extends HealthCheckSpecification {
         timedLoop(pingInterval + WAIT_OFFSET) {
             [haFlow.subFlows*.flowId, [FORWARD, REVERSE]].combinations().each {String flowId, Direction direction ->
                     def stats = flowStats.latencyOf(flowId).get(LATENCY, direction)
-                    assert stats != null && !stats.hasNonZeroValuesAfter(afterUpdateTime)
+                    assert stats != null && !stats.hasNonZeroValuesAfter(afterUpdateTime + 1000)
             }
         }
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/server42/Server42FlowRttSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/server42/Server42FlowRttSpec.groovy
@@ -516,7 +516,9 @@ class Server42FlowRttSpec extends HealthCheckSpecification {
         }
 
         and: "server42 stats are not available any more for the flow1 in the forward direction"
-        !flowStats.rttOf(flow1.getFlowId()).get(FLOW_RTT, FORWARD).hasNonZeroValuesAfter(timeWhenEndpointWereSwapped)
+        //give one second extra after swap
+        !flowStats.rttOf(flow1.getFlowId()).get(FLOW_RTT, FORWARD)
+                .hasNonZeroValuesAfter(timeWhenEndpointWereSwapped + 1000)
 
         cleanup:
         flow1 && flowHelperV2.deleteFlow(flow1.flowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/server42/Server42IslRttSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/server42/Server42IslRttSpec.groovy
@@ -665,7 +665,8 @@ class Server42IslRttSpec extends HealthCheckSpecification {
         if (statExist) {
             assert stats.hasNonZeroValuesAfter(checkpointTime.getTime())
         } else {
-            assert stats == null || !stats.hasNonZeroValuesAfter(checkpointTime.getTime())
+            //give 1 second between stop collecting stats command and actual stopping of stats collection
+            assert stats == null || !stats.hasNonZeroValuesAfter(checkpointTime.getTime() + 1000)
         }
     }
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/FlowStatSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/FlowStatSpec.groovy
@@ -101,8 +101,8 @@ class FlowStatSpec extends HealthCheckSpecification {
             statsHelper."force kilda to collect stats"()
             def newStats = flowStats.of(flow.getFlowId())
             assert newStats.get(FLOW_RAW_BYTES, srcSwitchId, mainForwardCookie).getNewestTimeStamp() ==
-                    stats.get(FLOW_RAW_BYTES, srcSwitchId, mainForwardCookie).getNewestTimeStamp() &&
-            newStats.get(FLOW_RAW_BYTES, srcSwitchId, mainReverseCookie).getNewestTimeStamp() ==
+                    stats.get(FLOW_RAW_BYTES, srcSwitchId, mainForwardCookie).getNewestTimeStamp()
+            assert newStats.get(FLOW_RAW_BYTES, srcSwitchId, mainReverseCookie).getNewestTimeStamp() ==
                     stats.get(FLOW_RAW_BYTES, srcSwitchId, mainReverseCookie).getNewestTimeStamp()
             stats = newStats
         }


### PR DESCRIPTION
Implements #5390

* Added one second of shift to avoid failing s42 statistics test on race condition when
stats stop to be collected
* Split failing flow stats test assertion to get better understanding why it's failing.