### PR TITLE
Allow BAD_OUT_PORT from OF errors

### DIFF
--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/flow/response/FlowErrorResponse.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/flow/response/FlowErrorResponse.java
@@ -65,6 +65,7 @@ public class FlowErrorResponse extends SpeakerFlowSegmentResponse {
         BAD_COMMAND,
         OPERATION_TIMED_OUT,
         MISSING_OF_FLOWS,
+        BAD_OUT_PORT,
         UNKNOWN
     }
 }

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/FlowSegmentReportErrorDecoder.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/command/flow/FlowSegmentReportErrorDecoder.java
@@ -1,0 +1,76 @@
+/* Copyright 2024 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.floodlight.command.flow;
+
+import org.openkilda.floodlight.flow.response.FlowErrorResponse.ErrorCode;
+import org.openkilda.floodlight.flow.response.FlowErrorResponse.FlowErrorResponseBuilder;
+
+import org.projectfloodlight.openflow.protocol.OFErrorMsg;
+import org.projectfloodlight.openflow.protocol.errormsg.OFBadActionErrorMsg;
+import org.projectfloodlight.openflow.protocol.errormsg.OFFlowModFailedErrorMsg;
+
+/**
+ * Utility class for decoding OF error messages.
+ */
+public abstract class FlowSegmentReportErrorDecoder {
+
+    /**
+     * Decode OF error message and fill error response.
+     *
+     * @param errorResponse error response
+     * @param error         OF error message
+     * @return true if error decoded successfully, false otherwise
+     */
+    public static boolean decodeError(FlowErrorResponseBuilder errorResponse, OFErrorMsg error) {
+        boolean result = true;
+        if (error instanceof OFFlowModFailedErrorMsg) {
+            decodeError(errorResponse, (OFFlowModFailedErrorMsg) error);
+        } else if (error instanceof OFBadActionErrorMsg) {
+            decodeError(errorResponse, (OFBadActionErrorMsg) error);
+        } else {
+            errorResponse.errorCode(ErrorCode.UNKNOWN);
+            result = false;
+        }
+        return result;
+    }
+
+    private static void decodeError(FlowErrorResponseBuilder errorResponse, OFFlowModFailedErrorMsg error) {
+        switch (error.getCode()) {
+            case UNSUPPORTED:
+                errorResponse.errorCode(ErrorCode.UNSUPPORTED);
+                break;
+            case BAD_COMMAND:
+                errorResponse.errorCode(ErrorCode.BAD_COMMAND);
+                break;
+            case BAD_FLAGS:
+                errorResponse.errorCode(ErrorCode.BAD_FLAGS);
+                break;
+            default:
+                errorResponse.errorCode(ErrorCode.UNKNOWN);
+        }
+    }
+
+    private static void decodeError(FlowErrorResponseBuilder errorResponse, OFBadActionErrorMsg error) {
+        switch (error.getCode()) {
+            case BAD_OUT_PORT:
+                errorResponse.errorCode(ErrorCode.BAD_OUT_PORT);
+                break;
+            default:
+                errorResponse.errorCode(ErrorCode.UNKNOWN);
+        }
+    }
+
+}

