### PR TITLE
[Java 8-17] Migrate from docker-compose to docker compose v2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,6 @@ The following packages are required for building OpenKilda controller:
  - GNU Make 4.1+
  - Open vSwitch 2.9+
 
-#### Python dependency notice
-
-We do not recommend upgrading pip and install docker-compose using the methods described below, bypassing the packer managers. Instead, please read the documentation for installing the [pip](https://pip.pypa.io/en/stable/installation/#upgrading-pip) and the [docker-compose](https://docs.docker.com/compose/install/).
-
-
 #### Dependency installation on Ubuntu 18.04
 
 For running a virtual environment (that is a Docker instance with the Open vSwitch service) it is required to have Linux kernel 4.18+ for OVS meters support.
@@ -88,11 +83,6 @@ wget -P /tmp/ https://bootstrap.pypa.io/get-pip.py \
   && sudo python3.8 /tmp/get-pip.py
 ```
 
-After pip upgrade install Docker compose:
-```shell
-sudo pip3 install docker-compose
-```
-
 #### Dependency installation on Ubuntu 20.04
 
 The following commands will install necessary dependencies on Ubuntu 20.04:
@@ -116,11 +106,6 @@ sudo pip3 install pip --upgrade
 ```shell
 wget -P /tmp/ https://bootstrap.pypa.io/get-pip.py \
   && sudo python3.8 /tmp/get-pip.py
-```
-
-After pip upgrade install Docker compose:
-```shell
-sudo pip3 install docker-compose
 ```
 
 #### Gradle
@@ -147,7 +132,6 @@ sudo apt-get install -y ca-certificates curl gnupg lsb-release \
   docker-ce \
   docker-ce-cli \
   containerd.io \
-  docker-compose-plugin \
 && sudo usermod -aG docker $USER
 # re-login or reboot to apply the usermod command
 ```
@@ -282,7 +266,7 @@ northbound:
 After making these changes, we need to configure a remote debugging in a debugger. For example, in IntelliJ IDEA: navigate to ```Edit Configurations -> Remote```
 and set up the debug port as ```50505```. For more details, please see the documentation of a particular debugger application.
 
-Next, we just run ```docker-compose up```. If everything above was done correctly you must see:
+Next, we just run ```docker compose up```. If everything above was done correctly you must see:
 
 ```
 "java -agentlib:jdwp=transport=dt_socket,address=50505,suspend=n,server=y -jar northbound.jar"
@@ -337,7 +321,7 @@ wfm:
     - "50506:50506"
 ```
 
-After executing ```docker-compose up``` you should see the following log record ```Listening for transport dt_socket at address: 50506```
+After executing ```docker compose up``` you should see the following log record ```Listening for transport dt_socket at address: 50506```
 in the WFM logs.
 
 Now, after we configure the remote debugger to connect to the port ```50506```, we'll be able to debug both components: WFM and Storm.
@@ -346,7 +330,7 @@ For more details, please see the documentation of a particular debugger applicat
 
 In order to debug a topology, for example, ```NetworkTopology```: 
 create (or open if already exists) ```NetworkTopology.main``` application debug configuration and add ```--local``` to Program arguments, 
-execute ```docker-compose up``` and run in the debug mode ```NetworkTopology.main```.
+execute ```docker compose up``` and run in the debug mode ```NetworkTopology.main```.
 
 ### How to run tests
 
@@ -407,7 +391,7 @@ git clone git@github.com:<your_github_account>/open-kilda.git vm-dev
 cd vm-dev
 git checkout mvp1rc
 make build-base
-docker-compose build
+docker compose build
 make unit
 make up-test-mode
 ```

--- a/confd/templates/makefile/makefile.tmpl
+++ b/confd/templates/makefile/makefile.tmpl
@@ -32,13 +32,13 @@ build-server42dpdk:
 {{end}}
 
 build-latest: build-base compile-green
-	docker-compose build
+	docker compose build
 
 build-stable: build-base compile-blue
-	TAG=$(STABLE_TAG) docker-compose build
+	TAG=$(STABLE_TAG) docker compose build
 
 run-dev:
-	docker-compose up
+	docker compose up
 
 up-test-mode:
 	@echo ~~
@@ -47,33 +47,33 @@ up-test-mode:
 	@echo ~~
 	@echo
 	cp -n .env.example .env
-	TAG=$(STABLE_TAG) docker-compose up -d --scale northbound-blue-green=0 {{if not (exists "/no_grpc_speaker")}}--scale grpc-speaker-blue-green=0{{end}}
-	docker-compose logs -f wfm
+	TAG=$(STABLE_TAG) docker compose up -d --scale northbound-blue-green=0 {{if not (exists "/no_grpc_speaker")}}--scale grpc-speaker-blue-green=0{{end}}
+	docker compose logs -f wfm
 	$(MAKE) -C tools/elk-dashboards
 
 up-stable:
 	cp -n .env.example .env
-	docker-compose stop northbound-blue-green
-	TAG=$(STABLE_TAG) WFM_TOPOLOGIES_MODE=blue docker-compose up -d --scale northbound-blue-green=0 {{if not (exists "/no_grpc_speaker")}}--scale grpc-speaker-blue-green=0{{end}}
-	docker-compose logs -f wfm
+	docker compose stop northbound-blue-green
+	TAG=$(STABLE_TAG) WFM_TOPOLOGIES_MODE=blue docker compose up -d --scale northbound-blue-green=0 {{if not (exists "/no_grpc_speaker")}}--scale grpc-speaker-blue-green=0{{end}}
+	docker compose logs -f wfm
 	$(MAKE) -C tools/elk-dashboards
 
 up-green:
 	cp -n .env.example .env
-	docker-compose stop northbound
-	WFM_TOPOLOGIES_MODE=green docker-compose up -d --scale northbound=0 floodlight_2 northbound-blue-green wfm {{if not (exists "/no_grpc_speaker")}}grpc-speaker-blue-green{{end}}
-	docker-compose logs -f wfm
+	docker compose stop northbound
+	WFM_TOPOLOGIES_MODE=green docker compose up -d --scale northbound=0 floodlight_2 northbound-blue-green wfm {{if not (exists "/no_grpc_speaker")}}grpc-speaker-blue-green{{end}}
+	docker compose logs -f wfm
 	$(MAKE) -C tools/elk-dashboards
 
 up-blue:
 	cp -n .env.example .env
-	docker-compose stop northbound-blue-green
-	TAG=$(STABLE_TAG) WFM_TOPOLOGIES_MODE=blue docker-compose up -d --scale northbound-blue-green=0 floodlight_1 wfm
-	docker-compose logs -f wfm
+	docker compose stop northbound-blue-green
+	TAG=$(STABLE_TAG) WFM_TOPOLOGIES_MODE=blue docker compose up -d --scale northbound-blue-green=0 floodlight_1 wfm
+	docker compose logs -f wfm
 	$(MAKE) -C tools/elk-dashboards
 
 up-log-mode: up-test-mode
-	docker-compose logs -f
+	docker compose logs -f
 
 # keeping run-test for backwards compatibility (documentation) .. should deprecate
 run-test: up-log-mode
@@ -116,8 +116,8 @@ sonar: update-props
 
 .PHONY: clean-test
 clean-test:
-	docker-compose down
-	docker-compose rm -fv
+	docker compose down
+	docker compose rm -fv
 	docker volume list -q | grep kilda | xargs -r docker volume  rm
 
 .PHONY: clean

--- a/docker/base/hacks/load_kilda_dev_ubuntu.sh
+++ b/docker/base/hacks/load_kilda_dev_ubuntu.sh
@@ -87,5 +87,4 @@ echo ##########################
 sudo apt-get update
 sudo apt-get install -y apt-utils python python-pip tox
 sudo pip install --upgrade pip
-sudo     pip install docker-compose
 

--- a/docker/base/hacks/usecase/flow.crud.make
+++ b/docker/base/hacks/usecase/flow.crud.make
@@ -39,11 +39,11 @@ help:
 up:
 	# NB: just specifying the minimal set .. taking advantage of embedded dependencies to bring
 	#     up the remaining containers
-	docker-compose up -d mininet floodlight storm-supervisor \
+	docker compose up -d mininet floodlight storm-supervisor \
 	topology-engine kibana
 
 down:
-	docker-compose down
+	docker compose down
 
 clean:
 	${MAKE} clean-test
@@ -65,12 +65,12 @@ stop:
 login-storm:
 	@echo ""
 	@echo "NB: For Logs, look at /opt/storm/logs/[workers-artifacts]"
-	docker-compose exec storm-supervisor "/bin/bash"
+	docker compose exec storm-supervisor "/bin/bash"
 
 login-mininet:
 	@echo ""
 	@echo "NB: For examples, look at /app/examples or /usr/share/doc/mininet/examples"
-	docker-compose exec mininet "/bin/bash"
+	docker compose exec mininet "/bin/bash"
 
 
 

--- a/docker/base/hacks/usecase/network.disco.make
+++ b/docker/base/hacks/usecase/network.disco.make
@@ -46,11 +46,11 @@ help:
 up:
 	# NB: just specifying the minimal set .. taking advantage of embedded dependencies to bring
 	#     up the remaining containers
-	docker-compose up -d mininet floodlight storm-supervisor \
+	docker compose up -d mininet floodlight storm-supervisor \
 	topology-engine kibana
 
 down:
-	docker-compose down
+	docker compose down
 
 clean:
 	${MAKE} clean-test
@@ -72,7 +72,7 @@ stop:
 login:
 	@echo ""
 	@echo "NB: For Logs, look at /opt/storm/logs/[workers-artifacts]"
-	docker-compose exec storm-supervisor "/bin/bash"
+	docker compose exec storm-supervisor "/bin/bash"
 
 ## =~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=
 ## Lifecycle Network Topologies

--- a/docker/db-migration/migrations/README.md
+++ b/docker/db-migration/migrations/README.md
@@ -52,7 +52,7 @@ changeSet:
 
 To start DB update by hands you need to build migration container
 ```shell script
-docker-compose build db_migration
+docker compose build db_migration
 ```
 
 And execute following command (for DB on some foreign host):

--- a/docker/db-mysql-migration/migrations/README.md
+++ b/docker/db-mysql-migration/migrations/README.md
@@ -49,7 +49,7 @@ can execute liquibase with arbitrary parameters.
 
 To create an image, navigate to the root of the OpenKilda project and execute:
 ```shell script
-docker-compose build db_mysql_migration
+docker compose build db_mysql_migration
 ```
 
 For executing a migration script (you can override other environment variables as well). `NO_SLEEP` parameter will exit the


### PR DESCRIPTION
This change removes `docker-compose` which is no longer supported. After this change we can upgrade `docker` on our Ubuntu and remove `docker-compose` at all.
Some Ubuntu machines might have a warning: `WARNING: Your kernel does not support swap limit capabilities. Limitation discarded.` Which could be resolved as it is described on [the docker page](https://docs.docker.com/engine/install/troubleshoot/#kernel-cgroup-swap-limit-capabilities). I'll copy-paste it here:

Edit the `/etc/default/grub` file. Add or edit the `GRUB_CMDLINE_LINUX` line to add the following two key-value pairs:
```
GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
```
Save and close the file.
Update the GRUB boot loader.
```
sudo update-grub
```
The changes take effect when you reboot the system.

There is another bug in the current docker that makes the output flickering. I believe there is an issue for that on docker and it will be resolved in the following versions. (It could be seen when doing `make up-stable` just before wfm installs the topologies)