### PR TITLE
open-kilda-4485 [GUI] missing permission validation on the 'useractivity' page

### DIFF
--- a/src-gui/ui/src/app/modules/useractivity/useractivity.component.html
+++ b/src-gui/ui/src/app/modules/useractivity/useractivity.component.html
@@ -1,110 +1,116 @@
 <div id="switchdetails_div">
-  <form [formGroup]="userActivityForm" id="userActivityForm" #roleform="ngForm">
-  <div class="row form-group clearfix">
-    <div class="col-sm-6">
-      <div class="row">
-        <label class='col-sm-3 col-form-label'>Start Date:</label>
-        <div class='col-sm-6'>
-          <input datetime-picker placeholder="Date Time"  [maxDate] = "currentDate"  (change)="onStartDateChange($event)" formControlName="fromDateControl" style="height: 35px !important; font-size: 12px !important;">
+    <form [formGroup]="userActivityForm" id="userActivityForm" #roleform="ngForm">
+        <div class="row form-group clearfix">
+            <div class="col-sm-6">
+                <div class="row">
+                    <label class='col-sm-3 col-form-label'>Start Date:</label>
+                    <div class='col-sm-6'>
+                        <input datetime-picker placeholder="Date Time" [maxDate]="currentDate"
+                               (change)="onStartDateChange($event)" formControlName="fromDateControl"
+                               style="height: 35px !important; font-size: 12px !important;">
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6">
+                <div class="row">
+                    <label class='col-sm-3 col-form-label'>End Date:</label>
+                    <div class='col-sm-6'>
+                        <input datetime-picker placeholder="Date Time" (change)="onEndDateChange($event)"
+                               formControlName="toDateControl"
+                               style="height: 35px !important; font-size: 12px !important;">
+                    </div>
+                    <div class="col-sm-3">
+                        <a href="javascript:void(0)" (click)="setToCurrentDate()"
+                           style="font-size: 14px; margin: 0px -13px;">Set to now</a>
+                    </div>
+                </div>
+            </div>
         </div>
-      </div>
-    </div>
-    <div class="col-sm-6">
-      <div class="row">
-        <label class='col-sm-3 col-form-label'>End Date:</label>
-        <div class='col-sm-6'>
-          <input datetime-picker placeholder="Date Time" (change)="onEndDateChange($event)" formControlName="toDateControl" style="height: 35px !important; font-size: 12px !important;">
-        </div>
-        <div class="col-sm-3">
-          <a href="javascript:void(0)" (click)="setToCurrentDate()" style="font-size: 14px; margin: 0px -13px;">Set to now</a>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="row form-group clearfix">
-    <div class="col-sm-6">
-      <div class="row">
-        <label class='col-sm-3 col-form-label'>Type:</label>
-        <div class='col-sm-6'>
-          <ng-select
-          formControlName="typeControl"
-           [items]="typeDropdownList"
-           bindLabel="name"
-           bindValue="id"
-           labelForId="id"
-           [multiple]="true"
-           placeholder="Select Type"
-           clearAllText="Clear"
-           (change)="onTypeInputChange($event)">
-             
-           </ng-select>
-        </div>
-      </div>
-    </div>
-    <div class="col-sm-6">
-      <div class="row">
-        <label class='col-sm-3 col-form-label'>Username:</label>
-        <div class='col-sm-6'>
-          <ng-select
-          formControlName="usernameControl"
-           [items]="userDrowdonList"
-           bindLabel="user_name"
-           bindValue="user_id"
-           labelForId="user_id"
-           [multiple]="true"
-           placeholder="Select Username"
-           clearAllText="Clear"
-           (change)="onUsernameInputChange($event)">
-             
-           </ng-select>
+        <div class="row form-group clearfix">
+            <div class="col-sm-6">
+                <div class="row">
+                    <label class='col-sm-3 col-form-label'>Type:</label>
+                    <div class='col-sm-6'>
+                        <ng-select
+                                formControlName="typeControl"
+                                [items]="typeDropdownList"
+                                bindLabel="name"
+                                bindValue="id"
+                                labelForId="id"
+                                [multiple]="true"
+                                placeholder="Select Type"
+                                clearAllText="Clear"
+                                (change)="onTypeInputChange($event)">
 
