### PR TITLE
[Java 8-17] Zookeeper startup script fix create-zknode-and-start.sh

### DIFF
--- a/docker/zookeeper/bin/create-zknode-and-start.sh
+++ b/docker/zookeeper/bin/create-zknode-and-start.sh
@@ -5,11 +5,12 @@ set -m
 /opt/zookeeper/bin/zkServer.sh start-foreground &
 
 # ensure health-checks were passed
-for attemp in $(seq 1 3); do
+for attemp in $(seq 1 5); do
   if jps | grep -q QuorumPeer; then
-    sleep 3
+    break
   else
     echo "Zookeeper hasn't been started yet"
+    sleep 3
   fi
 done
 


### PR DESCRIPTION
Zookeeper node creation script should properly wait while zookeeper 'QuorumPeerMain' process start and only then try to create all the nodes.

It fixes the problem when apps cannot create z-nodes for blue-green feature.

The problem is that zookeeper startup script tried to create the nodes before main zookeeper 'QuorumPeerMain' process started.  Moreover existed logic that checks the existence of the 'QuorumPeerMain' process in a loop was wrong.


Still need to think about better solution and may be continue checking  QuorumPeerMain process even after 5 attempts . 