### PR TITLE
Add parameters validation to get flow and HA-flow history API.

### DIFF
--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/utils/flowhistory/FlowHistoryRangeConstraints.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/utils/flowhistory/FlowHistoryRangeConstraints.java
@@ -46,7 +46,7 @@ public class FlowHistoryRangeConstraints {
     public FlowHistoryRangeConstraints(Optional<Long> timeFromInput,
                                        Optional<Long> timeToInput,
                                        Optional<Integer> maxCountInput) {
-        if (timeFromInput.isPresent() && timeToInput.isPresent() && timeFromInput.get() > timeToInput.get()) {
+        if (isTimeFromAfterTimeTo(timeFromInput, timeToInput)) {
             throw new MessageException(RequestCorrelationId.getId(), System.currentTimeMillis(),
                     ErrorType.PARAMETERS_INVALID, format("Invalid 'timeFrom' and 'timeTo' arguments: %s and %s",
                     timeFromInput.get(), timeToInput.get()),
@@ -74,6 +74,10 @@ public class FlowHistoryRangeConstraints {
         contentRangeRequiredPredicate = size ->
                 (!maxCountInput.isPresent() && !timeFromInput.isPresent() && !timeToInput.isPresent()
                         && size > DEFAULT_MAX_HISTORY_RECORD_COUNT);
+    }
+
+    private boolean isTimeFromAfterTimeTo(Optional<Long> timeFromInput, Optional<Long> timeToInput) {
+        return timeFromInput.isPresent() && timeToInput.isPresent() && timeFromInput.get() > timeToInput.get();
     }
 
     public boolean isContentRangeRequired(int size) {

--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/utils/flowhistory/FlowHistoryRangeConstraints.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/utils/flowhistory/FlowHistoryRangeConstraints.java
@@ -46,6 +46,13 @@ public class FlowHistoryRangeConstraints {
     public FlowHistoryRangeConstraints(Optional<Long> timeFromInput,
                                        Optional<Long> timeToInput,
                                        Optional<Integer> maxCountInput) {
+        if (timeFromInput.isPresent() && timeToInput.isPresent() && timeFromInput.get() > timeToInput.get()) {
+            throw new MessageException(RequestCorrelationId.getId(), System.currentTimeMillis(),
+                    ErrorType.PARAMETERS_INVALID, format("Invalid 'timeFrom' and 'timeTo' arguments: %s and %s",
+                    timeFromInput.get(), timeToInput.get()),
+                    "'timeFrom' must be less than or equal to 'timeTo'");
+        }
+
         this.timeFrom = timeFromInput.map(LongToInstantConverter::convert).orElseGet(() -> Instant.ofEpochSecond(0L));
         this.timeTo = timeToInput.map(LongToInstantConverter::convert).orElseGet(Instant::now);
 
@@ -66,7 +73,7 @@ public class FlowHistoryRangeConstraints {
 
         contentRangeRequiredPredicate = size ->
                 (!maxCountInput.isPresent() && !timeFromInput.isPresent() && !timeToInput.isPresent()
-                        && size == DEFAULT_MAX_HISTORY_RECORD_COUNT);
+                        && size > DEFAULT_MAX_HISTORY_RECORD_COUNT);
     }
 
     public boolean isContentRangeRequired(int size) {

--- a/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/utils/flowhistory/FlowHistoryRangeConstraintsTest.java
+++ b/src-java/northbound-service/northbound/src/test/java/org/openkilda/northbound/utils/flowhistory/FlowHistoryRangeConstraintsTest.java
@@ -1,0 +1,90 @@
+/* Copyright 2023 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.northbound.utils.flowhistory;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.openkilda.messaging.error.MessageException;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Optional;
+
+class FlowHistoryRangeConstraintsTest {
+    @Test
+    void validateTimeParametersTest() {
+        assertThrows(MessageException.class, () ->
+                new FlowHistoryRangeConstraints(Optional.of(300L), Optional.of(20L), Optional.empty()));
+
+        assertDoesNotThrow(() ->
+                new FlowHistoryRangeConstraints(Optional.of(20L), Optional.of(300L), Optional.empty()));
+
+        assertDoesNotThrow(() ->
+                new FlowHistoryRangeConstraints(Optional.empty(), Optional.of(300L), Optional.empty()));
+
+        assertDoesNotThrow(() ->
+                new FlowHistoryRangeConstraints(Optional.of(20L), Optional.empty(), Optional.empty()));
+    }
+
+    @Test
+    void whenNoTimeParameterProvided_defaultIsSet() {
+        FlowHistoryRangeConstraints f1 = new FlowHistoryRangeConstraints(
+                Optional.empty(), Optional.of(300L), Optional.empty());
+        assertEquals(Instant.ofEpochSecond(0L), f1.getTimeFrom());
+
+        FlowHistoryRangeConstraints f2 = new FlowHistoryRangeConstraints(
+                Optional.of(300L), Optional.empty(), Optional.empty());
+        assertTrue(f2.getTimeTo().isBefore(Instant.now().plusNanos(1)));
+
+        FlowHistoryRangeConstraints f3 = new FlowHistoryRangeConstraints(
+                Optional.empty(), Optional.empty(), Optional.empty());
+        assertEquals(Instant.ofEpochSecond(0L), f3.getTimeFrom());
+        assertTrue(f3.getTimeTo().isBefore(Instant.now().plusNanos(1)));
+    }
+
+    @Test
+    void maxCountTest() {
+        assertThrows(MessageException.class, () ->
+                new FlowHistoryRangeConstraints(Optional.empty(), Optional.empty(), Optional.of(-5)));
+
+        assertDoesNotThrow(() ->
+                new FlowHistoryRangeConstraints(Optional.empty(), Optional.empty(), Optional.empty()));
+
+        assertDoesNotThrow(() ->
+                new FlowHistoryRangeConstraints(Optional.empty(), Optional.empty(), Optional.of(12)));
+    }
+
+    @Test
+    void contentRangeRequiredTest() {
+        FlowHistoryRangeConstraints f1 = new FlowHistoryRangeConstraints(
+                Optional.empty(), Optional.of(300L), Optional.empty());
+        assertFalse(f1.isContentRangeRequired(142));
+        FlowHistoryRangeConstraints f2 = new FlowHistoryRangeConstraints(
+                Optional.of(300L), Optional.empty(),  Optional.empty());
+        assertFalse(f2.isContentRangeRequired(142));
+        FlowHistoryRangeConstraints f3 = new FlowHistoryRangeConstraints(
+                Optional.empty(), Optional.empty(), Optional.of(1));
+        assertFalse(f3.isContentRangeRequired(142));
+        FlowHistoryRangeConstraints f4 = new FlowHistoryRangeConstraints(
+                Optional.empty(), Optional.empty(), Optional.empty());
+        assertTrue(f4.isContentRangeRequired(142));
+    }
+}


### PR DESCRIPTION
This fix adds a validation for time from and time to parameters. If time from is after time to an error is displayed.