### PR TITLE
Fix a bug with writing history before the history event is created.

### DIFF
--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowProcessingWithHistorySupportFsm.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/FlowProcessingWithHistorySupportFsm.java
@@ -142,7 +142,8 @@ public abstract class FlowProcessingWithHistorySupportFsm<T extends AbstractStat
     }
 
     /**
-     * Add a history record on the new event.
+     * Add a history record on the new event. Pay attention that this method prepends the Flow ID to the task ID,
+     * which is later used for fetching the history. If other methods in an FSM don't do the same, the history is lost.
      */
     public void saveNewEventToHistory(String flowId, String action, FlowEventData.Event event) {
         String taskId = KeyProvider.joinKeys(flowId, getCommandContext().getCorrelationId());

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/CreateNewHistoryEventAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/common/actions/CreateNewHistoryEventAction.java
@@ -1,0 +1,43 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.fsm.common.actions;
+
+import org.openkilda.persistence.PersistenceManager;
+import org.openkilda.wfm.share.history.model.FlowEventData;
+import org.openkilda.wfm.topology.flowhs.fsm.common.FlowProcessingWithHistorySupportFsm;
+
+/**
+ * This action is useful to execute before any other actions in an FSM. This way you don't need to worry about
+ * creating a new history event and focus on business logic.
+ * @param <T> State machine type must support sending history, the persistence and the Flow ID must be available
+ * @param <S> State type is generic
+ * @param <E> Event type is generic
+ * @param <C> Context type is generic
+ */
+public class CreateNewHistoryEventAction<T extends FlowProcessingWithHistorySupportFsm<T, S, E, C, ?, ?>, S, E, C>
+        extends FlowProcessingWithHistorySupportAction<T, S, E, C> {
+    private final FlowEventData.Event historyEvent;
+
+    public CreateNewHistoryEventAction(PersistenceManager persistenceManager, FlowEventData.Event historyEvent) {
+        super(persistenceManager);
+        this.historyEvent = historyEvent;
+    }
+
+    @Override
+    protected void perform(S from, S to, E event, C context, T stateMachine) {
+        stateMachine.saveNewEventToHistory("A new history event is created.", historyEvent);
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/create/actions/FlowValidateAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/create/actions/FlowValidateAction.java
@@ -21,7 +21,6 @@ import org.openkilda.messaging.error.InvalidFlowException;
 import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.persistence.repositories.KildaFeatureTogglesRepository;
 import org.openkilda.persistence.repositories.RepositoryFactory;
-import org.openkilda.wfm.share.history.model.FlowEventData;
 import org.openkilda.wfm.share.logger.FlowOperationsDashboardLogger;
 import org.openkilda.wfm.topology.flowhs.exception.FlowProcessingException;
 import org.openkilda.wfm.topology.flowhs.fsm.common.actions.NbTrackableWithHistorySupportAction;
@@ -79,12 +78,8 @@ public class FlowValidateAction extends
 
         stateMachine.setTargetFlow(request);
 
-        if (event != Event.RETRY) {
-            stateMachine.saveNewEventToHistory("Flow was validated successfully", FlowEventData.Event.CREATE);
-        } else {
-            // no need to save a new event into DB, it should already exist there.
-            stateMachine.saveActionToHistory("Flow was validated successfully");
-        }
+        stateMachine.saveActionToHistory("Flow was validated successfully",
+                event == Event.RETRY ? "Retrying the operation" : null);
 
         return Optional.empty();
     }


### PR DESCRIPTION
This is a proposal how to fix the issue of saving a history action before the parent history event is created. If this is acceptable, then we can do the same for other FSMs. The same issue is reproducible at least for HA flow.

closes #4738 