### PR TITLE
[TEST]: #5504: Storm: Updating network topology manipulation

### DIFF
--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/DockerHelper.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/DockerHelper.groovy
@@ -59,4 +59,12 @@ class DockerHelper {
     private String getNetworkName() {
         dockerClient.listNetworks()*.name().find { it.contains('_default') && it.contains('kilda') }
     }
+
+    String execute(String containerId, String [] command) {
+        def execCreation = dockerClient.execCreate(containerId, command,
+                DockerClient.ExecCreateParam.attachStdout(), DockerClient.ExecCreateParam.attachStderr())
+        def output = dockerClient.execStart(execCreation.id())
+        def execOutput = output.readFully()
+        return execOutput
+    }
 }

--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/model/ContainerName.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/model/ContainerName.groovy
@@ -3,7 +3,8 @@ package org.openkilda.functionaltests.helpers.model
 enum ContainerName {
     GRPC("grpc-speaker"),
     GRPC_STUB("grpc-stub"),
-    WFM("wfm")
+    WFM("wfm"),
+    STORM("storm-ui")
 
     private final String id;
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/StormLcmSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/StormLcmSpec.groovy
@@ -21,6 +21,7 @@ import org.openkilda.testing.Constants
 import org.springframework.beans.factory.annotation.Value
 import spock.lang.Ignore
 import spock.lang.Isolated
+import spock.lang.Issue
 import spock.lang.Narrative
 import spock.lang.Shared
 
@@ -110,10 +111,14 @@ class StormLcmSpec extends HealthCheckSpecification {
     }
 
     @Ignore
+    @Issue("https://github.com/telstra/open-kilda/issues/5506 (ISL between deactivated switches is in a DISCOVERED state)")
     @Tags(LOW_PRIORITY)
     def "System's able to fail an ISL if switches on both ends go offline during restart of network topology"() {
+        given: "Actual network topology"
+        String networkTopologyName = wfmManipulator.getStormActualNetworkTopology()
+
         when: "Kill network topology"
-        wfmManipulator.killTopology("network")
+        wfmManipulator.killTopology(networkTopologyName)
 
         and: "Disconnect switches on both ends of ISL"
         def islUnderTest = topology.islsForActiveSwitches.first()
@@ -121,7 +126,7 @@ class StormLcmSpec extends HealthCheckSpecification {
         def dstBlockData = lockKeeper.knockoutSwitch(islUnderTest.dstSwitch, RW)
 
         and: "Deploy network topology back"
-        wfmManipulator.deployTopology("network")
+        wfmManipulator.deployTopology(networkTopologyName)
         def networkDeployed = true
         TimeUnit.SECONDS.sleep(45) //after deploy topology needs more time to actually begin working
 
@@ -139,7 +144,7 @@ class StormLcmSpec extends HealthCheckSpecification {
         }
 
         cleanup:
-        !networkDeployed && wfmManipulator.deployTopology("network")
+        networkTopologyName && !networkDeployed && wfmManipulator.deployTopology(networkTopologyName)
         srcBlockData && lockKeeper.reviveSwitch(islUnderTest.srcSwitch, srcBlockData)
         dstBlockData && lockKeeper.reviveSwitch(islUnderTest.dstSwitch, dstBlockData)
         Wrappers.wait(discoveryTimeout + WAIT_OFFSET * 3) {


### PR DESCRIPTION
Additional interaction with a storm-ui container has been added to identify the actual network topology name
(up-stable -> `network_blue`, up-test-mode -> `network`).

This test is disabled due to the existing issue https://github.com/telstra/open-kilda/issues/5506