### PR TITLE
[TEST]: Improvement #5390: Cleanup: Optional ISLs resetting if required

### DIFF
--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/extension/tags/Tag.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/extension/tags/Tag.groovy
@@ -19,4 +19,9 @@ enum Tag {
 
     //speed
     SLOW,//usually for 1minute+ tests
+
+    //topology links recovering only when an error occurred during test execution
+    ISL_RECOVER_ON_FAIL,
+    //resetting cost and bandwidth only when an error occurred during test execution
+    ISL_PROPS_DB_RESET
 }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/listeners/DoCleanupListener.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/listeners/DoCleanupListener.groovy
@@ -1,14 +1,24 @@
 package org.openkilda.functionaltests.listeners
 
 import static groovyx.gpars.GParsPool.withPool
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_PROPS_DB_RESET
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
+import static org.openkilda.functionaltests.helpers.Wrappers.wait
+import static org.openkilda.messaging.info.event.IslChangeType.FAILED
+import static org.openkilda.testing.Constants.TOPOLOGY_DISCOVERING_TIME
 
+import org.openkilda.functionaltests.extension.tags.Tags
+import org.openkilda.functionaltests.helpers.PortAntiflapHelper
 import org.openkilda.testing.model.topology.TopologyDefinition
+import org.openkilda.testing.service.database.Database
 import org.openkilda.testing.service.northbound.NorthboundService
 
+import groovy.util.logging.Slf4j
 import org.spockframework.runtime.model.ErrorInfo
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 
+@Slf4j
 class DoCleanupListener extends AbstractSpringListener {
 
     @Autowired
@@ -17,8 +27,16 @@ class DoCleanupListener extends AbstractSpringListener {
     @Autowired @Qualifier("islandNb")
     NorthboundService northbound
 
+    @Autowired
+    Database database
+
+    @Autowired
+    PortAntiflapHelper antiflap
+
+
     @Override
     void error(ErrorInfo error) {
+        context && context.autowireCapableBeanFactory.autowireBean(this)
         def thrown = error.exception
         if (thrown instanceof AssertionError) {
             if (thrown.getMessage() && thrown.getMessage().contains("SwitchValidationExtendedResult(")) {
@@ -26,6 +44,28 @@ class DoCleanupListener extends AbstractSpringListener {
                     topology.activeSwitches.eachParallel { sw ->
                         northbound.synchronizeSwitch(sw.dpId, true)
                     }
+                }
+            }
+        }
+        if (error.method.name && ISL_PROPS_DB_RESET in error.method.getAnnotation(Tags)?.value()) {
+            log.info("Resetting ISLs bandwidth due to the failure in " + error.method.parent.name + "\nISLs: " + topology.isls)
+            database.resetIslsBandwidth(topology.isls)
+            log.info("Resetting ISLs cost due to the failure in " + error.method.parent.name)
+            database.resetCosts(topology.isls)
+        }
+
+        if (error.method.name && ISL_RECOVER_ON_FAIL in error.method.getAnnotation(Tags)?.value()) {
+            def failedLinks = northbound.getAllLinks().findAll { it.state == FAILED }
+            failedLinks && log.info("ISLs recovering(ports up) due to the failure in " + error.method.parent.name)
+            failedLinks.collectMany { return [it.source.switchId, it.destination.switchId] }.unique()
+                    .each { switchId ->
+                        northbound.getPorts(switchId).findAll { port -> port.config == ["PORT_DOWN"] }
+                                .each { portDetails -> antiflap.portUp(switchId, portDetails.portNumber) }
+                    }
+            if (failedLinks) {
+                log.info("Waiting for ISLs to become DISCOVERED")
+                wait(TOPOLOGY_DISCOVERING_TIME) {
+                    assert northbound.getActiveLinks().size() == topology.islsForActiveSwitches.size() * 2
                 }
             }
         }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
@@ -1,5 +1,6 @@
 package org.openkilda.functionaltests.spec.flows
 
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
 
 import org.openkilda.functionaltests.error.flow.FlowNotCreatedExpectedError
 import org.openkilda.functionaltests.error.flow.FlowNotCreatedWithConflictExpectedError
@@ -465,6 +466,7 @@ class FlowCrudSpec extends HealthCheckSpecification {
         database.resetCosts(topology.isls)
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Error is returned if there is no available path to #data.isolatedSwitchType switch"() {
         given: "A switch that has no connection to other switches"
         def isolatedSwitch = switchPairs.all().nonNeighbouring().random().src
@@ -696,6 +698,7 @@ Failed to find path with requested bandwidth=${IMPOSSIBLY_HIGH_BANDWIDTH}/)
         ]
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Unable to create a flow on an isl port when ISL status is FAILED"() {
         given: "An inactive isl with failed state"
         Isl isl = topology.islsForActiveSwitches.find { it.aswitch && it.dstSwitch }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV1Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV1Spec.groovy
@@ -1,5 +1,8 @@
 package org.openkilda.functionaltests.spec.flows
 
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_PROPS_DB_RESET
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
+
 import org.openkilda.functionaltests.error.flow.FlowNotCreatedExpectedError
 import org.openkilda.functionaltests.error.flow.FlowNotCreatedWithConflictExpectedError
 import org.openkilda.functionaltests.error.flow.FlowNotCreatedWithMissingPathExpectedError
@@ -492,6 +495,7 @@ class FlowCrudV1Spec extends HealthCheckSpecification {
         database.resetCosts(topology.isls)
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Error is returned if there is no available path to #data.isolatedSwitchType switch"() {
         given: "A switch that has no connection to other switches"
         def isolatedSwitch = switchPairs.all().nonNeighbouring().random().src
@@ -664,6 +668,7 @@ Failed to find path with requested bandwidth=$flow.maximumBandwidth/).matches(er
         ]
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Unable to create a flow on an isl port when ISL status is FAILED"() {
         given: "An inactive isl with failed state"
         Isl isl = topology.islsForActiveSwitches.find { it.aswitch && it.dstSwitch }
@@ -855,6 +860,7 @@ are not connected to the controller/).matches(exc)
         flows.each { it && flowHelper.deleteFlow(it) }
     }
 