-        </div>
-        <div class="col-sm-3">
-          <span class="btn kilda_btn" (click)="getFilteredDetails()" style="margin-right:65px;">Go</span>
-        </div>
-      </div>
-    </div>
-  </div>
-</form>
+                        </ng-select>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6">
+                <div class="row">
+                    <label *ngIf="commonService.hasPermission('menu_user_management')" class='col-sm-3 col-form-label'>Username:</label>
+                    <div *ngIf="commonService.hasPermission('menu_user_management')" class='col-sm-6'>
+                        <ng-select
+                                formControlName="usernameControl"
+                                [items]="userDrowdonList"
+                                bindLabel="user_name"
+                                bindValue="user_id"
+                                labelForId="user_id"
+                                [multiple]="true"
+                                placeholder="Select Username"
+                                clearAllText="Clear"
+                                (change)="onUsernameInputChange($event)">
 
-<div  class="col-sm-11 filter" [hidden]="!showFilterBlock"> 
+                        </ng-select>
+                    </div>
+                    <div class="col-sm-3">
+                        <span class="btn kilda_btn" (click)="getFilteredDetails()" style="margin-right:65px;">Go</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
 
-        <div  id="selectedFilter" class="selectedFilter form-group">
-          <label class="labelFilter text-label" style="margin-left: -13px; margin-bottom: 5px; margin-top: 10px; margin-right: 0px; font-size:13px;">Selected Filters</label>
-           <ul class="selected-filter" style="float: none; margin-left: 97px;">
-            <li id="typeFilterSelected" [hidden]= "!showTypeFilter">
+    <div class="col-sm-11 filter" [hidden]="!showFilterBlock">
+
+        <div id="selectedFilter" class="selectedFilter form-group">
+            <label class="labelFilter text-label"
+                   style="margin-left: -13px; margin-bottom: 5px; margin-top: 10px; margin-right: 0px; font-size:13px;">Selected
+                Filters</label>
+            <ul class="selected-filter" style="float: none; margin-left: 97px;">
+                <li id="typeFilterSelected" [hidden]="!showTypeFilter">
               <span class="badge badge-secondary">
                 <span class="badge-heading">Type : </span>
                 <span class="selectedValues">{{typeValue}}</span>
                 <span (click)="removeTypeFilter()" class="closeBadge">X</span>
               </span>
-            </li>
-            <li id="usernameFilterSelected" [hidden]= "!showUsernameFilter">
+                </li>
+                <li id="usernameFilterSelected" [hidden]="!showUsernameFilter">
               <span class="badge badge-secondary">
                 <span class="badge-heading">Username : </span>
                 <span class="selectedValues">{{usernameValue}}</span>
-                <span (click)="removeUsernameFilter()" class="closeBadge" >X</span>
+                <span (click)="removeUsernameFilter()" class="closeBadge">X</span>
               </span>
-            </li>
-            <li id="fromFilterSelected" [hidden]="!showStartDateFilter">
-              <span class="badge badge-secondary" >
+                </li>
+                <li id="fromFilterSelected" [hidden]="!showStartDateFilter">
+              <span class="badge badge-secondary">
                 <span class="badge-heading">From : </span>
                 <span class="selectedValues">{{startDate}}</span>
-                <span (click)="removeStartDateFilter()" class="closeBadge" >X</span>
+                <span (click)="removeStartDateFilter()" class="closeBadge">X</span>
               </span>
-            </li>
-            <li id="toFilterSelected" [hidden]="!showEndDateFilter">
+                </li>
+                <li id="toFilterSelected" [hidden]="!showEndDateFilter">
               <span class="badge badge-secondary">
                 <span class="badge-heading">To : </span>
                 <span class="selectedValues">{{endDate}}</span>
-                <span (click)="removeEndDateFilter()" class="closeBadge" >X</span>
+                <span (click)="removeEndDateFilter()" class="closeBadge">X</span>
               </span>
-            </li>
-           </ul>
+                </li>
+            </ul>
         </div>
-      
-      </div>
-  
 
- <app-useractivity-list [data]="userActivityData" *ngIf="!loadActivityData"></app-useractivity-list>
+    </div>
+
+
+    <app-useractivity-list [data]="userActivityData" *ngIf="!loadActivityData"></app-useractivity-list>
 </div>

