### PR TITLE
5390: [TEST] Replace switch validation with switch synchronization where possible pt. I

### DIFF
--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/model/SwitchPair.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/model/SwitchPair.groovy
@@ -47,6 +47,11 @@ class SwitchPair {
     }
 
     @JsonIgnore
+    List<Switch> toList() {
+        return [src, dst]
+    }
+
+    @JsonIgnore
     SwitchPair getReversed() {
         new SwitchPair(src: dst,
                 dst: src,

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/BaseSpecification.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/BaseSpecification.groovy
@@ -115,12 +115,6 @@ class BaseSpecification extends Specification {
                 "but current active profile is '${this.profile}'")
     }
 
-    void verifySwitchRules(SwitchId switchId) {
-        def rules = northbound.validateSwitchRules(switchId)
-        assert rules.excessRules.empty
-        assert rules.missingRules.empty
-    }
-
     // this cleanup section should be removed after fixing the issue https://github.com/telstra/open-kilda/issues/5480
     void deleteAnyFlowsLeftoversIssue5480() {
         Wrappers.benchmark("Deleting flows leftovers") {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudSpec.groovy
@@ -107,9 +107,8 @@ class FlowCrudSpec extends HealthCheckSpecification {
         }
 
         expect: "No rule discrepancies on every switch of the flow"
-        wait(WAIT_OFFSET) { //due to instability on jenkins
-            switches.each { verifySwitchRules(it.dpId) }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(switches*.getDpId()).isEmpty()
+
 
         and: "No discrepancies when doing flow validation"
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
@@ -143,7 +142,7 @@ class FlowCrudSpec extends HealthCheckSpecification {
         }
 
         and: "No rule discrepancies on every switch of the flow"
-        switches.each { sw -> wait(WAIT_OFFSET) { verifySwitchRules(sw.dpId) } }
+        switchHelper.synchronizeAndGetFixedEntries(switches*.getDpId()).isEmpty()
 
         cleanup:
         !flowIsDeleted && flow && flowHelperV2.deleteFlow(flow.flowId)
@@ -346,7 +345,7 @@ class FlowCrudSpec extends HealthCheckSpecification {
         flowHelperV2.addFlow(flow)
 
         expect: "No rule discrepancies on the switch"
-        verifySwitchRules(flow.source.switchId)
+        !switchHelper.synchronizeAndGetFixedEntries(flow.source.switchId).isPresent()
 
         and: "No discrepancies when doing flow validation"
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
@@ -359,7 +358,7 @@ class FlowCrudSpec extends HealthCheckSpecification {
         def flowIsDeleted = true
 
         and: "No rule discrepancies on the switch after delete"
-        wait(WAIT_OFFSET) { verifySwitchRules(flow.source.switchId) }
+        !switchHelper.synchronizeAndGetFixedEntries(flow.source.switchId).isPresent()
 
         cleanup:
         !flowIsDeleted && flowHelperV2.deleteFlow(flow.flowId)
@@ -549,9 +548,7 @@ class FlowCrudSpec extends HealthCheckSpecification {
 
         and: "All related switches have no discrepancies in rules"
         switches.each {
-            def validation = northbound.validateSwitch(it.dpId)
-            validation.verifyMeterSectionsAreEmpty(["excess", "misconfigured", "missing"])
-            validation.verifyRuleSectionsAreEmpty(["excess", "missing"])
+            assert !switchHelper.synchronizeAndGetFixedEntries(it.dpId).isPresent()
             def swProps = switchHelper.getCachedSwProps(it.dpId)
             def amountOfServer42Rules = (swProps.server42FlowRtt && it.dpId in [srcSwitch.dpId, dstSwitch.dpId]) ? 1 : 0
             if (swProps.server42FlowRtt) {
@@ -559,7 +556,8 @@ class FlowCrudSpec extends HealthCheckSpecification {
                     amountOfServer42Rules += 1
             }
             def amountOfFlowRules = 3 + amountOfServer42Rules
-            assert validation.rules.proper.findAll { !new Cookie(it).serviceFlag }.size() == amountOfFlowRules
+            assert switchHelper.validate(it.getDpId()).rules.proper.findAll { !new Cookie(it.getCookie()).serviceFlag }
+                    .size() == amountOfFlowRules
         }
 
         cleanup: "Remove the flow"
@@ -1011,10 +1009,7 @@ types .* or update switch properties and add needed encapsulation type./).matche
         }
 
         and: "The src switch passes switch validation"
-        with(northbound.validateSwitch(srcSwitch.dpId)) { validation ->
-            validation.verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            validation.verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        !switchHelper.synchronizeAndGetFixedEntries(srcSwitch.getDpId()).isPresent()
 
         when: "Update the flow: switch id on the dst endpoint"
         def newDstSwitch = allSwitches[2]
@@ -1069,12 +1064,7 @@ types .* or update switch properties and add needed encapsulation type./).matche
 
         and: "The new and old dst switches pass switch validation"
         wait(RULES_DELETION_TIME) {
-            [dstSwitch, newDstSwitch]*.dpId.each { switchId ->
-                with(northbound.validateSwitch(switchId)) { validation ->
-                    validation.verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-                    validation.verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-                }
-            }
+            assert switchHelper.validateAndGetFixedEntries([dstSwitch.getDpId(), newDstSwitch.getDpId()]).isEmpty()
         }
 
         cleanup:
@@ -1111,14 +1101,7 @@ types .* or update switch properties and add needed encapsulation type./).matche
 
         and: "All involved switches pass switch validation"
         def involvedSwitchIds = (currentPath*.switchId + newCurrentPath*.switchId).unique()
-        withPool {
-            involvedSwitchIds.eachParallel { SwitchId swId ->
-                with(northbound.validateSwitch(swId)) { validation ->
-                    validation.verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-                    validation.verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-                }
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(involvedSwitchIds).isEmpty()
 
         cleanup: "Revert system to original state"
         flow && flowHelperV2.deleteFlow(flow.flowId)
@@ -1211,14 +1194,7 @@ types .* or update switch properties and add needed encapsulation type./).matche
         }
 
         and: "All involved switches pass switch validation"
-        withPool {
-            currentPath*.switchId.eachParallel { SwitchId swId ->
-                with(northbound.validateSwitch(swId)) { validation ->
-                    validation.verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-                    validation.verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-                }
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(currentPath*.switchId).isEmpty()
 
         cleanup: "Revert system to original state"
         flow && flowHelperV2.deleteFlow(flow.flowId)
@@ -1258,12 +1234,7 @@ types .* or update switch properties and add needed encapsulation type./).matche
         }
 
         and: "Involved switches pass switch validation"
-        [swPair.src, swPair.dst].each { sw ->
-            with(northbound.validateSwitch(sw.dpId)) { validation ->
-                validation.verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-                validation.verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(swPair.toList()*.dpId).isEmpty()
 
         cleanup:
         flow && flowHelperV2.deleteFlow(flow.flowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV1Spec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowCrudV1Spec.groovy
@@ -101,7 +101,7 @@ class FlowCrudV1Spec extends HealthCheckSpecification {
         }
 
         expect: "No rule discrepancies on every switch of the flow"
-        switches.each { verifySwitchRules(it.dpId) }
+        switchHelper.synchronizeAndGetFixedEntries(switches*.getDpId()).isEmpty()
 
         and: "No discrepancies when doing flow validation"
         northbound.validateFlow(flow.id).each { direction -> assert direction.asExpected }
@@ -135,7 +135,7 @@ class FlowCrudV1Spec extends HealthCheckSpecification {
         }
 
         and: "No rule discrepancies on every switch of the flow"
-        switches.each { sw -> Wrappers.wait(WAIT_OFFSET) { verifySwitchRules(sw.dpId) } }
+        switchHelper.synchronizeAndGetFixedEntries(switches*.getDpId()).isEmpty()
 
         cleanup:
         !flowIsDeleted && flow && flowHelper.deleteFlow(flow.id)
@@ -337,7 +337,7 @@ class FlowCrudV1Spec extends HealthCheckSpecification {
         flowHelper.addFlow(flow)
 
         expect: "No rule discrepancies on the switch"
-        verifySwitchRules(flow.source.datapath)
+        !switchHelper.synchronizeAndGetFixedEntries(flow.source.datapath).isPresent()
 
         and: "No discrepancies when doing flow validation"
         northbound.validateFlow(flow.id).each { direction -> assert direction.asExpected }
@@ -350,7 +350,7 @@ class FlowCrudV1Spec extends HealthCheckSpecification {
         def flowIsDeleted = true
 
         and: "No rule discrepancies on the switch after delete"
-        Wrappers.wait(WAIT_OFFSET) { verifySwitchRules(flow.source.datapath) }
+        !switchHelper.synchronizeAndGetFixedEntries(flow.source.datapath).isPresent()
 
         cleanup:
         !flowIsDeleted && flowHelper.deleteFlow(flow.id)
@@ -580,9 +580,7 @@ Failed to find path with requested bandwidth=$flow.maximumBandwidth/).matches(er
 
         and: "All related switches have no discrepancies in rules"
         switches.each {
-            def validation = northbound.validateSwitch(it.dpId)
-            validation.verifyMeterSectionsAreEmpty(["excess", "misconfigured", "missing"])
-            validation.verifyRuleSectionsAreEmpty(["excess", "missing"])
+            assert !switchHelper.validateAndGetFixedEntries(it.getDpId()).isPresent()
             def swProps = switchHelper.getCachedSwProps(it.dpId)
             def amountOfServer42Rules = (swProps.server42FlowRtt && it.dpId in [srcSwitch.dpId,dstSwitch.dpId]) ? 1 : 0
             if (swProps.server42FlowRtt) {
@@ -590,7 +588,8 @@ Failed to find path with requested bandwidth=$flow.maximumBandwidth/).matches(er
                     amountOfServer42Rules += 1
             }
             def amountOfFlowRules = 3 + amountOfServer42Rules
-            assert validation.rules.proper.findAll { !new Cookie(it).serviceFlag }.size() == amountOfFlowRules
+            assert switchHelper.validate(it.getDpId()).rules.proper
+                    .findAll { !new Cookie(it.getCookie()).serviceFlag }.size() == amountOfFlowRules
         }
 
         cleanup: "Remove the flow"
@@ -830,7 +829,7 @@ are not connected to the controller/).matches(exc)
         }
         producer.close()
 
-        assert northbound.validateSwitch(sw.dpId).meters.excess.size() == amountOfExcessMeters
+        assert switchHelper.validate(sw.dpId).meters.excess.size() == amountOfExcessMeters
 
         when: "Create several flows"
         List<String> flows = []
@@ -852,9 +851,8 @@ are not connected to the controller/).matches(exc)
          in reality we've already created excess meters 32..42
          excess meters should NOT be just allocated to the created flow
          they should be recreated(burst size should be recalculated) */
-        def validateSwitchInfo = northbound.validateSwitch(sw.dpId)
-        validateSwitchInfo.verifyRuleSectionsAreEmpty(["missing", "excess"])
-        validateSwitchInfo.verifyMeterSectionsAreEmpty(["missing", "misconfigured", "excess"])
+        def validateSwitchInfo = switchHelper.validate(sw.dpId)
+        validateSwitchInfo.isAsExpected()
         validateSwitchInfo.meters.proper.size() == amountOfFlows * 2 // one flow creates two meters
 
         cleanup: "Delete the flows and excess meters"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MirrorEndpointsSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MirrorEndpointsSpec.groovy
@@ -141,9 +141,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
         findMirrorRule(rules, oppositeDirection) == null
 
         and: "Related switches and flow pass validation"
-        pathHelper.getInvolvedSwitches(flow.flowId).each {
-            northbound.validateSwitch(it.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
-        }
+        switchHelper.synchronizeAndGetFixedEntries(pathHelper.getInvolvedSwitches(flow.flowId)*.getDpId()).isEmpty()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         when: "Traffic briefly runs through the flow"
@@ -207,14 +205,14 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
         !fl.getGroupsStats(swPair.src.dpId).group.find { it.groupNumber == groupId }
 
         and: "Src switch and flow pass validation"
-        northbound.validateSwitch(swPair.src.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
+        !switchHelper.synchronizeAndGetFixedEntries(swPair.src.dpId).isPresent()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         when: "Delete the flow"
         flowHelperV2.deleteFlow(flow.flowId)
 
         then: "Src switch pass validation"
-        northbound.validateSwitch(swPair.src.dpId).verifyRuleSectionsAreEmpty()
+        !switchHelper.synchronizeAndGetFixedEntries(swPair.src.dpId).isPresent()
         def testDone = true
 
         cleanup:
@@ -253,7 +251,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
 
         then: "Mirror point is created and Active"
         and: "Flow and switch pass validation"
-        northbound.validateSwitch(swPair.src.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
+        !switchHelper.synchronizeAndGetFixedEntries(swPair.src.dpId).isPresent()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         when: "Swap flow paths"
@@ -263,7 +261,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
         }
 
         then: "Flow and switch both pass validation"
-        northbound.validateSwitch(swPair.src.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
+        !switchHelper.synchronizeAndGetFixedEntries(swPair.src.dpId).isPresent()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         and: "Flow passes main traffic"
@@ -306,9 +304,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
 
         then: "Mirror point is created and Active"
         and: "Related switches and flow pass validation"
-        pathHelper.getInvolvedSwitches(flow.flowId).each {
-            northbound.validateSwitch(it.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
-        }
+        switchHelper.synchronizeAndGetFixedEntries(pathHelper.getInvolvedSwitches(flow.flowId)*.getDpId()).isEmpty()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         and: "Flow passes traffic on main path as well as to the mirror (if possible to check)"
@@ -357,9 +353,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
         }
 
         then: "Related switches and flow pass validation"
-        pathHelper.getInvolvedSwitches(flow.flowId).each {
-            northbound.validateSwitch(it.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
-        }
+        switchHelper.synchronizeAndGetFixedEntries(pathHelper.getInvolvedSwitches(flow.flowId)*.getDpId()).isEmpty()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         cleanup:
@@ -406,7 +400,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
 
         then: "Mirror point is created and Active"
         and: "Flow and src switch both pass validation"
-        northbound.validateSwitch(swPair.src.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
+        !switchHelper.synchronizeAndGetFixedEntries(swPair.src.dpId).isPresent()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         cleanup:
@@ -444,7 +438,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
         database.getMirrorPoints().empty
 
         and: "Related switch pass validation"
-        northbound.validateSwitch(swPair.dst.dpId).verifyRuleSectionsAreEmpty()
+        !switchHelper.synchronizeAndGetFixedEntries(swPair.dst.dpId).isPresent()
         def testComplete = true
 
         cleanup:
@@ -569,7 +563,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
         })
 
         then: "Flow and affected switch are valid"
-        northbound.validateSwitch(swPair.dst.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
+        !switchHelper.synchronizeAndGetFixedEntries(swPair.dst.dpId).isPresent()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         and: "Mirror rule has updated port/vlan values"
@@ -610,9 +604,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
 
         then: "Mirror point is created and Active"
         and: "Related switches and flow pass validation"
-        pathHelper.getInvolvedSwitches(flow.flowId).each {
-            northbound.validateSwitch(it.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
-        }
+        switchHelper.synchronizeAndGetFixedEntries(pathHelper.getInvolvedSwitches(flow.flowId)*.getDpId()).isEmpty()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         and: "Flow passes traffic on main path as well as to the mirror"
@@ -656,9 +648,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
         flowHelperV2.createMirrorPoint(flow.flowId, mirrorEndpoint)
 
         then: "Mirror point is created, flow and switches are valid"
-        pathHelper.getInvolvedSwitches(flow.flowId).each {
-            northbound.validateSwitch(it.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
-        }
+        switchHelper.synchronizeAndGetFixedEntries(pathHelper.getInvolvedSwitches(flow.flowId)*.getDpId()).isEmpty()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         and: "Traffic examination reports packets on mirror point"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PartialUpdateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PartialUpdateSpec.groovy
@@ -298,10 +298,7 @@ class PartialUpdateSpec extends HealthCheckSpecification {
         }
 
         and: "The src switch passes switch validation"
-        with(northbound.validateSwitch(srcSwitch.dpId)) { validation ->
-            validation.verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            validation.verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        !switchHelper.synchronizeAndGetFixedEntries(srcSwitch.dpId).isPresent()
 
         cleanup:
         flow && flowHelperV2.deleteFlow(flow.flowId)
@@ -352,18 +349,12 @@ class PartialUpdateSpec extends HealthCheckSpecification {
 
         and: "The new and old dst switches pass switch validation"
         Wrappers.wait(RULES_DELETION_TIME) {
-            [dstSwitch, newDstSwitch]*.dpId.each { switchId ->
-                with(northbound.validateSwitch(switchId)) { validation ->
-                    validation.verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-                    validation.verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-                }
-            }
+            assert switchHelper.validateAndGetFixedEntries([dstSwitch, newDstSwitch]*.dpId).isEmpty()
         }
-        def dstSwitchesAreFine = false
 
         cleanup:
         flow && flowHelperV2.deleteFlow(flow.flowId)
-        !dstSwitchesAreFine && [dstSwitch, newDstSwitch]*.dpId.each { northbound.synchronizeSwitch(it, true) }
+        switchHelper.synchronizeAndGetFixedEntries([dstSwitch, newDstSwitch]*.dpId).isEmpty()
     }
 
     def "Able to update flow encapsulationType using partial update"() {
@@ -445,10 +436,7 @@ class PartialUpdateSpec extends HealthCheckSpecification {
         }
 
         and: "The switch passes switch validation"
-        with(northbound.validateSwitch(flow.source.switchId)) { validation ->
-            validation.verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            validation.verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        !switchHelper.synchronizeAndGetFixedEntries(flow.source.switchId).isPresent()
 
         cleanup:
         flow && flowHelperV2.deleteFlow(flow.flowId)
@@ -505,10 +493,7 @@ class PartialUpdateSpec extends HealthCheckSpecification {
         }
 
         and: "The switch passes switch validation"
-        with(northbound.validateSwitch(flow.source.switchId)) { validation ->
-            validation.verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            validation.verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        !switchHelper.synchronizeAndGetFixedEntries(flow.source.switchId).isPresent()
 
         cleanup:
         flow && flowHelperV2.deleteFlow(flow.flowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
@@ -214,11 +214,11 @@ class ProtectedPathSpec extends HealthCheckSpecification {
 
         and: "No rule discrepancies on every switch of the flow on the main path"
         def mainSwitches = pathHelper.getInvolvedSwitches(currentPath)
-        mainSwitches.each { verifySwitchRules(it.dpId) }
+        switchHelper.synchronizeAndGetFixedEntries(mainSwitches*.getDpId()).isEmpty()
 
         and: "No rule discrepancies on every switch of the flow on the protected path)"
         def protectedSwitches = pathHelper.getInvolvedSwitches(currentProtectedPath)
-        protectedSwitches.each { verifySwitchRules(it.dpId) }
+        switchHelper.synchronizeAndGetFixedEntries(protectedSwitches*.getDpId()).isEmpty()
 
         and: "The flow allows traffic(on the main path)"
         def traffExam = traffExamProvider.get()
@@ -277,21 +277,7 @@ class ProtectedPathSpec extends HealthCheckSpecification {
         and: "Transit switches store the correct info about rules and meters"
         def involvedTransitSwitches = (currentPath[1..-2].switchId + currentProtectedPath[1..-2].switchId).unique()
         Wrappers.wait(WAIT_OFFSET) {
-            involvedTransitSwitches.each { switchId ->
-                def amountOfRules = (switchId in currentProtectedPath*.switchId &&
-                        switchId in currentPath*.switchId) ? 4 : 2
-                if (northbound.getSwitch(switchId).description.contains("OF_12")) {
-                    def switchValidateInfo = northbound.validateSwitchRules(switchId)
-                    assert switchValidateInfo.properRules.findAll { !new Cookie(it).serviceFlag }.size() == amountOfRules
-                    assert switchValidateInfo.missingRules.size() == 0
-                    assert switchValidateInfo.excessRules.size() == 0
-                } else {
-                    def switchValidateInfo = northbound.validateSwitch(switchId)
-                    assert switchValidateInfo.rules.proper.findAll { !new Cookie(it).serviceFlag }.size() == amountOfRules
-                    switchValidateInfo.verifyRuleSectionsAreEmpty(["missing", "excess"])
-                    switchValidateInfo.verifyMeterSectionsAreEmpty()
-                }
-            }
+            assert switchHelper.validateAndGetFixedEntries(involvedTransitSwitches).isEmpty()
         }
 
         and: "No rule discrepancies when doing flow validation"
@@ -302,11 +288,11 @@ class ProtectedPathSpec extends HealthCheckSpecification {
 
         and: "No rule discrepancies on every switch of the flow on the main path"
         def newMainSwitches = pathHelper.getInvolvedSwitches(newCurrentPath)
-        newMainSwitches.each { verifySwitchRules(it.dpId) }
+        switchHelper.synchronizeAndGetFixedEntries(newMainSwitches*.getDpId()).isEmpty()
 
         and: "No rule discrepancies on every switch of the flow on the protected path)"
         def newProtectedSwitches = pathHelper.getInvolvedSwitches(newCurrentProtectedPath)
-        newProtectedSwitches.each { verifySwitchRules(it.dpId) }
+        switchHelper.synchronizeAndGetFixedEntries(newProtectedSwitches*.getDpId()).isEmpty()
 
         and: "The flow allows traffic(on the protected path)"
         withPool {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ThrottlingRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ThrottlingRerouteSpec.groovy
@@ -199,10 +199,10 @@ class ThrottlingRerouteSpec extends HealthCheckSpecification {
         !northboundV2.getAllFlows().find { it.flowId == flow.flowId}
 
         and: "Related switches have no excess rules"
-        //wait, server42 rules may take some time to disappear after flow removal
-        Wrappers.wait(RULES_DELETION_TIME) { pathHelper.getInvolvedSwitches(PathHelper.convert(path)).each {
-            verifySwitchRules(it.dpId)
-        }}
+        Wrappers.wait(RULES_DELETION_TIME) {
+            switchHelper.validateAndGetFixedEntries(
+                    pathHelper.getInvolvedSwitches(PathHelper.convert(path))*.getDpId()).isEmpty()
+        }
 
         cleanup:
         flow && !flowIsDeleted && northboundV2.deleteFlow(flow.flowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowCreateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowCreateSpec.groovy
@@ -3,7 +3,6 @@ package org.openkilda.functionaltests.spec.flows.haflows
 import org.openkilda.functionaltests.error.haflow.HaFlowNotCreatedExpectedError
 import org.openkilda.functionaltests.error.haflow.HaFlowNotCreatedWithConflictExpectedError
 
-import static groovyx.gpars.GParsPool.withPool
 import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.TOPOLOGY_DEPENDENT
 import static org.openkilda.testing.Constants.FLOW_CRUD_TIMEOUT
@@ -16,7 +15,6 @@ import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.functionaltests.helpers.YFlowHelper
 import org.openkilda.functionaltests.helpers.model.SwitchTriplet
 import org.openkilda.messaging.payload.flow.FlowState
-import org.openkilda.model.SwitchId
 import org.openkilda.northbound.dto.v2.haflows.HaFlowCreatePayload
 import org.openkilda.northbound.dto.v2.haflows.HaFlowPingPayload
 
@@ -77,11 +75,7 @@ class HaFlowCreateSpec extends HealthCheckSpecification {
         }
 
         and: "And involved switches pass validation"
-        withPool {
-            involvedSwitchIds.eachParallel { SwitchId swId ->
-                assert northboundV2.validateSwitch(swId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(involvedSwitchIds).isEmpty()
 
         cleanup:
         haFlow && !flowRemoved && haFlowHelper.deleteHaFlow(haFlow.haFlowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowIntentionalRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowIntentionalRerouteSpec.groovy
@@ -69,11 +69,7 @@ class HaFlowIntentionalRerouteSpec extends HealthCheckSpecification {
         northboundV2.getHaFlowPaths(haFlow.haFlowId) == currentPathResponse
 
         and: "And involved switches pass validation"
-        withPool {
-            haFlowHelper.getInvolvedSwitches(currentPathResponse).eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(haFlowHelper.getInvolvedSwitches(currentPathResponse)).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
@@ -145,11 +141,7 @@ class HaFlowIntentionalRerouteSpec extends HealthCheckSpecification {
 
         and: "And involved switches pass validation"
         def allInvolvedSwitchIds = oldInvolvedSwitchIds + haFlowHelper.getInvolvedSwitches(getPathsResponse)
-        withPool {
-            allInvolvedSwitchIds.eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(allInvolvedSwitchIds).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
@@ -205,11 +197,7 @@ class HaFlowIntentionalRerouteSpec extends HealthCheckSpecification {
 
         and: "And involved switches pass validation"
         def allInvolvedSwitchIds = oldInvolvedSwitchIds + haFlowHelper.getInvolvedSwitches(updatedPaths)
-        withPool {
-            allInvolvedSwitchIds.eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(allInvolvedSwitchIds).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowPathSwapSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowPathSwapSpec.groovy
@@ -86,11 +86,7 @@ class HaFlowPathSwapSpec extends HealthCheckSpecification {
 
         and: "All involved switches pass switch validation"
         def involvedSwitches = haFlowHelper.getInvolvedSwitches(haFlowPathInfoAfter)
-        withPool {
-            involvedSwitches.eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(involvedSwitches).isEmpty()
 
         and: "Traffic passes through HA-Flow"
         if (swT.isHaTraffExamAvailable()) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowProtectedSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowProtectedSpec.groovy
@@ -60,14 +60,10 @@ class HaFlowProtectedSpec extends HealthCheckSpecification {
         // and: "HA-Flow and related sub-flows are valid"
         // northboundV2.validateHaFlow(haFlow.haFlowId).asExpected
 
-        and: "All involved switches passes switch validation"
-        withPool {
-            (switchesBeforeUpdate + switchesAfterUpdate).eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        and: "All involved switches pass switch validation"
+        switchHelper.synchronizeAndGetFixedEntries(switchesBeforeUpdate + switchesAfterUpdate).isEmpty()
 
-        and: "HA-flow pass validation"
+        and: "HA-flow passes validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
 
         cleanup:
@@ -106,12 +102,8 @@ class HaFlowProtectedSpec extends HealthCheckSpecification {
         // and: "HA-Flow and related sub-flows are valid"
         // northboundV2.validateHaFlow(haFlow.haFlowId).asExpected
 
-        and: "All involved switches passes switch validation"
-        withPool {
-            (switchesBeforeUpdate + switchesAfterUpdate).eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        and: "All involved switches pass switch validation"
+        switchHelper.synchronizeAndGetFixedEntries(switchesBeforeUpdate + switchesAfterUpdate).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
@@ -147,11 +139,7 @@ class HaFlowProtectedSpec extends HealthCheckSpecification {
         expect northboundV2.getHaFlow(haFlow.haFlowId), sameBeanAs(haFlow, ignores)
 
         and: "And involved switches pass validation"
-        withPool {
-            haFlowHelper.getInvolvedSwitches(haFlow.haFlowId).eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(haFlowHelper.getInvolvedSwitches(haFlow.haFlowId)).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowRerouteSpec.groovy
@@ -2,7 +2,6 @@ package org.openkilda.functionaltests.spec.flows.haflows
 
 import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
 
-import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.functionaltests.model.stats.HaFlowStats
 
 import static groovyx.gpars.GParsPool.withPool
@@ -24,7 +23,6 @@ import org.openkilda.functionaltests.helpers.HaFlowHelper
 import org.openkilda.functionaltests.helpers.PathHelper
 import org.openkilda.messaging.info.event.PathNode
 import org.openkilda.messaging.payload.flow.FlowState
-import org.openkilda.model.SwitchId
 import org.openkilda.model.history.DumpType
 import org.openkilda.testing.model.topology.TopologyDefinition.Isl
 import org.openkilda.testing.service.northbound.model.HaFlowActionType
@@ -95,11 +93,7 @@ class HaFlowRerouteSpec extends HealthCheckSpecification {
 
         and: "All involved switches pass switch validation"
         def allInvolvedSwitchIds = haFlowHelper.getInvolvedSwitches(oldPaths) + haFlowHelper.getInvolvedSwitches(newPaths)
-        withPool {
-            allInvolvedSwitchIds.eachParallel { SwitchId switchId ->
-                northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(allInvolvedSwitchIds).isEmpty()
         
         and: "Traffic passes through HA-Flow"
         if (swT.isHaTraffExamAvailable()) {
@@ -176,11 +170,7 @@ class HaFlowRerouteSpec extends HealthCheckSpecification {
 
         and: "All involved switches pass switch validation"
         def allInvolvedSwitchIds = haFlowHelper.getInvolvedSwitches(oldPaths) + haFlowHelper.getInvolvedSwitches(newPaths)
-        withPool {
-            allInvolvedSwitchIds.eachParallel { SwitchId switchId ->
-                northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(allInvolvedSwitchIds).isEmpty()
 
         cleanup: "Bring port involved in the original path up and delete the HA-flow"
         haFlow && haFlowHelper.deleteHaFlow(haFlow.haFlowId)
@@ -233,11 +223,7 @@ class HaFlowRerouteSpec extends HealthCheckSpecification {
         }
 
         and: "All involved switches pass switch validation"
-        withPool {
-            haFlowHelper.getInvolvedSwitches(oldPaths).eachParallel { SwitchId switchId ->
-                northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(haFlowHelper.getInvolvedSwitches(oldPaths)).isEmpty()
 
         cleanup: "Bring port involved in the original path up and delete the HA-flow"
         haFlow && haFlowHelper.deleteHaFlow(haFlow.haFlowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowUpdateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowUpdateSpec.groovy
@@ -1,14 +1,11 @@
 package org.openkilda.functionaltests.spec.flows.haflows
 
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs
-import static groovyx.gpars.GParsPool.withPool
-import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static spock.util.matcher.HamcrestSupport.expect
 
 import org.openkilda.functionaltests.HealthCheckSpecification
 import org.openkilda.functionaltests.error.haflow.HaFlowNotUpdatedExpectedError
 import org.openkilda.functionaltests.helpers.HaFlowHelper
-import org.openkilda.model.SwitchId
 import org.openkilda.northbound.dto.v2.haflows.HaFlow
 import org.openkilda.northbound.dto.v2.haflows.HaFlowPatchEndpoint
 import org.openkilda.northbound.dto.v2.haflows.HaFlowPatchPayload
@@ -46,11 +43,7 @@ class HaFlowUpdateSpec extends HealthCheckSpecification {
         expect northboundV2.getHaFlow(haFlow.haFlowId), sameBeanAs(haFlow, ignores)
 
         and: "And involved switches pass validation"
-        withPool {
-            haFlowHelper.getInvolvedSwitches(haFlow.haFlowId).eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(haFlowHelper.getInvolvedSwitches(haFlow.haFlowId)).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
@@ -120,11 +113,7 @@ class HaFlowUpdateSpec extends HealthCheckSpecification {
         expect northboundV2.getHaFlow(haFlow.haFlowId), sameBeanAs(haFlow, ignores)
 
         and: "And involved switches pass validation"
-        withPool {
-            haFlowHelper.getInvolvedSwitches(haFlow.haFlowId).eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(haFlowHelper.getInvolvedSwitches(haFlow.haFlowId)).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
@@ -150,11 +139,7 @@ class HaFlowUpdateSpec extends HealthCheckSpecification {
         expect northboundV2.getHaFlow(haFlow.haFlowId), sameBeanAs(haFlow, ignores)
 
         and: "And involved switches pass validation"
-        withPool {
-            haFlowHelper.getInvolvedSwitches(haFlow.haFlowId).eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(haFlowHelper.getInvolvedSwitches(haFlow.haFlowId)).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
@@ -277,11 +262,7 @@ class HaFlowUpdateSpec extends HealthCheckSpecification {
         new HaFlowNotUpdatedExpectedError(data.errorDescription).matches(exc)
 
         and: "And involved switches pass validation"
-        withPool {
-            involvedSwitchIds.eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(involvedSwitchIds).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
@@ -340,12 +321,9 @@ At least one of subflow endpoint switch id must differ from shared endpoint swit
         then: "Error is received"
         def exc = thrown(HttpClientErrorException)
         new HaFlowNotUpdatedExpectedError(data.errorDescrPattern).matches(exc)
+
         and: "And involved switches pass validation"
-        withPool {
-            involvedSwitchIds.eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(involvedSwitchIds).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/SubFlowSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/SubFlowSpec.groovy
@@ -41,14 +41,10 @@ class SubFlowSpec extends HealthCheckSpecification {
         then: "Human readable error is returned"
         def e = thrown(HttpClientErrorException)
         new FlowNotModifiedExpectedError(subFlow.flowId).matches(e)
+
         and: "All involved switches pass switch validation"
-        def involvedSwitches = pathHelper.getInvolvedYSwitches(yFlow.YFlowId)
-        involvedSwitches.each { sw ->
-            northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northbound.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured"])
-            northbound.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "misconfigured"])
-        }
+        def involvedSwitches = pathHelper.getInvolvedYSwitches(yFlow.YFlowId)*.getDpId()
+        switchHelper.synchronizeAndGetFixedEntries(involvedSwitches).isEmpty()
 
         and: "Y-Flow is UP"
         and: "Sub flows are UP"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowCreateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowCreateSpec.groovy
@@ -100,11 +100,8 @@ class YFlowCreateSpec extends HealthCheckSpecification {
         }
 
         and: "All involved switches pass switch validation"
-        def involvedSwitches = pathHelper.getInvolvedYSwitches(paths)
-        involvedSwitches.each { sw ->
-            northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northbound.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        def involvedSwitches = pathHelper.getInvolvedYSwitches(paths)*.getDpId()
+        switchHelper.synchronizeAndGetFixedEntries(involvedSwitches).isEmpty()
 
         and: "Bandwidth is properly consumed on shared and non-shared ISLs"
         def allLinksAfter = northbound.getAllLinks()
@@ -191,11 +188,8 @@ class YFlowCreateSpec extends HealthCheckSpecification {
 
         and: "All involved switches pass switch validation"
         // https://github.com/telstra/open-kilda/issues/3411
-        northbound.synchronizeSwitch(yFlow.sharedEndpoint.switchId, true)
-        involvedSwitches.each { sw ->
-            northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northbound.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        switchHelper.synchronize(yFlow.sharedEndpoint.switchId)
+        switchHelper.synchronizeAndGetFixedEntries(involvedSwitches).isEmpty()
 
         cleanup:
         yFlow && !flowRemoved && yFlowHelper.deleteYFlow(yFlow.YFlowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowPathSwapSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowPathSwapSpec.groovy
@@ -112,11 +112,8 @@ class YFlowPathSwapSpec extends HealthCheckSpecification {
 
         and: "All involved switches passes switch validation"
         def yFlowPaths = northboundV2.getYFlowPaths(yFlow.YFlowId)
-        def involvedSwitches = pathHelper.getInvolvedYSwitches(yFlowPaths)
-        involvedSwitches.each { sw ->
-            northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northbound.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        def involvedSwitches = pathHelper.getInvolvedYSwitches(yFlowPaths)*.getDpId()
+        switchHelper.synchronizeAndGetFixedEntries(involvedSwitches).isEmpty()
 
         when: "Traffic starts to flow on both sub-flows with maximum bandwidth (if applicable)"
         def traffExam = traffExamProvider.get()
@@ -243,11 +240,8 @@ class YFlowPathSwapSpec extends HealthCheckSpecification {
 
         and: "All involved switches passes switch validation"
         def yFlowPaths = northboundV2.getYFlowPaths(yFlow.YFlowId)
-        def involvedSwitches = pathHelper.getInvolvedYSwitches(yFlowPaths)
-        involvedSwitches.each { sw ->
-            northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northbound.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        def involvedSwitches = pathHelper.getInvolvedYSwitches(yFlowPaths)*.getDpId()
+        switchHelper.synchronizeAndGetFixedEntries(involvedSwitches).isEmpty()
 
         when: "Restore port status"
         def portUp = antiflap.portUp(islToBreak.dstSwitch.dpId, islToBreak.dstPort)
@@ -285,11 +279,7 @@ class YFlowPathSwapSpec extends HealthCheckSpecification {
 
         and: "All involved switches passes switch validation"
         def yFlowPathsAfter = northboundV2.getYFlowPaths(yFlow.YFlowId)
-        def involvedSwitchesAfter = pathHelper.getInvolvedYSwitches(yFlowPathsAfter)
-        involvedSwitchesAfter.each { sw ->
-            northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northbound.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        switchHelper.synchronizeAndGetFixedEntries(pathHelper.getInvolvedYSwitches(yFlowPathsAfter)*.getDpId()).isEmpty()
 
         cleanup: "Revert system to original state"
         yFlow && yFlowHelper.deleteYFlow(yFlow.YFlowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowProtectedSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowProtectedSpec.groovy
@@ -68,12 +68,9 @@ class YFlowProtectedSpec extends HealthCheckSpecification {
             assert northbound.validateFlow(it.flowId).each { direction -> assert direction.asExpected }
         }
 
-        and: "All involved switches passes switch validation"
+        and: "All involved switches pass switch validation"
         def involvedSwitches = pathHelper.getInvolvedYSwitches(northboundV2.getYFlowPaths(yFlow.YFlowId))
-        involvedSwitches.each { sw ->
-            northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northbound.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        switchHelper.synchronizeAndGetFixedEntries(involvedSwitches*.getDpId()).isEmpty()
 
         when: "Disable protected path via partial update"
         def patch = YFlowPatchPayload.builder().allocateProtectedPath(false).build()
@@ -98,10 +95,7 @@ class YFlowProtectedSpec extends HealthCheckSpecification {
         }
 
         and: "All involved switches passes switch validation"
-        involvedSwitches.each { sw ->
-            northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northbound.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        switchHelper.synchronizeAndGetFixedEntries(involvedSwitches*.getDpId()).isEmpty()
 
         cleanup:
         yFlow && yFlowHelper.deleteYFlow(yFlow.YFlowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowRerouteSpec.groovy
@@ -107,11 +107,7 @@ class YFlowRerouteSpec extends HealthCheckSpecification {
         }
 
         and: "All involved switches pass switch validation"
-        def involvedSwitches = pathHelper.getInvolvedYSwitches(paths)
-        involvedSwitches.each { sw ->
-            northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northbound.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        switchHelper.synchronizeAndGetFixedEntries(pathHelper.getInvolvedYSwitches(paths)*.getDpId()).isEmpty()
 
         when: "Traffic starts to flow on both sub-flows with maximum bandwidth (if applicable)"
         def traffExam = traffExamProvider.get()

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowUpdateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowUpdateSpec.groovy
@@ -57,10 +57,7 @@ class YFlowUpdateSpec extends HealthCheckSpecification {
         expect northboundV2.getYFlow(yFlow.YFlowId), sameBeanAs(yFlow, ignores)
 
         and: "All related switches have no discrepancies"
-        involvedSwitches.each { sw ->
-            northboundV2.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northboundV2.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        switchHelper.synchronizeAndGetFixedEntries(involvedSwitches*.getDpId()).isEmpty()
 
         cleanup:
         yFlow && yFlowHelper.deleteYFlow(yFlow.YFlowId)
@@ -134,10 +131,7 @@ class YFlowUpdateSpec extends HealthCheckSpecification {
         expect northboundV2.getYFlow(yFlow.YFlowId), sameBeanAs(yFlow, ignores)
 
         and: "All related switches have no discrepancies"
-        involvedSwitches.each { sw ->
-            northboundV2.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northboundV2.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        switchHelper.synchronizeAndGetFixedEntries(involvedSwitches*.getDpId()).isEmpty()
 
         cleanup:
         yFlow && yFlowHelper.deleteYFlow(yFlow.YFlowId)
@@ -184,9 +178,7 @@ class YFlowUpdateSpec extends HealthCheckSpecification {
         expect northboundV2.getYFlow(yFlow.YFlowId), sameBeanAs(yFlow, ignores)
 
         and: "All related switches have no discrepancies"
-        northboundV2.validateSwitch(switchId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        northboundV2.validateSwitch(switchId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-
+        !switchHelper.synchronizeAndGetFixedEntries(switchId).isPresent()
 
         cleanup:
         yFlow && yFlowHelper.deleteYFlow(yFlow.YFlowId)
@@ -216,10 +208,7 @@ class YFlowUpdateSpec extends HealthCheckSpecification {
         expect northboundV2.getYFlow(yFlow.YFlowId), sameBeanAs(yFlow, ignores)
 
         and: "All related switches have no discrepancies"
-        involvedSwitches.each { sw ->
-            northboundV2.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northboundV2.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        switchHelper.synchronizeAndGetFixedEntries(involvedSwitches*.getDpId()).isEmpty()
 
         cleanup:
         yFlow && yFlowHelper.deleteYFlow(yFlow.YFlowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslReplugSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslReplugSpec.groovy
@@ -90,11 +90,8 @@ class IslReplugSpec extends HealthCheckSpecification {
         def newIslIsRemoved = true
 
         and: "The src and dst switches of the isl pass switch validation"
-        [isl.srcSwitch.dpId, isl.dstSwitch.dpId, notConnectedIsl.srcSwitch.dpId].unique().each { swId ->
-            with(northbound.validateSwitch(swId)) { validationResponse ->
-                validationResponse.verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(
+                [isl.srcSwitch.dpId, isl.dstSwitch.dpId, notConnectedIsl.srcSwitch.dpId].unique()).isEmpty()
 
         cleanup:
         if (!originIslIsUp) {
@@ -157,11 +154,8 @@ class IslReplugSpec extends HealthCheckSpecification {
         /* Need wait because of parallel s42 tests. Sw validation may show a missing s42 rule. Just wait for it.
         If problem persists, add a 'read' resource lock for s42_toggle */
         Wrappers.wait(WAIT_OFFSET) {
-            [isl.srcSwitch.dpId, isl.dstSwitch.dpId, notConnectedIsl.srcSwitch.dpId].unique().each { swId ->
-                with(northbound.validateSwitch(swId)) { validationResponse ->
-                    validationResponse.verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-                }
-            }
+            switchHelper.validateAndGetFixedEntries(
+                    [isl.srcSwitch.dpId, isl.dstSwitch.dpId, notConnectedIsl.srcSwitch.dpId].unique()).isEmpty()
         }
 
         cleanup:

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
@@ -794,14 +794,7 @@ class LinkSpec extends HealthCheckSpecification {
         }
 
         and: "Source and destination switches pass switch validation"
-        withPool {
-            [switchPair.src.dpId, switchPair.dst.dpId].eachParallel { SwitchId swId ->
-                with(northbound.validateSwitch(swId)) { validation ->
-                    validation.verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-                    validation.verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-                }
-            }
-        }
+        switchHelper.synchronizeAndGetFixedEntries(switchPair.toList()*.getDpId()).isEmpty()
 
         cleanup:
         flow && flowHelperV2.deleteFlow(flow.flowId)
@@ -854,17 +847,11 @@ class LinkSpec extends HealthCheckSpecification {
         }
 
         and: "The src/dst switches are valid"
-        /** https://github.com/telstra/open-kilda/issues/3906
-        [isl.srcSwitch, isl.dstSwitch].each {
-            //Similar to https://github.com/telstra/open-kilda/issues/3906 but for Server42 ISL RTT rules.
-            if (!it.prop || (it.prop.server42IslRtt == "DISABLED")) {
-                def validateInfo = northbound.validateSwitch(it.dpId).rules
-                assert validateInfo.missing.empty
-                assert validateInfo.excess.empty
-                assert validateInfo.misconfigured.empty
-            }
-        } */
-
+        //https://github.com/telstra/open-kilda/issues/3906
+        def switchesNotAffectedBy3906 = [isl.srcSwitch, isl.dstSwitch].findAll {
+            !it.prop || (it.prop.server42IslRtt == "DISABLED")
+        }
+        switchHelper.validateAndGetFixedEntries(switchesNotAffectedBy3906*.getDpId()).isEmpty()
 
         cleanup:
         aSwitchForwardRuleIsDeleted && lockKeeper.addFlows([isl.aswitch])

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/RoundTripIslSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/RoundTripIslSpec.groovy
@@ -230,7 +230,7 @@ round trip latency rule is removed on the dst switch"() {
         northbound.deleteSwitchRules(dstSw.dpId, DeleteRulesAction.REMOVE_ROUND_TRIP_LATENCY)
         def isRoundTripRuleDeleted = true
         Wrappers.wait(RULES_DELETION_TIME) {
-            assert northbound.validateSwitch(dstSw.dpId).rules.missing.size() == 1
+            assert switchHelper.validateAndGetFixedEntries(dstSw.dpId).get().rules.missing.size() == 1
         }
 
         then: "The round trip latency ISL is FAILED"
@@ -268,7 +268,7 @@ round trip latency rule is removed on the dst switch"() {
         northbound.installSwitchRules(dstSw.dpId, InstallRulesAction.INSTALL_ROUND_TRIP_LATENCY)
         isRoundTripRuleDeleted = false
         Wrappers.wait(RULES_INSTALLATION_TIME) {
-            assert northbound.validateSwitch(dstSw.dpId).rules.missing.empty
+            assert !switchHelper.validateAndGetFixedEntries(dstSw.dpId).isPresent()
         }
 
         then: "Round trip status is available for the given ISL in both directions"
@@ -287,7 +287,7 @@ round trip latency rule is removed on the dst switch"() {
                 assert allLinks.findAll { it.state == DISCOVERED }.size() == topology.islsForActiveSwitches.size() * 2
                 assert islUtils.getIslInfo(allLinks, roundTripIsl).get().roundTripStatus == DISCOVERED
                 assert islUtils.getIslInfo(allLinks, roundTripIsl.reversed).get().roundTripStatus == DISCOVERED
-                assert northbound.validateSwitch(dstSw.dpId).rules.missing.empty
+                assert !switchHelper.validateAndGetFixedEntries(dstSw.dpId).isPresent()
             }
         }
         database.resetCosts(topology.isls)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesSpec.groovy
@@ -263,11 +263,11 @@ class DefaultRulesSpec extends HealthCheckSpecification {
             excessRules.empty
             properRules.sort() == sw.defaultCookies.findAll { it != data.cookie }.sort()
         }
-        verifyAll(northbound.validateSwitch(sw.dpId)) {
-            rules.missing == deletedRules
+        verifyAll(switchHelper.validateAndGetFixedEntries(sw.dpId).get()) {
+            rules.missing*.getCookie() == deletedRules
             rules.misconfigured.empty
             rules.excess.empty
-            rules.proper.sort() == sw.defaultCookies.findAll { it != data.cookie }.sort()
+            rules.proper*.getCookie().sort() == sw.defaultCookies.findAll { it != data.cookie }.sort()
         }
 
         cleanup: "Install default rules back"
@@ -329,11 +329,11 @@ class DefaultRulesSpec extends HealthCheckSpecification {
             excessRules.empty
             properRules.sort() == sw.defaultCookies.findAll { it != data.cookie }.sort()
         }
-        verifyAll(northbound.validateSwitch(sw.dpId)) {
-            rules.missing == deletedRules
+        verifyAll(switchHelper.validateAndGetFixedEntries(sw.dpId).get()) {
+            rules.missing*.getCookie() == deletedRules
             rules.misconfigured.empty
             rules.excess.empty
-            rules.proper.sort() == sw.defaultCookies.findAll { it != data.cookie }.sort()
+            rules.proper*.getCookie().sort() == sw.defaultCookies.findAll { it != data.cookie }.sort()
         }
 
         cleanup: "Install default rules back"
@@ -399,11 +399,11 @@ class DefaultRulesSpec extends HealthCheckSpecification {
             excessRules.empty
             properRules.sort() == sw.defaultCookies.findAll { it != SERVER_42_FLOW_RTT_TURNING_COOKIE }.sort()
         }
-        verifyAll(northbound.validateSwitch(sw.dpId)) {
-            rules.missing == [SERVER_42_FLOW_RTT_TURNING_COOKIE]
+        verifyAll(switchHelper.validateAndGetFixedEntries(sw.dpId).get()) {
+            rules.missing*.getCookie() == [SERVER_42_FLOW_RTT_TURNING_COOKIE]
             rules.misconfigured.empty
             rules.excess.empty
-            rules.proper.sort() == sw.defaultCookies.findAll { it != SERVER_42_FLOW_RTT_TURNING_COOKIE }.sort()
+            rules.proper*.getCookie().sort() == sw.defaultCookies.findAll { it != SERVER_42_FLOW_RTT_TURNING_COOKIE }.sort()
         }
 
         when: "Install the server42 turning rule"
@@ -458,11 +458,11 @@ class DefaultRulesSpec extends HealthCheckSpecification {
             excessRules.empty
             properRules.sort() == sw.defaultCookies.findAll { it != SERVER_42_ISL_RTT_TURNING_COOKIE }.sort()
         }
-        verifyAll(northbound.validateSwitch(sw.dpId)) {
-            rules.missing == [SERVER_42_ISL_RTT_TURNING_COOKIE]
+        verifyAll(switchHelper.validateAndGetFixedEntries(sw.dpId).get()) {
+            rules.missing*.getCookie() == [SERVER_42_ISL_RTT_TURNING_COOKIE]
             rules.misconfigured.empty
             rules.excess.empty
-            rules.proper.sort() == sw.defaultCookies.findAll { it != SERVER_42_ISL_RTT_TURNING_COOKIE }.sort()
+            rules.proper*.getCookie().sort() == sw.defaultCookies.findAll { it != SERVER_42_ISL_RTT_TURNING_COOKIE }.sort()
         }
 
         when: "Install the server42 ISL RTT turning rule"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/MetersSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/MetersSpec.groovy
@@ -231,11 +231,7 @@ on a #switchType switch"() {
         newMeterEntries*.rate.each { verifyRateSizeOnWb5164(it, flow.maximumBandwidth) }
 
         and: "Switch validation shows no discrepancies in meters"
-        def metersValidation = northbound.validateSwitch(sw.dpId).meters
-        metersValidation.proper.size() == 2 + sw.defaultMeters.size()
-        metersValidation.excess.empty
-        metersValidation.missing.empty
-        metersValidation.misconfigured.empty
+        !switchHelper.synchronizeAndGetFixedEntries(sw.dpId).isPresent()
 
         and: "Flow validation shows no discrepancies in meters"
         northbound.validateFlow(flow.flowId).each { assert it.asExpected }
@@ -400,11 +396,7 @@ meters in flow rules at all (#srcSwitch - #dstSwitch flow)"() {
         newMeters*.burstSize.each { assert it == switchHelper.getExpectedBurst(sw.dpId, flowRate) }
 
         and: "Switch validation shows no discrepancies in meters"
-        def metersValidation = northbound.validateSwitch(sw.dpId).meters
-        metersValidation.proper.size() == 2 + sw.defaultMeters.size()
-        metersValidation.excess.empty
-        metersValidation.missing.empty
-        metersValidation.misconfigured.empty
+        !switchHelper.synchronizeAndGetFixedEntries(sw.dpId).isPresent()
 
         and: "Flow validation shows no discrepancies in meters"
         northbound.validateFlow(flow.flowId).each { assert it.asExpected }
@@ -457,11 +449,7 @@ meters in flow rules at all (#srcSwitch - #dstSwitch flow)"() {
         newMeters*.burstSize.every { it == expectedBurstSize }
 
         and: "Switch validation shows no discrepancies in meters"
-        def metersValidation = northbound.validateSwitch(sw.dpId).meters
-        metersValidation.proper.size() == 2 + sw.defaultMeters.size()
-        metersValidation.excess.empty
-        metersValidation.missing.empty
-        metersValidation.misconfigured.empty
+        !switchHelper.synchronizeAndGetFixedEntries(sw.dpId).isPresent()
 
         and: "Flow validation shows no discrepancies in meters"
         northbound.validateFlow(flow.flowId).each { assert it.asExpected }
@@ -516,11 +504,7 @@ meters in flow rules at all (#srcSwitch - #dstSwitch flow)"() {
         }
 
         and: "Switch validation shows no discrepancies in meters"
-        def metersValidation = northbound.validateSwitch(sw.dpId).meters
-        metersValidation.proper.size() == 2 + sw.defaultMeters.size()
-        metersValidation.excess.empty
-        metersValidation.missing.empty
-        metersValidation.misconfigured.empty
+        !switchHelper.synchronizeAndGetFixedEntries(sw.dpId).isPresent()
 
         and: "Flow validation shows no discrepancies in meters"
         northbound.validateFlow(flow.flowId).each { assert it.asExpected }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchActivationSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchActivationSpec.groovy
@@ -65,13 +65,13 @@ class SwitchActivationSpec extends HealthCheckSpecification {
         northbound.deleteMeter(switchPair.src.dpId, nonDefaultMeterIds[0])
         northbound.deleteSwitchRules(switchPair.src.dpId, DeleteRulesAction.IGNORE_DEFAULTS)
         Wrappers.wait(WAIT_OFFSET) {
-            verifyAll(northbound.validateSwitch(switchPair.src.dpId)) {
+            with(switchHelper.validateAndGetFixedEntries(switchPair.src.dpId).get()) {
                 it.rules.missing.containsAll(createdCookies)
-                it.rules.missingHex.containsAll(createdHexCookies)
-                it.verifyRuleSectionsAreEmpty(["proper", "excess"])
-                it.verifyHexRuleSectionsAreEmpty(["properHex", "excessHex"])
+                it.rules.excess.empty
+                it.rules.misconfigured.empty
                 it.meters.missing.size() == 1
-                it.verifyMeterSectionsAreEmpty(["proper", "misconfigured", "excess"])
+                it.meters.excess.empty
+                it.meters.misconfigured.empty
             }
         }
 
@@ -81,19 +81,12 @@ class SwitchActivationSpec extends HealthCheckSpecification {
         switchHelper.reviveSwitch(switchPair.src, blockData)
 
         then: "Missing flow rules/meters were synced during switch activation"
-        def switchValidationInfo = northbound.validateSwitch(switchPair.src.dpId)
-        verifyAll {
-            switchValidationInfo.rules.proper.containsAll(createdCookies)
-            switchValidationInfo.rules.properHex.containsAll(createdHexCookies)
-            switchValidationInfo.verifyRuleSectionsAreEmpty(["missing", "excess"])
-            switchValidationInfo.verifyHexRuleSectionsAreEmpty(["missingHex", "excessHex"])
-            switchValidationInfo.meters.proper*.meterId == originalMeterIds.sort()
-            switchValidationInfo.verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        !switchHelper.synchronizeAndGetFixedEntries(switchPair.src.dpId).isPresent()
+        def switchIsSynchronized = true
 
         cleanup: "Delete the flow and activate switch if required"
         flowHelperV2.deleteFlow(flow.flowId)
-        blockData && !switchValidationInfo && switchHelper.reviveSwitch(switchPair.src, blockData, true)
+        blockData && !switchIsSynchronized && switchHelper.reviveSwitch(switchPair.src, blockData, true)
 
     }
 
@@ -145,13 +138,13 @@ class SwitchActivationSpec extends HealthCheckSpecification {
         producer.flush()
 
         Wrappers.wait(WAIT_OFFSET) {
-            verifyAll(northbound.validateSwitch(sw.dpId)) {
+            verifyAll(switchHelper.validateAndGetFixedEntries(sw.dpId).get()) {
                 it.rules.excess.size() == 3
-                it.rules.excessHex.size() == 3
-                it.verifyRuleSectionsAreEmpty(["proper", "missing"])
-                it.verifyHexRuleSectionsAreEmpty(["properHex", "missingHex"])
+                it.rules.misconfigured.empty
+                it.rules.missing.empty
                 it.meters.excess.size() == 1
-                it.verifyMeterSectionsAreEmpty(["missing", "proper", "misconfigured"])
+                it.meters.misconfigured.empty
+                it.meters.missing.empty
             }
         }
 
@@ -161,14 +154,11 @@ class SwitchActivationSpec extends HealthCheckSpecification {
         switchHelper.reviveSwitch(sw, blockData)
 
         then: "Excess meters/rules were synced during switch activation"
-        def switchValidationInfo = northbound.validateSwitch(sw.dpId)
-        verifyAll {
-            switchValidationInfo.verifyRuleSectionsAreEmpty(["missing", "excess", "proper"])
-            switchValidationInfo.verifyHexRuleSectionsAreEmpty(["missingHex", "excessHex", "properHex"])
-        }
+        !switchHelper.synchronizeAndGetFixedEntries(sw.dpId).isPresent()
+        def isSwitchSynchronized = true
 
         cleanup:
-        blockData && !switchValidationInfo && switchHelper.reviveSwitch(sw, blockData, true)
+        blockData && !isSwitchSynchronized && switchHelper.reviveSwitch(sw, blockData, true)
     }
 
     @Tags([SMOKE_SWITCHES])
@@ -219,13 +209,13 @@ class SwitchActivationSpec extends HealthCheckSpecification {
         producer.flush()
 
         Wrappers.wait(WAIT_OFFSET) {
-            verifyAll(northbound.validateSwitch(sw.dpId)) {
+            verifyAll(switchHelper.validateAndGetFixedEntries(sw.dpId).get()) {
                 it.rules.excess.size() == 3
-                it.rules.excessHex.size() == 3
-                it.verifyRuleSectionsAreEmpty(["proper", "missing"])
-                it.verifyHexRuleSectionsAreEmpty(["properHex", "missingHex"])
+                it.rules.missing.empty
+                it.rules.misconfigured.empty
                 it.meters.excess.size() == 1
-                it.verifyMeterSectionsAreEmpty(["missing", "proper", "misconfigured"])
+                it.meters.misconfigured.empty
+                it.meters.missing.empty
             }
         }
 
@@ -235,14 +225,11 @@ class SwitchActivationSpec extends HealthCheckSpecification {
         switchHelper.reviveSwitch(sw, blockData)
 
         then: "Excess meters/rules were synced during switch activation"
-        def switchValidationInfo = northbound.validateSwitch(sw.dpId)
-        verifyAll {
-            switchValidationInfo.verifyRuleSectionsAreEmpty(["missing", "excess", "proper"])
-            switchValidationInfo.verifyHexRuleSectionsAreEmpty(["missingHex", "excessHex", "properHex"])
-        }
+        !switchHelper.synchronizeAndGetFixedEntries(sw.dpId).isPresent()
+        def isSwitchSynchronized = true
 
         cleanup:
-        blockData && !switchValidationInfo && switchHelper.reviveSwitch(sw, blockData, true)
+        blockData && !isSwitchSynchronized && switchHelper.reviveSwitch(sw, blockData, true)
     }
 
     @Tags([SMOKE, SMOKE_SWITCHES, LOCKKEEPER])

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
@@ -114,9 +114,7 @@ class SwitchFailuresSpec extends HealthCheckSpecification {
         }
 
         and: "Blinking switch has no rule anomalies"
-        def validation = northbound.validateSwitch(swPair.src.dpId)
-        validation.verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
-        validation.verifyMeterSectionsAreEmpty(["missing", "misconfigured", "excess"])
+        !switchHelper.validateAndGetFixedEntries(swPair.src.dpId).isPresent()
 
         and: "Flow validation is OK"
         northbound.validateFlow(flow.flowId).each { assert it.asExpected }
@@ -153,10 +151,7 @@ class SwitchFailuresSpec extends HealthCheckSpecification {
         }
 
         and: "Dst switch validation shows no missing rules"
-        with(northbound.validateSwitch(dstSwitch.dpId)) {
-            it.verifyRuleSectionsAreEmpty(["missing", "proper", "misconfigured"])
-            it.verifyMeterSectionsAreEmpty(["missing", "misconfigured", "proper", "excess"])
-        }
+        !switchHelper.validateAndGetFixedEntries(dstSwitch.dpId).isPresent()
 
         when: "Try to validate flow"
         northbound.validateFlow(flow.flowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
@@ -309,11 +309,11 @@ class SwitchesSpec extends HealthCheckSpecification {
                 [descr    : "synchronizing rules on",
                  operation: { getNorthbound().synchronizeSwitchRules(NON_EXISTENT_SWITCH_ID) }],
                 [descr    : "synchronizing",
-                 operation: { getNorthbound().synchronizeSwitch(NON_EXISTENT_SWITCH_ID, true) }],
+                 operation: { switchHelper.validateAndGetFixedEntries(NON_EXISTENT_SWITCH_ID) }],
                 [descr    : "validating rules on",
                  operation: { getNorthbound().validateSwitchRules(NON_EXISTENT_SWITCH_ID) }],
                 [descr    : "validating",
-                 operation: { getNorthbound().validateSwitch(NON_EXISTENT_SWITCH_ID) }]
+                 operation: { switchHelper.validateAndGetFixedEntries(NON_EXISTENT_SWITCH_ID) }]
         ]
     }
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/RetriesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/RetriesSpec.groovy
@@ -427,7 +427,7 @@ class RetriesIsolatedSpec extends HealthCheckSpecification {
 
         and: "Src/dst switches are valid"
         wait(WAIT_OFFSET * 2) { //due to instability
-            [flow.source.switchId, flow.destination.switchId].each { verifySwitchRules(it) }
+            switchHelper.validateAndGetFixedEntries([flow.source.switchId, flow.destination.switchId]).isEmpty()
         }
 
         cleanup:


### PR DESCRIPTION
* Added methods synchronizeAndGetFixedEntries() into SwitchHelper
* Replaced validation calls with new methods in org.openkilda.functionaltests.spec.flows,
org.openkilda.functionaltests.spec.links,
org.openkilda.functionaltests.spec.server42,
org.openkilda.functionaltests.spec.switches (partially)
* Added method SwitchPair.toList()