+    @Tags([ISL_RECOVER_ON_FAIL, ISL_PROPS_DB_RESET])
     def "System doesn't create flow when reverse path has different bandwidth than forward path on the second link"() {
         given: "Two active not neighboring switches"
         def switchPair = topologyHelper.getAllNotNeighboringSwitchPairs().find {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowDiversitySpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowDiversitySpec.groovy
@@ -2,6 +2,7 @@ package org.openkilda.functionaltests.spec.flows
 
 import static groovyx.gpars.GParsExecutorsPool.withPool
 import static org.junit.jupiter.api.Assumptions.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.helpers.FlowHistoryConstants.CREATE_ACTION
@@ -208,7 +209,7 @@ class FlowDiversitySpec extends HealthCheckSpecification {
         [flow1, flow2, flow3].each { it && flowHelperV2.deleteFlow(it.flowId) }
     }
 
-    @Tags(SMOKE)
+    @Tags([SMOKE, ISL_RECOVER_ON_FAIL])
     def "Diverse flows are built through the same path if there are no alternative paths available"() {
         given: "Two active neighboring switches with two not overlapping paths at least"
         def switchPair = getSwitchPair(2)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowLoopSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowLoopSpec.groovy
@@ -1,5 +1,7 @@
 package org.openkilda.functionaltests.spec.flows
 
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
+
 import org.openkilda.functionaltests.error.flowloop.FlowLoopNotCreatedExpectedError
 import org.openkilda.functionaltests.error.flow.FlowNotFoundExpectedError
 import org.openkilda.functionaltests.error.flow.FlowNotUpdatedExpectedError
@@ -287,6 +289,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
         }
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "System is able to reroute a flow when flowLoop is created on it"() {
         given: "A multi switch flow with one alternative path at least"
         def allTraffGenSwIds = topology.activeTraffGens*.switchConnected*.dpId
@@ -442,6 +445,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
         [flow1, flow2, flow3].each { it && flowHelperV2.deleteFlow(it.flowId) }
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "System is able to autoSwapPath for a protected flow when flowLoop is created on it"() {
         given: "Two active switches with three diverse paths at least"
         def allTraffGenSwIds = topology.activeTraffGens*.switchConnected*.dpId

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/IntentionalRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/IntentionalRerouteSpec.groovy
@@ -4,6 +4,7 @@ import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs
 import static groovyx.gpars.GParsPool.withPool
 import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_PROPS_DB_RESET
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 import static org.openkilda.testing.Constants.DEFAULT_COST
 import static org.openkilda.testing.Constants.WAIT_OFFSET
@@ -33,6 +34,7 @@ class IntentionalRerouteSpec extends HealthCheckSpecification {
     @Autowired @Shared
     Provider<TraffExamService> traffExamProvider
 
+    @Tags(ISL_PROPS_DB_RESET)
     def "Not able to reroute to a path with not enough bandwidth available"() {
         given: "A flow with alternate paths available"
         def switchPair = topologyHelper.getAllNeighboringSwitchPairs().find { it.paths.size() > 1 } ?:
@@ -81,6 +83,7 @@ class IntentionalRerouteSpec extends HealthCheckSpecification {
         }
     }
 
+    @Tags(ISL_PROPS_DB_RESET)
     def "Able to reroute to a better path if it has enough bandwidth"() {
         given: "A flow with alternate paths available"
         def switchPair = topologyHelper.getAllNeighboringSwitchPairs().find { it.paths.size() > 1 } ?:
@@ -195,6 +198,7 @@ class IntentionalRerouteSpec extends HealthCheckSpecification {
         flow && flowHelperV2.deleteFlow(flow.flowId)
     }
 
+    @Tags(ISL_PROPS_DB_RESET)
     def "Able to reroute to a path with not enough bandwidth available in case ignoreBandwidth=true"() {
         given: "A flow with alternate paths available"
         def switchPair = topologyHelper.getAllNeighboringSwitchPairs().find { it.paths.size() > 1 } ?:
@@ -311,7 +315,7 @@ class IntentionalRerouteSpec extends HealthCheckSpecification {
         flow && flowHelperV2.deleteFlow(flow.flowId)
     }
 
-    @Tags([LOW_PRIORITY])
+    @Tags([LOW_PRIORITY, ISL_PROPS_DB_RESET])
     def "Not able to reroute to a path with not enough bandwidth available [v1 api]"() {
         given: "A flow with alternate paths available"
         def switchPair = topologyHelper.getAllNeighboringSwitchPairs().find { it.paths.size() > 1 } ?:
@@ -358,7 +362,7 @@ class IntentionalRerouteSpec extends HealthCheckSpecification {
         }
     }
 
-    @Tags([LOW_PRIORITY])
+    @Tags([LOW_PRIORITY, ISL_PROPS_DB_RESET])
     def "Able to reroute to a better path if it has enough bandwidth [v1 api]"() {
         given: "A flow with alternate paths available"
         def switchPair = topologyHelper.getAllNeighboringSwitchPairs().find { it.paths.size() > 1 } ?:

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MirrorEndpointsSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MirrorEndpointsSpec.groovy
@@ -69,6 +69,10 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
     @Autowired @Shared
     FlowStats flowStats
 
+    def setupSpec() {
+        deleteAnyFlowsLeftoversIssue5480()
+    }
+
     @Tags([SMOKE, SMOKE_SWITCHES, TOPOLOGY_DEPENDENT])
     def "Able to CRUD a mirror endpoint on the src switch, mirror to the same switch diff port [#swPair.src.hwSwString, #mirrorDirection]#trafficDisclaimer"() {
         given: "A flow"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MultiRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MultiRerouteSpec.groovy
@@ -1,10 +1,12 @@
 package org.openkilda.functionaltests.spec.flows
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.*
 import static org.openkilda.functionaltests.helpers.Wrappers.wait
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.messaging.info.event.IslChangeType
 import org.openkilda.messaging.payload.flow.FlowState
 import org.openkilda.northbound.dto.v2.flows.FlowRequestV2
@@ -14,6 +16,7 @@ import java.util.concurrent.TimeUnit
 
 class MultiRerouteSpec extends HealthCheckSpecification {
 
+    @Tags([ISL_RECOVER_ON_FAIL, ISL_PROPS_DB_RESET])
     def "Simultaneous reroute of multiple flows should not oversubscribe any ISLs"() {
         given: "Many flows on the same path, with alt paths available"
         def switchPair = topologyHelper.getAllNeighboringSwitchPairs().find { it.paths.size() > 2 } ?:

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PinnedFlowSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PinnedFlowSpec.groovy
@@ -1,5 +1,7 @@
 package org.openkilda.functionaltests.spec.flows
 
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
+
 import org.openkilda.functionaltests.error.PinnedFlowNotReroutedExpectedError
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue
@@ -76,6 +78,7 @@ class PinnedFlowSpec extends HealthCheckSpecification {
         flow && flowHelperV2.deleteFlow(flow.flowId)
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "System doesn't reroute(automatically) pinned flow when flow path is partially broken"() {
         given: "A pinned flow going through a long not preferable path"
         def switchPair = topologyHelper.getAllNotNeighboringSwitchPairs().find { it.paths.size() > 1 } ?:

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
@@ -2,6 +2,8 @@ package org.openkilda.functionaltests.spec.flows
 
 import static groovyx.gpars.GParsPool.withPool
 import static org.junit.jupiter.api.Assumptions.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_PROPS_DB_RESET
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE_SWITCHES
@@ -324,6 +326,7 @@ class ProtectedPathSpec extends HealthCheckSpecification {
         flow && flowHelperV2.deleteFlow(flow.flowId)
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "System is able to switch #flowDescription flows to protected paths"() {
         given: "Two active not neighboring switches with three diverse paths at least"
         def initialIsls = northbound.getAllLinks()
@@ -413,6 +416,7 @@ class ProtectedPathSpec extends HealthCheckSpecification {
         "an unmetered"  | 0
     }
 
+    @Tags([ISL_RECOVER_ON_FAIL, ISL_PROPS_DB_RESET])
     def "Flow swaps to protected path when main path gets broken, becomes DEGRADED if protected path is unable to reroute(no bw)"() {
         given: "Two switches with 2 diverse paths at least"
         def switchPair = topologyHelper.switchPairs.find {
@@ -473,6 +477,7 @@ doesn't have links with enough bandwidth, Failed to find path with requested ban
         database.resetCosts(topology.isls)
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Flow swaps to protected path when main path gets broken, becomes DEGRADED if protected path is unable to reroute(no path)"() {
         given: "Two switches with 2 diverse paths at least"
         def switchPair = topologyHelper.switchPairs.find {
@@ -594,6 +599,7 @@ doesn't have links with enough bandwidth, Failed to find path with requested ban
         "an unmetered"  | 0
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "System is able to switch #flowDescription flow to protected path and ignores more preferable path when reroute\
  is automatical"() {
         given: "Two active not neighboring switches with three diverse paths at least"
@@ -695,7 +701,7 @@ doesn't have links with enough bandwidth, Failed to find path with requested ban
         flow && flowHelperV2.deleteFlow(flow.flowId)
     }
 
-    @Tags(LOW_PRIORITY)
+    @Tags([LOW_PRIORITY, ISL_PROPS_DB_RESET])
     def "Able to update a flow to enable protected path when there is not enough bandwidth"() {
         given: "Two active neighboring switches"
         def isls = topology.getIslsForActiveSwitches()
@@ -729,6 +735,7 @@ doesn't have links with enough bandwidth, Failed to find path with requested ban
         isls.each { database.resetIslBandwidth(it) }
     }
 
+    @Tags(ISL_PROPS_DB_RESET)
     def "Able to create a flow with protected path when there is not enough bandwidth and ignoreBandwidth=true"() {
         given: "Two active neighboring switches"
         def isls = topology.getIslsForActiveSwitches()
@@ -758,6 +765,7 @@ doesn't have links with enough bandwidth, Failed to find path with requested ban
         isls.each { database.resetIslBandwidth(it) }
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "System is able to recalculate protected path when protected path is broken"() {
         given: "Two active not neighboring switches with two diverse paths at least"
         def allIsls = northbound.getAllLinks()
@@ -853,6 +861,7 @@ doesn't have links with enough bandwidth, Failed to find path with requested ban
         database.resetCosts(topology.isls)
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     @IterationTag(tags = [LOW_PRIORITY], iterationNameRegex = /unmetered/)
     def "Able to update #flowDescription flow to enable protected path if all alternative paths are unavailable"() {
         given: "Two active neighboring switches with two not overlapping paths at least"
@@ -904,6 +913,7 @@ doesn't have links with enough bandwidth, Failed to find path with requested ban
         "an unmetered"  | 0
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     @IterationTag(tags = [LOW_PRIORITY], iterationNameRegex = /unmetered/)
     def "#flowDescription flow is DEGRADED when protected and alternative paths are not available"() {
         given: "Two active neighboring switches with two not overlapping paths at least"
@@ -969,6 +979,7 @@ doesn't have links with enough bandwidth, Failed to find path with requested ban
         "An unmetered"  | 0
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "System properly reroutes both paths if protected path breaks during auto-swap"() {
         given: "Switch pair with at least 4 diverse paths"
         def switchPair = topologyHelper.switchPairs.find {
@@ -1077,6 +1088,7 @@ doesn't have links with enough bandwidth, Failed to find path with requested ban
         northbound.deleteLinkProps(northbound.getLinkProps(topology.isls))
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Protected path is created in different POP even if this path is not preferable"(){
         given: "Not neighboring switch pair with three diverse paths at least"
         def allPaths // all possible paths
@@ -1244,6 +1256,7 @@ doesn't have links with enough bandwidth, Failed to find path with requested ban
                 "Could not swap paths: Flow $NON_EXISTENT_FLOW_ID not found"
     }
 
+    @Tags(ISL_PROPS_DB_RESET)
     def "Unable to create a flow with protected path when there is not enough bandwidth"() {
         given: "Two active neighboring switches"
         def isls = topology.getIslsForActiveSwitches()
@@ -1272,7 +1285,7 @@ doesn't have links with enough bandwidth, Failed to find path with requested ban
         !exc && flowHelperV2.deleteFlow(flow.flowId)
     }
 
-    @Tags(LOW_PRIORITY)
+    @Tags([LOW_PRIORITY, ISL_RECOVER_ON_FAIL])
     def "Unable to swap paths for an inactive flow"() {
         given: "Two active neighboring switches with two not overlapping paths at least"
         def switchPair = topologyHelper.getAllNeighboringSwitchPairs().find {
@@ -1429,6 +1442,7 @@ doesn't have links with enough bandwidth, Failed to find path with requested ban
         flow && flowHelperV2.deleteFlow(flow.flowId)
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     @IterationTag(tags = [LOW_PRIORITY], iterationNameRegex = /unmetered/)
     def "Unable to create #flowDescription flow with protected path if all alternative paths are unavailable"() {
         given: "Two active neighboring switches without alt paths"
@@ -1477,6 +1491,7 @@ doesn't have links with enough bandwidth, Failed to find path with requested ban
         "an unmetered"  | 0
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "System doesn't reroute main flow path when protected path is broken and new alt path is available\
 (altPath is more preferable than mainPath)"() {
         given: "Two active neighboring switches with three diverse paths at least"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathV1Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathV1Spec.groovy
@@ -2,6 +2,8 @@ package org.openkilda.functionaltests.spec.flows
 
 import static groovyx.gpars.GParsPool.withPool
 import static org.junit.jupiter.api.Assumptions.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_PROPS_DB_RESET
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 import static org.openkilda.functionaltests.helpers.FlowHistoryConstants.REROUTE_ACTION
 import static org.openkilda.functionaltests.helpers.FlowHistoryConstants.REROUTE_FAIL
@@ -186,6 +188,7 @@ class ProtectedPathV1Spec extends HealthCheckSpecification {
         flowHelper.deleteFlow(flow.id)
     }
 
+    @Tags(ISL_PROPS_DB_RESET)
     def "Unable to create a flow with protected path when there is not enough bandwidth"() {
         given: "Two active neighboring switches"
         def isls = topology.getIslsForActiveSwitches()
@@ -215,6 +218,7 @@ class ProtectedPathV1Spec extends HealthCheckSpecification {
         !exc && flowHelper.deleteFlow(flow.id)
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Unable to create #flowDescription flow with protected path if all alternative paths are unavailable"() {
         given: "Two active neighboring switches without alt paths"
         def switchPair = switchPairs.all().neighbouring().random()
@@ -463,6 +467,7 @@ class ProtectedPathV1Spec extends HealthCheckSpecification {
                 "Could not swap paths: Flow $NON_EXISTENT_FLOW_ID not found"
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Unable to swap paths for an inactive flow"() {
         given: "Two active neighboring switches with two not overlapping paths at least"
         def switchPair = topologyHelper.getAllNeighboringSwitchPairs().find {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
@@ -2,6 +2,7 @@ package org.openkilda.functionaltests.spec.flows
 
 import static groovyx.gpars.GParsPool.withPool
 import static org.junit.jupiter.api.Assumptions.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 import static org.openkilda.functionaltests.helpers.FlowHistoryConstants.REROUTE_ACTION
 import static org.openkilda.functionaltests.helpers.FlowHistoryConstants.REROUTE_FAIL
@@ -750,6 +751,7 @@ switches"() {
         !isTestCompleted && [swPair.src.dpId, swPair.dst.dpId].each { northbound.synchronizeSwitch(it, true) }
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Able to swap endpoints for two flows when all bandwidth on ISL is consumed"() {
         setup: "Create two flows with different source and the same destination switches"
         List<SwitchPair> switchPairs = topologyHelper.allNeighboringSwitchPairs.inject(null) { result, switchPair ->
@@ -843,6 +845,7 @@ switches"() {
         database.resetCosts(topology.isls)
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Unable to swap endpoints for two flows when not enough bandwidth on ISL"() {
         setup: "Create two flows with different source and the same destination switches"
         List<SwitchPair> switchPairs = topologyHelper.allNeighboringSwitchPairs.inject(null) { result, switchPair ->
@@ -932,7 +935,7 @@ switches"() {
         database.resetCosts(topology.isls)
     }
 
-    @Tags(LOW_PRIORITY)
+    @Tags([LOW_PRIORITY, ISL_RECOVER_ON_FAIL])
     def "Able to swap endpoints for two flows when not enough bandwidth on ISL and ignore_bandwidth=true"() {
         setup: "Create two flows with different source and the same destination switches"
         List<SwitchPair> switchPairs = topologyHelper.allNeighboringSwitchPairs.inject(null) { result, switchPair ->
@@ -1027,6 +1030,7 @@ switches"() {
     }
 
     @Ignore("https://github.com/telstra/open-kilda/issues/3770")
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Unable to swap endpoints for two flows when one of them is inactive"() {
         setup: "Create two flows with different source and the same destination switches"
         List<SwitchPair> switchPairs = topologyHelper.allNeighboringSwitchPairs.inject(null) { result, switchPair ->

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ThrottlingRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ThrottlingRerouteSpec.groovy
@@ -1,6 +1,7 @@
 package org.openkilda.functionaltests.spec.flows
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.VIRTUAL
 import static org.openkilda.functionaltests.helpers.FlowHistoryConstants.REROUTE_ACTION
@@ -41,7 +42,7 @@ class ThrottlingRerouteSpec extends HealthCheckSpecification {
     @Value('${reroute.hardtimeout}')
     int rerouteHardTimeout
 
-    @Tags(SMOKE)
+    @Tags([SMOKE, ISL_RECOVER_ON_FAIL])
     //    unignored. Tests needs supervision next builds
     def "Reroute is not performed while new reroutes are being issued"() {
         given: "Multiple flows that can be rerouted independently (use short unique paths)"
@@ -104,6 +105,7 @@ class ThrottlingRerouteSpec extends HealthCheckSpecification {
     }
 
     @Ignore("Unstable")
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Reroute is performed after hard timeout even though new reroutes are still being issued"() {
         given: "Multiple flows that can be rerouted independently (use short unique paths)"
         /* Here we will pick only short flows that consist of 2 switches, so that we can maximize amount of unique
@@ -179,6 +181,7 @@ class ThrottlingRerouteSpec extends HealthCheckSpecification {
         }
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Flow can be safely deleted while it is in the reroute window waiting for reroute"() {
         given: "A flow"
         def (Switch srcSwitch, Switch dstSwitch) = topology.activeSwitches
@@ -194,7 +197,7 @@ class ThrottlingRerouteSpec extends HealthCheckSpecification {
         def flowIsDeleted = true
 
         then: "The flow is not present in NB"
-        northboundV2.getAllFlows().empty
+        !northboundV2.getAllFlows().find { it.flowId == flow.flowId}
 
         and: "Related switches have no excess rules"
         //wait, server42 rules may take some time to disappear after flow removal

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowIntentionalRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowIntentionalRerouteSpec.groovy
@@ -2,9 +2,11 @@ package org.openkilda.functionaltests.spec.flows.haflows
 
 import static groovyx.gpars.GParsPool.withPool
 import static org.junit.jupiter.api.Assumptions.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_PROPS_DB_RESET
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 
 import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.HaFlowHelper
 import org.openkilda.functionaltests.helpers.HaPathHelper
 import org.openkilda.functionaltests.helpers.PathHelper
@@ -33,6 +35,7 @@ class HaFlowIntentionalRerouteSpec extends HealthCheckSpecification {
     @Shared
     HaPathHelper haPathHelper
 
+    @Tags(ISL_PROPS_DB_RESET)
     def "Not able to reroute to a path with not enough bandwidth available"() {
         given: "An HA-flow with alternate paths available"
         def swT = topologyHelper.findSwitchTripletWithAlternativePaths()
@@ -85,6 +88,7 @@ class HaFlowIntentionalRerouteSpec extends HealthCheckSpecification {
         }
     }
 
+    @Tags(ISL_PROPS_DB_RESET)
     def "Able to reroute to a better path if it has enough bandwidth"() {
         given: "An HA-flow with alternate paths available"
         def swT = topologyHelper.findSwitchTripletWithAlternativePaths()
@@ -158,6 +162,7 @@ class HaFlowIntentionalRerouteSpec extends HealthCheckSpecification {
         thinIsl && [thinIsl, thinIsl.reversed].each { database.resetIslBandwidth(it) }
     }
 
+    @Tags(ISL_PROPS_DB_RESET)
     def "Able to reroute to a path with not enough bandwidth available in case ignoreBandwidth=true"() {
         given: "A HA-flow with alternate paths available"
         def swT = topologyHelper.findSwitchTripletWithAlternativePaths()

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowPingSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowPingSpec.groovy
@@ -1,5 +1,7 @@
 package org.openkilda.functionaltests.spec.flows.haflows
 
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
+
 import org.openkilda.functionaltests.HealthCheckSpecification
 import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.HaFlowHelper
@@ -89,7 +91,7 @@ class HaFlowPingSpec extends HealthCheckSpecification {
         haFlow && haFlowHelper.deleteHaFlow(haFlow.haFlowId)
     }
 
-    @Tags([LOW_PRIORITY])
+    @Tags([LOW_PRIORITY, ISL_RECOVER_ON_FAIL])
     def "Unable to ping one of the HA-subflows via periodic pings if related ISL is broken"() {
         given: "Pinned HA-flow with periodic pings turned on which won't be rerouted after ISL fails"
         def swT = topologyHelper.findSwitchTripletWithSharedEpInTheMiddleOfTheChain()

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowRerouteSpec.groovy
@@ -1,5 +1,7 @@
 package org.openkilda.functionaltests.spec.flows.haflows
 
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
+
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.functionaltests.model.stats.HaFlowStats
 
@@ -42,7 +44,7 @@ class HaFlowRerouteSpec extends HealthCheckSpecification {
     @Shared
     HaFlowStats haFlowStats
 
-    @Tags([TOPOLOGY_DEPENDENT])
+    @Tags([TOPOLOGY_DEPENDENT, ISL_RECOVER_ON_FAIL])
     def "Valid HA-flow can be rerouted"() {
         given: "An HA-flow"
         def swT = topologyHelper.findSwitchTripletWithAlternativePaths()
@@ -124,7 +126,7 @@ class HaFlowRerouteSpec extends HealthCheckSpecification {
         database.resetCosts(topology.isls)
     }
 
-    @Tags(SMOKE)
+    @Tags([SMOKE, ISL_RECOVER_ON_FAIL])
     def "HA-flow in 'Down' status is rerouted when discovering a new ISL"() {
         given: "An HA-flow"
         def swT = topologyHelper.findSwitchTripletWithAlternativeFirstPortPaths()
@@ -189,7 +191,7 @@ class HaFlowRerouteSpec extends HealthCheckSpecification {
         }
     }
 
-    @Tags(SMOKE)
+    @Tags([SMOKE, ISL_RECOVER_ON_FAIL])
     def "HA-flow goes to 'Down' status when ISl of the HA-flow fails and there is no alt path to reroute"() {
         given: "An HA-flow without alternative paths"
         def swT = topologyHelper.findSwitchTripletWithDifferentEndpoints()

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowCreateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowCreateSpec.groovy
@@ -64,7 +64,9 @@ class YFlowCreateSpec extends HealthCheckSpecification {
         northboundV2.getYFlow(yFlow.YFlowId).YPoint
 
         and: "2 sub-flows are created, visible via regular 'dump flows' API"
-        northboundV2.getAllFlows()*.flowId.sort() == yFlow.subFlows*.flowId.sort()
+        def regularFlowIds = northboundV2.getAllFlows()*.flowId
+        yFlow.subFlows.first().flowId in regularFlowIds
+        yFlow.subFlows.last().flowId in regularFlowIds
 
         and: "History has relevant entries about y-flow creation"
         Wrappers.wait(FLOW_CRUD_TIMEOUT) { flowHelper.getLatestHistoryEntry(yFlow.YFlowId).payload.last().action == CREATE_SUCCESS_Y }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowPathSwapSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowPathSwapSpec.groovy
@@ -1,5 +1,8 @@
 package org.openkilda.functionaltests.spec.flows.yflows
 
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_PROPS_DB_RESET
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
+
 import org.openkilda.functionaltests.model.stats.FlowStats
 
 import static groovyx.gpars.GParsPool.withPool
@@ -150,6 +153,7 @@ class YFlowPathSwapSpec extends HealthCheckSpecification {
         yFlow && yFlowHelper.deleteYFlow(yFlow.YFlowId)
     }
 
+    @Tags([ISL_RECOVER_ON_FAIL, ISL_PROPS_DB_RESET])
     def "System is able to switch a y-flow to protected paths"() {
         given: "A y-flow with protected paths"
         def swT = findSwitchTripletForYFlowWithProtectedPaths()
@@ -331,7 +335,7 @@ class YFlowPathSwapSpec extends HealthCheckSpecification {
                 "Y-flow $NON_EXISTENT_FLOW_ID not found"
     }
 
-    @Tags(LOW_PRIORITY)
+    @Tags([LOW_PRIORITY, ISL_RECOVER_ON_FAIL, ISL_PROPS_DB_RESET])
     def "Unable to swap paths for an inactive y-flow"() {
         given: "A y-flow with protected paths"
         def swT = findSwitchTripletForYFlowWithProtectedPaths()

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowRerouteSpec.groovy
@@ -1,5 +1,6 @@
 package org.openkilda.functionaltests.spec.flows.yflows
 
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 
 import org.openkilda.functionaltests.error.yflow.YFlowRerouteExpectedError
@@ -53,7 +54,7 @@ class YFlowRerouteSpec extends HealthCheckSpecification {
     @Autowired @Shared
     FlowStats flowStats
 
-    @Tags([TOPOLOGY_DEPENDENT])
+    @Tags([TOPOLOGY_DEPENDENT, ISL_RECOVER_ON_FAIL])
     def "Valid y-flow can be rerouted"() {
         given: "A qinq y-flow"
         def swT = topologyHelper.switchTriplets.find { it ->
@@ -287,7 +288,7 @@ class YFlowRerouteSpec extends HealthCheckSpecification {
         yFlow && yFlowHelper.deleteYFlow(yFlow.YFlowId)
     }
 
-    @Tags([LOW_PRIORITY])
+    @Tags([LOW_PRIORITY, ISL_RECOVER_ON_FAIL])
     def "Y-Flow reroute has not been executed when one sub-flow is on the best path and there is no alternative path for another sub-flow due to the down ISLs" () {
         given: "Y-Flow has been created successfully"
         def swT = topologyHelper.switchTriplets.findAll{ SwitchTriplet.ALL_ENDPOINTS_DIFFERENT(it)}.first()

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/BfdSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/BfdSpec.groovy
@@ -1,5 +1,7 @@
 package org.openkilda.functionaltests.spec.links
 
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
+
 import org.openkilda.functionaltests.error.link.LinkBfdNotSetExpectedError
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue
@@ -208,6 +210,7 @@ class BfdSpec extends HealthCheckSpecification {
         }
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Deleting a failed BFD link also removes the BFD session from it"() {
         given: "An inactive a-switch link with BFD session"
         def isl = topology.islsForActiveSwitches.find { it.srcSwitch.noviflow && it.dstSwitch.noviflow &&

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkMaintenanceSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkMaintenanceSpec.groovy
@@ -1,6 +1,7 @@
 package org.openkilda.functionaltests.spec.links
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.testing.Constants.DEFAULT_COST
 import static org.openkilda.testing.Constants.PATH_INSTALLATION_TIME
@@ -95,6 +96,7 @@ class LinkMaintenanceSpec extends HealthCheckSpecification {
         isl && northbound.setLinkMaintenance(islUtils.toLinkUnderMaintenance(isl, false, false))
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Flows are rerouted to a path with link under maintenance when there are no other paths available"() {
         given: "Two active not neighboring switches with two possible paths at least"
         def switchPair = topologyHelper.getAllNotNeighboringSwitchPairs().find { it.paths.size() > 1 } ?:

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkPropertiesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkPropertiesSpec.groovy
@@ -1,5 +1,7 @@
 package org.openkilda.functionaltests.spec.links
 
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
+
 import org.openkilda.functionaltests.error.link.LinkPropertiesNotUpdatedExpectedError
 
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
@@ -207,7 +209,7 @@ class LinkPropertiesSpec extends HealthCheckSpecification {
         !linkPropsAreDeleted && northbound.deleteLinkProps(northbound.getLinkProps(topology.isls))
     }
 
-    @Tags(SMOKE)
+    @Tags([SMOKE, ISL_RECOVER_ON_FAIL])
     def "Newly discovered link gets cost and max bandwidth from link props"() {
         given: "An active ISL"
         def isl = topology.islsForActiveSwitches.first()

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
@@ -2,6 +2,7 @@ package org.openkilda.functionaltests.spec.links
 
 import static groovyx.gpars.GParsPool.withPool
 import static org.junit.jupiter.api.Assumptions.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
 import static org.openkilda.functionaltests.extension.tags.Tag.LOCKKEEPER
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE_SWITCHES
@@ -35,6 +36,10 @@ import java.util.concurrent.TimeUnit
 class LinkSpec extends HealthCheckSpecification {
     @Value('${antiflap.cooldown}')
     int antiflapCooldown
+
+    def setupSpec() {
+        deleteAnyFlowsLeftoversIssue5480()
+    }
 
     @Tags([SMOKE_SWITCHES, SMOKE, LOCKKEEPER])
     def "Link (not BFD) status is properly changed when link connectivity is broken (not port down)"() {
@@ -129,7 +134,7 @@ class LinkSpec extends HealthCheckSpecification {
         database.resetCosts(topology.isls)
     }
 
-    @Tags(SMOKE)
+    @Tags([SMOKE, ISL_RECOVER_ON_FAIL])
     def "Get all flows (UP/DOWN) going through a particular link"() {
         given: "Two active not neighboring switches"
         def switchPair = switchPairs.all().nonNeighbouring().random()
@@ -357,6 +362,7 @@ class LinkSpec extends HealthCheckSpecification {
         exc.responseBodyAsString.contains("ISL must NOT be in active state")
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Able to delete an inactive #islDescription link and re-discover it back afterwards"() {
         given: "An inactive link"
         assumeTrue(isl as boolean, "Unable to locate $islDescription ISL for this test")
@@ -715,6 +721,7 @@ class LinkSpec extends HealthCheckSpecification {
         getIsl().srcSwitch.dpId | getIsl().srcPort | getIsl().dstSwitch.dpId | null      | "dst_port"
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Unable to delete inactive link with flowPath"() {
         given: "An inactive link with flow on it"
         def switchPair = switchPairs.all().neighbouring().random()
@@ -748,6 +755,7 @@ class LinkSpec extends HealthCheckSpecification {
         database.resetCosts(topology.isls)
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Able to delete an active link with flowPath if using force delete"() {
         given: "Two active neighboring switches and two possible paths at least"
         def switchPair = topologyHelper.getAllNeighboringSwitchPairs().find {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/RoundTripIslSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/RoundTripIslSpec.groovy
@@ -3,6 +3,7 @@ package org.openkilda.functionaltests.spec.links
 import static groovyx.gpars.GParsPool.withPool
 import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
 import static org.openkilda.functionaltests.extension.tags.Tag.LOCKKEEPER
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE_SWITCHES
 import static org.openkilda.messaging.info.event.IslChangeType.DISCOVERED
@@ -34,6 +35,7 @@ class RoundTripIslSpec extends HealthCheckSpecification {
     via the 'knockoutSwitch' method on the stage env*/
     Integer customWaitOffset = WAIT_OFFSET * 4
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Isl with round-trip properly changes status after port events(#descr)"() {
         given: "Round-trip ISL with a-switch"
         def cleanupActions = []
@@ -362,6 +364,7 @@ round trip latency rule is removed on the dst switch"() {
         }
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Able to delete failed ISL without force if it was discovered with disabled portDiscovery on a switch"() {
         given: "A deleted round trip latency ISL"
         Isl roundTripIsl = topology.islsForActiveSwitches.find {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/UnstableIslSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/UnstableIslSpec.groovy
@@ -1,12 +1,14 @@
 package org.openkilda.functionaltests.spec.links
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
 import static org.openkilda.messaging.info.event.IslChangeType.DISCOVERED
 import static org.openkilda.messaging.info.event.IslChangeType.FAILED
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 import static org.openkilda.testing.service.floodlight.model.FloodlightConnectMode.RW
 
 import org.openkilda.functionaltests.HealthCheckSpecification
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.PathHelper
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.info.event.PathNode
@@ -100,6 +102,7 @@ class UnstableIslSpec extends HealthCheckSpecification {
 
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "ISL is marked as 'unstable' after port down and system takes it into account during flow creation"() {
         given: "Two active neighboring switches with two parallel links"
         def switchPair = topologyHelper.getAllNeighboringSwitchPairs().find {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/FlowStatSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/FlowStatSpec.groovy
@@ -1,5 +1,7 @@
 package org.openkilda.functionaltests.spec.stats
 
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
+
 import org.openkilda.functionaltests.model.stats.FlowStats
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue
@@ -207,6 +209,7 @@ class FlowStatSpec extends HealthCheckSpecification {
         northbound.deleteLinkProps(northbound.getLinkProps(topology.isls))
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "System collects stats when a protected flow was automatically rerouted"() {
         given: "Two active not neighboring switches with three not overlapping paths at least"
         def traffGenSwitches = topology.activeTraffGens*.switchConnected*.dpId
@@ -283,6 +286,7 @@ class FlowStatSpec extends HealthCheckSpecification {
         database.resetCosts(topology.isls)
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "System collects stat when protected flow is DEGRADED"() {
         given: "Two active not neighboring switches with two not overlapping paths at least"
         def traffGenSwitches = topology.activeTraffGens*.switchConnected*.dpId

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/FlowRulesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/FlowRulesSpec.groovy
@@ -3,6 +3,7 @@ package org.openkilda.functionaltests.spec.switches
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs
 import static groovyx.gpars.GParsPool.withPool
 import static org.junit.jupiter.api.Assumptions.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE_SWITCHES
@@ -553,7 +554,7 @@ class FlowRulesSpec extends HealthCheckSpecification {
         flow && flowHelperV2.deleteFlow(flow.flowId)
     }
 
-    @Tags([SMOKE, SMOKE_SWITCHES])
+    @Tags([SMOKE, SMOKE_SWITCHES, ISL_RECOVER_ON_FAIL])
     def "Traffic counters in ingress rule are reset on flow rerouting(multiTable mode)"() {
         given: "Two active neighboring switches and two possible flow paths at least"
         def allTraffgenSwitchIds = topology.activeTraffGens*.switchConnected*.dpId

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortHistorySpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortHistorySpec.groovy
@@ -1,6 +1,7 @@
 package org.openkilda.functionaltests.spec.switches
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE_SWITCHES
 import static org.openkilda.functionaltests.helpers.model.PortHistoryEvent.ANTI_FLAP_ACTIVATED
@@ -14,6 +15,7 @@ import static org.openkilda.testing.service.floodlight.model.FloodlightConnectMo
 
 import org.openkilda.functionaltests.HealthCheckSpecification
 import org.openkilda.functionaltests.extension.tags.IterationTag
+import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.functionaltests.helpers.model.PortHistoryEvent
 import org.openkilda.messaging.info.event.IslChangeType
@@ -36,7 +38,7 @@ class PortHistorySpec extends HealthCheckSpecification {
     //it means how often the 'ANTI_FLAP_PERIODIC_STATS' is logged in port history
     def antiflapDumpingInterval = 60
 
-    @IterationTag(tags = [SMOKE, SMOKE_SWITCHES], iterationNameRegex = /direct/)
+    @IterationTag(tags = [SMOKE, SMOKE_SWITCHES, ISL_RECOVER_ON_FAIL], iterationNameRegex = /direct/)
     def "Port history are created for the port down/up actions when link is #islDescription"() {
         given: "A link"
         assumeTrue(isl as boolean, "Unable to find $islDescription ISL for this test")
@@ -118,6 +120,7 @@ class PortHistorySpec extends HealthCheckSpecification {
         ]
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Port history should not be returned in case timeline is incorrect (timeBefore > timeAfter)"() {
         given: "A direct link with port history"
         def timestampBefore = System.currentTimeMillis()
@@ -160,6 +163,7 @@ class PortHistorySpec extends HealthCheckSpecification {
         portHistory.isEmpty()
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Port history is available when switch is DEACTIVATED"() {
         given: "A direct link"
         def timestampBefore = System.currentTimeMillis()

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortPropertiesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortPropertiesSpec.groovy
@@ -1,5 +1,7 @@
 package org.openkilda.functionaltests.spec.switches
 
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
+
 import org.openkilda.functionaltests.error.PortNotFoundExpectedError
 import org.openkilda.functionaltests.error.SwitchNotFoundExpectedError
 
@@ -115,6 +117,7 @@ class PortPropertiesSpec extends HealthCheckSpecification {
         def exc = thrown(HttpClientErrorException)
         new PortNotFoundExpectedError(sw.dpId, nonExistentPort, ~/Port not found exception/).matches(exc)    }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "System doesn't discover link when port discovery property is disabled"() {
         given: "A deleted link"
         def sw = topology.activeSwitches.first()

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchMaintenanceSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchMaintenanceSpec.groovy
@@ -1,6 +1,7 @@
 package org.openkilda.functionaltests.spec.switches
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.testing.Constants.DEFAULT_COST
 import static org.openkilda.testing.Constants.PATH_INSTALLATION_TIME
@@ -119,6 +120,7 @@ class SwitchMaintenanceSpec extends HealthCheckSpecification {
         northbound.deleteLinkProps(northbound.getLinkProps(topology.isls))
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Link discovered by a switch under maintenance is marked as maintained"() {
         given: "An active link"
         def isl = topology.islsForActiveSwitches.first()

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchPortConfigSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchPortConfigSpec.groovy
@@ -1,5 +1,7 @@
 package org.openkilda.functionaltests.spec.switches
 
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
+
 import org.openkilda.functionaltests.model.stats.SwitchStats
 import org.openkilda.functionaltests.model.stats.SwitchStatsMetric
 import org.springframework.beans.factory.annotation.Autowired
@@ -27,7 +29,7 @@ class SwitchPortConfigSpec extends HealthCheckSpecification {
     @Autowired @Shared
     SwitchStats switchStats;
 
-    @Tags([TOPOLOGY_DEPENDENT, SMOKE])
+    @Tags([TOPOLOGY_DEPENDENT, SMOKE, ISL_RECOVER_ON_FAIL])
     def "Able to bring ISL-busy port down/up on an #isl.srcSwitch.ofVersion switch #isl.srcSwitch.dpId"() {
         when: "Bring port down on the switch"
         def portDownTime = new Date().getTime()

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
@@ -1,5 +1,7 @@
 package org.openkilda.functionaltests.spec.switches
 
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
+
 import org.openkilda.functionaltests.error.SwitchNotFoundExpectedError
 import spock.lang.Shared
 
@@ -63,6 +65,7 @@ class SwitchesSpec extends HealthCheckSpecification {
         new SwitchNotFoundExpectedError(NON_EXISTENT_SWITCH_ID).matches(error)
     }
 
+    @Tags(ISL_RECOVER_ON_FAIL)
     def "Systems allows to get a flow that goes through a switch"() {
         given: "Two active not neighboring switches with two diverse paths at least"
         def switchPair = topologyHelper.getAllNotNeighboringSwitchPairs().find {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/toggles/FeatureTogglesV2Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/toggles/FeatureTogglesV2Spec.groovy
@@ -1,5 +1,7 @@
 package org.openkilda.functionaltests.spec.toggles
 
+import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
+
 import org.openkilda.functionaltests.error.flow.FlowForbiddenToCreateExpectedError
 import org.openkilda.functionaltests.error.flow.FlowForbiddenToDeleteExpectedError
 import org.openkilda.functionaltests.error.flow.FlowForbiddenToUpdateExpectedError
@@ -127,7 +129,7 @@ class FeatureTogglesV2Spec extends HealthCheckSpecification {
         newFlow && !deletedNewFlow && flowHelper.deleteFlow(newFlow.id)
     }
 
-    @Tags(HARDWARE)
+    @Tags([HARDWARE, ISL_RECOVER_ON_FAIL])
     @ResourceLock(DEFAULT_FLOW_ENCAP)
     def "Flow encapsulation type is changed while auto rerouting according to 'flows_reroute_using_default_encap_type' \
 feature toggle"() {
@@ -215,7 +217,7 @@ feature toggle"() {
     }
 
     @Ignore("https://github.com/telstra/open-kilda/issues/2955")
-    @Tags(HARDWARE)
+    @Tags([HARDWARE, ISL_RECOVER_ON_FAIL])
     @ResourceLock(DEFAULT_FLOW_ENCAP)
     def "Flow encapsulation type is not changed while syncing/auto rerouting/updating according to \
 'flows_reroute_using_default_encap_type' if switch doesn't support new type of encapsulation"() {
@@ -303,7 +305,7 @@ feature toggle"() {
         database.resetCosts(topology.isls)
     }
 
-    @Tags(LOW_PRIORITY)
+    @Tags([LOW_PRIORITY, ISL_RECOVER_ON_FAIL])
     def "System doesn't reroute flow when flows_reroute_on_isl_discovery: false"() {
         given: "A flow with alternative paths"
         def switchPair = topologyHelper.getAllNeighboringSwitchPairs().find {

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/database/Database.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/database/Database.java
@@ -46,6 +46,8 @@ public interface Database {
 
     boolean resetIslBandwidth(Isl isl);
 
+    boolean resetIslsBandwidth(List<Isl> isls);
+
     int getIslCost(Isl isl);
 
     boolean updateIslCost(Isl isl, int value);

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/database/DatabaseSupportImpl.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/database/DatabaseSupportImpl.java
@@ -221,6 +221,24 @@ public class DatabaseSupportImpl implements Database {
     }
 
     /**
+     * Set ISLs bandwidth to be equal to its speed (the default situation).
+     *
+     * @return true if at least 1 ISL was affected
+     */
+    @Override
+    public boolean resetIslsBandwidth(List<Isl> isls) {
+        return transactionManager.doInTransaction(() -> {
+            Collection<org.openkilda.model.Isl> dbIsls = getIsls(isls);
+            dbIsls.forEach(link -> {
+                link.setMaxBandwidth(link.getSpeed());
+                link.setAvailableBandwidth(link.getSpeed());
+                link.setDefaultMaxBandwidth(link.getSpeed());
+            });
+            return dbIsls.size() > 0;
+        });
+    }
+
+    /**
      * Remove all inactive switches.
      *
      * @return true if at least 1 switch was deleted


### PR DESCRIPTION
In the scope of the cleanup section, sometimes a link deletion issue occurs. As a result, the rest of the cleanup section has not been executed, and test leftovers (in our case, it is ISL setup) cause failures of some tests. As a solution, an additional cleanup has been added(resetting ISLs bandwidth/cost). Also, ISL recovering has been added when the appropriate test executions failed (tests include portDown event)