--- a/src-gui/ui/src/app/modules/useractivity/useractivity.component.ts
+++ b/src-gui/ui/src/app/modules/useractivity/useractivity.component.ts
@@ -1,217 +1,222 @@
-import { Component, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup, FormControl, Validators } from '@angular/forms';
-import { NgOption } from '@ng-select/ng-select';
-import { UserActivityService } from '../../common/services/user-activity.service';
-import { ToastrService } from 'ngx-toastr';
+import {Component, OnInit} from '@angular/core';
+import {FormBuilder, FormGroup} from '@angular/forms';
+import {UserActivityService} from '../../common/services/user-activity.service';
+import {ToastrService} from 'ngx-toastr';
 import * as _moment from 'moment';
-import { LoaderService } from '../../common/services/loader.service';
-import { Title } from '@angular/platform-browser';
-import { CommonService } from 'src/app/common/services/common.service';
-import { Router } from '@angular/router';
-import { MessageObj } from 'src/app/common/constants/constants';
+import {LoaderService} from '../../common/services/loader.service';
+import {Title} from '@angular/platform-browser';
+import {CommonService} from '../../common/services/common.service';
+import {Router} from '@angular/router';
+import {MessageObj} from '../../common/constants/constants';
 
 @Component({
-  selector: 'app-useractivity',
-  templateUrl: './useractivity.component.html',
-  styleUrls: ['./useractivity.component.css']
+    selector: 'app-useractivity',
+    templateUrl: './useractivity.component.html',
+    styleUrls: ['./useractivity.component.css']
 })
 export class UseractivityComponent implements OnInit {
-	moment = (_moment as any).default ? (_moment as any).default : _moment;
-	userActivityData: any = [];
-	startDate: any;
-	endDate: any;
-	currentDate: any = this.moment().format('YYYY/MM/DD HH:mm');
-	type = [];
-	username = [];
-	showFilterBlock = false;
-	showStartDateFilter = false;
-	showEndDateFilter = false;
-	showTypeFilter = false;
-	showUsernameFilter = false;
-	userDrowdonList = [];
-	typeDropdownList = [];
-	userActivityForm: FormGroup;
-	typeData: NgOption[];
-	userId = [];
-	typeValue: any;
-	usernameValue: string;
-	loadActivityData = false;
+    moment = (_moment as any).default ? (_moment as any).default : _moment;
+    userActivityData: any = [];
+    startDate: any;
+    endDate: any;
+    currentDate: any = this.moment().format('YYYY/MM/DD HH:mm');
+    type = [];
+    username = [];
+    showFilterBlock = false;
+    showStartDateFilter = false;
+    showEndDateFilter = false;
+    showTypeFilter = false;
+    showUsernameFilter = false;
+    userDrowdonList = [];
+    typeDropdownList = [];
+    userActivityForm: FormGroup;
+    userId = [];
+    typeValue: any;
+    usernameValue: string;
+    loadActivityData = false;
 
-  constructor( private userActivityService: UserActivityService,
-		private toastr: ToastrService,
-		private formBuilder: FormBuilder,
-		private loaderService: LoaderService,
-		private titleService: Title	,
-		private commonService: CommonService,
-		private router: Router,
-		private toaster: ToastrService
-		) {
+    constructor(private userActivityService: UserActivityService,
+                private toastr: ToastrService,
+                private formBuilder: FormBuilder,
+                private loaderService: LoaderService,
+                private titleService: Title,
+                public commonService: CommonService,
+                private router: Router,
+                private toaster: ToastrService
+    ) {
 
-			if (!this.commonService.hasPermission('menu_user_activity')) {
-				this.toaster.error(MessageObj.unauthorised);
-				 this.router.navigate(['/home']);
-				}
-		}
+        if (!this.commonService.hasPermission('menu_user_activity')) {
+            this.toaster.error(MessageObj.unauthorised);
+            this.router.navigate(['/home']);
+        }
 
-  ngOnInit() {
-	this.titleService.setTitle('OPEN KILDA - User Activity');
-	this.loaderService.show(MessageObj.loading_user_activity);
-	this.startDate =  this.moment().subtract(7, 'days').format('YYYY/MM/DD HH:mm');
-	this.endDate = this.moment().format('YYYY/MM/DD HH:mm');
-    this.callDropdownService();
-  	this.userActivityForm = this.formBuilder.group({
-      typeControl: [''],
-      usernameControl: [''],
-      toDateControl: [''],
-      fromDateControl: ['']
-	});
-	this.userActivityForm.controls['fromDateControl'].setValue(this.startDate);
-	this.userActivityForm.controls['toDateControl'].setValue(this.endDate);
-	this.showStartDateFilter = true;
-	this.showEndDateFilter = true;
-	this.getFilteredDetails();
-  }
+        if (this.commonService.hasPermission('menu_user_management')) {
+            this.callDropdownService();
+        } else {
+            this.userId = [localStorage.getItem('user_id')];
+        }
 
 
-callDropdownService() {
-    this.userActivityService.getDropdownList().subscribe((data: any) => {
-		this.typeDropdownList = data.activity_types;
-		this.userDrowdonList = data.activity_users;
-	 }, error => {
-       this.toastr.error('No type dropdown data', 'Error');
-     });
-  }
+    }
 
-  onStartDateChange(event) {
-	  this.startDate = event.target.value;
-	  if (this.moment(new Date(this.startDate)).isAfter(this.moment(new Date(this.endDate)))) {
-		this.toastr.error('Start Date must me less than End Date', 'Error');
-		this.startDate = null;
-		event.target.value = '';
-		return;
-	} else if (this.moment(new Date(this.startDate)).isAfter(this.moment(new Date()))) {
-		this.toastr.error('Start Date must me less than current Date and Time', 'Error');
-		this.startDate = null;
-		event.target.value = '';
-		return;
-	}
-  	if (this.startDate !== '') {
-  		this.showStartDateFilter = true;
-  	} else {
-  		this.showStartDateFilter = false;
-  	}
-  	this.checkAllFilters();
-  }
+    ngOnInit() {
+        this.titleService.setTitle('OPEN KILDA - User Activity');
+        this.loaderService.show(MessageObj.loading_user_activity);
+        this.startDate = this.moment().subtract(7, 'days').format('YYYY/MM/DD HH:mm');
+        this.endDate = this.moment().format('YYYY/MM/DD HH:mm');
+        this.userActivityForm = this.formBuilder.group({
+            typeControl: [''],
+            usernameControl: [''],
+            toDateControl: [''],
+            fromDateControl: ['']
+        });
+        this.userActivityForm.controls['fromDateControl'].setValue(this.startDate);
+        this.userActivityForm.controls['toDateControl'].setValue(this.endDate);
+        this.showStartDateFilter = true;
+        this.showEndDateFilter = true;
+        this.getFilteredDetails();
+    }
 
-  onEndDateChange(event) {
-	  this.endDate = event.target.value;
-	  if (this.moment(new Date(this.startDate)).isAfter(this.moment(new Date(this.endDate)))) {
-		  this.toastr.error('End Date must me greater than Start Date', 'Error');
-		  this.endDate = null;
-		  event.target.value = '';
-		  return;
-	  }
-  	if (this.endDate !== '') {
-  		this.showEndDateFilter = true;
-  	} else {
-  		this.showEndDateFilter = false;
-  	}
-  	this.checkAllFilters();
-  }
+    callDropdownService() {
+        this.userActivityService.getDropdownList().subscribe((data: any) => {
+            this.typeDropdownList = data.activity_types;
+            this.userDrowdonList = data.activity_users;
+        }, error => {
+            this.toastr.error('No type dropdown data', 'Error');
+        });
+    }
 
-  onTypeInputChange(event) {
-  	this.type = [];
-  	if (event.length > 0) {
-  	for (let i = 0 ; i < event.length; i++) {
-  		this.type.push(event[i].name);
-  	}}
-  	this.typeValue = this.type.toString();
-  	if (this.type.toString() !== '') {
-  		this.showTypeFilter = true;
-  	} else {
-  		this.showTypeFilter = false;
-  	}
-  	this.checkAllFilters();
-  }
+    onStartDateChange(event) {
+        this.startDate = event.target.value;
+        if (this.moment(new Date(this.startDate)).isAfter(this.moment(new Date(this.endDate)))) {
+            this.toastr.error('Start Date must me less than End Date', 'Error');
+            this.startDate = null;
+            event.target.value = '';
+            return;
+        } else if (this.moment(new Date(this.startDate)).isAfter(this.moment(new Date()))) {
+            this.toastr.error('Start Date must me less than current Date and Time', 'Error');
+            this.startDate = null;
+            event.target.value = '';
+            return;
+        }
+        if (this.startDate !== '') {
+            this.showStartDateFilter = true;
+        } else {
+            this.showStartDateFilter = false;
+        }
+        this.checkAllFilters();
+    }
 
-  onUsernameInputChange(event) {
-		this.userId = [];
-		this.username = [];
-  		if (event.length > 0) {
-	  	for (let i = 0 ; i < event.length ; i++) {
-  			this.userId.push(event[i].user_id);
-	  		this.username.push(event[i].user_name);
-  		}}
+    onEndDateChange(event) {
+        this.endDate = event.target.value;
+        if (this.moment(new Date(this.startDate)).isAfter(this.moment(new Date(this.endDate)))) {
+            this.toastr.error('End Date must me greater than Start Date', 'Error');
+            this.endDate = null;
+            event.target.value = '';
+            return;
+        }
+        if (this.endDate !== '') {
+            this.showEndDateFilter = true;
+        } else {
+            this.showEndDateFilter = false;
+        }
+        this.checkAllFilters();
+    }
 
-  	this.usernameValue = this.username.toString();
-  	if (this.username.toString() !== '') {
-  		this.showUsernameFilter = true;
-  	} else {
-  		this.showUsernameFilter = false;
-  	}
-  	this.checkAllFilters();
-  }
+    onTypeInputChange(event) {
+        this.type = [];
+        if (event.length > 0) {
+            for (let i = 0; i < event.length; i++) {
+                this.type.push(event[i].name);
+            }
+        }
+        this.typeValue = this.type.toString();
+        if (this.type.toString() !== '') {
+            this.showTypeFilter = true;
+        } else {
+            this.showTypeFilter = false;
+        }
+        this.checkAllFilters();
+    }
 
-  checkAllFilters() {
-  	if (this.showUsernameFilter === false && this.showTypeFilter === false &&
-  	 this.showEndDateFilter === false && this.showStartDateFilter === false ) {
-  		this.showFilterBlock = false;
-  	} else {
-  		this.showFilterBlock = true;
-  	}
-  }
+    onUsernameInputChange(event) {
+        this.userId = [];
+        this.username = [];
+        if (event.length > 0) {
+            for (let i = 0; i < event.length; i++) {
+                this.userId.push(event[i].user_id);
+                this.username.push(event[i].user_name);
+            }
+        }
 
-  getFilteredDetails() {
-	this.loadActivityData = true;
-    this.loaderService.show(MessageObj.loading_user_activity);
-  	this.userActivityService.getFilteredUserActivityList(this.userId, this.type, this.startDate, this.endDate).subscribe((data: any) => {
-    data = data.sort(function(a, b) {
-    return b.activityTime - a.activityTime;
-    });
-    this.loaderService.hide();
-	this.userActivityData = data;
-	this.loadActivityData = false;
-     }, error => {
-       this.loaderService.hide();
-	   this.toastr.error(MessageObj.no_user_activity, 'Error');
-	   this.userActivityData = [];
-	   this.loadActivityData = false;
+        this.usernameValue = this.username.toString();
+        if (this.username.toString() !== '') {
+            this.showUsernameFilter = true;
+        } else {
+            this.showUsernameFilter = false;
+        }
+        this.checkAllFilters();
+    }
 
-     });
-  }
+    checkAllFilters() {
+        if (this.showUsernameFilter === false && this.showTypeFilter === false &&
+            this.showEndDateFilter === false && this.showStartDateFilter === false) {
+            this.showFilterBlock = false;
+        } else {
+            this.showFilterBlock = true;
+        }
+    }
 
-  removeStartDateFilter() {
-  	this.startDate = '';
-    this.userActivityForm.controls['fromDateControl'].setValue('');
-  	this.showStartDateFilter = false;
-  	this.checkAllFilters();
-  }
+    getFilteredDetails() {
+        this.loadActivityData = true;
+        this.loaderService.show(MessageObj.loading_user_activity);
+        this.userActivityService.getFilteredUserActivityList(this.userId, this.type, this.startDate, this.endDate).subscribe((data: any) => {
+            data = data.sort(function (a, b) {
+                return b.activityTime - a.activityTime;
+            });
+            this.loaderService.hide();
+            this.userActivityData = data;
+            this.loadActivityData = false;
+        }, error => {
+            this.loaderService.hide();
+            this.toastr.error(MessageObj.no_user_activity, 'Error');
+            this.userActivityData = [];
+            this.loadActivityData = false;
+        });
+    }
 
-  removeEndDateFilter() {
-  	this.endDate = '';
-  	this.showEndDateFilter = false;
-    this.userActivityForm.controls['toDateControl'].setValue('');
-  	this.checkAllFilters();
-  }
+    removeStartDateFilter() {
+        this.startDate = '';
+        this.userActivityForm.controls['fromDateControl'].setValue('');
+        this.showStartDateFilter = false;
+        this.checkAllFilters();
+    }
 
-  removeUsernameFilter() {
-  	this.userId = [];
-    this.userActivityForm.controls['usernameControl'].setValue([]);
-  	this.showUsernameFilter = false;
-  	this.checkAllFilters();
-  }
+    removeEndDateFilter() {
+        this.endDate = '';
+        this.showEndDateFilter = false;
+        this.userActivityForm.controls['toDateControl'].setValue('');
+        this.checkAllFilters();
+    }
 
-  removeTypeFilter() {
-  	this.type = [];
-    this.userActivityForm.controls['typeControl'].setValue([]);
-   	this.showTypeFilter = false;
-  	this.checkAllFilters();
-  }
+    removeUsernameFilter() {
+        this.userId = [];
+        this.userActivityForm.controls['usernameControl'].setValue([]);
+        this.showUsernameFilter = false;
+        this.checkAllFilters();
+    }
 
-  setToCurrentDate() {
-  	this.endDate = this.moment().format('YYYY/MM/DD HH:mm');
-  	this.userActivityForm.controls['toDateControl'].setValue(this.endDate);
-  	const event = { 'target' : { 'value': this.endDate}} ;
-  	this.onEndDateChange(event);
-  }
+    removeTypeFilter() {
+        this.type = [];
+        this.userActivityForm.controls['typeControl'].setValue([]);
+        this.showTypeFilter = false;
+        this.checkAllFilters();
+    }
+
+    setToCurrentDate() {
+        this.endDate = this.moment().format('YYYY/MM/DD HH:mm');
+        this.userActivityForm.controls['toDateControl'].setValue(this.endDate);
+        const event = {'target': {'value': this.endDate}};
+        this.onEndDateChange(event);
+    }
 }


