### PR TITLE
[TEST] Unignore tests which can be run

### DIFF
--- a/src-java/testing/functional-tests/build.gradle
+++ b/src-java/testing/functional-tests/build.gradle
@@ -100,7 +100,7 @@ tasks.withType(Test) {
     }
     retry { //test-retry plugin config
         maxRetries = 2
-        maxFailures = 30
+        maxFailures = 50
         failOnPassedAfterRetry = false
     }
 }

--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/error/AbstractExpectedError.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/error/AbstractExpectedError.groovy
@@ -3,6 +3,7 @@ package org.openkilda.functionaltests.error
 import org.openkilda.messaging.error.MessageError
 import org.springframework.http.HttpStatus
 import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.HttpStatusCodeException
 
 import java.util.regex.Pattern
 
@@ -18,7 +19,7 @@ abstract class AbstractExpectedError extends HttpClientErrorException{
         this.descriptionPattern = messagePattern
     }
 
-    boolean matches(HttpClientErrorException exception) {
+    boolean matches(HttpStatusCodeException exception) {
         MessageError messageError = exception.responseBodyAsString.to(MessageError)
         assert exception.statusCode == this.statusCode
         assert messageError.getErrorMessage() == this.message

--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/error/flow/FlowEndpointsNotSwappedExpectedError.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/error/flow/FlowEndpointsNotSwappedExpectedError.groovy
@@ -1,0 +1,15 @@
+package org.openkilda.functionaltests.error.flow
+
+import org.openkilda.functionaltests.error.AbstractExpectedError
+import org.springframework.http.HttpStatus
+
+import java.util.regex.Pattern
+
+class FlowEndpointsNotSwappedExpectedError extends AbstractExpectedError{
+    final static HttpStatus statusCode = HttpStatus.INTERNAL_SERVER_ERROR
+    final static String message = "Could not swap endpoints"
+
+    FlowEndpointsNotSwappedExpectedError(Pattern descriptionPattern) {
+        super(statusCode, message, descriptionPattern)
+    }
+}

--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/model/SwitchPairs.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/model/SwitchPairs.groovy
@@ -63,6 +63,13 @@ class SwitchPairs {
         return this
     }
 
+    SwitchPairs withExactlyNNonOverlappingPaths(int nonOverlappingPaths) {
+        switchPairs = switchPairs.findAll {
+            it.paths.unique(false) { a, b -> a.intersect(b) == [] ? 1 : 0 }.size() == nonOverlappingPaths
+        }
+        return this
+    }
+
     SwitchPairs withShortestPathShorterThanOthers() {
         switchPairs = switchPairs.findAll { it.getPaths()[0].size() != it.getPaths()[1].size() }
         return this
@@ -119,7 +126,7 @@ class SwitchPairs {
     }
 
     SwitchPairs excludeSwitches(List<Switch> switchesList) {
-        switchPairs = switchPairs.findAll { !(it.src in switchesList) || !(it.dst in switchesList) }
+        switchPairs = switchPairs.findAll { !(it.src in switchesList) && !(it.dst in switchesList) }
         return this
     }
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowSyncSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowSyncSpec.groovy
@@ -30,7 +30,6 @@ class FlowSyncSpec extends HealthCheckSpecification {
     def "Able to synchronize a flow (install missing flow rules, reinstall existing) without rerouting"() {
         given: "An intermediate-switch flow with deleted rules on src switch"
         def switchPair = switchPairs.all().nonNeighbouring().random()
-        assumeTrue(switchPair.asBoolean(), "Need a not-neighbouring switch pair for this test")
 
         def flow = flowHelperV2.randomFlow(switchPair)
         flowHelperV2.addFlow(flow)
@@ -73,71 +72,6 @@ class FlowSyncSpec extends HealthCheckSpecification {
 
         cleanup: "Delete the flow"
         flow && flowHelperV2.deleteFlow(flow.flowId)
-    }
-
-    @Ignore("After PR4817 flow sync never change existing paths")
-    def "Able to synchronize a flow (install missing flow rules, reinstall existing) with rerouting"() {
-        given: "An intermediate-switch flow with two possible paths at least and deleted rules on src switch"
-        def switchPair = switchPairs.all().nonNeighbouring().withAtLeastNPaths(2).random()
-
-        def flow = flowHelperV2.randomFlow(switchPair)
-        flowHelperV2.addFlow(flow)
-        def flowPath = PathHelper.convert(northbound.getFlowPath(flow.flowId))
-
-        def involvedSwitches = pathHelper.getInvolvedSwitches(flow.flowId)
-        List<Long> rulesToDelete = getFlowRules(switchPair.src)*.cookie
-        rulesToDelete.each { northbound.deleteSwitchRules(switchPair.src.dpId, it) }
-        Wrappers.wait(RULES_DELETION_TIME) {
-            assert getFlowRules(switchPair.src).size() == flowRulesCount - rulesToDelete.size()
-        }
-
-        and: "Make one of the alternative flow paths more preferable than the current one"
-        switchPair.paths.findAll { it != flowPath }.each { pathHelper.makePathMorePreferable(it, flowPath) }
-
-        when: "Synchronize the flow"
-        def syncTime = new Date()
-        def rerouteResponse = northbound.synchronizeFlow(flow.flowId)
-        Wrappers.wait(WAIT_OFFSET) { assert northboundV2.getFlowStatus(flow.flowId).status == FlowState.UP }
-
-        then: "The flow is rerouted"
-        def newFlowPath = PathHelper.convert(northbound.getFlowPath(flow.flowId))
-        int seqId = 0
-
-        rerouteResponse.rerouted
-        rerouteResponse.path.path == newFlowPath
-        rerouteResponse.path.path.each { assert it.seqId == seqId++ }
-
-        newFlowPath != flowPath
-
-        and: "Flow rules are installed/reinstalled on switches remained from the original flow path"
-        def involvedSwitchesAfterSync = pathHelper.getInvolvedSwitches(flow.flowId)
-        involvedSwitchesAfterSync.findAll { it in involvedSwitches }.each { sw ->
-            Wrappers.wait(RULES_INSTALLATION_TIME) {
-                def flowRules = getFlowRules(sw)
-                assert flowRules.size() == flowRulesCount
-                flowRules.each {
-                    assert it.durationSeconds < TimeCategory.minus(new Date(), syncTime).toMilliseconds() / 1000.0
-                }
-            }
-        }
-
-        and: "Flow rules are installed on new switches involved in the current flow path"
-        involvedSwitchesAfterSync.findAll { !(it in involvedSwitches) }.each { sw ->
-            Wrappers.wait(RULES_INSTALLATION_TIME) { assert getFlowRules(sw).size() == flowRulesCount }
-        }
-
-        and: "Flow rules are deleted from switches that are NOT involved in the current flow path"
-        involvedSwitches.findAll { !(it in involvedSwitchesAfterSync) }.each { sw ->
-            Wrappers.wait(RULES_DELETION_TIME) { assert getFlowRules(sw).empty }
-        } || true  // switches after sync may include all switches involved in the flow before sync
-
-        and: "Flow is valid"
-        northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
-
-        cleanup: "Delete the flow and link props, reset link costs"
-        flow && flowHelperV2.deleteFlow(flow.flowId)
-        northbound.deleteLinkProps(northbound.getLinkProps(topology.isls))
-        database.resetCosts(topology.isls)
     }
 
     List<FlowEntry> getFlowRules(Switch sw) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowCreateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowCreateSpec.groovy
@@ -5,6 +5,7 @@ import org.openkilda.functionaltests.error.yflow.YFlowNotCreatedWithConflictExpe
 
 import static groovyx.gpars.GParsPool.withPool
 import static org.junit.jupiter.api.Assumptions.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 import static org.openkilda.functionaltests.extension.tags.Tag.TOPOLOGY_DEPENDENT
 import static org.openkilda.functionaltests.helpers.FlowHistoryConstants.CREATE_SUCCESS
@@ -408,7 +409,7 @@ source: switchId="${flow.sharedEndpoint.switchId}" port=${flow.sharedEndpoint.po
         }
     }
 
-    @Tags([TOPOLOGY_DEPENDENT])
+    @Tags([HARDWARE])
     def "System forbids to create a y-flow with conflict: shared endpoint port is inside a LAG group"() {
         given: "A LAG port"
         def swT = topologyHelper.switchTriplets.find { it.shared.features.contains(SwitchFeature.LAG) }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslMinPortSpeedSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslMinPortSpeedSpec.groovy
@@ -1,6 +1,7 @@
 package org.openkilda.functionaltests.spec.links
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.TOPOLOGY_DEPENDENT
 import static org.openkilda.messaging.info.event.IslChangeType.DISCOVERED
@@ -18,7 +19,7 @@ Sometimes an ISL have different port speed on its edges.
 In that case, we need to set ISL capacity and all bandwidth parameters according to minimal speed value.
 Eg. 10G on one side, and 1G on another side, the ISL should have a 1G capacity.""")
 class IslMinPortSpeedSpec extends HealthCheckSpecification {
-    @Tags([SMOKE, TOPOLOGY_DEPENDENT])
+    @Tags([SMOKE, HARDWARE])
     def "System sets min port speed for isl capacity"() {
         given: "Two ports with different port speed"
         def isl = topology.islsForActiveSwitches.find {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslReplugSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslReplugSpec.groovy
@@ -2,6 +2,7 @@ package org.openkilda.functionaltests.spec.links
 
 import static org.junit.Assume.assumeNotNull
 import static org.junit.jupiter.api.Assumptions.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.TOPOLOGY_DEPENDENT
 import static org.openkilda.functionaltests.model.stats.SwitchStatsMetric.FLOW_SYSTEM_PACKETS
@@ -30,6 +31,7 @@ class IslReplugSpec extends HealthCheckSpecification {
     @Autowired @Shared
     SwitchStats switchStats
 
+    @Tags(HARDWARE)
     def "Round-trip ISL status changes to MOVED when replugging it into another switch"() {
         given: "A connected a-switch link, round-trip-enabled"
         and: "A non-connected a-switch link with round-trip support"
@@ -230,7 +232,8 @@ class IslReplugSpec extends HealthCheckSpecification {
         def expectedIsl = islUtils.replug(islToPlug, true, islToPlugInto, true, true)
 
         then: "The potential self-loop ISL is not present in the list of ISLs (wait for discovery interval)"
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
+        sleep(discoveryInterval * 1000)
+        Wrappers.wait(WAIT_OFFSET) {
             def allLinks = northbound.getAllLinks()
             !islUtils.getIslInfo(allLinks, expectedIsl).present
             !islUtils.getIslInfo(allLinks, expectedIsl.reversed).present

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/server42/Server42IslRttSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/server42/Server42IslRttSpec.groovy
@@ -314,6 +314,7 @@ class Server42IslRttSpec extends HealthCheckSpecification {
         }
     }
 
+    @Tags([HARDWARE])
     def "SERVER_42_ISL_RTT rules are updated according to changes in swProps"() {
         def server42switchIds = topology.getActiveServer42Switches()*.dpId
         def sw = topology.getActiveServer42Switches().find { it.wb5164 && it.dpId in server42switchIds }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesSpec.groovy
@@ -3,6 +3,7 @@ package org.openkilda.functionaltests.spec.switches
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs
 import static org.assertj.core.api.Assertions.assertThat
 import static org.junit.jupiter.api.Assumptions.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE_SWITCHES
 import static org.openkilda.functionaltests.extension.tags.Tag.TOPOLOGY_DEPENDENT
@@ -371,7 +372,7 @@ class DefaultRulesSpec extends HealthCheckSpecification {
         ].combinations()
     }
 
-    @Tags([TOPOLOGY_DEPENDENT, SMOKE_SWITCHES])
+    @Tags([TOPOLOGY_DEPENDENT, SMOKE_SWITCHES, HARDWARE])
     def "Able to delete/install the server42 Flow RTT turning rule on a switch"() {
         setup: "Select a switch which support server42 turning rule"
         def sw = topology.activeSwitches.find { it.features.contains(SwitchFeature.NOVIFLOW_SWAP_ETH_SRC_ETH_DST) } ?:

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/MetersSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/MetersSpec.groovy
@@ -55,6 +55,7 @@ class MetersSpec extends HealthCheckSpecification {
     static MIN_RATE_KBPS = 64
     static CENTEC_MIN_BURST = 1024 // Driven by the Centec specification
     static CENTEC_MAX_BURST = 32000 // Driven by the Centec specification
+    static final String NOT_OVS_REGEX = /^(?!.*\bOVS\b).*/
 
     @Value('${burst.coefficient}')
     double burstCoefficient
@@ -64,6 +65,7 @@ class MetersSpec extends HealthCheckSpecification {
     }
 
     @Tags([TOPOLOGY_DEPENDENT, SMOKE, SMOKE_SWITCHES])
+    @IterationTag(tags = [HARDWARE], iterationNameRegex = NOT_OVS_REGEX)
     def "Able to delete a meter from a #switchType switch"() {
         assumeTrue(switches as boolean, "Unable to find required switches in topology")
 
@@ -102,6 +104,7 @@ class MetersSpec extends HealthCheckSpecification {
     }
 
     @Tags([TOPOLOGY_DEPENDENT])
+    @IterationTag(tags = [HARDWARE], iterationNameRegex = NOT_OVS_REGEX)
     def "Unable to delete a meter with invalid ID=#meterId on a #switchType switch"() {
         assumeTrue(switches as boolean, "Unable to find required switches in topology")
 
@@ -198,8 +201,8 @@ class MetersSpec extends HealthCheckSpecification {
                 assumeTrue(false, "Unable to find Noviflow Wb5164 switches in topology"))
     }
 
-    @Tags([TOPOLOGY_DEPENDENT])
-    @IterationTag(tags = [SMOKE_SWITCHES], iterationNameRegex = /ignore_bandwidth=false/)
+    @Tags([TOPOLOGY_DEPENDENT, SMOKE_SWITCHES])
+    @IterationTag(tags = [HARDWARE], iterationNameRegex = NOT_OVS_REGEX)
     def "Meters are created/deleted when creating/deleting a single-switch flow with ignore_bandwidth=#ignoreBandwidth \
 on a #switchType switch"() {
         assumeTrue(switches as boolean, "Unable to find required switches in topology")
@@ -263,6 +266,7 @@ on a #switchType switch"() {
     }
 
     @Tags([TOPOLOGY_DEPENDENT])
+    @IterationTag(tags = [HARDWARE], iterationNameRegex = NOT_OVS_REGEX)
     def "Meters are not created when creating a single-switch flow with maximum_bandwidth=0 on a #switchType switch"() {
         assumeTrue(switches as boolean, "Unable to find required switches in topology")
 
@@ -296,6 +300,7 @@ on a #switchType switch"() {
     }
 
     @Tags([TOPOLOGY_DEPENDENT])
+    @IterationTag(tags = [HARDWARE], iterationNameRegex = NOT_OVS_REGEX)
     def "Source/destination switches have meters only in flow ingress rule and intermediate switches don't have \
 meters in flow rules at all (#srcSwitch - #dstSwitch flow)"() {
         def switchPair = switchPairs.all().nonNeighbouring()
@@ -366,6 +371,7 @@ meters in flow rules at all (#srcSwitch - #dstSwitch flow)"() {
     }
 
     @Tags([TOPOLOGY_DEPENDENT, SMOKE_SWITCHES])
+    @IterationTag(tags = [HARDWARE], iterationNameRegex = NOT_OVS_REGEX)
     def "Meter burst size is correctly set on #data.switchType switches for #flowRate flow rate"() {
         setup: "A single-switch flow with #flowRate kbps bandwidth is created on OpenFlow 1.3 compatible switch"
         def switches = data.switches
@@ -527,6 +533,7 @@ meters in flow rules at all (#srcSwitch - #dstSwitch flow)"() {
     }
 
     @Tags([TOPOLOGY_DEPENDENT, SMOKE_SWITCHES])
+    @IterationTag(tags = [HARDWARE], iterationNameRegex = NOT_OVS_REGEX)
     def "System allows to reset meter values to defaults without reinstalling rules for #data.description flow"() {
         given: "Switches combination (#data.description)"
         assumeTrue(data.switches.size() > 1, "Desired switch combination is not available in current topology")

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchActivationSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchActivationSpec.groovy
@@ -97,7 +97,7 @@ class SwitchActivationSpec extends HealthCheckSpecification {
 
     }
 
-    @Tags([HARDWARE])
+    @Tags([SMOKE_SWITCHES])
     def "Excess transitVlanRules/meters are synced from a new switch before connecting to the controller"() {
         given: "A switch with excess rules/meters and not connected to the controller"
         def sw = topology.getActiveSwitches().first()
@@ -171,7 +171,7 @@ class SwitchActivationSpec extends HealthCheckSpecification {
         blockData && !switchValidationInfo && switchHelper.reviveSwitch(sw, blockData, true)
     }
 
-    @Tags([HARDWARE])
+    @Tags([SMOKE_SWITCHES])
     def "Excess vxlanRules/meters are synced from a new switch before connecting to the controller"() {
         given: "A switch with excess rules/meters and not connected to the controller"
         def sw = topology.getActiveSwitches().find { switchHelper.isVxlanEnabled(it.dpId) }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
@@ -92,7 +92,7 @@ class SwitchFailuresSpec extends HealthCheckSpecification {
     @Ignore("https://github.com/telstra/open-kilda/issues/3398")
     def "System is able to finish the reroute if switch blinks in the middle of it"() {
         given: "A flow"
-        def swPair = topologyHelper.allNotNeighboringSwitchPairs.find { it.paths.size() > 1 }
+        def swPair = switchPairs.all().nonNeighbouring().withAtLeastNPaths(2).random()
         def flow = flowHelperV2.addFlow(flowHelperV2.randomFlow(swPair))
 
         when: "Current path breaks and reroute starts"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchValidationSingleSwFlowSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchValidationSingleSwFlowSpec.groovy
@@ -1,12 +1,15 @@
 package org.openkilda.functionaltests.spec.switches
 
+import org.openkilda.functionaltests.extension.tags.IterationTag
 import org.openkilda.messaging.model.FlowDirectionType
 
 import static org.junit.jupiter.api.Assumptions.assumeTrue
+import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE_SWITCHES
 import static org.openkilda.functionaltests.extension.tags.Tag.TOPOLOGY_DEPENDENT
 import static org.openkilda.functionaltests.helpers.SwitchHelper.isDefaultMeter
+import static org.openkilda.functionaltests.spec.switches.MetersSpec.NOT_OVS_REGEX
 import static org.openkilda.model.MeterId.MAX_SYSTEM_RULE_METER_ID
 import static org.openkilda.model.MeterId.MIN_FLOW_METER_ID
 import static org.openkilda.testing.Constants.RULES_INSTALLATION_TIME
@@ -46,7 +49,7 @@ Description of fields:
 - excess - those meters/rules, which are present on a switch, but are NOT present in db
 - proper - meters/rules values are the same on a switch and in db
 """)
-@Tags([SMOKE_SWITCHES])
+@Tags([SMOKE_SWITCHES, TOPOLOGY_DEPENDENT])
 class SwitchValidationSingleSwFlowSpec extends HealthCheckSpecification {
     @Value("#{kafkaTopicsConfig.getSpeakerSwitchManagerTopic()}")
     String speakerTopic
@@ -58,7 +61,8 @@ class SwitchValidationSingleSwFlowSpec extends HealthCheckSpecification {
         deleteAnyFlowsLeftoversIssue5480()
     }
 
-    @Tags([TOPOLOGY_DEPENDENT, SMOKE])
+    @Tags([SMOKE])
+    @IterationTag(tags = [HARDWARE], iterationNameRegex = NOT_OVS_REGEX)
     def "Switch validation is able to store correct information on a #switchType switch in the 'proper' section"() {
         assumeTrue(switches as boolean, "Unable to find required switches in topology")
 
@@ -120,7 +124,7 @@ class SwitchValidationSingleSwFlowSpec extends HealthCheckSpecification {
         "OVS"              | getVirtualSwitches()
     }
 
-    @Tags([TOPOLOGY_DEPENDENT])
+    @IterationTag(tags = [HARDWARE], iterationNameRegex = NOT_OVS_REGEX)
     def "Switch validation is able to detect meter info into the 'misconfigured' section on a #switchType switch"() {
         assumeTrue(switches as boolean, "Unable to find required switches in topology")
 
@@ -235,7 +239,7 @@ class SwitchValidationSingleSwFlowSpec extends HealthCheckSpecification {
         "OVS"              | getVirtualSwitches()
     }
 
-    @Tags([TOPOLOGY_DEPENDENT])
+    @IterationTag(tags = [HARDWARE], iterationNameRegex = NOT_OVS_REGEX)
     def "Switch validation is able to detect meter info into the 'missing' section on a #switchType switch"() {
         assumeTrue(switches as boolean, "Unable to find required switches in topology")
 
@@ -305,7 +309,7 @@ class SwitchValidationSingleSwFlowSpec extends HealthCheckSpecification {
         "OVS"              | getVirtualSwitches()
     }
 
-    @Tags([TOPOLOGY_DEPENDENT])
+    @IterationTag(tags = [HARDWARE], iterationNameRegex = NOT_OVS_REGEX)
     def "Switch validation is able to detect meter info into the 'excess' section on a #switchType switch"() {
         assumeTrue(switches as boolean, "Unable to find required switches in topology")
 
@@ -380,7 +384,7 @@ class SwitchValidationSingleSwFlowSpec extends HealthCheckSpecification {
         "OVS"              | getVirtualSwitches()
     }
 
-    @Tags([TOPOLOGY_DEPENDENT])
+    @IterationTag(tags = [HARDWARE], iterationNameRegex = NOT_OVS_REGEX)
     def "Switch validation is able to detect rule info into the 'missing' section on a #switchType switch"() {
         assumeTrue(switches as boolean, "Unable to find required switches in topology")
 
@@ -438,7 +442,7 @@ class SwitchValidationSingleSwFlowSpec extends HealthCheckSpecification {
         "OVS"              | getVirtualSwitches()
     }
 
-    @Tags([TOPOLOGY_DEPENDENT])
+    @IterationTag(tags = [HARDWARE], iterationNameRegex = NOT_OVS_REGEX)
     def "Switch validation is able to detect rule/meter info into the 'excess' section on a #switchType switch"() {
         assumeTrue(switches as boolean, "Unable to find required switches in topology")
 
@@ -543,22 +547,7 @@ class SwitchValidationSingleSwFlowSpec extends HealthCheckSpecification {
         "OVS"              | getVirtualSwitches()
     }
 
-    def "Able to get the switch validate info on a NOT supported switch"() {
-        given: "Not supported switch"
-        def sw = topology.activeSwitches.find { it.ofVersion == "OF_12" }
-        assumeTrue(sw as boolean, "Unable to find required switches in topology")
-
-        when: "Try to invoke the switch validate request"
-        def response = northbound.validateSwitch(sw.dpId)
-
-        then: "Response without meter section is returned"
-        response.rules.proper.findAll { !new Cookie(it).serviceFlag }.empty
-        response.rules.missing.empty
-        response.rules.excess.empty
-        !response.meters
-    }
-
-    @Tags([TOPOLOGY_DEPENDENT])
+    @IterationTag(tags = [HARDWARE], iterationNameRegex = NOT_OVS_REGEX)
     def "Able to validate and sync a #switchType switch having missing rules of single-port single-switch flow"() {
         assumeTrue(sw as boolean, "Unable to find $switchType switch in topology")
         given: "A single-port single-switch flow"


### PR DESCRIPTION
* Added 'HARDWARE' tag for tests which demand models or features that are not
supported by virtual switches
* Removed legacy ignored tests which either require non-supported by kilda function or
OF 1.2 switches
* Unignored several tests after bugfixes
* Increased limit of failed tests to retry