### PR TITLE
Simple flow: move saving history dumps so that they saved before or after the IN_PROGRESS state

### DIFF
--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocatePrimaryResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocatePrimaryResourcesAction.java
@@ -100,7 +100,7 @@ public class AllocatePrimaryResourcesAction extends
         setMirrorPointsToNewPath(oldPaths.getForwardPathId(), newForwardPathId);
         setMirrorPointsToNewPath(oldPaths.getReversePathId(), newReversePathId);
 
-        saveAllocationActionWithDumpsToHistory(stateMachine, tmpFlow, "primary", createdPaths);
+        stateMachine.saveActionToHistory("Primary resources have been allocated");
     }
 
     @Override

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocateProtectedResourcesAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/AllocateProtectedResourcesAction.java
@@ -109,7 +109,7 @@ public class AllocateProtectedResourcesAction extends
                     stateMachine.getSharedBandwidthGroupId());
             log.debug("New protected path has been created: {}", createdPaths);
 
-            saveAllocationActionWithDumpsToHistory(stateMachine, tmpFlow, "protected", createdPaths);
+            stateMachine.saveActionToHistory("Protected resources have been allocated");
         }
     }
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/CompleteFlowPathRemovalAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/CompleteFlowPathRemovalAction.java
@@ -77,6 +77,7 @@ public class CompleteFlowPathRemovalAction extends
                 updateIslsForFlowPath(removedPaths.getReverse());
             }
             if (removedPaths != null) {
+                // TODO this saves a dump with paths' status IN_PROGRESS and state BEFORE which is confusing for users
                 saveRemovalActionWithDumpToHistory(stateMachine, originalFlow, removedPaths);
             }
         }

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/UpdateFlowAction.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/fsm/update/actions/UpdateFlowAction.java
@@ -26,9 +26,6 @@ import org.openkilda.persistence.PersistenceManager;
 import org.openkilda.persistence.repositories.RepositoryFactory;
 import org.openkilda.persistence.repositories.SwitchRepository;
 import org.openkilda.wfm.error.FlowNotFoundException;
-import org.openkilda.wfm.share.history.model.DumpType;
-import org.openkilda.wfm.share.history.model.FlowDumpData;
-import org.openkilda.wfm.share.mappers.HistoryMapper;
 import org.openkilda.wfm.topology.flowhs.exception.FlowProcessingException;
 import org.openkilda.wfm.topology.flowhs.fsm.common.actions.NbTrackableWithHistorySupportAction;
 import org.openkilda.wfm.topology.flowhs.fsm.update.FlowUpdateContext;
@@ -90,12 +87,10 @@ public class UpdateFlowAction extends
                 stateMachine.setNewPrimaryReversePath(flow.getReversePathId());
                 stateMachine.setNewProtectedForwardPath(flow.getProtectedForwardPathId());
                 stateMachine.setNewProtectedReversePath(flow.getProtectedReversePathId());
-                FlowDumpData dumpData = HistoryMapper.INSTANCE.map(flow, flow.getForwardPath(), flow.getReversePath(),
-                        DumpType.STATE_AFTER);
-                stateMachine.saveActionWithDumpToHistory("New endpoints were stored for flow",
+
+                stateMachine.saveActionToHistory("New endpoints were stored for flow",
                         format("The flow endpoints were updated for: %s / %s",
-                                flow.getSrcSwitch(), flow.getDestSwitch()),
-                        dumpData);
+                                flow.getSrcSwitch(), flow.getDestSwitch()));
             }
         });
 


### PR DESCRIPTION
This change moves saving history with dumps `BEFORE` to the earlier stage, before any changes are made to the flow, and dumps `AFTER` to the later stage, after the correct statuses are already set.

closes #5373 