### PR TITLE
#5390: [TEST] Fix flaky HA-Flow ping test

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/VxlanFlowSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/VxlanFlowSpec.groovy
@@ -140,10 +140,12 @@ class VxlanFlowSpec extends HealthCheckSpecification {
             northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
         }
 
-        and: "Flow is pingable"
-        verifyAll(northbound.pingFlow(flow.flowId, new PingInput())) {
-            forward.pingSuccess
-            reverse.pingSuccess
+        and: "Flow is pingable (though sometimes we have to wait)"
+        Wrappers.wait(WAIT_OFFSET) {
+            verifyAll(northbound.pingFlow(flow.flowId, new PingInput())) {
+                forward.pingSuccess
+                reverse.pingSuccess
+            }
         }
 
         and: "Rules are recreated"

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/tsdb/model/StatsResult.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/tsdb/model/StatsResult.java
@@ -62,7 +62,7 @@ public class StatsResult {
 
     public boolean hasNonZeroValuesAfter(long timestamp) {
         return dataPoints.keySet().stream()
-                .anyMatch(tstamp -> tstamp >= timestamp && dataPoints.get(tstamp) > 0);
+                .anyMatch(tstamp -> tstamp >= timestamp && dataPoints.get(tstamp) != 0);
     }
 
     public boolean hasValue(long expectedValue) {


### PR DESCRIPTION
Implements #5390

* Fixed incorrect condition in StatsResult.hasNonZeroValuesAfter() method which caused test to fail sometimes.
* Added waiter for ping success after changing flow incapsulation (seems like there was a race condition, when FlowFetcher couldn't receive flow incapsulation after flow update)