### PR TITLE
[TEST]: Storm: Disabling test that caused topology deletion issue

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/StormLcmSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/StormLcmSpec.groovy
@@ -19,6 +19,7 @@ import org.openkilda.northbound.dto.v2.flows.FlowRequestV2
 import org.openkilda.testing.Constants
 
 import org.springframework.beans.factory.annotation.Value
+import spock.lang.Ignore
 import spock.lang.Isolated
 import spock.lang.Narrative
 import spock.lang.Shared
@@ -108,6 +109,7 @@ class StormLcmSpec extends HealthCheckSpecification {
         flows.each { flowHelperV2.deleteFlow(it.flowId) }
     }
 
+    @Ignore
     @Tags(LOW_PRIORITY)
     def "System's able to fail an ISL if switches on both ends go offline during restart of network topology"() {
         when: "Kill network topology"


### PR DESCRIPTION
The issue occurred during rebuilding topology in the scope of the retry mechanism. The StormLcmSpec is the last executed and currently ignored test that creates and deletes incorrect network topology. As a result, we have two network topologies: `network` and `network_blue` and random issue during old topology creation(ex.: link deletion timeout, link wasn't deleted,  etc.) The reason why we have `network_blue` instead of the `network `is that we use different commands during Kilda deployment (up-stable -> network_blue, up-test-mode -> network).