### PR TITLE
Fix a bug when a misconfigured rule with incorrect cookie is not re-installed.

### DIFF
--- a/src-java/swmanager-topology/swmanager-storm-topology/src/main/java/org/openkilda/wfm/topology/switchmanager/fsm/SwitchSyncFsm.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/main/java/org/openkilda/wfm/topology/switchmanager/fsm/SwitchSyncFsm.java
@@ -299,6 +299,9 @@ public class SwitchSyncFsm extends AbstractBaseFsm<SwitchSyncFsm, SwitchSyncStat
                 List<FlowSpeakerData> misconfiguredRulesToInstall = validationResult.getExpectedEntries().stream()
                         .filter(entry -> entry instanceof FlowSpeakerData)
                         .map(entry -> (FlowSpeakerData) entry)
+                        //This filter cannot find the actual rule to install if the misconfigured rule has an incorrect
+                        //cookie. The misconfigured rule will be removed here and the proper rule is installed because
+                        //SwitchValidation marks the same rule as a missing one.
                         .filter(flowEntry -> reinstalledRulesCookies.contains(flowEntry.getCookie().getValue()))
                         .collect(Collectors.toList());
                 toInstall.addAll(misconfiguredRulesToInstall);

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/service/impl/ValidationServiceImplTest.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/service/impl/ValidationServiceImplTest.java
@@ -21,6 +21,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -630,7 +631,10 @@ public class ValidationServiceImplTest {
                 true);
 
         assertTrue(response.getExcessRules().isEmpty());
-        assertTrue(response.getMissingRules().isEmpty());
+        assertFalse(response.getMissingRules().isEmpty(),
+                "The rule is considered missing, because the misconfigured rule has an incorrect cookie "
+                        + "and SwitchSync has no way to pick the correct rule for installation using this cookie.");
+        assertNotEquals(expected.get(0).getCookie(), misconfigured.getCookie());
         assertFalse(response.getMisconfiguredRules().isEmpty());
         assertTrue(response.getProperRules().isEmpty());
         assertFalse(response.isAsExpected());


### PR DESCRIPTION
This fix marks a misconfigured rule with an incorrect cookie as missing. Because of this change switch sync will remove the misconfigured rule because it is in the list of misconfigured and it will install the proper rule because it is in the list of missing rules.
It means that the same rule could be places in both categories. However, when doing the sync operation, these rules are distinct: a missing rule to install has the proper cookie, a misconfigured rule to remove has another cookie.

When performing the same reproductions steps as in the linked issue, now the validate response has the misconfigured rules in both "misconfigured" and "missing" and the sync response has fix for both of them simultaneously: remove misconfigured (with the wrong cookie) and install the correct one (with the correct cookie).