--- a/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/FlowErrorResponseTest.java
+++ b/src-java/floodlight-service/floodlight-modules/src/test/java/org/openkilda/floodlight/command/flow/FlowErrorResponseTest.java
@@ -1,0 +1,134 @@
+/* Copyright 2024 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.floodlight.command.flow;
+
+import org.openkilda.floodlight.flow.response.FlowErrorResponse;
+import org.openkilda.floodlight.flow.response.FlowErrorResponse.ErrorCode;
+import org.openkilda.floodlight.flow.response.FlowErrorResponse.FlowErrorResponseBuilder;
+import org.openkilda.floodlight.model.FlowSegmentMetadata;
+import org.openkilda.messaging.MessageContext;
+import org.openkilda.model.SwitchId;
+import org.openkilda.model.cookie.Cookie;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.projectfloodlight.openflow.protocol.OFBadActionCode;
+import org.projectfloodlight.openflow.protocol.OFErrorMsg;
+import org.projectfloodlight.openflow.protocol.OFFlowModFailedCode;
+import org.projectfloodlight.openflow.protocol.ver13.OFErrorMsgsVer13;
+
+import java.util.UUID;
+
+public class FlowErrorResponseTest {
+
+    @Test
+    public void decodeErrorBadOutPort() {
+        FlowErrorResponseBuilder errorResponse = makeErrorTemplate();
+        ErrorCode expectedErrorCode =  ErrorCode.BAD_OUT_PORT;
+
+        OFErrorMsg errorMsg = OFErrorMsgsVer13.INSTANCE.buildBadActionErrorMsg()
+                .setCode(OFBadActionCode.BAD_OUT_PORT).build();
+        boolean result = FlowSegmentReportErrorDecoder.decodeError(errorResponse, errorMsg);
+
+        Assertions.assertTrue(result);
+        Assertions.assertEquals(expectedErrorCode, errorResponse.build().getErrorCode());
+    }
+
+    @Test
+    public void decodeErrorUnsupported() {
+        FlowErrorResponseBuilder errorResponse = makeErrorTemplate();
+        ErrorCode expectedErrorCode =  ErrorCode.UNSUPPORTED;
+
+        OFErrorMsg errorMsg = OFErrorMsgsVer13.INSTANCE.buildFlowModFailedErrorMsg()
+                .setCode(OFFlowModFailedCode.UNSUPPORTED).build();
+        boolean result = FlowSegmentReportErrorDecoder.decodeError(errorResponse, errorMsg);
+
+        Assertions.assertTrue(result);
+        Assertions.assertEquals(expectedErrorCode, errorResponse.build().getErrorCode());
+    }
+
+    @Test
+    public void decodeErrorBadCommand() {
+        FlowErrorResponseBuilder errorResponse = makeErrorTemplate();
+        ErrorCode expectedErrorCode =  ErrorCode.BAD_COMMAND;
+
+        OFErrorMsg errorMsg = OFErrorMsgsVer13.INSTANCE.buildFlowModFailedErrorMsg()
+                .setCode(OFFlowModFailedCode.BAD_COMMAND).build();
+        boolean result = FlowSegmentReportErrorDecoder.decodeError(errorResponse, errorMsg);
+
+        Assertions.assertTrue(result);
+        Assertions.assertEquals(expectedErrorCode, errorResponse.build().getErrorCode());
+    }
+
+    @Test
+    public void decodeErrorBadFlags() {
+        FlowErrorResponseBuilder errorResponse = makeErrorTemplate();
+        ErrorCode expectedErrorCode =  ErrorCode.BAD_FLAGS;
+
+        OFErrorMsg errorMsg = OFErrorMsgsVer13.INSTANCE.buildFlowModFailedErrorMsg()
+                .setCode(OFFlowModFailedCode.BAD_FLAGS).build();
+        boolean result = FlowSegmentReportErrorDecoder.decodeError(errorResponse, errorMsg);
+
+        Assertions.assertTrue(result);
+        Assertions.assertEquals(expectedErrorCode, errorResponse.build().getErrorCode());
+    }
+
+    @Test
+    public void decodeErrorUnknownFlowModError() {
+        FlowErrorResponseBuilder errorResponse = makeErrorTemplate();
+        ErrorCode expectedErrorCode =  ErrorCode.UNKNOWN;
+
+        OFErrorMsg errorMsg = OFErrorMsgsVer13.INSTANCE.buildFlowModFailedErrorMsg()
+                .setCode(OFFlowModFailedCode.EPERM).build();
+        boolean result = FlowSegmentReportErrorDecoder.decodeError(errorResponse, errorMsg);
+
+        Assertions.assertTrue(result);
+        Assertions.assertEquals(expectedErrorCode, errorResponse.build().getErrorCode());
+    }
+
+    @Test
+    public void decodeErrorUnknownBadActionError() {
+        FlowErrorResponseBuilder errorResponse = makeErrorTemplate();
+        ErrorCode expectedErrorCode =  ErrorCode.UNKNOWN;
+
+        OFErrorMsg errorMsg = OFErrorMsgsVer13.INSTANCE.buildBadActionErrorMsg()
+                .setCode(OFBadActionCode.EPERM).build();
+        boolean result = FlowSegmentReportErrorDecoder.decodeError(errorResponse, errorMsg);
+
+        Assertions.assertTrue(result);
+        Assertions.assertEquals(expectedErrorCode, errorResponse.build().getErrorCode());
+    }
+
+    @Test
+    public void decodeErrorUnknownError() {
+        FlowErrorResponseBuilder errorResponse = makeErrorTemplate();
+        ErrorCode expectedErrorCode =  ErrorCode.UNKNOWN;
+
+        OFErrorMsg errorMsg = OFErrorMsgsVer13.INSTANCE.buildBsnError().build();
+        boolean result = FlowSegmentReportErrorDecoder.decodeError(errorResponse, errorMsg);
+
+        Assertions.assertFalse(result);
+        Assertions.assertEquals(expectedErrorCode, errorResponse.build().getErrorCode());
+    }
+
+    private FlowErrorResponseBuilder makeErrorTemplate() {
+        return FlowErrorResponse.errorBuilder()
+                .messageContext(new MessageContext())
+                .commandId(UUID.randomUUID())
+                .switchId(new SwitchId(1))
+                .metadata(new FlowSegmentMetadata("test", new Cookie(1)));
+    }
+}


### PR DESCRIPTION
Floodligth was receiving BAD_OUT_PORT openflow error messages but FlowSegmentReport didn't know how to manage them. So it was returning UNKNOWN error. This commit fixes this behaviour by adding BAD_OUT_PORT to the possible errors.