### PR TITLE
Disable syslog clients on storm workers

### DIFF
--- a/confd/templates/storm/log4j2/cluster.xml.tmpl
+++ b/confd/templates/storm/log4j2/cluster.xml.tmpl
@@ -75,28 +75,16 @@ Do not change this file, all changes will be lost. Change corresponding template
             <KeyValuePair key="correlation_id" value="${ctx:correlation_id}"/>
         </JsonLayout>
     </Socket>
-
-    <Syslog name="syslog" format="RFC5424" charset="UTF-8" host="localhost" port="514"
-            protocol="UDP" appName="[${sys:daemon.name}]" mdcId="mdc" includeMDC="true"
-            facility="LOCAL5" enterpriseNumber="18060" newLine="true" exceptionPattern="%rEx{full}"
-            messageId="[${sys:user.name}:S0]" id="storm" immediateFlush="true" immediateFail="true"/>
 </appenders>
 <loggers>
-
-    <Logger name="org.apache.storm.logging.filters.AccessLoggingFilter" level="info" additivity="false">
-        <AppenderRef ref="WEB-ACCESS"/>
-        <AppenderRef ref="syslog"/>
-    </Logger>
     <Logger name="org.apache.storm.logging.ThriftAccessLogger" level="info" additivity="false">
         <AppenderRef ref="THRIFT-ACCESS"/>
-        <AppenderRef ref="syslog"/>
     </Logger>
     <Logger name="org.apache.storm.metric.LoggingClusterMetricsConsumer" level="info" additivity="false">
         <appender-ref ref="METRICS"/>
     </Logger>
     <root level="info"> <!-- We log everything -->
         <appender-ref ref="A1"/>
-        <appender-ref ref="syslog"/>
         <appender-ref ref="LOGSTASH"/>
     </root>
 </loggers>

--- a/confd/templates/storm/log4j2/worker.xml.tmpl
+++ b/confd/templates/storm/log4j2/worker.xml.tmpl
@@ -77,16 +77,10 @@ Do not change this file, all changes will be lost. Change corresponding template
             <KeyValuePair key="correlation_id" value="${ctx:correlation_id}"/>
         </JsonLayout>
     </Socket>
-
-    <Syslog name="syslog" format="RFC5424" charset="UTF-8" host="localhost" port="514"
-        protocol="UDP" appName="[${sys:storm.id}:${sys:worker.port}]" mdcId="mdc" includeMDC="true"
-        facility="LOCAL5" enterpriseNumber="18060" newLine="true" exceptionPattern="%rEx{full}"
-        messageId="[${sys:user.name}:${sys:logging.sensitivity}]" id="storm" immediateFail="true" immediateFlush="true"/>
 </appenders>
 <loggers>
     <root level="info"> <!-- We log everything -->
         <appender-ref ref="A1"/>
-        <appender-ref ref="syslog"/>
         <appender-ref ref="LOGSTASH"/>
     </root>
     <Logger name="org.apache.storm.metric.LoggingMetricsConsumer" level="info" additivity="false">
@@ -94,11 +88,9 @@ Do not change this file, all changes will be lost. Change corresponding template
     </Logger>
     <Logger name="STDERR" level="INFO">
         <appender-ref ref="STDERR"/>
-        <appender-ref ref="syslog"/>
     </Logger>
     <Logger name="STDOUT" level="INFO">
         <appender-ref ref="STDOUT"/>
-        <appender-ref ref="syslog"/>
     </Logger>
 </loggers>
 </configuration>


### PR DESCRIPTION
This change disables syslog clients on storm workers since we don't have syslog server available. The logs from storm are still written into logstash and available to read via kibana.