### PR TITLE
#5390: [TEST] Avoid possibility of Y-Flow's subflows vlan conflict

### DIFF
--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/YFlowHelper.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/YFlowHelper.groovy
@@ -73,7 +73,7 @@ class YFlowHelper {
                 .portNumber(randomEndpointPort(sharedSwitch, useTraffgenPorts, busyEndpoints))
                 .build()
         def subFlows = [firstSwitch, secondSwitch].collect {sw ->
-            def seVlan = randomVlan()
+            def seVlan = randomVlan(busyEndpoints*.vlan)
             busyEndpoints << new SwitchPortVlan(se.switchId, se.portNumber, seVlan)
             def ep = SubFlowUpdatePayload.builder()
                     .sharedEndpoint(YFlowSharedEndpointEncapsulation.builder().vlanId(seVlan).build())
@@ -117,11 +117,11 @@ class YFlowHelper {
 
         def subFlows = (0..1).collect {
             def payload = Wrappers.retry(3, 0) {
-                def seVlan = randomVlan()
+                def seVlan = randomVlan(busyEndpoints*.vlan)
                 if (busyEndpoints.contains(new SwitchPortVlan(sw.dpId, sePort, seVlan))) {
                     throw new Exception("Generated sub-flow conflicts with existing endpoints.")
                 }
-                def epVlan = randomVlan();
+                def epVlan = randomVlan(busyEndpoints*.vlan);
                 if (busyEndpoints.contains(new SwitchPortVlan(sw.dpId, epPort, epVlan))) {
                     throw new Exception("Generated sub-flow conflicts with existing endpoints.")
                 }
@@ -264,7 +264,7 @@ class YFlowHelper {
      */
     private FlowEndpointV2 randomEndpoint(Switch sw, boolean useTraffgenPorts = true, List<SwitchPortVlan> busyEps) {
         return new FlowEndpointV2(
-                sw.dpId, randomEndpointPort(sw, useTraffgenPorts, busyEps), randomVlan(),
+                sw.dpId, randomEndpointPort(sw, useTraffgenPorts, busyEps), randomVlan(busyEps*.vlan),
                 new DetectConnectedDevicesV2(false, false))
     }
 
@@ -291,8 +291,8 @@ class YFlowHelper {
         return port
     }
 
-    private int randomVlan() {
-        return KILDA_ALLOWED_VLANS.shuffled().first()
+    private int randomVlan(List<Integer> busyVlans = []) {
+        return (KILDA_ALLOWED_VLANS - busyVlans).shuffled().first()
     }
 
     private String generateDescription() {


### PR DESCRIPTION
Implements #5390

* Fixes rare problem when the same vlan id chosen randomly for Y-Flow's subflows.