### PR TITLE
Add default options for gradle

### DIFF
--- a/confd/templates/makefile/makefile.tmpl
+++ b/confd/templates/makefile/makefile.tmpl
@@ -93,10 +93,10 @@ clean-sources:
 	cd src-java && ./gradlew clean
 
 compile compile-blue: update-props-blue compile-common
-	cd src-java && ./gradlew buildAndCopyArtifacts -PdestPath=../docker/BUILD --info --stacktrace $(GRADLE_COMPILE_PARAMS)
+	cd src-java && ./gradlew buildAndCopyArtifacts -PdestPath=../docker/BUILD $(GRADLE_COMPILE_PARAMS)
 
 compile-green: update-props-green compile-common
-	cd src-java && ./gradlew buildAndCopyArtifacts -PdestPath=../docker/BUILD --info --stacktrace $(GRADLE_COMPILE_PARAMS)
+	cd src-java && ./gradlew buildAndCopyArtifacts -PdestPath=../docker/BUILD $(GRADLE_COMPILE_PARAMS)
 
 compile-common:
 	$(MAKE) -C src-python/lab-service/lab test

--- a/src-java/build.gradle
+++ b/src-java/build.gradle
@@ -29,6 +29,7 @@ subprojects {
 
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'
+        options.fork = true
     }
 
     repositories {

--- a/src-java/gradle.properties
+++ b/src-java/gradle.properties
@@ -1,0 +1,26 @@
+# Default parameters for Gradle tasks in the root project are propagated to the downstream projects.
+# These default parameters could be overridden by passing arguments to the make command in the following way:
+#     make build-stable GRADLE_COMPILE_PARAMS="-x test -q"
+
+# Execute Gradle as a daemon.
+org.gradle.daemon=true
+
+# Equivalent to --build-cache; this enables caching, significantly speeding up consecutive runs.
+org.gradle.caching=true
+
+# Maximum memory set to 4G. If OutOfMemoryError persists, consider increasing the value and adding the -Xms4g parameter.
+org.gradle.jvmargs=-Xmx4g
+
+# This parameter performs the configuration phase before all other tasks and only when needed, optimizing Gradle for not so big projects.
+org.gradle.configureondemand=true
+
+# Enable parallel execution of Gradle tasks. Max workers set to 7, optimal for most modern PCs with hyper-threading and more than 4 physical cores.
+# This configuration ensures at least 1 core remains for OS purposes, preventing console glitches, SSH connection drops, and similar issues.
+org.gradle.parallel=true
+org.gradle.workers.max=7
+
+# Suppress gradle welcome messages.
+org.gradle.welcome=never
+
+# Display only info messages. Alternatively, one could use the 'quiet' level to reduce the output.
+org.gradle.logging.level=info


### PR DESCRIPTION
This change add default parameters to gradle, so that when we deploy OpenKilda using `make`, the build will be use incremental cache, parallel execution, and configure all projects in advance before executing tasks.

Gradle command line parameters have precedence. If somebody needs to tweak gradle build further, it is possible to pass the parameters when executing make command (it is the same as it was before):
```shell
make build-stable GRADLE_COMPILE_PARAMS="-x test -q"
```
In this example, build without executing unit tests and with the log verbosity level quiet. 

Java compile fork option creates a dedicated process for the Java compiler. The impact is not so significant, but it works a bit faster because of different spin up and garbage collection strategies.

closes #5155 