### PR TITLE
#5390: [TEST] Prevent one way to false fail Flow Monitoring test

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowMonitoringSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowMonitoringSpec.groovy
@@ -161,7 +161,7 @@ and flowLatencyMonitoringReactions is disabled in featureToggle"() {
         flowHelperV2.addFlow(flow)
         //wait for generating some flow-monitoring stats
         wait(flowSlaCheckIntervalSeconds + WAIT_OFFSET) {
-            assert flowStats.rttOf(flow.getFlowId()).get(FLOW_RTT, REVERSE, FLOW_MONITORING).hasNonZeroValues()
+            assert flowStats.rttOf(flow.getFlowId()).get(FLOW_RTT, FORWARD, FLOW_MONITORING).hasNonZeroValues()
         }
         pathHelper.convert(northbound.getFlowPath(flow.flowId)) == mainPath
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MaxLatencySpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MaxLatencySpec.groovy
@@ -213,6 +213,7 @@ class MaxLatencySpec extends HealthCheckSpecification {
         assert pathHelper.convert(northbound.getFlowPath(flow.flowId)) == mainPath
 
         and: "Init auto reroute (bring port down on the src switch)"
+        setLatencyForPaths(10, 15)
         def islToBreak = pathHelper.getInvolvedIsls(mainPath).first()
         antiflap.portDown(islToBreak.srcSwitch.dpId, islToBreak.srcPort)
 


### PR DESCRIPTION
Implements #5390

* Changed flow RTT stats to FORWARD one in Flow Monitoring spec because the REVERSE ones seem to arrive to TSDB with higher delay
* Added call to modify ISL latencies in Max Latency spec to avoid refreshing latencies in DB before triggering rerouting