### PR TITLE
Remove the deprecated authentication plugin for the MySQL container.

### DIFF
--- a/confd/templates/docker-compose/docker-compose.tmpl
+++ b/confd/templates/docker-compose/docker-compose.tmpl
@@ -127,7 +127,7 @@ services:
   mysql_db:
     hostname: mysql.pendev
     image: mysql:8.0.34
-    command: --default-authentication-plugin=mysql_native_password
+    command: --default-authentication-plugin=caching_sha2_password
     volumes:
       - ./docker/mysql/setup_data:/docker-entrypoint-initdb.d
       - sql_data:/var/lib/mysql


### PR DESCRIPTION
After this fix the newly created MySQL container no longer uses the deprecated authentication plugin and uses the recommended one.
In order to test, deploy OpenKilda, find the ID of the MySQL container:
```bash
docker ps | grep mysql
```
and then display the logs of that container:
```bash
docker logs be35
```
note that there are no more warning messages in the log about the deprecated authentication plugin.

closes #5460 