### PR TITLE
#5390: [TEST] Debug enabled for flaky Flow Monitoring spec

### DIFF
--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/Wrappers.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/Wrappers.groovy
@@ -3,6 +3,8 @@ package org.openkilda.functionaltests.helpers
 import groovy.transform.InheritConstructors
 import groovy.util.logging.Slf4j
 
+import static java.lang.System.currentTimeMillis
+
 @Slf4j
 class Wrappers {
 
@@ -67,8 +69,8 @@ class Wrappers {
      * @param closure code to repeat in a loop
      */
     static void timedLoop(double timeout, Closure closure) {
-        long endTime = System.currentTimeMillis() + (long) (timeout * 1000)
-        while (System.currentTimeMillis() < endTime) {
+        long endTime = currentTimeMillis() + (long) (timeout * 1000)
+        while (currentTimeMillis() < endTime) {
             closure.call()
         }
     }
@@ -84,13 +86,16 @@ class Wrappers {
      * @return True if wait was successful, throws WaitTimeoutException otherwise
      */
     static boolean wait(double timeout, double retryInterval = 0.5, Closure closure) {
-        long endTime = System.currentTimeMillis() + (long) (timeout * 1000)
+        long endTime = currentTimeMillis() + (long) (timeout * 1000)
         long sleepTime = (long) (retryInterval * 1000)
         Throwable thrown = null
-        while (System.currentTimeMillis() < endTime) {
+        while (currentTimeMillis() < endTime) {
             try {
                 def result = closure.call()
                 if (result || result == null) {
+                    log.debug("Closure: ${closure.toString()}\n" +
+                            "Took ${(currentTimeMillis() - (endTime - (long) (timeout * 1000))) * 1000} seconds\n" +
+                            "Limit was ${timeout} seconds")
                     return true
                 } else {
                     thrown = null
@@ -112,12 +117,12 @@ class Wrappers {
      * @return result of the given closure
      */
     static def benchmark(name, closure) {
-        def start = System.currentTimeMillis()
+        def start = currentTimeMillis()
         def result
         try {
             result = closure.call()
         } finally {
-            def now = System.currentTimeMillis()
+            def now = currentTimeMillis()
             log.debug("$name took " + (now - start) + "ms")
         }
         return result

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowMonitoringSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowMonitoringSpec.groovy
@@ -15,6 +15,7 @@ import static org.openkilda.functionaltests.helpers.Wrappers.wait
 import static org.openkilda.functionaltests.model.stats.Direction.FORWARD
 import static org.openkilda.functionaltests.model.stats.Direction.REVERSE
 import static org.openkilda.functionaltests.model.stats.FlowStatsMetric.FLOW_RTT
+import static org.openkilda.functionaltests.model.stats.Origin.FLOW_MONITORING
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
@@ -97,7 +98,7 @@ class FlowMonitoringSpec extends HealthCheckSpecification {
         flowHelperV2.addFlow(flow)
         //wait for generating some flow-monitoring stats
         wait(flowSlaCheckIntervalSeconds + WAIT_OFFSET) {
-            flowStats.rttOf(flow.getFlowId()).get(FLOW_RTT, FORWARD).hasNonZeroValues()
+            assert flowStats.rttOf(flow.getFlowId()).get(FLOW_RTT, FORWARD, FLOW_MONITORING).hasNonZeroValues()
         }
 
         def path = northbound.getFlowPath(flow.flowId)
@@ -160,7 +161,7 @@ and flowLatencyMonitoringReactions is disabled in featureToggle"() {
         flowHelperV2.addFlow(flow)
         //wait for generating some flow-monitoring stats
         wait(flowSlaCheckIntervalSeconds + WAIT_OFFSET) {
-            flowStats.rttOf(flow.getFlowId()).get(FLOW_RTT, REVERSE).hasNonZeroValues()
+            assert flowStats.rttOf(flow.getFlowId()).get(FLOW_RTT, REVERSE, FLOW_MONITORING).hasNonZeroValues()
         }
         pathHelper.convert(northbound.getFlowPath(flow.flowId)) == mainPath
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/StormLcmSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/StormLcmSpec.groovy
@@ -140,7 +140,7 @@ class StormLcmSpec extends HealthCheckSpecification {
         !networkDeployed && wfmManipulator.deployTopology("network")
         srcBlockData && lockKeeper.reviveSwitch(islUnderTest.srcSwitch, srcBlockData)
         dstBlockData && lockKeeper.reviveSwitch(islUnderTest.dstSwitch, dstBlockData)
-        Wrappers.wait(WAIT_OFFSET + discoveryTimeout) {
+        Wrappers.wait(discoveryTimeout + WAIT_OFFSET * 3) {
             assert database.getIsls(topology.getIsls()).every {it.status == IslStatus.ACTIVE}
             assert northbound.getAllLinks().every {it.state == IslChangeType.DISCOVERED}
         }


### PR DESCRIPTION
Implements #5390

* Failing Flow Monitoring tests now show why they can't find RTT stats
* Increased timeout to wait for links to resurrect after storm restart
* Added debug log to store the actual time of waiting in Wrappers.wait() method