### PR TITLE
[TEST] Refactoring the way to choose switch pairs for test

### DIFF
--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/TopologyHelper.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/TopologyHelper.groovy
@@ -41,60 +41,12 @@ class TopologyHelper {
     @Autowired
     FloodlightsHelper flHelper
 
-    /**
-     * Get a switch pair of random switches.
-     *
-     * @param forceDifferent whether to exclude the picked src switch when looking for dst switch
-     * @deprecated Use new mechanism from org.openkilda.functionaltests.helpers.model.SwitchPairs class
-     */
-    @Deprecated
-    Tuple2<Switch, Switch> getRandomSwitchPair(boolean forceDifferent = true) {
-        def randomSwitch = { List<Switch> switches ->
-            switches[new Random().nextInt(switches.size())]
-        }
-        def src = randomSwitch(topology.activeSwitches)
-        def dst = randomSwitch(forceDifferent ? topology.activeSwitches - src : topology.activeSwitches)
-        return new Tuple2(src, dst)
+    List<SwitchPair> getAllSwitchPairs(boolean includeReverse = true) {
+        return getSwitchPairs(includeReverse)
     }
 
-    SwitchPairs getAllSwitchPairs(boolean includeReverse = false) {
-        return new SwitchPairs(getSwitchPairs(includeReverse))
-    }
-
-    /**
-     * @deprecated Use new mechanism from org.openkilda.functionaltests.helpers.model.SwitchPairs class
-     */
-    @Deprecated
-    SwitchPair getSingleSwitchPair() {
-        return SwitchPair.singleSwitchInstance(topology.activeSwitches.first())
-    }
-
-    /**
-     * @deprecated Use new mechanism from org.openkilda.functionaltests.helpers.model.SwitchPairs class
-     */
-    @Deprecated
     List<SwitchPair> getAllSingleSwitchPairs() {
         return topology.activeSwitches.collect { SwitchPair.singleSwitchInstance(it) }
-    }
-
-    /**
-     * @deprecated Use new mechanism from org.openkilda.functionaltests.helpers.model.SwitchPairs class
-     */
-    @Deprecated
-    SwitchPair getNeighboringSwitchPair() {
-        getSwitchPairs().find {
-            it.paths.min { it.size() }?.size() == 2
-        }
-    }
-
-    /**
-     * @deprecated Use new mechanism from org.openkilda.functionaltests.helpers.model.SwitchPairs class
-     */
-    @Deprecated
-    SwitchPair getNotNeighboringSwitchPair() {
-        getSwitchPairs().find {
-            it.paths.min { it.size() }?.size() > 2
-        }
     }
 
     /**
@@ -208,9 +160,9 @@ class TopologyHelper {
     }
 
     SwitchTriplet findSwitchTripletWithSharedEpInTheMiddleOfTheChain() {
-        def pairSharedEpAndEp1 = getAllSwitchPairs().neighbouring().random()
+        def pairSharedEpAndEp1 = new SwitchPairs(getAllSwitchPairs()).neighbouring().random()
         //shared endpoint should be in the middle of the switches chain to deploy ha-flow without shared path
-        def pairEp1AndEp2 = getAllSwitchPairs().neighbouring().excludePairs([pairSharedEpAndEp1]).includeSwitch(pairSharedEpAndEp1.src).random()
+        def pairEp1AndEp2 = new SwitchPairs(getAllSwitchPairs()).neighbouring().excludePairs([pairSharedEpAndEp1]).includeSwitch(pairSharedEpAndEp1.src).random()
         Switch thirdSwitch = pairSharedEpAndEp1.src == pairEp1AndEp2.dst ? pairEp1AndEp2.src : pairEp1AndEp2.dst
         return switchTriplets.find {
                     it.shared.dpId == pairSharedEpAndEp1.src.dpId

--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/model/SwitchPairs.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/model/SwitchPairs.groovy
@@ -1,54 +1,85 @@
 package org.openkilda.functionaltests.helpers.model
 
+import org.openkilda.functionaltests.helpers.SwitchHelper
+import org.openkilda.functionaltests.helpers.TopologyHelper
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Scope
+import org.springframework.stereotype.Component
+
 import static org.junit.jupiter.api.Assumptions.assumeFalse
 
 import org.openkilda.testing.model.topology.TopologyDefinition.Switch
 
+import static org.openkilda.model.SwitchFeature.NOVIFLOW_COPY_FIELD
+import static org.springframework.beans.factory.config.ConfigurableBeanFactory.SCOPE_PROTOTYPE
+
 /**
  * Class which simplifies search for corresponding switch pair. Just chain existing methods to combine requirements
- * Usage: topologyHelper.getAllSwitchPairs()
+ * Usage: switchPairs.all()
  * .nonNeighouring()
  * .withAllTraffgerns()
  * .random()
  * Also it eliminates need to verify if no switch can be found (skips test immediately)
  */
+
+@Component
+@Scope(SCOPE_PROTOTYPE)
 class SwitchPairs {
-    private List<SwitchPair> switchPairs
+    List<SwitchPair> switchPairs
+    @Autowired
+    SwitchHelper switchHelper
+    @Autowired
+    TopologyHelper topologyHelper
 
     SwitchPairs(List<SwitchPair> switchPairs) {
         this.switchPairs = switchPairs
     }
 
+    SwitchPairs all(Boolean includeReverse = true) {
+        switchPairs = topologyHelper.getAllSwitchPairs(includeReverse)
+        return this
+    }
+
+    SwitchPairs singleSwitch() {
+        switchPairs = topologyHelper.getAllSingleSwitchPairs()
+        return this
+    }
+
     SwitchPairs withAtLeastNNonOverlappingPaths(int nonOverlappingPaths) {
-        return new SwitchPairs(switchPairs.findAll {
-            it.paths.unique(false) { a, b -> a.intersect(b) == [] ? 1 : 0 }.size() >= nonOverlappingPaths})
+        switchPairs = switchPairs.findAll {
+            it.paths.unique(false) { a, b -> a.intersect(b) == [] ? 1 : 0 }.size() >= nonOverlappingPaths
+        }
+        return this
     }
 
     SwitchPairs withShortestPathShorterThanOthers() {
-        return new SwitchPairs(switchPairs.findAll {it.getPaths()[0].size() != it.getPaths()[1].size()})
+        switchPairs = switchPairs.findAll { it.getPaths()[0].size() != it.getPaths()[1].size() }
+        return this
     }
 
     SwitchPairs nonNeighbouring() {
-        return new SwitchPairs(switchPairs.findAll { it.paths.min { it.size() }?.size() > 2})
+        switchPairs = switchPairs.findAll { it.paths.min { it.size() }?.size() > 2 }
+        return this
     }
+
     SwitchPairs neighbouring() {
-        return new SwitchPairs(switchPairs.findAll { it.paths.min { it.size() }?.size() == 2})
+        switchPairs = switchPairs.findAll { it.paths.min { it.size() }?.size() == 2 }
+        return this
     }
 
     SwitchPairs excludePairs(List<SwitchPair> excludePairs) {
-        return new SwitchPairs(switchPairs.findAll { !excludePairs.contains(it) })
+        switchPairs = switchPairs.findAll { !excludePairs.contains(it) }
+        return this
     }
 
     SwitchPairs sortedByShortestPathLengthAscending() {
-        return new SwitchPairs(switchPairs.sort {it.paths.min { it.size() }?.size() > 2})
-    }
-
-    SwitchPairs sortedBySmallestPathsAmount() {
-        return new SwitchPairs(switchPairs.sort{it.paths.size()})
+        switchPairs = switchPairs.sort { it.paths.min { it.size() }?.size() > 2 }
+        return this
     }
 
     SwitchPair random() {
-        return new SwitchPairs(switchPairs.shuffled()).first()
+        switchPairs = switchPairs.shuffled()
+        return this.first()
     }
 
     SwitchPair first() {
@@ -57,14 +88,52 @@ class SwitchPairs {
     }
 
     SwitchPairs includeSwitch(Switch sw) {
-        return new SwitchPairs(switchPairs.findAll { it.src == sw || it.dst == sw})
+        switchPairs = switchPairs.findAll { it.src == sw || it.dst == sw }
+        return this
     }
 
     SwitchPairs excludeSwitches(List<Switch> switchesList) {
-        return new SwitchPairs(switchPairs.findAll { !(it.src in switchesList) || !(it.dst in switchesList)})
+        switchPairs = switchPairs.findAll { !(it.src in switchesList) || !(it.dst in switchesList) }
+        return this
     }
 
     List<Switch> collectSwitches() {
         switchPairs.collectMany { return [it.src, it.dst] }.unique()
+    }
+
+    SwitchPairs withAtLeastNTraffgensOnSource(int traffgensConnectedToSource) {
+        switchPairs = switchPairs.findAll { it.getSrc().getTraffGens().size() >= traffgensConnectedToSource }
+        return this
+    }
+
+    SwitchPairs withBothSwitchesVxLanEnabled() {
+        switchPairs = switchPairs.findAll { [it.src, it.dst].every { sw -> switchHelper.isVxlanEnabled(sw.dpId) } }
+        return this
+    }
+
+    SwitchPairs withIslRttSupport() {
+        this.assertAllSwitchPairsAreNeighbouring()
+        switchPairs = switchPairs.findAll { [it.src, it.dst].every { it.features.contains(NOVIFLOW_COPY_FIELD) } }
+        return this
+    }
+
+    SwitchPairs withExactlyNIslsBetweenSwitches(int expectedIslsBetweenSwitches) {
+        this.assertAllSwitchPairsAreNeighbouring()
+        switchPairs = switchPairs.findAll { it.paths.findAll { it.size() == 2 }.size() == expectedIslsBetweenSwitches }
+        return this
+    }
+
+    SwitchPairs withMoreThanNIslsBetweenSwitches(int expectedMinimalIslsBetweenSwitches) {
+        this.assertAllSwitchPairsAreNeighbouring()
+        switchPairs = switchPairs.findAll {
+                    it.paths.findAll { it.size() == 2 }
+                            .size() > expectedMinimalIslsBetweenSwitches
+                }
+        return this
+    }
+
+    private void assertAllSwitchPairsAreNeighbouring() {
+        assert switchPairs.size() == this.neighbouring().getSwitchPairs().size(),
+                "This method is applicable only to the neighbouring switch pairs"
     }
 }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/BaseSpecification.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/BaseSpecification.groovy
@@ -1,5 +1,7 @@
 package org.openkilda.functionaltests
 
+import org.openkilda.functionaltests.helpers.model.SwitchPairs
+
 import static groovyx.gpars.GParsPool.withPool
 import static org.junit.jupiter.api.Assumptions.assumeTrue
 
@@ -69,6 +71,8 @@ class BaseSpecification extends Specification {
     StatsHelper statsHelper
     @Autowired @Shared
     LabService labService
+    @Autowired @Shared
+    SwitchPairs switchPairs
 
     @Value('${spring.profiles.active}') @Shared
     String profile

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/configuration/ConfigurationSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/configuration/ConfigurationSpec.groovy
@@ -35,12 +35,13 @@ class ConfigurationSpec extends HealthCheckSpecification {
     @Shared
     FlowEncapsulationType defaultEncapsulationType = FlowEncapsulationType.TRANSIT_VLAN
 
+
     def "System takes into account default flow encapsulation type while creating a flow"() {
         when: "Create a flow without encapsulation type"
-        def switchPair = topologyHelper.getAllNeighboringSwitchPairs().find { swP ->
-            [swP.src, swP.dst].every { sw -> switchHelper.isVxlanEnabled(sw.dpId) }
-        }
-        assumeTrue(switchPair != null, "Unable to find required switch pair in topology")
+        def switchPair = switchPairs.all()
+                .neighbouring()
+                .withBothSwitchesVxLanEnabled()
+                .random()
         def flow1 = flowHelperV2.randomFlow(switchPair)
         flow1.encapsulationType = null
         flowHelperV2.addFlow(flow1)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/BandwidthSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/BandwidthSpec.groovy
@@ -23,7 +23,7 @@ class BandwidthSpec extends HealthCheckSpecification {
     @Tags(SMOKE)
     def "Available bandwidth on ISLs changes respectively when creating/updating/deleting a flow"() {
         given: "Two active not neighboring switches"
-        def switchPair = topologyHelper.getNotNeighboringSwitchPair()
+        def switchPair = switchPairs.all().nonNeighbouring().random()
 
         when: "Create a flow with a valid bandwidth"
         def linksBeforeFlowCreate = northbound.getAllLinks()
@@ -111,7 +111,7 @@ class BandwidthSpec extends HealthCheckSpecification {
 
     def "Unable to exceed bandwidth limit on ISL when creating a flow"() {
         given: "Two active switches"
-        def switchPair = topologyHelper.getNeighboringSwitchPair()
+        def switchPair = switchPairs.all().neighbouring().random()
 
         when: "Create a flow with a bandwidth that exceeds available bandwidth on ISL"
         def involvedBandwidths = []
@@ -135,7 +135,7 @@ class BandwidthSpec extends HealthCheckSpecification {
 
     def "Unable to exceed bandwidth limit on ISL when updating a flow"() {
         given: "Two active switches"
-        def switchPair = topologyHelper.getNeighboringSwitchPair()
+        def switchPair = switchPairs.all().neighbouring().random()
 
         when: "Create a flow with a valid bandwidth"
         def maximumBandwidth = 1000
@@ -166,7 +166,7 @@ class BandwidthSpec extends HealthCheckSpecification {
 
     def "Able to exceed bandwidth limit on ISL when creating/updating a flow with ignore_bandwidth=true"() {
         given: "Two active switches"
-        def switchPair = topologyHelper.getNeighboringSwitchPair()
+        def switchPair = switchPairs.all().neighbouring().random()
 
         when: "Create a flow with a bandwidth that exceeds available bandwidth on ISL (ignore_bandwidth=true)"
         def linksBeforeFlowCreate = northbound.getAllLinks()
@@ -206,7 +206,7 @@ class BandwidthSpec extends HealthCheckSpecification {
 
     def "Able to update bandwidth to maximum link speed without using alternate links"() {
         given: "Two active neighboring switches"
-        def switchPair = topologyHelper.getNeighboringSwitchPair()
+        def switchPair = switchPairs.all().neighbouring().random()
 
         // We need to handle the case when there are parallel links between chosen switches. So we make all parallel
         // links except the first link not preferable to avoid flow reroute when updating the flow.
@@ -247,7 +247,7 @@ class BandwidthSpec extends HealthCheckSpecification {
 
     def "System doesn't allow to exceed bandwidth limit on ISL while updating a flow with ignore_bandwidth=false"() {
         given: "Two active switches"
-        def switchPair = topologyHelper.getNeighboringSwitchPair()
+        def switchPair = switchPairs.all().neighbouring().random()
 
         when: "Create a flow with a bandwidth that exceeds available bandwidth on ISL (ignore_bandwidth=true)"
         def linksBeforeFlowCreate = northbound.getAllLinks()
@@ -288,7 +288,7 @@ class BandwidthSpec extends HealthCheckSpecification {
     @Tags([LOW_PRIORITY])
     def "Unable to exceed bandwidth limit on ISL when creating a flow [v1 api]"() {
         given: "Two active switches"
-        def switchPair = topologyHelper.getNeighboringSwitchPair()
+        def switchPair = switchPairs.all().neighbouring().random()
 
         when: "Create a flow with a bandwidth that exceeds available bandwidth on ISL"
         def involvedBandwidths = []

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
@@ -467,7 +467,7 @@ class FlowCrudSpec extends HealthCheckSpecification {
 
     def "Error is returned if there is no available path to #data.isolatedSwitchType switch"() {
         given: "A switch that has no connection to other switches"
-        def isolatedSwitch = topologyHelper.notNeighboringSwitchPair.src
+        def isolatedSwitch = switchPairs.all().nonNeighbouring().random().src
         def flow = data.getFlow(isolatedSwitch)
         topology.getBusyPortsForSwitch(isolatedSwitch).each { port ->
             antiflap.portDown(isolatedSwitch.dpId, port)
@@ -568,7 +568,7 @@ class FlowCrudSpec extends HealthCheckSpecification {
 
     def "Unable to create a flow with #problem"() {
         given: "A flow with #problem"
-        def switchPair = topologyHelper.getNotNeighboringSwitchPair()
+        def switchPair = switchPairs.all().nonNeighbouring().random()
         def flow = flowHelperV2.randomFlow(switchPair, false)
         flow = update(flow)
         when: "Try to create a flow"
@@ -825,7 +825,7 @@ Failed to find path with requested bandwidth=${IMPOSSIBLY_HIGH_BANDWIDTH}/)
     @Tags(LOW_PRIORITY)
     def "System allows to set/update description/priority/max-latency for a flow"() {
         given: "Two active neighboring switches"
-        def switchPair = topologyHelper.getNeighboringSwitchPair()
+        def switchPair = switchPairs.all().neighbouring().random()
 
         and: "Value for each field"
         def initPriority = 100
@@ -878,7 +878,7 @@ Failed to find path with requested bandwidth=${IMPOSSIBLY_HIGH_BANDWIDTH}/)
 
     def "System doesn't ignore encapsulationType when flow is created with ignoreBandwidth = true"() {
         given: "Two active switches"
-        def swPair = topologyHelper.getNeighboringSwitchPair().find {
+        def swPair = switchPairs.all().neighbouring().getSwitchPairs().find {
             [it.src, it.dst].any { !switchHelper.isVxlanEnabled(it.dpId) }
         } ?: assumeTrue(false, "Unable to find required switches in topology")
 
@@ -1245,7 +1245,7 @@ types .* or update switch properties and add needed encapsulation type./).matche
     def "System allows to update single switch flow to multi switch flow"() {
         given: "A single switch flow with enabled lldp/arp on the dst side"
         assumeTrue(useMultitable, "This test can be run in multiTable mode due to lldp/arp")
-        def swPair = topologyHelper.getNeighboringSwitchPair()
+        def swPair = switchPairs.all().neighbouring().random()
         def flow = flowHelperV2.singleSwitchFlow(swPair.src)
         flow.destination.detectConnectedDevices.lldp = true
         flow.destination.detectConnectedDevices.arp = true
@@ -1401,7 +1401,7 @@ types .* or update switch properties and add needed encapsulation type./).matche
     @Tags(LOW_PRIORITY)
     def "Unable to update to a flow with maxLatencyTier2 higher as maxLatency)"() {
         given: "A flow"
-        def swPair = topologyHelper.getRandomSwitchPair()
+        def swPair = switchPairs.singleSwitch().random()
         def flow = flowHelperV2.randomFlow(swPair)
         flowHelperV2.addFlow(flow)
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV1Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV1Spec.groovy
@@ -494,7 +494,7 @@ class FlowCrudV1Spec extends HealthCheckSpecification {
 
     def "Error is returned if there is no available path to #data.isolatedSwitchType switch"() {
         given: "A switch that has no connection to other switches"
-        def isolatedSwitch = topologyHelper.notNeighboringSwitchPair.src
+        def isolatedSwitch = switchPairs.all().nonNeighbouring().random().src
         def flow = data.getFlow(isolatedSwitch)
         topology.getBusyPortsForSwitch(isolatedSwitch).each { port ->
             antiflap.portDown(isolatedSwitch.dpId, port)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowDiversitySpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowDiversitySpec.groovy
@@ -322,7 +322,7 @@ class FlowDiversitySpec extends HealthCheckSpecification {
 
     def "Able to get flow paths with correct overlapping segments stats (casual + single-switch flows)"() {
         given: "Two active not neighboring switches"
-        def switchPair = topologyHelper.getNotNeighboringSwitchPair()
+        def switchPair = switchPairs.all().nonNeighbouring().random()
         and: "Create a casual flow going through these switches"
         def flow1 = flowHelperV2.randomFlow(switchPair, false)
         flowHelperV2.addFlow(flow1)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowLoopSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowLoopSpec.groovy
@@ -356,7 +356,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
 
     def "System is able to detect and sync missing flowLoop rules"() {
         given: "An active flow with created flowLoop on the src switch"
-        def switchPair = topologyHelper.getNeighboringSwitchPair()
+        def switchPair = switchPairs.all().neighbouring().random()
         def flow = flowHelperV2.randomFlow(switchPair)
         flowHelperV2.addFlow(flow)
         northboundV2.createFlowLoop(flow.flowId, new FlowLoopPayload(switchPair.src.dpId))
@@ -627,7 +627,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
     @Tags(LOW_PRIORITY)
     def "Attempt to create the exact same flowLoop twice just reinstalls the rules"() {
         given: "An active multi switch flow with created flowLoop on the src switch"
-        def switchPair = topologyHelper.getNeighboringSwitchPair()
+        def switchPair = switchPairs.all().neighbouring().random()
         def flow = flowHelperV2.randomFlow(switchPair)
         flowHelperV2.addFlow(flow)
         northboundV2.createFlowLoop(flow.flowId, new FlowLoopPayload(switchPair.src.dpId))
@@ -670,7 +670,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
     @Tags(LOW_PRIORITY)
     def "Unable to create flowLoop when a switch is deactivated"() {
         given: "An active flow"
-        def switchPair = topologyHelper.getNeighboringSwitchPair()
+        def switchPair = switchPairs.all().neighbouring().random()
         def flow = flowHelperV2.randomFlow(switchPair)
         flowHelperV2.addFlow(flow)
 
@@ -706,7 +706,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
     @Tags(LOW_PRIORITY)
     def "Unable to create flowLoop on the src switch when it is already created on the dst switch"() {
         given: "An active flow with created flowLoop on the src switch"
-        def switchPair = topologyHelper.getNeighboringSwitchPair()
+        def switchPair = switchPairs.all().neighbouring().random()
         def flow = flowHelperV2.randomFlow(switchPair)
         flowHelperV2.addFlow(flow)
         northboundV2.createFlowLoop(flow.flowId, new FlowLoopPayload(switchPair.src.dpId))
@@ -726,7 +726,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
     @Tags(LOW_PRIORITY)
     def "Unable to create flowLoop on a transit switch"() {
         given: "An active multi switch flow with transit switch"
-        def switchPair = topologyHelper.getNotNeighboringSwitchPair()
+        def switchPair = switchPairs.all().nonNeighbouring().random()
         def flow = flowHelperV2.randomFlow(switchPair)
         flowHelperV2.addFlow(flow)
         def transitSwId = PathHelper.convert(northbound.getFlowPath(flow.flowId))[1].switchId
@@ -770,7 +770,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
     @Tags(LOW_PRIORITY)
     def "Unable to create flowLoop on a non existent switch"() {
         given: "An active multi switch flow"
-        def swP = topologyHelper.getNeighboringSwitchPair()
+        def swP = switchPairs.all().neighbouring().random()
         def flow = flowHelperV2.randomFlow(swP)
         flowHelperV2.addFlow(flow)
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowPingSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowPingSpec.groovy
@@ -332,7 +332,7 @@ class FlowPingSpec extends HealthCheckSpecification {
 
     def "Able to turn on periodic pings on a flow"() {
         when: "Create a flow with periodic pings turned on"
-        def endpointSwitches = topologyHelper.notNeighboringSwitchPair
+        def endpointSwitches = switchPairs.all().nonNeighbouring().random()
         def flow = flowHelperV2.randomFlow(endpointSwitches).tap {
             it.periodicPings = true
         }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowSyncSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowSyncSpec.groovy
@@ -29,7 +29,7 @@ class FlowSyncSpec extends HealthCheckSpecification {
     @Tags([SMOKE_SWITCHES, SMOKE])
     def "Able to synchronize a flow (install missing flow rules, reinstall existing) without rerouting"() {
         given: "An intermediate-switch flow with deleted rules on src switch"
-        def switchPair = topologyHelper.getNotNeighboringSwitchPair()
+        def switchPair = switchPairs.all().nonNeighbouring().random()
         assumeTrue(switchPair.asBoolean(), "Need a not-neighbouring switch pair for this test")
 
         def flow = flowHelperV2.randomFlow(switchPair)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowValidationNegativeSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowValidationNegativeSpec.groovy
@@ -84,19 +84,19 @@ class FlowValidationNegativeSpec extends HealthCheckSpecification {
         [flowToBreak, intactFlow].each { it && flowHelperV2.deleteFlow(it.flowId) }
 
         where:
-        flowConfig      | switchPair                                        | item | switchNo | flowType
-        "single switch" | getTopologyHelper().getSingleSwitchPair()         | 0    | "single" | "forward"
-        "single switch" | getTopologyHelper().getSingleSwitchPair()         | 0    | "single" | "reverse"
-        "neighbouring"  | getTopologyHelper().getNeighboringSwitchPair()    | 0    | "first"  | "forward"
-        "neighbouring"  | getTopologyHelper().getNeighboringSwitchPair()    | 0    | "first"  | "reverse"
-        "neighbouring"  | getTopologyHelper().getNeighboringSwitchPair()    | 1    | "last"   | "forward"
-        "neighbouring"  | getTopologyHelper().getNeighboringSwitchPair()    | 1    | "last"   | "reverse"
-        "transit"       | getTopologyHelper().getNotNeighboringSwitchPair() | 0    | "first"  | "forward"
-        "transit"       | getTopologyHelper().getNotNeighboringSwitchPair() | 0    | "first"  | "reverse"
-        "transit"       | getTopologyHelper().getNotNeighboringSwitchPair() | 1    | "middle" | "forward"
-        "transit"       | getTopologyHelper().getNotNeighboringSwitchPair() | 1    | "middle" | "reverse"
-        "transit"       | getTopologyHelper().getNotNeighboringSwitchPair() | -1   | "last"   | "forward"
-        "transit"       | getTopologyHelper().getNotNeighboringSwitchPair() | -1   | "last"   | "reverse"
+        flowConfig      | switchPair                                   | item | switchNo | flowType
+        "single switch" | switchPairs.singleSwitch().random()          | 0    | "single" | "forward"
+        "single switch" | switchPairs.singleSwitch().random()          | 0    | "single" | "reverse"
+        "neighbouring"  | switchPairs.all().neighbouring().random()    | 0    | "first"  | "forward"
+        "neighbouring"  | switchPairs.all().neighbouring().random()    | 0    | "first"  | "reverse"
+        "neighbouring"  | switchPairs.all().neighbouring().random()    | 1    | "last"   | "forward"
+        "neighbouring"  | switchPairs.all().neighbouring().random()    | 1    | "last"   | "reverse"
+        "transit"       | switchPairs.all().nonNeighbouring().random() | 0    | "first"  | "forward"
+        "transit"       | switchPairs.all().nonNeighbouring().random() | 0    | "first"  | "reverse"
+        "transit"       | switchPairs.all().nonNeighbouring().random() | 1    | "middle" | "forward"
+        "transit"       | switchPairs.all().nonNeighbouring().random() | 1    | "middle" | "reverse"
+        "transit"       | switchPairs.all().nonNeighbouring().random() | -1   | "last"   | "forward"
+        "transit"       | switchPairs.all().nonNeighbouring().random() | -1   | "last"   | "reverse"
     }
 
     def "Unable to #data.description a non-existent flow"() {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PartialUpdateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PartialUpdateSpec.groovy
@@ -237,7 +237,7 @@ class PartialUpdateSpec extends HealthCheckSpecification {
 
     def "Able to do partial update on a single-switch flow"() {
         given: "A single-switch flow"
-        def swPair = topologyHelper.singleSwitchPair
+        def swPair = switchPairs.singleSwitch().random()
         def flow = flowHelperV2.randomFlow(swPair)
         flowHelperV2.addFlow(flow)
         def originalCookies = northbound.getSwitchRules(swPair.src.dpId).flowEntries.findAll {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
@@ -1432,7 +1432,7 @@ doesn't have links with enough bandwidth, Failed to find path with requested ban
     @IterationTag(tags = [LOW_PRIORITY], iterationNameRegex = /unmetered/)
     def "Unable to create #flowDescription flow with protected path if all alternative paths are unavailable"() {
         given: "Two active neighboring switches without alt paths"
-        def switchPair = topologyHelper.getNeighboringSwitchPair()
+        def switchPair = switchPairs.all().neighbouring().random()
         List<PathNode> broughtDownPorts = []
 
         switchPair.paths.sort { it.size() }[1..-1].unique {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathV1Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathV1Spec.groovy
@@ -217,7 +217,7 @@ class ProtectedPathV1Spec extends HealthCheckSpecification {
 
     def "Unable to create #flowDescription flow with protected path if all alternative paths are unavailable"() {
         given: "Two active neighboring switches without alt paths"
-        def switchPair = topologyHelper.getNeighboringSwitchPair()
+        def switchPair = switchPairs.all().neighbouring().random()
         List<PathNode> broughtDownPorts = []
 
         switchPair.paths.sort { it.size() }[1..-1].unique {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/QinQFlowSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/QinQFlowSpec.groovy
@@ -313,7 +313,7 @@ class QinQFlowSpec extends HealthCheckSpecification {
         [srcVlanId, srcInnerVlanId, dstVlanId, dstInnerVlanId, swPair] << [
                 [[10, 20, 30, 40],
                  [10, 20, 0, 0]],
-                getUniqueSwitchPairs(topologyHelper.getAllSingleSwitchPairs())
+                getUniqueSwitchPairs(switchPairs.singleSwitch().getSwitchPairs())
         ].combinations().collect { it.flatten() }
         trafficDisclaimer = swPair.src.traffGens.size > 1 ? "" : " !WARN: No traffic check!"
     }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
@@ -79,7 +79,7 @@ class SwapEndpointSpec extends HealthCheckSpecification {
         where:
         data << [
                 [description: "no vlan vs vlan on the same port on src switch"].tap {
-                    def switchPair = getTopologyHelper().getNotNeighboringSwitchPair()
+                    def switchPair = getTopologyHelper().getAllSwitchPairs().nonNeighbouring().random()
                     def flow1 = getFlowHelper().randomFlow(switchPair)
                     flow1.source.portNumber = getFreePort(switchPair.src, [switchPair.dst])
                     flow1.source.vlanId = 0
@@ -92,7 +92,7 @@ class SwapEndpointSpec extends HealthCheckSpecification {
                             getFlowHelper().toFlowEndpointV2(flow2.destination))
                 },
                 [description: "same port, swap vlans on dst switch + third idle novlan flow on that port"].tap {
-                    def switchPair = getTopologyHelper().getNotNeighboringSwitchPair()
+                    def switchPair = getTopologyHelper().getAllSwitchPairs().nonNeighbouring().random()
                     def flow1 = getFlowHelper().randomFlow(switchPair)
                     def flow2 = getFlowHelper().randomFlow(switchPair, false, [flow1])
                     flow1.destination.portNumber = getFreePort(switchPair.dst, [switchPair.src])
@@ -108,7 +108,7 @@ class SwapEndpointSpec extends HealthCheckSpecification {
                             getFlowHelper().toFlowEndpointV2(flow1.destination))
                 },
                 [description: "vlan on src1 <-> vlan on dst2, same port numbers"].tap {
-                    def switchPair = getTopologyHelper().getNotNeighboringSwitchPair()
+                    def switchPair = getTopologyHelper().getAllSwitchPairs().nonNeighbouring().random()
                     def flow1 = getFlowHelper().randomFlow(switchPair)
                     def flow2 = getFlowHelper().randomFlow(switchPair, false, [flow1])
                     flow1.source.portNumber = getFreePort(switchPair.src, [switchPair.dst])
@@ -122,7 +122,7 @@ class SwapEndpointSpec extends HealthCheckSpecification {
                             getFlowHelper().toFlowEndpointV2(flow2.destination).tap { it.vlanId = flow1.source.vlanId })
                 },
                 [description: "port on dst1 <-> port on src2, vlans are equal"].tap {
-                    def switchPair = getTopologyHelper().getNotNeighboringSwitchPair()
+                    def switchPair = getTopologyHelper().getAllSwitchPairs().nonNeighbouring().random()
                     def flow1 = getFlowHelper().randomFlow(switchPair, false)
                     def flow2 = getFlowHelper().randomFlow(switchPair, false, [flow1])
                     flow1.destination.portNumber = getFreePort(switchPair.dst, [switchPair.src],
@@ -141,7 +141,7 @@ class SwapEndpointSpec extends HealthCheckSpecification {
                             getFlowHelper().toFlowEndpointV2(flow2.destination))
                 },
                 [description: "switch on src1 <-> switch on dst2, other params random"].tap {
-                    def switchPair = getTopologyHelper().getNotNeighboringSwitchPair()
+                    def switchPair = getTopologyHelper().getAllSwitchPairs().nonNeighbouring().random()
                     def flow1 = getFlowHelper().randomFlow(switchPair)
                     def flow2 = getFlowHelper().randomFlow(switchPair, false, [flow1])
                     flow1.source.portNumber = getFreePort(switchPair.src, [switchPair.dst])
@@ -157,7 +157,7 @@ class SwapEndpointSpec extends HealthCheckSpecification {
                                     .tap { it.switchId = flow1.source.datapath })
                 },
                 [description: "both endpoints swap, same switches"].tap {
-                    def switchPair = getTopologyHelper().getNotNeighboringSwitchPair()
+                    def switchPair = getTopologyHelper().getAllSwitchPairs().nonNeighbouring().random()
                     def flow1 = getFlowHelper().randomFlow(switchPair)
                     def flow2 = getFlowHelper().randomFlow(switchPair, false, [flow1])
                     flow1.source.portNumber = getFreePort(switchPair.src, [switchPair.dst])
@@ -173,7 +173,7 @@ class SwapEndpointSpec extends HealthCheckSpecification {
                             getFlowHelper().toFlowEndpointV2(flow1.destination))
                 },
                 [description: "endpoints src1 <-> dst2, same switches"].tap {
-                    def switchPair = getTopologyHelper().getNotNeighboringSwitchPair()
+                    def switchPair = getTopologyHelper().getAllSwitchPairs().nonNeighbouring().random()
                     def flow1 = getFlowHelper().randomFlow(switchPair)
                     def flow2 = getFlowHelper().randomFlow(switchPair, false, [flow1])
                     flow1.source.portNumber = getFreePort(switchPair.src, [switchPair.dst])
@@ -424,7 +424,7 @@ switches"() {
         endpointsPart << ["vlans", "ports", "switches"]
         proprtyName << ["vlanId", "portNumber", "datapath"]
         description = "src1 <-> dst2, dst1 <-> src2"
-        flow1SwitchPair = getTopologyHelper().getNotNeighboringSwitchPair()
+        flow1SwitchPair = getTopologyHelper().getAllSwitchPairs().nonNeighbouring().random()
         flow2SwitchPair = getDifferentNotNeighboringSwitchPair(flow1SwitchPair)
         flow1 = getFirstFlow(flow1SwitchPair, flow2SwitchPair)
         flow2 = getSecondFlow(flow1SwitchPair, flow2SwitchPair, flow1)
@@ -502,7 +502,7 @@ switches"() {
                      it.flow2Src = it.flow1.destination
                      it.flow2Dst = it.flow2.destination
                  }].collect { iterationData ->
-            def flow1SwitchPair = getTopologyHelper().getNotNeighboringSwitchPair()
+            def flow1SwitchPair = getTopologyHelper().getAllSwitchPairs().nonNeighbouring().random()
             def flow2SwitchPair = getDifferentNotNeighboringSwitchPair(flow1SwitchPair)
             def flow1 = getFirstFlow(flow1SwitchPair, flow2SwitchPair)
             [flow1SwitchPair: flow1SwitchPair, flow2SwitchPair: flow2SwitchPair, flow1: flow1].tap(iterationData)
@@ -515,7 +515,7 @@ switches"() {
 
     def "Unable to swap endpoints for existing flow and non-existing flow"() {
         given: "An active flow"
-        def switchPair = topologyHelper.getNeighboringSwitchPair()
+        def switchPair = switchPairs.all().neighbouring().random()
         def flow1 = flowHelper.randomFlow(switchPair)
         def flow2 = flowHelper.randomFlow(switchPair)
         flowHelper.addFlow(flow1)
@@ -649,7 +649,7 @@ switches"() {
                      flow2Src = changePropertyValue(flow2.source, "portNumber", flow1.destination.portNumber)
                      flow2Dst = flow2.destination
                  }].collect { iterationData ->
-            def flow1SwitchPair = getTopologyHelper().getNotNeighboringSwitchPair()
+            def flow1SwitchPair = getTopologyHelper().getAllSwitchPairs().nonNeighbouring().random()
             def flow2SwitchPair = getDifferentNotNeighboringSwitchPair(flow1SwitchPair)
             def flow1 = getFirstFlow(flow1SwitchPair, flow2SwitchPair)
             [flow1SwitchPair: flow1SwitchPair, flow2SwitchPair: flow2SwitchPair, flow1: flow1].tap(iterationData)
@@ -702,7 +702,7 @@ switches"() {
                      flow2Src = changePropertyValue(flow2.source, "portNumber", flow1.source.portNumber)
                      flow2Dst = flow1.destination
                  }].collect { iterationData ->
-            def flow1SwitchPair = getTopologyHelper().getNotNeighboringSwitchPair()
+            def flow1SwitchPair = getTopologyHelper().getAllSwitchPairs().nonNeighbouring().random()
             def flow2SwitchPair = getDifferentNotNeighboringSwitchPair(flow1SwitchPair)
             def flow1 = getFirstFlow(flow1SwitchPair, flow2SwitchPair)
             def flow2 = getSecondFlow(flow1SwitchPair, flow2SwitchPair, flow1)
@@ -1168,7 +1168,7 @@ switches"() {
                      flow2Src = flow1.destination
                      flow2Dst = flow2.destination
                  }].collect { iterationData ->
-            def flow1SwitchPair = getTopologyHelper().getNotNeighboringSwitchPair()
+            def flow1SwitchPair = getTopologyHelper().getAllSwitchPairs().nonNeighbouring().random()
             def flow2SwitchPair = getDifferentNotNeighboringSwitchPair(flow1SwitchPair)
             def flow1 = getFlowHelper().randomFlow(flow1SwitchPair)
             def flow2 = getFlowHelper().randomFlow(flow2SwitchPair, false, [flow1]).tap {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowRerouteSpec.groovy
@@ -180,9 +180,9 @@ class YFlowRerouteSpec extends HealthCheckSpecification {
     def "Y-Flow reroute has been executed when more preferable path is available for both sub-flows (shared path cost was changed)" () {
         given: "The appropriate switches have been collected"
         //y-flow with shared path is created when shared_ep+ep1->neighbour && ep1+ep2->neighbour && shared_ep+ep2->not neighbour
-        def pairSharedEpAndEp1 = topologyHelper.getAllSwitchPairs().neighbouring().first()
-        def sharedEpNeighbouringSwitches = topologyHelper.getAllSwitchPairs().neighbouring().includeSwitch(pairSharedEpAndEp1.src).collectSwitches()
-        def pairEp1AndEp2 = topologyHelper.getAllSwitchPairs().neighbouring().excludePairs([pairSharedEpAndEp1])
+        def pairSharedEpAndEp1 = switchPairs.all().neighbouring().first()
+        def sharedEpNeighbouringSwitches = switchPairs.all().neighbouring().includeSwitch(pairSharedEpAndEp1.src).collectSwitches()
+        def pairEp1AndEp2 = switchPairs.all().neighbouring().excludePairs([pairSharedEpAndEp1])
                 .includeSwitch(pairSharedEpAndEp1.dst).excludeSwitches(sharedEpNeighbouringSwitches).first()
         def swT = new SwitchTriplet(shared: pairSharedEpAndEp1.src, ep1: pairEp1AndEp2.src, ep2: pairEp1AndEp2.dst)
 
@@ -231,9 +231,9 @@ class YFlowRerouteSpec extends HealthCheckSpecification {
     def "Y-Flow reroute has been executed when more preferable path is available for one of the sub-flows" () {
         given: "The appropriate switches have been collected"
         //y-flow with shared path is created when shared_ep+ep1->neighbour && ep1+ep2->neighbour && shared_ep+ep2->not neighbour
-        def pairSharedEpAndEp1 = topologyHelper.getAllSwitchPairs().neighbouring().first()
-        def sharedEpNeighbouringSwitches = topologyHelper.getAllSwitchPairs().neighbouring().includeSwitch(pairSharedEpAndEp1.src).collectSwitches()
-        def pairEp1AndEp2 = topologyHelper.getAllSwitchPairs().neighbouring().excludePairs([pairSharedEpAndEp1])
+        def pairSharedEpAndEp1 = switchPairs.all().neighbouring().first()
+        def sharedEpNeighbouringSwitches = switchPairs.all().neighbouring().includeSwitch(pairSharedEpAndEp1.src).collectSwitches()
+        def pairEp1AndEp2 = switchPairs.all().neighbouring().excludePairs([pairSharedEpAndEp1])
                 .includeSwitch(pairSharedEpAndEp1.dst).excludeSwitches(sharedEpNeighbouringSwitches).first()
         def swT = new SwitchTriplet(shared: pairSharedEpAndEp1.src, ep1: pairEp1AndEp2.src, ep2: pairEp1AndEp2.dst)
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
@@ -132,7 +132,7 @@ class LinkSpec extends HealthCheckSpecification {
     @Tags(SMOKE)
     def "Get all flows (UP/DOWN) going through a particular link"() {
         given: "Two active not neighboring switches"
-        def switchPair = topologyHelper.getNotNeighboringSwitchPair()
+        def switchPair = switchPairs.all().nonNeighbouring().random()
 
         and: "Forward flow from source switch to destination switch"
         def flow1 = flowHelperV2.randomFlow(switchPair).tap { it.pinned = true }
@@ -717,7 +717,7 @@ class LinkSpec extends HealthCheckSpecification {
 
     def "Unable to delete inactive link with flowPath"() {
         given: "An inactive link with flow on it"
-        def switchPair = topologyHelper.getNeighboringSwitchPair()
+        def switchPair = switchPairs.all().neighbouring().random()
         def flow = flowHelperV2.randomFlow(switchPair)
         flow.pinned = true
         flowHelperV2.addFlow(flow)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/network/PathCheckSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/network/PathCheckSpec.groovy
@@ -22,7 +22,7 @@ class PathCheckSpec extends HealthCheckSpecification {
     @Tags(SMOKE)
     def "No path validation errors for valid path without limitations"() {
         given: "Path for non-neighbouring switches"
-        def path = topologyHelper.getAllSwitchPairs().nonNeighbouring().random()
+        def path = switchPairs.all().nonNeighbouring().random()
                 .getPaths().sort { it.size() }.first()
 
         when: "Check the path without limitations"
@@ -39,7 +39,7 @@ class PathCheckSpec extends HealthCheckSpecification {
     @Tags(SMOKE)
     def "Path check errors returned for each segment and each type of problem"() {
         given: "Path of at least three switches"
-        def switchPair = topologyHelper.getAllSwitchPairs().nonNeighbouring().random()
+        def switchPair = switchPairs.all().nonNeighbouring().random()
         def path = switchPair.getPaths()
                 .sort { it.size() }
                 .first()
@@ -69,7 +69,7 @@ class PathCheckSpec extends HealthCheckSpecification {
     @Tags(LOW_PRIORITY)
     def "Latency check errors are returned for the whole existing flow"() {
         given: "Path of at least three switches"
-        def switchPair = topologyHelper.getAllSwitchPairs().nonNeighbouring().random()
+        def switchPair = switchPairs.all().nonNeighbouring().random()
         def path = switchPair.getPaths()
                 .sort { it.size() }
                 .first()
@@ -100,7 +100,7 @@ class PathCheckSpec extends HealthCheckSpecification {
     @Tags(LOW_PRIORITY)
     def "Path intersection check errors are returned for each segment of existing flow"() {
         given: "Flow has been created successfully"
-        def switchPair = topologyHelper.getAllSwitchPairs().nonNeighbouring().first()
+        def switchPair = switchPairs.all().nonNeighbouring().first()
         def flow = flowHelperV2.addFlow(flowHelperV2.randomFlow(switchPair, false))
         def flowPathDetails = northbound.getFlowPath(flow.flowId)
 
@@ -133,8 +133,8 @@ class PathCheckSpec extends HealthCheckSpecification {
     @Tags(LOW_PRIORITY)
     def "Path intersection check errors are returned for each segment of each flow in diverse group"() {
         given: "List of required neighbouring switches has been collected"
-        def firstSwitchPair = topologyHelper.getAllSwitchPairs().neighbouring().random()
-        def secondSwitchPair = topologyHelper.getAllSwitchPairs().neighbouring().excludePairs([firstSwitchPair])
+        def firstSwitchPair = switchPairs.all().neighbouring().random()
+        def secondSwitchPair = switchPairs.all().neighbouring().excludePairs([firstSwitchPair])
                 .includeSwitch(firstSwitchPair.dst).random()
 
         and:"Two flows in one diverse group have been created"
@@ -147,7 +147,7 @@ class PathCheckSpec extends HealthCheckSpecification {
         def flow2Path = northbound.getFlowPath(flow2.flowId)
 
         when: "Check potential path that has intersection ONLY with one flow from diverse group"
-        LinkedList<PathNode> pathToCheck = topologyHelper.getAllSwitchPairs().neighbouring().excludePairs([firstSwitchPair, secondSwitchPair])
+        LinkedList<PathNode> pathToCheck = switchPairs.all().neighbouring().excludePairs([firstSwitchPair, secondSwitchPair])
               .includeSwitch(firstSwitchPair.src).random().paths.first()
 
         if(pathToCheck.last().switchId != firstSwitchPair.src.dpId) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/network/PathsSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/network/PathsSpec.groovy
@@ -31,7 +31,7 @@ class PathsSpec extends HealthCheckSpecification {
     @Tags(SMOKE)
     def "Get paths between not neighboring switches"() {
         given: "Two active not neighboring switches"
-        def switchPair = topologyHelper.getAllSwitchPairs()
+        def switchPair = switchPairs.all()
                 .nonNeighbouring()
                 .random()
 
@@ -63,7 +63,7 @@ class PathsSpec extends HealthCheckSpecification {
     @Tags(LOW_PRIORITY)
     def "Able to get paths between switches for the LATENCY strategy"() {
         given: "Two active not neighboring switches"
-        def switchPair = topologyHelper.getAllSwitchPairs()
+        def switchPair = switchPairs.all()
                 .nonNeighbouring()
                 .random()
 
@@ -106,7 +106,7 @@ class PathsSpec extends HealthCheckSpecification {
 
     def "Unable to get paths with max_latency strategy without max latency parameter"() {
         given: "Two active not neighboring switches"
-        def switchPair = topologyHelper.getAllSwitchPairs()
+        def switchPair = switchPairs.all()
         .nonNeighbouring()
         .random()
 
@@ -125,7 +125,7 @@ class PathsSpec extends HealthCheckSpecification {
     @Tags(LOW_PRIORITY)
     def "Unable to get a path for a 'vxlan' flowEncapsulationType when switches do not support it"() {
         given: "Two active not supported 'vxlan' flowEncapsulationType switches"
-        def switchPair = topologyHelper.getAllSwitchPairs().random()
+        def switchPair = switchPairs.all().random()
         Map<Switch, SwitchPropertiesDto> initProps = [switchPair.src, switchPair.dst].collectEntries {
             [(it): switchHelper.getCachedSwProps(it.dpId)]
         }
@@ -158,7 +158,7 @@ class PathsSpec extends HealthCheckSpecification {
     @Unroll
     def "Protected path is #isIncludedString included into path list if #isIncludedString requested"() {
         given: "Two switches with potential protected path"
-        def switchPair = topologyHelper.getAllSwitchPairs()
+        def switchPair = switchPairs.all()
                 .withAtLeastNNonOverlappingPaths(2)
                 .random()
 
@@ -177,7 +177,7 @@ class PathsSpec extends HealthCheckSpecification {
     @Tags(LOW_PRIORITY)
     def "Protected path is null if it doesn't match criteria"() {
         given: "Two non-neighbouring switches with the one path shorter than others"
-        def switchPair = topologyHelper.getAllSwitchPairs()
+        def switchPair = switchPairs.all()
                 .nonNeighbouring()
                 .withShortestPathShorterThanOthers()
                 .sortedByShortestPathLengthAscending()

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/LagPortSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/LagPortSpec.groovy
@@ -202,12 +202,8 @@ class LagPortSpec extends HealthCheckSpecification {
     def "Able to create a singleSwitchFlow on a LAG port"() {
         given: "A switch with two traffgens and one LAG port"
         and: "A flow on the LAG port"
-        def allTraffGenSwitchIds = topology.activeTraffGens*.switchConnected*.dpId
-        assumeTrue(allTraffGenSwitchIds.size() > 1, "Unable to find active traffgen")
-        def swPair = topologyHelper.getAllSingleSwitchPairs().find {
-            it.src.dpId in allTraffGenSwitchIds && it.src.traffGens.size() > 1
-        }
-        assumeTrue(swPair.asBoolean(), "Unable to find required switch in topology")
+        def swPair = switchPairs.singleSwitch()
+                .withAtLeastNTraffgensOnSource(2).random()
         def traffgenSrcSwPort = swPair.src.traffGens[0].switchPort
         def traffgenDstSwPort = swPair.src.traffGens[1].switchPort
         def payload = new LagPortRequest(portNumbers: [traffgenSrcSwPort])
@@ -337,7 +333,7 @@ on switch $sw.dpId is used as part of LAG port $lagPort/).matches(exc)
 
     def "Unable to create a LAG port with port which is used as mirrorPort"() {
         given: "A flow with mirrorPoint"
-        def swP = topologyHelper.getNeighboringSwitchPair()
+        def swP = switchPairs.all().neighbouring().random()
         def flow = flowHelperV2.randomFlow(swP, false)
         flowHelperV2.addFlow(flow)
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchActivationSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchActivationSpec.groovy
@@ -44,7 +44,7 @@ class SwitchActivationSpec extends HealthCheckSpecification {
     @Tags([SMOKE, SMOKE_SWITCHES, LOCKKEEPER])
     def "Missing flow rules/meters are installed on a new switch before connecting to the controller"() {
         given: "A switch with missing flow rules/meters and not connected to the controller"
-        def switchPair = topologyHelper.getNeighboringSwitchPair()
+        def switchPair = switchPairs.all().neighbouring().random()
         def flow = flowHelperV2.randomFlow(switchPair)
         flowHelperV2.addFlow(flow)
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchSyncSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchSyncSpec.groovy
@@ -169,7 +169,7 @@ class SwitchSyncSpec extends HealthCheckSpecification {
 
     def "Able to synchronize #switchKind switch (delete excess rules and meters)"() {
         given: "Flow with intermediate switches"
-        def switchPair = topologyHelper.getAllSwitchPairs().nonNeighbouring().random()
+        def switchPair = switchPairs.all().nonNeighbouring().random()
         def flow = flowHelperV2.randomFlow(switchPair)
         flowHelperV2.addFlow(flow)
         def switchId = getSwitch(flow)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/ContentionSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/ContentionSpec.groovy
@@ -22,7 +22,7 @@ class ContentionSpec extends BaseSpecification {
         when: "Create the same flow in parallel multiple times"
         def flowsAmount = 20
         def group = new DefaultPGroup(flowsAmount)
-        def flow = flowHelperV2.randomFlow(topologyHelper.notNeighboringSwitchPair)
+        def flow = flowHelperV2.randomFlow(switchPairs.all().nonNeighbouring().random())
         def tasks = (1..flowsAmount).collect {
             group.task { flowHelperV2.addFlow(flow) }
         }
@@ -88,7 +88,7 @@ class ContentionSpec extends BaseSpecification {
 
     def "Reroute can be simultaneously performed with sync rules requests, removeExcess=#removeExcess"() {
         given: "A flow with reroute potential"
-        def switches = topologyHelper.getNotNeighboringSwitchPair()
+        def switches = switchPairs.all().nonNeighbouring().random()
         def flow = flowHelperV2.randomFlow(switches)
         flowHelperV2.addFlow(flow)
         def currentPath = pathHelper.convert(northbound.getFlowPath(flow.flowId))

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/StormLcmSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/StormLcmSpec.groovy
@@ -58,7 +58,7 @@ class StormLcmSpec extends HealthCheckSpecification {
         List<FlowRequestV2> flows = []
         def flowsAmount = topology.activeSwitches.size() * 3
         flowsAmount.times {
-            def flow = flowHelperV2.randomFlow(*topologyHelper.getRandomSwitchPair(false), false, flows)
+            def flow = flowHelperV2.randomFlow(switchPairs.all().random(), false, flows)
             flow.maximumBandwidth = 500000
             flowHelperV2.addFlow(flow)
             flows << flow

--- a/src-java/testing/performance-tests/src/test/groovy/org/openkilda/performancetests/spec/EnduranceSpec.groovy
+++ b/src-java/testing/performance-tests/src/test/groovy/org/openkilda/performancetests/spec/EnduranceSpec.groovy
@@ -202,7 +202,7 @@ idle, mass manual reroute. Step repeats pre-defined number of times"
 
     def createFlow(waitForRules = false, boolean protectedPath = false) {
         Wrappers.silent {
-            def flow = flowHelper.randomFlow(*topoHelper.getRandomSwitchPair(), false, flows)
+            def flow = flowHelper.randomFlow(*topoHelper.getAllSwitchPairs().random(), false, flows)
             flow.allocateProtectedPath = protectedPath
             log.info "creating flow $flow.id"
             waitForRules ? flowHelper.addFlow(flow) : northbound.addFlow(flow)

--- a/src-java/testing/performance-tests/src/test/groovy/org/openkilda/performancetests/spec/EnduranceV2Spec.groovy
+++ b/src-java/testing/performance-tests/src/test/groovy/org/openkilda/performancetests/spec/EnduranceV2Spec.groovy
@@ -166,7 +166,8 @@ idle, mass manual reroute, isl break. Step repeats pre-defined number of times"
         ]
         //define payload generating method that will be called each time flow creation is issued
         makeFlowPayload = {
-            def flow = flowHelperV2.randomFlow(*topoHelper.getRandomSwitchPair(), false, flows)
+            def flow = flowHelperV2.randomFlow(*topoHelper.getAllSwitchPairs().random(),
+                    false, flows)
             flow.maximumBandwidth = 200000
             flow.allocateProtectedPath = r.nextBoolean()
             return flow


### PR DESCRIPTION
* Topology helper methods getRandomSwitchPair(), getSingleSwitchPair(), getAllSingleSwitchPairs(), getNeighboringSwitchPair(), getNotNeighboringSwitchPair(), getAllNeighboringSwitchPairs() (partially) were replaced with methods from SwitchPairs class.