### PR TITLE
Use new instance of cache map instead of cleaning

### DIFF
--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/service/ActionService.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/service/ActionService.java
@@ -66,7 +66,7 @@ public class ActionService implements FlowSlaMonitoringCarrier {
     private final int shardCount;
 
     @VisibleForTesting
-    protected Map<FsmKey, FlowLatencyMonitoringFsm> fsms = new HashMap<>();
+    protected Map<FsmKey, FlowLatencyMonitoringFsm> fsms = createNewFsmMapInstance();
 
     public ActionService(FlowOperationsCarrier carrier, PersistenceManager persistenceManager,
                          Clock clock, Duration timeout, float threshold, int shardCount) {
@@ -181,7 +181,7 @@ public class ActionService implements FlowSlaMonitoringCarrier {
      * Remove all current fsms.
      */
     public void purge() {
-        fsms.clear();
+        fsms = createNewFsmMapInstance();
     }
 
     @Override
@@ -242,5 +242,13 @@ public class ActionService implements FlowSlaMonitoringCarrier {
     private static class FsmKey {
         String flowId;
         FlowDirection direction;
+    }
+
+    /**
+     * Instead of map.clear() we are creating a new map here.
+     * We need it because map.clear() doesn't shrink already allocated map capacity, size of which can be significant.
+     */
+    private static Map<FsmKey, FlowLatencyMonitoringFsm> createNewFsmMapInstance() {
+        return new HashMap<>();
     }
 }

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/service/FlowCacheService.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/service/FlowCacheService.java
@@ -50,7 +50,7 @@ public class FlowCacheService {
     private final Duration flowRttStatsExpirationTime;
     private final FlowCacheBoltCarrier carrier;
     private boolean active;
-    private final Map<String, FlowState> flowStates;
+    private Map<String, FlowState> flowStates;
     private final FlowRepository flowRepository;
     private final HaSubFlowRepository haSubFlowRepository;
 
@@ -59,7 +59,7 @@ public class FlowCacheService {
         this.clock = clock;
         this.flowRttStatsExpirationTime = flowRttStatsExpirationTime;
         this.carrier = carrier;
-        flowStates = new HashMap<>();
+        flowStates = createNewFlowStateInstance();
         active = false;
         flowRepository = persistenceManager.getRepositoryFactory().createFlowRepository();
         haSubFlowRepository = persistenceManager.getRepositoryFactory().createHaSubFlowRepository();
@@ -153,7 +153,7 @@ public class FlowCacheService {
      */
     public void deactivate() {
         if (active) {
-            flowStates.clear();
+            flowStates = createNewFlowStateInstance();
             log.info("Flow cache cleared.");
             active = false;
         }
@@ -206,5 +206,13 @@ public class FlowCacheService {
     @VisibleForTesting
     protected boolean flowStatesIsEmpty() {
         return flowStates.isEmpty();
+    }
+
+    /**
+     * Instead of map.clear() we are creating a new map here.
+     * We need it because map.clear() doesn't shrink already allocated map capacity, size of which can be significant.
+     */
+    private static Map<String, FlowState> createNewFlowStateInstance() {
+        return new HashMap<>();
     }
 }

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/service/IslCacheService.java
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/src/main/java/org/openkilda/wfm/topology/flowmonitoring/service/IslCacheService.java
@@ -49,7 +49,7 @@ public class IslCacheService {
         this.clock = clock;
         this.islRttLatencyExpiration = islRttLatencyExpiration;
         active = false;
-        linkStates = new HashMap<>();
+        linkStates = createNewLinkStateInstance();
         islRepository = persistenceManager.getRepositoryFactory().createIslRepository();
     }
 
@@ -74,7 +74,7 @@ public class IslCacheService {
      */
     public void deactivate() {
         if (active) {
-            linkStates.clear();
+            linkStates = createNewLinkStateInstance();
             log.info("Isl cache cleared.");
             active = false;
         }
@@ -167,5 +167,13 @@ public class IslCacheService {
     @VisibleForTesting
     protected boolean linkStatesIsEmpty() {
         return linkStates.isEmpty();
+    }
+
+    /**
+     * Instead of map.clear() we are creating a new map here.
+     * We need it because map.clear() doesn't shrink already allocated map capacity, size of which can be significant.
+     */
+    private Map<Link, LinkState> createNewLinkStateInstance() {
+        return new HashMap<>();
     }
 }

--- a/src-java/opentsdb-topology/opentsdb-storm-topology/src/main/java/org/openkilda/wfm/topology/opentsdb/models/Storage.java
+++ b/src-java/opentsdb-topology/opentsdb-storm-topology/src/main/java/org/openkilda/wfm/topology/opentsdb/models/Storage.java
@@ -36,10 +36,10 @@ public class Storage implements Serializable {
     public static final char TAG_VALUE_DELIMITER = ':';
     public static final String NULL_TAG = "NULL_TAG";
 
-    private final Map<String, DatapointValue> map;
+    private Map<String, DatapointValue> map;
 
     public Storage() {
-        this.map = new HashMap<>();
+        this.map = createNewMapInstance();
     }
 
     public void add(Datapoint datapoint) {
@@ -50,9 +50,15 @@ public class Storage implements Serializable {
         return map.get(createKey(datapoint));
     }
 
+    /**
+     * Removes datapoints from the storage if they are older than now() - ttlInMillis.
+     */
     public void removeOutdated(long ttlInMillis) {
         long now = System.currentTimeMillis();
         map.entrySet().removeIf(entry -> now - entry.getValue().getTime() > ttlInMillis);
+        if (map.isEmpty()) {
+            map = createNewMapInstance();
+        }
     }
 
     public int size() {
@@ -93,6 +99,14 @@ public class Storage implements Serializable {
             sortedTags.put(key, entry.getValue());
         }
         return sortedTags;
+    }
+
+    /**
+     * Instead of map.clear() we are creating a new map here.
+     * We need it because map.clear() doesn't shrink already allocated map capacity, size of which can be significant.
+     */
+    private static Map<String, DatapointValue> createNewMapInstance() {
+        return new HashMap<>();
     }
 
     @Value

--- a/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/KildaEntryCacheService.java
+++ b/src-java/stats-topology/stats-storm-topology/src/main/java/org/openkilda/wfm/topology/stats/service/KildaEntryCacheService.java
@@ -95,12 +95,11 @@ public class KildaEntryCacheService {
     /**
      * Cookie to flow and meter to flow maps.
      */
-    private final HashSetValuedHashMap<CookieCacheKey, KildaEntryDescriptor> cookieToFlow =
-            new HashSetValuedHashMap<>();
-    private final HashSetValuedHashMap<MeterCacheKey, KildaEntryDescriptor> switchAndMeterToFlow =
-            new HashSetValuedHashMap<>();
-    private final HashSetValuedHashMap<GroupCacheKey, KildaEntryDescriptor> switchAndGroupToFlow =
-            new HashSetValuedHashMap<>();
+    private HashSetValuedHashMap<CookieCacheKey, KildaEntryDescriptor> cookieToFlow = createNewCookieCacheInstance();
+    private HashSetValuedHashMap<MeterCacheKey, KildaEntryDescriptor> switchAndMeterToFlow =
+            createNewMeterCacheInstance();
+    private HashSetValuedHashMap<GroupCacheKey, KildaEntryDescriptor> switchAndGroupToFlow =
+            createNewGroupCacheInstance();
 
     public KildaEntryCacheService(PersistenceManager persistenceManager, KildaEntryCacheCarrier carrier) {
         RepositoryFactory repositoryFactory = persistenceManager.getRepositoryFactory();
@@ -548,8 +547,32 @@ public class KildaEntryCacheService {
     }
 
     private void clearCache() {
-        cookieToFlow.clear();
-        switchAndMeterToFlow.clear();
-        switchAndGroupToFlow.clear();
+        cookieToFlow = createNewCookieCacheInstance();
+        switchAndMeterToFlow = createNewMeterCacheInstance();
+        switchAndGroupToFlow = createNewGroupCacheInstance();
+    }
+
+    /**
+     * Instead of map.clear() we are creating a new map here.
+     * We need it because map.clear() doesn't shrink already allocated map capacity, size of which can be significant.
+     */
+    private static HashSetValuedHashMap<CookieCacheKey, KildaEntryDescriptor> createNewCookieCacheInstance() {
+        return new HashSetValuedHashMap<>();
+    }
+
+    /**
+     * Instead of map.clear() we are creating a new map here.
+     * We need it because map.clear() doesn't shrink already allocated map capacity, size of which can be significant.
+     */
+    private static HashSetValuedHashMap<MeterCacheKey, KildaEntryDescriptor>  createNewMeterCacheInstance() {
+        return new HashSetValuedHashMap<>();
+    }
+
+    /**
+     * Instead of map.clear() we are creating a new map here.
+     * We need it because map.clear() doesn't shrink already allocated map capacity, size of which can be significant.
+     */
+    private static HashSetValuedHashMap<GroupCacheKey, KildaEntryDescriptor> createNewGroupCacheInstance() {
+        return new HashSetValuedHashMap<>();
     }
 }


### PR DESCRIPTION
Creation of a new map instance was used instead of map.clear() to clear a cache. We need it because map.clear() doesn't shrink already allocated map capacity, size of which can be significant.

INFO for QAs: 
Following topologies was updated:
* otsdb
* flow monitoring
* stats

How to check that PR works correctly:
1. Create a flow.
2. Deactivate and activate back each topology. Here you can find how to do it: https://github.com/telstra/open-kilda/issues/5455 (step 2).
3. Check
* stats topology - there are fresh otsdb/victoria metrics for the flow like `kilda.flow.packets`
* flow monitoring - there are fresh otsdb/victoria metrics `kilda.flow.rtt` with tag `origin=flow-monitoring` (can be missed if server42 is active for the flow)
* otsdb topology - there are any fresh metric in otsdb/victoria