### PR DESCRIPTION
added permission (menu_user_management) check for user activity page

problem described here: closes: https://github.com/telstra/open-kilda/issues/4485


Steps to reproduce:
1) Create user with permission 'menu_user_activity', but without 'menu_user_management'
2) change the password for the created user:
<img width="1376" alt="image" src="https://github.com/telstra/open-kilda/assets/9297385/789c73c0-2772-484e-8f04-a73d657aacdb">
3) Copy the password to the clipboard
4) login to the newly created user and go to the 'user activity page'
<img width="1421" alt="image" src="https://github.com/telstra/open-kilda/assets/9297385/91f8fa47-36db-43b0-87f5-52431921ad93">
5) Result: Username selectbox  is not shown for the users who have no 'menu_user_management' permission. Also as you may see on the last screenshot the user activity data is loaded via the following get request:
`/openkilda/api/useractivity/log?userId=2&startTime...`  it has userId urlParameter that is used to pass the needed user, this parameter is not new and I decided to use it to load only activity data for loged in user. For example for users with the 'menu_user_management' permission get request looks like this:
`/openkilda/api/useractivity/log?userId=&startTime...`. So while approach that I filter the activityData is not the best(because still it is possible to load needed userActivity data just passing zero arguments, but this is another scope..), I see no alternative option to solve the task without significant code changes.

closes: #4485 