### PR TITLE
5390: [TEST]: Replace switch validation with switch synchronization where possible

### DIFF
--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/model/SwitchPair.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/model/SwitchPair.groovy
@@ -47,6 +47,11 @@ class SwitchPair {
     }
 
     @JsonIgnore
+    List<Switch> toList() {
+        return [src, dst]
+    }
+
+    @JsonIgnore
     SwitchPair getReversed() {
         new SwitchPair(src: dst,
                 dst: src,

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/BaseSpecification.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/BaseSpecification.groovy
@@ -115,12 +115,6 @@ class BaseSpecification extends Specification {
                 "but current active profile is '${this.profile}'")
     }
 
-    void verifySwitchRules(SwitchId switchId) {
-        def rules = northbound.validateSwitchRules(switchId)
-        assert rules.excessRules.empty
-        assert rules.missingRules.empty
-    }
-
     // this cleanup section should be removed after fixing the issue https://github.com/telstra/open-kilda/issues/5480
     void deleteAnyFlowsLeftoversIssue5480() {
         Wrappers.benchmark("Deleting flows leftovers") {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowDiversitySpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowDiversitySpec.groovy
@@ -353,7 +353,7 @@ class FlowDiversitySpec extends HealthCheckSpecification {
             [flow1, flow2, flow3].eachParallel { it && flowHelperV2.deleteFlow(it.flowId) }
         }
         //https://github.com/telstra/open-kilda/issues/5221
-        switchHelper.synchronize([switchPair.getSrc().getDpId(), switchPair.getDst().getDpId()])
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(switchPair.toList()*.getDpId())
     }
 
     @Tags([LOW_PRIORITY])

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowLoopSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowLoopSpec.groovy
@@ -7,7 +7,6 @@ import org.openkilda.functionaltests.error.flow.FlowNotFoundExpectedError
 import org.openkilda.functionaltests.error.flow.FlowNotUpdatedExpectedError
 
 import static groovyx.gpars.GParsPool.withPool
-import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.HARDWARE
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE_SWITCHES
@@ -95,8 +94,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
         getFlowLoopRules(switchPair.dst.dpId).empty
 
         and: "The src switch is valid"
-        northbound.validateSwitch(switchPair.src.dpId)
-                .verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
+        switchHelper.synchronizeAndCollectFixedDiscrepancies([switchPair.getSrc().getDpId()]).isEmpty()
 
         when: "Send traffic via flow in the forward direction"
         def traffExam = traffExamProvider.get()
@@ -173,8 +171,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
         }
 
         and: "The src switch is valid"
-        northbound.validateSwitch(switchPair.src.dpId)
-                .verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(switchPair.getSrc().getDpId()).isPresent()
 
         and: "Flow allows traffic"
         withPool {
@@ -272,16 +269,11 @@ class FlowLoopSpec extends HealthCheckSpecification {
             assert getFlowLoopRules(switchPair.dst.dpId).empty
         }
 
-        and: "The dst switch is valid"
-        northbound.validateSwitch(switchPair.src.dpId)
-                .verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        def testIsCompleted = true
+        and: "Both switches are valid"
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(switchPair.toList()*.getDpId()).isEmpty()
 
         cleanup: "Delete the flow"
         flow && !flowIsDeleted && flowHelperV2.deleteFlow(flow.flowId)
-        !testIsCompleted && [switchPair.src.dpId, switchPair.dst.dpId].each {
-            northbound.synchronizeSwitch(it, true)
-        }
     }
 
     @Tags(ISL_RECOVER_ON_FAIL)
@@ -326,8 +318,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
         getFlowLoopRules(switchPair.dst.dpId).size() == 2
 
         and: "The src switch is valid"
-        northbound.validateSwitch(switchPair.src.dpId)
-                .verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(switchPair.getSrc().getDpId()).isPresent()
 
         and: "Flow doesn't allow traffic, because it is grubbed by flowLoop rules"
         def traffExam = traffExamProvider.get()
@@ -355,6 +346,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
     def "System is able to detect and sync missing flowLoop rules"() {
         given: "An active flow with created flowLoop on the src switch"
         def switchPair = switchPairs.all().neighbouring().random()
+        def sourceSwitchId = switchPair.getSrc().getDpId()
         def flow = flowHelperV2.randomFlow(switchPair)
         flowHelperV2.addFlow(flow)
         northboundV2.createFlowLoop(flow.flowId, new FlowLoopPayload(switchPair.src.dpId))
@@ -365,15 +357,15 @@ class FlowLoopSpec extends HealthCheckSpecification {
         }
 
         when: "Delete flowLoop rules"
-        flowLoopRules.each { northbound.deleteSwitchRules(switchPair.src.dpId, it) }
+        flowLoopRules.each { northbound.deleteSwitchRules(sourceSwitchId, it) }
 
         then: "System detects missing flowLoop rules"
         Wrappers.wait(RULES_DELETION_TIME) {
-            assert northbound.validateSwitch(switchPair.src.dpId).rules.missing.sort() == flowLoopRules.sort()
+            assert switchHelper.validate(sourceSwitchId).rules.missing*.cookie.sort() == flowLoopRules.sort()
         }
 
         when: "Sync the src switch"
-        def syncResponse = northbound.synchronizeSwitch(switchPair.src.dpId, true)
+        def syncResponse = switchHelper.synchronizeAndCollectFixedDiscrepancies(sourceSwitchId).get()
 
         then: "Sync response contains flowLoop rules into the installed section"
         syncResponse.rules.installed.sort() == flowLoopRules.sort()
@@ -382,12 +374,12 @@ class FlowLoopSpec extends HealthCheckSpecification {
         Wrappers.wait(RULES_INSTALLATION_TIME) {
             assert getFlowLoopRules(switchPair.src.dpId).size() == 2
         }
-        northbound.validateSwitch(switchPair.src.dpId).rules.missing.empty
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(switchPair.src.dpId).isPresent()
         def testIsCompleted = true
 
         cleanup:
         flow && flowHelperV2.deleteFlow(flow.flowId)
-        !testIsCompleted && northbound.synchronizeSwitch(switchPair.src.dpId, true)
+        !testIsCompleted && switchHelper.synchronize(switchPair.src.dpId)
     }
 
     @Tags(LOW_PRIORITY)
@@ -481,8 +473,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
             def flowLoopRules = getFlowLoopRules(switchPair.src.dpId)
             assert flowLoopRules.size() == 2
             assert flowLoopRules*.packetCount.every { it == 0 }
-            northbound.validateSwitch(switchPair.src.dpId)
-                    .verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
+            assert !switchHelper.validateAndCollectFoundDiscrepancies(switchPair.getSrc().getDpId()).isPresent()
         }
 
         when: "Send traffic via flow"
@@ -543,7 +534,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
         and: "The switch is valid"
         Wrappers.wait(RULES_INSTALLATION_TIME) {
             assert getFlowLoopRules(sw.dpId).size() == 2
-            northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
+            assert !switchHelper.validateAndCollectFoundDiscrepancies(sw.getDpId()).isPresent()
         }
 
 
@@ -563,12 +554,10 @@ class FlowLoopSpec extends HealthCheckSpecification {
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         and: "The switch is valid"
-        northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        def testIsCompleted = true
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(sw.getDpId()).isPresent()
 
         cleanup:
         flow && flowHelperV2.deleteFlow(flow.flowId)
-        !testIsCompleted && northbound.synchronizeSwitch(sw.dpId, true)
     }
 
     @Tags(LOW_PRIORITY)
@@ -596,8 +585,8 @@ class FlowLoopSpec extends HealthCheckSpecification {
         and: "The switch is valid"
         Wrappers.wait(RULES_INSTALLATION_TIME) {
             assert getFlowLoopRules(sw.dpId).size() == 2
-            northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
         }
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(sw.getDpId()).isPresent()
 
         when: "Delete the flow with created flowLoop"
         flowHelperV2.deleteFlow(flow.flowId)
@@ -607,12 +596,10 @@ class FlowLoopSpec extends HealthCheckSpecification {
         getFlowLoopRules(sw.dpId).empty
 
         and: "The switch is valid"
-        northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        def testIsCompleted = true
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(sw.getDpId()).isPresent()
 
         cleanup: "Delete the flow"
         !flowIsDeleted && flowHelperV2.deleteFlow(flow.flowId)
-        !testIsCompleted && northbound.synchronizeSwitch(sw.dpId, true)
     }
 
     @Tags(LOW_PRIORITY)
@@ -632,9 +619,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
 
         and: "The src/dst switches are valid"
         Wrappers.wait(RULES_INSTALLATION_TIME) {
-            [switchPair.src, switchPair.dst].each {
-                northbound.validateSwitch(it.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            }
+            assert switchHelper.validateAndCollectFoundDiscrepancies(switchPair.toList()*.getDpId()).isEmpty()
         }
 
         and: "No extra rules are created on the src/dst switches"
@@ -653,9 +638,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
 
         cleanup:
         !flowIsDeleted && flowHelperV2.deleteFlow(flow.flowId)
-        if (!testIsCompleted) {
-            [switchPair.src, switchPair.dst].each { northbound.synchronizeSwitch(it.dpId, true) }
-        }
+        !testIsCompleted && switchHelper.synchronizeAndCollectFixedDiscrepancies(switchPair.toList()*.getDpId())
     }
 
     @Tags(LOW_PRIORITY)
@@ -752,11 +735,7 @@ class FlowLoopSpec extends HealthCheckSpecification {
         getFlowLoopRules(sw.dpId).empty
 
         and: "The switch is valid"
-        northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        def switchIsValid = true
-
-        cleanup:
-        !switchIsValid && northbound.synchronizeSwitch(sw.dpId, true)
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(sw.getDpId()).isPresent()
     }
 
     @Tags(LOW_PRIORITY)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowValidationNegativeSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowValidationNegativeSpec.groovy
@@ -1,6 +1,6 @@
 package org.openkilda.functionaltests.spec.flows
 
-import static org.junit.jupiter.api.Assumptions.assumeTrue
+
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.testing.Constants.NON_EXISTENT_FLOW_ID
 
@@ -66,18 +66,16 @@ class FlowValidationNegativeSpec extends HealthCheckSpecification {
         rules[damagedSwitch.toString()] == cookieToDelete.toString()
 
         and: "Affected switch should have one missing rule with the same cookie as the damaged flow"
-        def switchValidationResult = northbound.validateSwitchRules(damagedSwitch)
-        switchValidationResult.missingRules.size() == 1
-        switchValidationResult.missingRules[0] == cookieToDelete
+        def switchSynchronizationResult = switchHelper.synchronizeAndCollectFixedDiscrepancies(damagedSwitch).get()
+        switchSynchronizationResult.getRules().getMissing() == [cookieToDelete]
 
         and: "There should be no excess rules on the affected switch"
-        switchValidationResult.excessRules.size() == 0
+        switchSynchronizationResult.getRules().getExcess().isEmpty()
 
         and: "Validation of non-affected switches (if any) should succeed"
         if (damagedFlowSwitches.size() > 1) {
-            def nonAffectedSwitches = damagedFlowSwitches.findAll { it != damagedFlowSwitches[item] }
-            nonAffectedSwitches.each { sw -> assert northbound.validateSwitchRules(sw).missingRules.size() == 0 }
-            nonAffectedSwitches.each { sw -> assert northbound.validateSwitchRules(sw).excessRules.size() == 0 }
+            def nonAffectedSwitches = damagedFlowSwitches.findAll { it != damagedSwitch }
+            switchHelper.synchronizeAndCollectFixedDiscrepancies(nonAffectedSwitches).isEmpty()
         }
 
         cleanup: "Delete the flows"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MirrorEndpointsSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MirrorEndpointsSpec.groovy
@@ -141,9 +141,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
         findMirrorRule(rules, oppositeDirection) == null
 
         and: "Related switches and flow pass validation"
-        pathHelper.getInvolvedSwitches(flow.flowId).each {
-            northbound.validateSwitch(it.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(pathHelper.getInvolvedSwitches(flow.flowId)*.getDpId()).isEmpty()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         when: "Traffic briefly runs through the flow"
@@ -207,14 +205,14 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
         !fl.getGroupsStats(swPair.src.dpId).group.find { it.groupNumber == groupId }
 
         and: "Src switch and flow pass validation"
-        northbound.validateSwitch(swPair.src.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(swPair.src.dpId).isPresent()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         when: "Delete the flow"
         flowHelperV2.deleteFlow(flow.flowId)
 
         then: "Src switch pass validation"
-        northbound.validateSwitch(swPair.src.dpId).verifyRuleSectionsAreEmpty()
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(swPair.src.dpId).isPresent()
         def testDone = true
 
         cleanup:
@@ -253,7 +251,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
 
         then: "Mirror point is created and Active"
         and: "Flow and switch pass validation"
-        northbound.validateSwitch(swPair.src.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(swPair.src.dpId).isPresent()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         when: "Swap flow paths"
@@ -263,7 +261,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
         }
 
         then: "Flow and switch both pass validation"
-        northbound.validateSwitch(swPair.src.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(swPair.src.dpId).isPresent()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         and: "Flow passes main traffic"
@@ -306,9 +304,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
 
         then: "Mirror point is created and Active"
         and: "Related switches and flow pass validation"
-        pathHelper.getInvolvedSwitches(flow.flowId).each {
-            northbound.validateSwitch(it.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(pathHelper.getInvolvedSwitches(flow.flowId)*.getDpId()).isEmpty()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         and: "Flow passes traffic on main path as well as to the mirror (if possible to check)"
@@ -357,9 +353,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
         }
 
         then: "Related switches and flow pass validation"
-        pathHelper.getInvolvedSwitches(flow.flowId).each {
-            northbound.validateSwitch(it.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(pathHelper.getInvolvedSwitches(flow.flowId)*.getDpId()).isEmpty()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         cleanup:
@@ -406,7 +400,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
 
         then: "Mirror point is created and Active"
         and: "Flow and src switch both pass validation"
-        northbound.validateSwitch(swPair.src.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(swPair.src.dpId).isPresent()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         cleanup:
@@ -444,7 +438,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
         database.getMirrorPoints().empty
 
         and: "Related switch pass validation"
-        northbound.validateSwitch(swPair.dst.dpId).verifyRuleSectionsAreEmpty()
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(swPair.dst.dpId).isPresent()
         def testComplete = true
 
         cleanup:
@@ -569,7 +563,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
         })
 
         then: "Flow and affected switch are valid"
-        northbound.validateSwitch(swPair.dst.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(swPair.dst.dpId).isPresent()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         and: "Mirror rule has updated port/vlan values"
@@ -610,9 +604,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
 
         then: "Mirror point is created and Active"
         and: "Related switches and flow pass validation"
-        pathHelper.getInvolvedSwitches(flow.flowId).each {
-            northbound.validateSwitch(it.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(pathHelper.getInvolvedSwitches(flow.flowId)*.getDpId()).isEmpty()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         and: "Flow passes traffic on main path as well as to the mirror"
@@ -656,9 +648,7 @@ class MirrorEndpointsSpec extends HealthCheckSpecification {
         flowHelperV2.createMirrorPoint(flow.flowId, mirrorEndpoint)
 
         then: "Mirror point is created, flow and switches are valid"
-        pathHelper.getInvolvedSwitches(flow.flowId).each {
-            northbound.validateSwitch(it.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(pathHelper.getInvolvedSwitches(flow.flowId)*.getDpId()).isEmpty()
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         and: "Traffic examination reports packets on mirror point"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PartialUpdateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/PartialUpdateSpec.groovy
@@ -298,10 +298,7 @@ class PartialUpdateSpec extends HealthCheckSpecification {
         }
 
         and: "The src switch passes switch validation"
-        with(northbound.validateSwitch(srcSwitch.dpId)) { validation ->
-            validation.verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            validation.verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(srcSwitch.dpId).isPresent()
 
         cleanup:
         flow && flowHelperV2.deleteFlow(flow.flowId)
@@ -352,18 +349,12 @@ class PartialUpdateSpec extends HealthCheckSpecification {
 
         and: "The new and old dst switches pass switch validation"
         Wrappers.wait(RULES_DELETION_TIME) {
-            [dstSwitch, newDstSwitch]*.dpId.each { switchId ->
-                with(northbound.validateSwitch(switchId)) { validation ->
-                    validation.verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-                    validation.verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-                }
-            }
+            assert switchHelper.validateAndCollectFoundDiscrepancies([dstSwitch, newDstSwitch]*.dpId).isEmpty()
         }
-        def dstSwitchesAreFine = false
 
         cleanup:
         flow && flowHelperV2.deleteFlow(flow.flowId)
-        !dstSwitchesAreFine && [dstSwitch, newDstSwitch]*.dpId.each { northbound.synchronizeSwitch(it, true) }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies([dstSwitch, newDstSwitch]*.dpId)
     }
 
     def "Able to update flow encapsulationType using partial update"() {
@@ -445,10 +436,7 @@ class PartialUpdateSpec extends HealthCheckSpecification {
         }
 
         and: "The switch passes switch validation"
-        with(northbound.validateSwitch(flow.source.switchId)) { validation ->
-            validation.verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            validation.verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(flow.source.switchId).isPresent()
 
         cleanup:
         flow && flowHelperV2.deleteFlow(flow.flowId)
@@ -505,10 +493,7 @@ class PartialUpdateSpec extends HealthCheckSpecification {
         }
 
         and: "The switch passes switch validation"
-        with(northbound.validateSwitch(flow.source.switchId)) { validation ->
-            validation.verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            validation.verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(flow.source.switchId).isPresent()
 
         cleanup:
         flow && flowHelperV2.deleteFlow(flow.flowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ThrottlingRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ThrottlingRerouteSpec.groovy
@@ -198,11 +198,11 @@ class ThrottlingRerouteSpec extends HealthCheckSpecification {
         then: "The flow is not present in NB"
         !northboundV2.getAllFlows().find { it.flowId == flow.flowId}
 
-        and: "Related switches have no excess rules"
-        //wait, server42 rules may take some time to disappear after flow removal
-        Wrappers.wait(RULES_DELETION_TIME) { pathHelper.getInvolvedSwitches(PathHelper.convert(path)).each {
-            verifySwitchRules(it.dpId)
-        }}
+        and: "Related switches have no excess rules, though need to wait until server42 rules are deleted"
+        Wrappers.wait(RULES_DELETION_TIME) {
+            switchHelper.validateAndCollectFoundDiscrepancies(
+                    pathHelper.getInvolvedSwitches(PathHelper.convert(path))*.getDpId()).isEmpty()
+        }
 
         cleanup:
         flow && !flowIsDeleted && northboundV2.deleteFlow(flow.flowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowCreateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowCreateSpec.groovy
@@ -3,7 +3,6 @@ package org.openkilda.functionaltests.spec.flows.haflows
 import org.openkilda.functionaltests.error.haflow.HaFlowNotCreatedExpectedError
 import org.openkilda.functionaltests.error.haflow.HaFlowNotCreatedWithConflictExpectedError
 
-import static groovyx.gpars.GParsPool.withPool
 import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.TOPOLOGY_DEPENDENT
 import static org.openkilda.testing.Constants.FLOW_CRUD_TIMEOUT
@@ -16,7 +15,6 @@ import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.functionaltests.helpers.YFlowHelper
 import org.openkilda.functionaltests.helpers.model.SwitchTriplet
 import org.openkilda.messaging.payload.flow.FlowState
-import org.openkilda.model.SwitchId
 import org.openkilda.northbound.dto.v2.haflows.HaFlowCreatePayload
 import org.openkilda.northbound.dto.v2.haflows.HaFlowPingPayload
 
@@ -77,11 +75,7 @@ class HaFlowCreateSpec extends HealthCheckSpecification {
         }
 
         and: "And involved switches pass validation"
-        withPool {
-            involvedSwitchIds.eachParallel { SwitchId swId ->
-                assert northboundV2.validateSwitch(swId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(involvedSwitchIds).isEmpty()
 
         cleanup:
         haFlow && !flowRemoved && haFlowHelper.deleteHaFlow(haFlow.haFlowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowIntentionalRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowIntentionalRerouteSpec.groovy
@@ -14,7 +14,6 @@ import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.info.event.PathNode
 import org.openkilda.messaging.payload.flow.FlowState
 import org.openkilda.model.FlowEncapsulationType
-import org.openkilda.model.SwitchId
 import org.openkilda.northbound.dto.v2.haflows.HaFlowPaths
 import org.openkilda.northbound.dto.v2.haflows.HaFlowRerouteResult
 import org.openkilda.northbound.dto.v2.haflows.HaSubFlow
@@ -69,11 +68,7 @@ class HaFlowIntentionalRerouteSpec extends HealthCheckSpecification {
         northboundV2.getHaFlowPaths(haFlow.haFlowId) == currentPathResponse
 
         and: "And involved switches pass validation"
-        withPool {
-            haFlowHelper.getInvolvedSwitches(currentPathResponse).eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(haFlowHelper.getInvolvedSwitches(currentPathResponse)).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
@@ -145,11 +140,7 @@ class HaFlowIntentionalRerouteSpec extends HealthCheckSpecification {
 
         and: "And involved switches pass validation"
         def allInvolvedSwitchIds = oldInvolvedSwitchIds + haFlowHelper.getInvolvedSwitches(getPathsResponse)
-        withPool {
-            allInvolvedSwitchIds.eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(allInvolvedSwitchIds).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
@@ -205,11 +196,7 @@ class HaFlowIntentionalRerouteSpec extends HealthCheckSpecification {
 
         and: "And involved switches pass validation"
         def allInvolvedSwitchIds = oldInvolvedSwitchIds + haFlowHelper.getInvolvedSwitches(updatedPaths)
-        withPool {
-            allInvolvedSwitchIds.eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(allInvolvedSwitchIds).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowPathSwapSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowPathSwapSpec.groovy
@@ -2,7 +2,6 @@ package org.openkilda.functionaltests.spec.flows.haflows
 
 import org.openkilda.functionaltests.model.stats.HaFlowStats
 
-import static groovyx.gpars.GParsPool.withPool
 import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 import static org.openkilda.functionaltests.model.stats.Direction.FORWARD
@@ -18,7 +17,6 @@ import org.openkilda.functionaltests.helpers.PathHelper
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.messaging.error.MessageError
 import org.openkilda.messaging.payload.flow.FlowState
-import org.openkilda.model.SwitchId
 import org.openkilda.northbound.dto.v2.haflows.HaFlowPaths
 
 import org.springframework.beans.factory.annotation.Autowired
@@ -86,11 +84,7 @@ class HaFlowPathSwapSpec extends HealthCheckSpecification {
 
         and: "All involved switches pass switch validation"
         def involvedSwitches = haFlowHelper.getInvolvedSwitches(haFlowPathInfoAfter)
-        withPool {
-            involvedSwitches.eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(involvedSwitches).isEmpty()
 
         and: "Traffic passes through HA-Flow"
         if (swT.isHaTraffExamAvailable()) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowProtectedSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowProtectedSpec.groovy
@@ -1,14 +1,12 @@
 package org.openkilda.functionaltests.spec.flows.haflows
 
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs
-import static groovyx.gpars.GParsPool.withPool
 import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static spock.util.matcher.HamcrestSupport.expect
 
 import org.openkilda.functionaltests.HealthCheckSpecification
 import org.openkilda.functionaltests.helpers.HaFlowHelper
 import org.openkilda.functionaltests.helpers.YFlowHelper
-import org.openkilda.model.SwitchId
 import org.openkilda.northbound.dto.v2.haflows.HaFlow
 import org.openkilda.northbound.dto.v2.haflows.HaFlowPatchPayload
 
@@ -60,14 +58,10 @@ class HaFlowProtectedSpec extends HealthCheckSpecification {
         // and: "HA-Flow and related sub-flows are valid"
         // northboundV2.validateHaFlow(haFlow.haFlowId).asExpected
 
-        and: "All involved switches passes switch validation"
-        withPool {
-            (switchesBeforeUpdate + switchesAfterUpdate).eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        and: "All involved switches pass switch validation"
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(switchesBeforeUpdate + switchesAfterUpdate).isEmpty()
 
-        and: "HA-flow pass validation"
+        and: "HA-flow passes validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
 
         cleanup:
@@ -106,12 +100,8 @@ class HaFlowProtectedSpec extends HealthCheckSpecification {
         // and: "HA-Flow and related sub-flows are valid"
         // northboundV2.validateHaFlow(haFlow.haFlowId).asExpected
 
-        and: "All involved switches passes switch validation"
-        withPool {
-            (switchesBeforeUpdate + switchesAfterUpdate).eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        and: "All involved switches pass switch validation"
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(switchesBeforeUpdate + switchesAfterUpdate).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
@@ -147,11 +137,7 @@ class HaFlowProtectedSpec extends HealthCheckSpecification {
         expect northboundV2.getHaFlow(haFlow.haFlowId), sameBeanAs(haFlow, ignores)
 
         and: "And involved switches pass validation"
-        withPool {
-            haFlowHelper.getInvolvedSwitches(haFlow.haFlowId).eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(haFlowHelper.getInvolvedSwitches(haFlow.haFlowId)).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowRerouteSpec.groovy
@@ -2,7 +2,6 @@ package org.openkilda.functionaltests.spec.flows.haflows
 
 import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
 
-import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.functionaltests.model.stats.HaFlowStats
 
 import static groovyx.gpars.GParsPool.withPool
@@ -24,7 +23,6 @@ import org.openkilda.functionaltests.helpers.HaFlowHelper
 import org.openkilda.functionaltests.helpers.PathHelper
 import org.openkilda.messaging.info.event.PathNode
 import org.openkilda.messaging.payload.flow.FlowState
-import org.openkilda.model.SwitchId
 import org.openkilda.model.history.DumpType
 import org.openkilda.testing.model.topology.TopologyDefinition.Isl
 import org.openkilda.testing.service.northbound.model.HaFlowActionType
@@ -95,11 +93,7 @@ class HaFlowRerouteSpec extends HealthCheckSpecification {
 
         and: "All involved switches pass switch validation"
         def allInvolvedSwitchIds = haFlowHelper.getInvolvedSwitches(oldPaths) + haFlowHelper.getInvolvedSwitches(newPaths)
-        withPool {
-            allInvolvedSwitchIds.eachParallel { SwitchId switchId ->
-                northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(allInvolvedSwitchIds).isEmpty()
         
         and: "Traffic passes through HA-Flow"
         if (swT.isHaTraffExamAvailable()) {
@@ -176,11 +170,7 @@ class HaFlowRerouteSpec extends HealthCheckSpecification {
 
         and: "All involved switches pass switch validation"
         def allInvolvedSwitchIds = haFlowHelper.getInvolvedSwitches(oldPaths) + haFlowHelper.getInvolvedSwitches(newPaths)
-        withPool {
-            allInvolvedSwitchIds.eachParallel { SwitchId switchId ->
-                northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(allInvolvedSwitchIds).isEmpty()
 
         cleanup: "Bring port involved in the original path up and delete the HA-flow"
         haFlow && haFlowHelper.deleteHaFlow(haFlow.haFlowId)
@@ -233,11 +223,7 @@ class HaFlowRerouteSpec extends HealthCheckSpecification {
         }
 
         and: "All involved switches pass switch validation"
-        withPool {
-            haFlowHelper.getInvolvedSwitches(oldPaths).eachParallel { SwitchId switchId ->
-                northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(haFlowHelper.getInvolvedSwitches(oldPaths)).isEmpty()
 
         cleanup: "Bring port involved in the original path up and delete the HA-flow"
         haFlow && haFlowHelper.deleteHaFlow(haFlow.haFlowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowSyncSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowSyncSpec.groovy
@@ -93,7 +93,7 @@ class HaFlowSyncSpec extends HealthCheckSpecification {
 
         cleanup: "Delete the HA-flow"
         haFlow && haFlowHelper.deleteHaFlow(haFlow.haFlowId)
-        switchToManipulate && switchToManipulate.synchronize()
+        switchToManipulate && switchHelper.synchronize(switchToManipulate.getDpId())
 
         where: data << [
                 [protectedPath: false],
@@ -158,7 +158,7 @@ class HaFlowSyncSpec extends HealthCheckSpecification {
     }
 
     private void haRulesAreSynced(SwitchId swId, HaFlow haFlow, Date syncTime) {
-        assert northboundV2.validateSwitch(swId).asExpected
+        assert switchHelper.validate(swId).asExpected
         def haRules = switchRulesFactory.get(swId).forHaFlow(haFlow)
         assert !haRules.isEmpty()
         haRules.each {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowUpdateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowUpdateSpec.groovy
@@ -1,14 +1,11 @@
 package org.openkilda.functionaltests.spec.flows.haflows
 
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs
-import static groovyx.gpars.GParsPool.withPool
-import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static spock.util.matcher.HamcrestSupport.expect
 
 import org.openkilda.functionaltests.HealthCheckSpecification
 import org.openkilda.functionaltests.error.haflow.HaFlowNotUpdatedExpectedError
 import org.openkilda.functionaltests.helpers.HaFlowHelper
-import org.openkilda.model.SwitchId
 import org.openkilda.northbound.dto.v2.haflows.HaFlow
 import org.openkilda.northbound.dto.v2.haflows.HaFlowPatchEndpoint
 import org.openkilda.northbound.dto.v2.haflows.HaFlowPatchPayload
@@ -46,11 +43,7 @@ class HaFlowUpdateSpec extends HealthCheckSpecification {
         expect northboundV2.getHaFlow(haFlow.haFlowId), sameBeanAs(haFlow, ignores)
 
         and: "And involved switches pass validation"
-        withPool {
-            haFlowHelper.getInvolvedSwitches(haFlow.haFlowId).eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(haFlowHelper.getInvolvedSwitches(haFlow.haFlowId)).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
@@ -120,11 +113,7 @@ class HaFlowUpdateSpec extends HealthCheckSpecification {
         expect northboundV2.getHaFlow(haFlow.haFlowId), sameBeanAs(haFlow, ignores)
 
         and: "And involved switches pass validation"
-        withPool {
-            haFlowHelper.getInvolvedSwitches(haFlow.haFlowId).eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(haFlowHelper.getInvolvedSwitches(haFlow.haFlowId)).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
@@ -150,11 +139,7 @@ class HaFlowUpdateSpec extends HealthCheckSpecification {
         expect northboundV2.getHaFlow(haFlow.haFlowId), sameBeanAs(haFlow, ignores)
 
         and: "And involved switches pass validation"
-        withPool {
-            haFlowHelper.getInvolvedSwitches(haFlow.haFlowId).eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(haFlowHelper.getInvolvedSwitches(haFlow.haFlowId)).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
@@ -277,11 +262,7 @@ class HaFlowUpdateSpec extends HealthCheckSpecification {
         new HaFlowNotUpdatedExpectedError(data.errorDescription).matches(exc)
 
         and: "And involved switches pass validation"
-        withPool {
-            involvedSwitchIds.eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(involvedSwitchIds).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected
@@ -340,12 +321,9 @@ At least one of subflow endpoint switch id must differ from shared endpoint swit
         then: "Error is received"
         def exc = thrown(HttpClientErrorException)
         new HaFlowNotUpdatedExpectedError(data.errorDescrPattern).matches(exc)
+
         and: "And involved switches pass validation"
-        withPool {
-            involvedSwitchIds.eachParallel { SwitchId switchId ->
-                assert northboundV2.validateSwitch(switchId).isAsExpected()
-            }
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(involvedSwitchIds).isEmpty()
 
         and: "HA-flow pass validation"
         northboundV2.validateHaFlow(haFlow.getHaFlowId()).asExpected

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/SubFlowSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/SubFlowSpec.groovy
@@ -41,14 +41,10 @@ class SubFlowSpec extends HealthCheckSpecification {
         then: "Human readable error is returned"
         def e = thrown(HttpClientErrorException)
         new FlowNotModifiedExpectedError(subFlow.flowId).matches(e)
+
         and: "All involved switches pass switch validation"
-        def involvedSwitches = pathHelper.getInvolvedYSwitches(yFlow.YFlowId)
-        involvedSwitches.each { sw ->
-            northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northbound.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "misconfigured"])
-            northbound.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "misconfigured"])
-        }
+        def involvedSwitches = pathHelper.getInvolvedYSwitches(yFlow.YFlowId)*.getDpId()
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(involvedSwitches).isEmpty()
 
         and: "Y-Flow is UP"
         and: "Sub flows are UP"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowPathSwapSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowPathSwapSpec.groovy
@@ -112,11 +112,8 @@ class YFlowPathSwapSpec extends HealthCheckSpecification {
 
         and: "All involved switches passes switch validation"
         def yFlowPaths = northboundV2.getYFlowPaths(yFlow.YFlowId)
-        def involvedSwitches = pathHelper.getInvolvedYSwitches(yFlowPaths)
-        involvedSwitches.each { sw ->
-            northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northbound.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        def involvedSwitches = pathHelper.getInvolvedYSwitches(yFlowPaths)*.getDpId()
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(involvedSwitches).isEmpty()
 
         when: "Traffic starts to flow on both sub-flows with maximum bandwidth (if applicable)"
         def traffExam = traffExamProvider.get()
@@ -243,11 +240,8 @@ class YFlowPathSwapSpec extends HealthCheckSpecification {
 
         and: "All involved switches passes switch validation"
         def yFlowPaths = northboundV2.getYFlowPaths(yFlow.YFlowId)
-        def involvedSwitches = pathHelper.getInvolvedYSwitches(yFlowPaths)
-        involvedSwitches.each { sw ->
-            northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northbound.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        def involvedSwitches = pathHelper.getInvolvedYSwitches(yFlowPaths)*.getDpId()
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(involvedSwitches).isEmpty()
 
         when: "Restore port status"
         def portUp = antiflap.portUp(islToBreak.dstSwitch.dpId, islToBreak.dstPort)
@@ -285,11 +279,7 @@ class YFlowPathSwapSpec extends HealthCheckSpecification {
 
         and: "All involved switches passes switch validation"
         def yFlowPathsAfter = northboundV2.getYFlowPaths(yFlow.YFlowId)
-        def involvedSwitchesAfter = pathHelper.getInvolvedYSwitches(yFlowPathsAfter)
-        involvedSwitchesAfter.each { sw ->
-            northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northbound.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(pathHelper.getInvolvedYSwitches(yFlowPathsAfter)*.getDpId()).isEmpty()
 
         cleanup: "Revert system to original state"
         yFlow && yFlowHelper.deleteYFlow(yFlow.YFlowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowRerouteSpec.groovy
@@ -107,11 +107,7 @@ class YFlowRerouteSpec extends HealthCheckSpecification {
         }
 
         and: "All involved switches pass switch validation"
-        def involvedSwitches = pathHelper.getInvolvedYSwitches(paths)
-        involvedSwitches.each { sw ->
-            northbound.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northbound.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(pathHelper.getInvolvedYSwitches(paths)*.getDpId()).isEmpty()
 
         when: "Traffic starts to flow on both sub-flows with maximum bandwidth (if applicable)"
         def traffExam = traffExamProvider.get()

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowUpdateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowUpdateSpec.groovy
@@ -50,17 +50,14 @@ class YFlowUpdateSpec extends HealthCheckSpecification {
         def ignores = ["subFlows.timeUpdate", "subFlows.status", "timeUpdate", "status"]
         ignores.addAll(data.additionalIgnores)
         // https://github.com/telstra/open-kilda/issues/3411
-        northbound.synchronizeSwitch(oldSharedSwitch, true)
+        switchHelper.synchronize(oldSharedSwitch, true)
 
         then: "Requested updates are reflected in the response and in 'get' API"
         expect updateResponse, sameBeanAs(yFlow, ignores)
         expect northboundV2.getYFlow(yFlow.YFlowId), sameBeanAs(yFlow, ignores)
 
         and: "All related switches have no discrepancies"
-        involvedSwitches.each { sw ->
-            northboundV2.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northboundV2.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(involvedSwitches*.getDpId()).isEmpty()
 
         cleanup:
         yFlow && yFlowHelper.deleteYFlow(yFlow.YFlowId)
@@ -134,10 +131,7 @@ class YFlowUpdateSpec extends HealthCheckSpecification {
         expect northboundV2.getYFlow(yFlow.YFlowId), sameBeanAs(yFlow, ignores)
 
         and: "All related switches have no discrepancies"
-        involvedSwitches.each { sw ->
-            northboundV2.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northboundV2.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(involvedSwitches*.getDpId()).isEmpty()
 
         cleanup:
         yFlow && yFlowHelper.deleteYFlow(yFlow.YFlowId)
@@ -184,9 +178,7 @@ class YFlowUpdateSpec extends HealthCheckSpecification {
         expect northboundV2.getYFlow(yFlow.YFlowId), sameBeanAs(yFlow, ignores)
 
         and: "All related switches have no discrepancies"
-        northboundV2.validateSwitch(switchId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        northboundV2.validateSwitch(switchId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(switchId).isPresent()
 
         cleanup:
         yFlow && yFlowHelper.deleteYFlow(yFlow.YFlowId)
@@ -209,17 +201,14 @@ class YFlowUpdateSpec extends HealthCheckSpecification {
         def ignores = ["subFlows.timeUpdate", "subFlows.status", "timeUpdate", "status"]
         ignores.addAll(data.additionalIgnores)
         // https://github.com/telstra/open-kilda/issues/3411
-        northbound.synchronizeSwitch(oldSharedSwitch, true)
+        switchHelper.synchronize(oldSharedSwitch, true)
 
         then: "Requested updates are reflected in the response and in 'get' API"
         expect updateResponse, sameBeanAs(yFlow, ignores)
         expect northboundV2.getYFlow(yFlow.YFlowId), sameBeanAs(yFlow, ignores)
 
         and: "All related switches have no discrepancies"
-        involvedSwitches.each { sw ->
-            northboundV2.validateSwitch(sw.dpId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            northboundV2.validateSwitch(sw.dpId).verifyMeterSectionsAreEmpty(["missing", "excess", "misconfigured"])
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(involvedSwitches*.getDpId()).isEmpty()
 
         cleanup:
         yFlow && yFlowHelper.deleteYFlow(yFlow.YFlowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowValidationSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowValidationSpec.groovy
@@ -52,15 +52,15 @@ class YFlowValidationSpec extends HealthCheckSpecification {
         }
 
         and: "Switch validation detects missing y-flow rule"
-        with(northbound.validateSwitch(swIdToManipulate).rules) {
+        with(switchHelper.validate(swIdToManipulate).rules) {
             it.misconfigured.empty
             it.excess.empty
             it.missing.size() == sharedRules.size()
-            it.missing.sort() == sharedRules*.cookie.sort()
+            it.missing*.cookie.sort() == sharedRules*.cookie.sort()
         }
 
         when: "Synchronize the shared switch"
-        northbound.synchronizeSwitch(swIdToManipulate, false)
+        switchHelper.synchronize(swIdToManipulate, false)
 
         then: "Y-Flow/subFlow passes flow validation"
         northboundV2.validateYFlow(yFlow.YFlowId).asExpected
@@ -69,7 +69,7 @@ class YFlowValidationSpec extends HealthCheckSpecification {
         }
 
         and: "Switch passes validation"
-        northbound.validateSwitch(swIdToManipulate).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
+        switchHelper.validate(swIdToManipulate).isAsExpected()
 
         cleanup:
         yFlow && yFlowHelper.deleteYFlow(yFlow.YFlowId)
@@ -114,11 +114,11 @@ class YFlowValidationSpec extends HealthCheckSpecification {
         northbound.validateFlow(subFl_2.flowId).each { direction -> assert direction.asExpected }
 
         and: "Switch validation detects missing reverse rule only for the subFlow_1"
-        with(northbound.validateSwitch(swIdToManipulate).rules) {
+        with(switchHelper.validate(swIdToManipulate).rules) {
             it.misconfigured.empty
             it.excess.empty
             it.missing.size() == 1
-            it.missing[0] == cookieToDelete
+            it.missing[0].getCookie() == cookieToDelete
         }
 
         when: "Sync y-flow"
@@ -134,7 +134,7 @@ class YFlowValidationSpec extends HealthCheckSpecification {
         }
 
         and: "Switches pass validation"
-        northbound.validateSwitch(swIdToManipulate).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
+        switchHelper.validate(swIdToManipulate).isAsExpected()
 
         cleanup:
         yFlow && yFlowHelper.deleteYFlow(yFlow.YFlowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslReplugSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/IslReplugSpec.groovy
@@ -90,11 +90,8 @@ class IslReplugSpec extends HealthCheckSpecification {
         def newIslIsRemoved = true
 
         and: "The src and dst switches of the isl pass switch validation"
-        [isl.srcSwitch.dpId, isl.dstSwitch.dpId, notConnectedIsl.srcSwitch.dpId].unique().each { swId ->
-            with(northbound.validateSwitch(swId)) { validationResponse ->
-                validationResponse.verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            }
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(
+                [isl.srcSwitch.dpId, isl.dstSwitch.dpId, notConnectedIsl.srcSwitch.dpId].unique()).isEmpty()
 
         cleanup:
         if (!originIslIsUp) {
@@ -157,11 +154,8 @@ class IslReplugSpec extends HealthCheckSpecification {
         /* Need wait because of parallel s42 tests. Sw validation may show a missing s42 rule. Just wait for it.
         If problem persists, add a 'read' resource lock for s42_toggle */
         Wrappers.wait(WAIT_OFFSET) {
-            [isl.srcSwitch.dpId, isl.dstSwitch.dpId, notConnectedIsl.srcSwitch.dpId].unique().each { swId ->
-                with(northbound.validateSwitch(swId)) { validationResponse ->
-                    validationResponse.verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-                }
-            }
+            switchHelper.validateAndCollectFoundDiscrepancies(
+                    [isl.srcSwitch.dpId, isl.dstSwitch.dpId, notConnectedIsl.srcSwitch.dpId].unique()).isEmpty()
         }
 
         cleanup:

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/RoundTripIslSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/RoundTripIslSpec.groovy
@@ -230,7 +230,7 @@ round trip latency rule is removed on the dst switch"() {
         northbound.deleteSwitchRules(dstSw.dpId, DeleteRulesAction.REMOVE_ROUND_TRIP_LATENCY)
         def isRoundTripRuleDeleted = true
         Wrappers.wait(RULES_DELETION_TIME) {
-            assert northbound.validateSwitch(dstSw.dpId).rules.missing.size() == 1
+            assert switchHelper.validateAndCollectFoundDiscrepancies(dstSw.dpId).get().rules.missing.size() == 1
         }
 
         then: "The round trip latency ISL is FAILED"
@@ -268,7 +268,7 @@ round trip latency rule is removed on the dst switch"() {
         northbound.installSwitchRules(dstSw.dpId, InstallRulesAction.INSTALL_ROUND_TRIP_LATENCY)
         isRoundTripRuleDeleted = false
         Wrappers.wait(RULES_INSTALLATION_TIME) {
-            assert northbound.validateSwitch(dstSw.dpId).rules.missing.empty
+            assert !switchHelper.validateAndCollectFoundDiscrepancies(dstSw.dpId).isPresent()
         }
 
         then: "Round trip status is available for the given ISL in both directions"
@@ -287,7 +287,7 @@ round trip latency rule is removed on the dst switch"() {
                 assert allLinks.findAll { it.state == DISCOVERED }.size() == topology.islsForActiveSwitches.size() * 2
                 assert islUtils.getIslInfo(allLinks, roundTripIsl).get().roundTripStatus == DISCOVERED
                 assert islUtils.getIslInfo(allLinks, roundTripIsl.reversed).get().roundTripStatus == DISCOVERED
-                assert northbound.validateSwitch(dstSw.dpId).rules.missing.empty
+                assert !switchHelper.validateAndCollectFoundDiscrepancies(dstSw.dpId).isPresent()
             }
         }
         database.resetCosts(topology.isls)
@@ -404,12 +404,7 @@ round trip latency rule is removed on the dst switch"() {
 
         and: "The src/dst switches are valid"
         //https://github.com/telstra/open-kilda/issues/3906
-//        [roundTripIsl.srcSwitch, roundTripIsl.dstSwitch].each {
-//            def validateInfo = northbound.validateSwitch(it.dpId).rules
-//            assert validateInfo.missing.empty
-//            assert validateInfo.excess.empty
-//            assert validateInfo.misconfigured.empty
-//        }
+//        switchHelper.synchronizeAndGetFixedEntries([roundTripIsl.srcSwitch, roundTripIsl.dstSwitch]).isEmpty()
 
         when: "Disable portDiscovery on the dstPort"
         northboundV2.updatePortProperties(roundTripIsl.dstSwitch.dpId, roundTripIsl.dstPort,

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/server42/Server42FlowRttSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/server42/Server42FlowRttSpec.groovy
@@ -166,16 +166,7 @@ class Server42FlowRttSpec extends HealthCheckSpecification {
         }
 
         and: "Involved switches pass switch validation"
-        pathHelper.getInvolvedSwitches(flow.flowId).each { sw ->
-            verifyAll(northbound.validateSwitch(sw.dpId)) {
-                rules.missing.empty
-                rules.excess.empty
-                rules.misconfigured.empty
-                meters.missing.empty
-                meters.excess.empty
-                meters.misconfigured.empty
-            }
-        }
+        switchHelper.validateAndCollectFoundDiscrepancies(pathHelper.getInvolvedSwitches(flow.flowId)*.getDpId()).isEmpty()
 
         and: "Check if stats for forward and reverse flows are available"
         Wrappers.wait(STATS_FROM_SERVER42_LOGGING_TIMEOUT, 1) {
@@ -208,16 +199,7 @@ class Server42FlowRttSpec extends HealthCheckSpecification {
 
         expect: "Involved switches pass switch validation"
         Wrappers.wait(RULES_INSTALLATION_TIME) { //wait for s42 rules
-            pathHelper.getInvolvedSwitches(flow.flowId).each { sw ->
-                verifyAll(northbound.validateSwitch(sw.dpId)) {
-                    rules.missing.empty
-                    rules.excess.empty
-                    rules.misconfigured.empty
-                    meters.missing.empty
-                    meters.excess.empty
-                    meters.misconfigured.empty
-                }
-            }
+            switchHelper.synchronizeAndCollectFixedDiscrepancies(pathHelper.getInvolvedSwitches(flow.flowId)*.getDpId()).isEmpty()
         }
 
         when: "Wait for several seconds"
@@ -299,16 +281,7 @@ class Server42FlowRttSpec extends HealthCheckSpecification {
 
         then: "Involved switches pass switch validation"
         Wrappers.wait(RULES_INSTALLATION_TIME) {  //wait for s42 rules
-            pathHelper.getInvolvedSwitches(flow.flowId).each { sw ->
-                verifyAll(northbound.validateSwitch(sw.dpId)) {
-                    rules.missing.empty
-                    rules.excess.empty
-                    rules.misconfigured.empty
-                    meters.missing.empty
-                    meters.excess.empty
-                    meters.misconfigured.empty
-                }
-            }
+            switchHelper.validateAndCollectFoundDiscrepancies(pathHelper.getInvolvedSwitches(flow.flowId)*.getDpId()).isEmpty()
         }
 
         and: "Stats for both directions are available"
@@ -320,7 +293,7 @@ class Server42FlowRttSpec extends HealthCheckSpecification {
         when: "Disable flow rtt on dst switch"
         changeFlowRttSwitch(switchPair.dst, false)
         Wrappers.wait(RULES_INSTALLATION_TIME, 3) {
-            northboundV2.validateSwitch(switchPair.dst.dpId).isAsExpected()
+            assert !switchHelper.validateAndCollectFoundDiscrepancies(switchPair.dst.dpId).isPresent()
         }
         checkpointTime = new Date().getTime() + SERVER42_STATS_LAG * 1000
 
@@ -364,7 +337,8 @@ class Server42FlowRttSpec extends HealthCheckSpecification {
 
         then: "System detects missing rule on the src switch"
         Wrappers.wait(RULES_DELETION_TIME) {
-            assert northbound.validateSwitch(switchPair.src.dpId).rules.missing == [cookieToDelete]
+            assert switchHelper.validateAndCollectFoundDiscrepancies(switchPair.src.dpId).get()
+                    .rules.missing*.getCookie() == [cookieToDelete]
         }
         def timeWhenMissingRuleIsDetected = new Date().getTime()
 
@@ -394,7 +368,7 @@ class Server42FlowRttSpec extends HealthCheckSpecification {
 
         then: "Missing ingress server42 rule is reinstalled on the src switch"
         Wrappers.wait(RULES_INSTALLATION_TIME) {
-            assert northbound.validateSwitch(switchPair.src.dpId).rules.missing.empty
+            assert !switchHelper.validateAndCollectFoundDiscrepancies(switchPair.src.dpId).isPresent()
             assert northbound.getSwitchRules(switchPair.src.dpId).flowEntries.findAll {
                 new Cookie(it.cookie).getType() == CookieType.SERVER_42_FLOW_RTT_INGRESS
             }*.cookie.size() == 1
@@ -471,9 +445,7 @@ class Server42FlowRttSpec extends HealthCheckSpecification {
         and: "All switches are valid"
         def involvedSwitches = [fl1SwPair.src, fl1SwPair.dst, fl2SwPair.src, fl2SwPair.dst]*.dpId.unique()
         Wrappers.wait(RULES_INSTALLATION_TIME) {
-            involvedSwitches.each { swId ->
-                northbound.validateSwitch(swId).verifyRuleSectionsAreEmpty(["missing", "excess", "misconfigured"])
-            }
+            assert switchHelper.validateAndCollectFoundDiscrepancies(involvedSwitches).isEmpty()
         }
 
         and: "server42 stats are available for the flow2 in the forward direction"
@@ -578,12 +550,7 @@ class Server42FlowRttSpec extends HealthCheckSpecification {
         northbound.validateFlow(flow.flowId).each { direction -> assert direction.asExpected }
 
         and: "The src switch is valid"
-        [switchPair.src, switchPair.dst].each {
-            with(northbound.validateSwitch(it.dpId)) {
-                it.verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
-                it.verifyMeterSectionsAreEmpty(["missing", "misconfigured", "excess"])
-            }
-        }
+        switchHelper.synchronizeAndCollectFixedDiscrepancies(switchPair.toList()*.getDpId()).isEmpty()
 
         cleanup: "Revert system to original state"
         revertToOrigin([flow], flowRttFeatureStartState, initialSwitchRtt)
@@ -592,16 +559,16 @@ class Server42FlowRttSpec extends HealthCheckSpecification {
         data << [
                  [
                          flowDescription: "vxlan",
-                         switchPair     : switchPairs.all()
+                         switchPair     : {switchPairs.all()
                                  .withBothSwitchesConnectedToServer42()
                                  .withBothSwitchesVxLanEnabled()
                                  .withSourceSwitchNotManufacturedBy(WB5164)
-                                 .random(),
+                                 .random()} ,
                          flowTap        : { FlowRequestV2 fl -> fl.encapsulationType = VXLAN }
                  ],
                  [
                          flowDescription: "qinq",
-                         switchPair     : switchPairs.all().withBothSwitchesConnectedToServer42().random(),
+                         switchPair     : {switchPairs.all().withBothSwitchesConnectedToServer42().random()},
                          flowTap        : { FlowRequestV2 fl ->
                              fl.source.vlanId = 10
                              fl.source.innerVlanId = 100
@@ -643,10 +610,7 @@ class Server42FlowRttSpec extends HealthCheckSpecification {
         }
 
         and: "The src switch is valid"
-        with(northbound.validateSwitch(switchPair.src.dpId)) {
-            it.verifyRuleSectionsAreEmpty()
-            it.verifyMeterSectionsAreEmpty()
-        }
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(switchPair.src.dpId).isPresent()
 
         when: "Create a flow on the given switch pair"
         def flowCreateTime = new Date()
@@ -679,10 +643,7 @@ class Server42FlowRttSpec extends HealthCheckSpecification {
         }
 
         and: "The src switch is valid"
-        with(northbound.validateSwitch(switchPair.src.dpId)) {
-            it.verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
-            it.verifyMeterSectionsAreEmpty(["missing", "misconfigured", "excess"])
-        }
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(switchPair.src.dpId).isPresent()
 
         and: "Flow rtt stats are available"
         Wrappers.wait(STATS_FROM_SERVER42_LOGGING_TIMEOUT, 1) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesSpec.groovy
@@ -69,7 +69,7 @@ class DefaultRulesSpec extends HealthCheckSpecification {
         cleanup:
         blockData && !switchIsActivated && switchHelper.reviveSwitch(sw, blockData)
         if (!testIsCompleted) {
-            northbound.synchronizeSwitch(sw.dpId, true)
+            switchHelper.synchronize(sw.dpId)
             wait(RULES_INSTALLATION_TIME) {
                 assertThat(northbound.getSwitchRules(sw.dpId).flowEntries*.cookie.toArray()).as(sw.dpId.toString())
                         .containsExactlyInAnyOrder(*sw.defaultCookies)
@@ -230,7 +230,7 @@ class DefaultRulesSpec extends HealthCheckSpecification {
 
         cleanup:
         if (!testIsCompleted) {
-            northbound.synchronizeSwitch(sw.dpId, true)
+            switchHelper.synchronize(sw.dpId)
             wait(RULES_INSTALLATION_TIME) {
                 assert northbound.getSwitchRules(sw.dpId).flowEntries*.cookie.sort() == sw.defaultCookies.sort()
             }
@@ -263,11 +263,11 @@ class DefaultRulesSpec extends HealthCheckSpecification {
             excessRules.empty
             properRules.sort() == sw.defaultCookies.findAll { it != data.cookie }.sort()
         }
-        verifyAll(northbound.validateSwitch(sw.dpId)) {
-            rules.missing == deletedRules
+        verifyAll(switchHelper.validateAndCollectFoundDiscrepancies(sw.dpId).get()) {
+            rules.missing*.getCookie() == deletedRules
             rules.misconfigured.empty
             rules.excess.empty
-            rules.proper.sort() == sw.defaultCookies.findAll { it != data.cookie }.sort()
+            rules.proper*.getCookie().sort() == sw.defaultCookies.findAll { it != data.cookie }.sort()
         }
 
         cleanup: "Install default rules back"
@@ -329,11 +329,11 @@ class DefaultRulesSpec extends HealthCheckSpecification {
             excessRules.empty
             properRules.sort() == sw.defaultCookies.findAll { it != data.cookie }.sort()
         }
-        verifyAll(northbound.validateSwitch(sw.dpId)) {
-            rules.missing == deletedRules
+        verifyAll(switchHelper.validateAndCollectFoundDiscrepancies(sw.dpId).get()) {
+            rules.missing*.getCookie() == deletedRules
             rules.misconfigured.empty
             rules.excess.empty
-            rules.proper.sort() == sw.defaultCookies.findAll { it != data.cookie }.sort()
+            rules.proper*.getCookie().sort() == sw.defaultCookies.findAll { it != data.cookie }.sort()
         }
 
         cleanup: "Install default rules back"
@@ -399,11 +399,11 @@ class DefaultRulesSpec extends HealthCheckSpecification {
             excessRules.empty
             properRules.sort() == sw.defaultCookies.findAll { it != SERVER_42_FLOW_RTT_TURNING_COOKIE }.sort()
         }
-        verifyAll(northbound.validateSwitch(sw.dpId)) {
-            rules.missing == [SERVER_42_FLOW_RTT_TURNING_COOKIE]
+        verifyAll(switchHelper.validateAndCollectFoundDiscrepancies(sw.dpId).get()) {
+            rules.missing*.getCookie() == [SERVER_42_FLOW_RTT_TURNING_COOKIE]
             rules.misconfigured.empty
             rules.excess.empty
-            rules.proper.sort() == sw.defaultCookies.findAll { it != SERVER_42_FLOW_RTT_TURNING_COOKIE }.sort()
+            rules.proper*.getCookie().sort() == sw.defaultCookies.findAll { it != SERVER_42_FLOW_RTT_TURNING_COOKIE }.sort()
         }
 
         when: "Install the server42 turning rule"
@@ -458,11 +458,11 @@ class DefaultRulesSpec extends HealthCheckSpecification {
             excessRules.empty
             properRules.sort() == sw.defaultCookies.findAll { it != SERVER_42_ISL_RTT_TURNING_COOKIE }.sort()
         }
-        verifyAll(northbound.validateSwitch(sw.dpId)) {
-            rules.missing == [SERVER_42_ISL_RTT_TURNING_COOKIE]
+        verifyAll(switchHelper.validateAndCollectFoundDiscrepancies(sw.dpId).get()) {
+            rules.missing*.getCookie() == [SERVER_42_ISL_RTT_TURNING_COOKIE]
             rules.misconfigured.empty
             rules.excess.empty
-            rules.proper.sort() == sw.defaultCookies.findAll { it != SERVER_42_ISL_RTT_TURNING_COOKIE }.sort()
+            rules.proper*.getCookie().sort() == sw.defaultCookies.findAll { it != SERVER_42_ISL_RTT_TURNING_COOKIE }.sort()
         }
 
         when: "Install the server42 ISL RTT turning rule"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesValidationSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/DefaultRulesValidationSpec.groovy
@@ -48,11 +48,11 @@ class DefaultRulesValidationSpec extends HealthCheckSpecification {
         }
 
         and: "Rule validation shows all expected default rules in 'proper' section"
-        verifyAll(northbound.validateSwitch(sw.dpId)) {
+        verifyAll(switchHelper.validate(sw.dpId)) {
             rules.missing.empty
             rules.misconfigured.empty
             rules.excess.empty
-            assertThat sw.toString(), rules.proper, containsInAnyOrder(sw.defaultCookies.toArray())
+            assertThat sw.toString(), rules.proper*.cookie, containsInAnyOrder(sw.defaultCookies.toArray())
         }
 
         cleanup: "Restore original switch props"

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/MetersSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/MetersSpec.groovy
@@ -1,6 +1,5 @@
 package org.openkilda.functionaltests.spec.switches
 
-import org.openkilda.functionaltests.model.switches.Manufacturer
 
 import static com.shazam.shazamcrest.matcher.Matchers.sameBeanAs
 import static org.junit.jupiter.api.Assumptions.assumeTrue
@@ -27,7 +26,6 @@ import org.openkilda.functionaltests.HealthCheckSpecification
 import org.openkilda.functionaltests.extension.tags.IterationTag
 import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
-import org.openkilda.functionaltests.helpers.model.SwitchPair
 import org.openkilda.messaging.error.MessageError
 import org.openkilda.messaging.info.meter.MeterEntry
 import org.openkilda.messaging.info.rule.FlowEntry
@@ -231,11 +229,7 @@ on a #switchType switch"() {
         newMeterEntries*.rate.each { verifyRateSizeOnWb5164(it, flow.maximumBandwidth) }
 
         and: "Switch validation shows no discrepancies in meters"
-        def metersValidation = northbound.validateSwitch(sw.dpId).meters
-        metersValidation.proper.size() == 2 + sw.defaultMeters.size()
-        metersValidation.excess.empty
-        metersValidation.missing.empty
-        metersValidation.misconfigured.empty
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(sw.dpId).isPresent()
 
         and: "Flow validation shows no discrepancies in meters"
         northbound.validateFlow(flow.flowId).each { assert it.asExpected }
@@ -400,11 +394,7 @@ meters in flow rules at all (#srcSwitch - #dstSwitch flow)"() {
         newMeters*.burstSize.each { assert it == switchHelper.getExpectedBurst(sw.dpId, flowRate) }
 
         and: "Switch validation shows no discrepancies in meters"
-        def metersValidation = northbound.validateSwitch(sw.dpId).meters
-        metersValidation.proper.size() == 2 + sw.defaultMeters.size()
-        metersValidation.excess.empty
-        metersValidation.missing.empty
-        metersValidation.misconfigured.empty
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(sw.dpId).isPresent()
 
         and: "Flow validation shows no discrepancies in meters"
         northbound.validateFlow(flow.flowId).each { assert it.asExpected }
@@ -457,11 +447,7 @@ meters in flow rules at all (#srcSwitch - #dstSwitch flow)"() {
         newMeters*.burstSize.every { it == expectedBurstSize }
 
         and: "Switch validation shows no discrepancies in meters"
-        def metersValidation = northbound.validateSwitch(sw.dpId).meters
-        metersValidation.proper.size() == 2 + sw.defaultMeters.size()
-        metersValidation.excess.empty
-        metersValidation.missing.empty
-        metersValidation.misconfigured.empty
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(sw.dpId).isPresent()
 
         and: "Flow validation shows no discrepancies in meters"
         northbound.validateFlow(flow.flowId).each { assert it.asExpected }
@@ -516,11 +502,7 @@ meters in flow rules at all (#srcSwitch - #dstSwitch flow)"() {
         }
 
         and: "Switch validation shows no discrepancies in meters"
-        def metersValidation = northbound.validateSwitch(sw.dpId).meters
-        metersValidation.proper.size() == 2 + sw.defaultMeters.size()
-        metersValidation.excess.empty
-        metersValidation.missing.empty
-        metersValidation.misconfigured.empty
+        !switchHelper.synchronizeAndCollectFixedDiscrepancies(sw.dpId).isPresent()
 
         and: "Flow validation shows no discrepancies in meters"
         northbound.validateFlow(flow.flowId).each { assert it.asExpected }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
@@ -114,9 +114,7 @@ class SwitchFailuresSpec extends HealthCheckSpecification {
         }
 
         and: "Blinking switch has no rule anomalies"
-        def validation = northbound.validateSwitch(swPair.src.dpId)
-        validation.verifyRuleSectionsAreEmpty(["missing", "misconfigured", "excess"])
-        validation.verifyMeterSectionsAreEmpty(["missing", "misconfigured", "excess"])
+        !switchHelper.validateAndCollectFoundDiscrepancies(swPair.src.dpId).isPresent()
 
         and: "Flow validation is OK"
         northbound.validateFlow(flow.flowId).each { assert it.asExpected }
@@ -153,10 +151,7 @@ class SwitchFailuresSpec extends HealthCheckSpecification {
         }
 
         and: "Dst switch validation shows no missing rules"
-        with(northbound.validateSwitch(dstSwitch.dpId)) {
-            it.verifyRuleSectionsAreEmpty(["missing", "proper", "misconfigured"])
-            it.verifyMeterSectionsAreEmpty(["missing", "misconfigured", "proper", "excess"])
-        }
+        !switchHelper.validateAndCollectFoundDiscrepancies(dstSwitch.dpId).isPresent()
 
         when: "Try to validate flow"
         northbound.validateFlow(flow.flowId)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchesSpec.groovy
@@ -6,14 +6,11 @@ import org.openkilda.functionaltests.error.SwitchNotFoundExpectedError
 import spock.lang.Shared
 
 import static groovyx.gpars.GParsPool.withPool
-import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.LOW_PRIORITY
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE_SWITCHES
 import static org.openkilda.functionaltests.helpers.FlowHistoryConstants.REROUTE_ACTION
 import static org.openkilda.functionaltests.helpers.FlowHistoryConstants.REROUTE_FAIL
-import static org.openkilda.functionaltests.model.switches.Manufacturer.CENTEC
-import static org.openkilda.functionaltests.model.switches.Manufacturer.CENTEC
 import static org.openkilda.testing.Constants.NON_EXISTENT_SWITCH_ID
 import static org.openkilda.testing.Constants.WAIT_OFFSET
 import static org.openkilda.testing.service.floodlight.model.FloodlightConnectMode.RW
@@ -309,11 +306,11 @@ class SwitchesSpec extends HealthCheckSpecification {
                 [descr    : "synchronizing rules on",
                  operation: { getNorthbound().synchronizeSwitchRules(NON_EXISTENT_SWITCH_ID) }],
                 [descr    : "synchronizing",
-                 operation: { getNorthbound().synchronizeSwitch(NON_EXISTENT_SWITCH_ID, true) }],
+                 operation: { switchHelper.synchronize(NON_EXISTENT_SWITCH_ID) }],
                 [descr    : "validating rules on",
                  operation: { getNorthbound().validateSwitchRules(NON_EXISTENT_SWITCH_ID) }],
                 [descr    : "validating",
-                 operation: { getNorthbound().validateSwitch(NON_EXISTENT_SWITCH_ID) }]
+                 operation: { switchHelper.validate(NON_EXISTENT_SWITCH_ID) }]
         ]
     }
 


### PR DESCRIPTION
* Added methods synchronizeAndGetFixedEntries(), validateAndGetFixedEntries() into SwitchHelper
* Replaced validation calls with synchronization ones where possible (where it doesn't break the
test's logic)
* Replaced synchronous validation/synchronization calls with asynchronous ones
* Replaced direct northbound calls (validate/synchronize) with SwitchHelper methods