### PR TITLE
[Java 8-17] Replace deprecated usages fasterxml

### DIFF
--- a/src-gui/src/main/java/org/openkilda/model/PathNodeV2.java
+++ b/src-gui/src/main/java/org/openkilda/model/PathNodeV2.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.model;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/command/reroute/RerouteAffectedInactiveFlows.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/command/reroute/RerouteAffectedInactiveFlows.java
@@ -21,7 +21,7 @@ import org.openkilda.model.SwitchId;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/event/ConnectedDevicePacketBase.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/event/ConnectedDevicePacketBase.java
@@ -19,7 +19,7 @@ import org.openkilda.messaging.info.InfoData;
 import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/event/LldpInfoData.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/event/LldpInfoData.java
@@ -20,7 +20,7 @@ import org.openkilda.model.SwitchId;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/network/Path.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/network/Path.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.info.network;
 import org.openkilda.messaging.payload.flow.PathNodePayload;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/network/PathValidationResult.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/network/PathValidationResult.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.info.network;
 
 import org.openkilda.messaging.info.InfoData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -29,7 +29,7 @@ import java.util.List;
 @Value
 @Builder
 @EqualsAndHashCode(callSuper = false)
-@JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class PathValidationResult extends InfoData {
     Boolean isValid;
 

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/rule/FlowFieldActionBase.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/rule/FlowFieldActionBase.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.info.rule;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/rule/GroupBucket.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/rule/GroupBucket.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.info.rule;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.Value;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/rule/GroupEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/rule/GroupEntry.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.info.rule;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/rule/SwitchGroupEntries.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/rule/SwitchGroupEntries.java
@@ -20,7 +20,7 @@ import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/GroupInfoEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/GroupInfoEntry.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.info.switches;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/GroupsValidationEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/GroupsValidationEntry.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.info.switches;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/LogicalPortInfoEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/LogicalPortInfoEntry.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.info.switches;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/LogicalPortMisconfiguredInfoEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/LogicalPortMisconfiguredInfoEntry.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.info.switches;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/LogicalPortsSyncEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/LogicalPortsSyncEntry.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.info.switches;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/LogicalPortsValidationEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/LogicalPortsValidationEntry.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.info.switches;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/SwitchSyncResponse.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/SwitchSyncResponse.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.info.switches;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/SwitchValidationResponse.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/SwitchValidationResponse.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.info.switches;
 
 import org.openkilda.messaging.info.InfoData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/GroupInfoEntryV2.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/GroupInfoEntryV2.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.info.switches.v2;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/GroupsValidationEntryV2.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/GroupsValidationEntryV2.java
@@ -20,7 +20,7 @@ import static org.openkilda.messaging.Utils.getSize;
 import static org.openkilda.messaging.Utils.joinBooleans;
 import static org.openkilda.messaging.Utils.joinLists;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/LogicalPortInfoEntryV2.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/LogicalPortInfoEntryV2.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.info.switches.v2;
 
 import org.openkilda.messaging.info.switches.LogicalPortType;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/LogicalPortsValidationEntryV2.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/LogicalPortsValidationEntryV2.java
@@ -20,7 +20,7 @@ import static org.openkilda.messaging.Utils.getSize;
 import static org.openkilda.messaging.Utils.joinBooleans;
 import static org.openkilda.messaging.Utils.joinLists;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/MeterInfoEntryV2.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/MeterInfoEntryV2.java
@@ -16,7 +16,7 @@
 package org.openkilda.messaging.info.switches.v2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/MetersValidationEntryV2.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/MetersValidationEntryV2.java
@@ -20,7 +20,7 @@ import static org.openkilda.messaging.Utils.getSize;
 import static org.openkilda.messaging.Utils.joinBooleans;
 import static org.openkilda.messaging.Utils.joinLists;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/MisconfiguredInfo.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/MisconfiguredInfo.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.info.switches.v2;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/RuleInfoEntryV2.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/RuleInfoEntryV2.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.info.switches.v2;
 import org.openkilda.messaging.info.switches.v2.action.BaseAction;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/RulesValidationEntryV2.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/RulesValidationEntryV2.java
@@ -20,7 +20,7 @@ import static org.openkilda.messaging.Utils.getSize;
 import static org.openkilda.messaging.Utils.joinBooleans;
 import static org.openkilda.messaging.Utils.joinLists;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/SwitchValidationResponseV2.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/SwitchValidationResponseV2.java
@@ -22,7 +22,7 @@ import org.openkilda.messaging.Utils;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.split.SplitIterator;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/CopyFieldActionEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/CopyFieldActionEntry.java
@@ -16,7 +16,7 @@
 package org.openkilda.messaging.info.switches.v2.action;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Value;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/GroupActionEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/GroupActionEntry.java
@@ -16,7 +16,7 @@
 package org.openkilda.messaging.info.switches.v2.action;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Value;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/MeterActionEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/MeterActionEntry.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.info.switches.v2.action;
 import org.openkilda.model.MeterId;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Value;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/PopVlanActionEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/PopVlanActionEntry.java
@@ -16,7 +16,7 @@
 package org.openkilda.messaging.info.switches.v2.action;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Value;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/PopVxlanActionEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/PopVxlanActionEntry.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.info.switches.v2.action;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.NonNull;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/PortOutActionEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/PortOutActionEntry.java
@@ -16,7 +16,7 @@
 package org.openkilda.messaging.info.switches.v2.action;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Value;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/PushVlanActionEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/PushVlanActionEntry.java
@@ -16,7 +16,7 @@
 package org.openkilda.messaging.info.switches.v2.action;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Value;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/PushVxlanActionEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/PushVxlanActionEntry.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.info.switches.v2.action;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/SetFieldActionEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/SetFieldActionEntry.java
@@ -16,7 +16,7 @@
 package org.openkilda.messaging.info.switches.v2.action;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Value;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/SwapFieldActionEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/info/switches/v2/action/SwapFieldActionEntry.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.info.switches.v2.action;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.NonNull;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/DetectConnectedDevicesDto.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/DetectConnectedDevicesDto.java
@@ -16,7 +16,7 @@
 package org.openkilda.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/FlowPatch.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/FlowPatch.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.model;
 import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.PathComputationStrategy;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/MirrorPointStatusDto.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/MirrorPointStatusDto.java
@@ -16,7 +16,7 @@
 package org.openkilda.messaging.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/PatchEndpoint.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/PatchEndpoint.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.model;
 
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/SwitchLocation.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/SwitchLocation.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.model;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -26,7 +26,7 @@ import java.io.Serializable;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SwitchLocation implements Serializable {
 
     private Double latitude;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/SwitchPatch.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/model/SwitchPatch.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.model;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -26,7 +26,7 @@ import java.io.Serializable;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SwitchPatch implements Serializable {
 
     private String pop;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/flow/PathNodePayload.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/flow/PathNodePayload.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.payload.flow;
 import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/history/FlowStatusTimestampsEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/history/FlowStatusTimestampsEntry.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.payload.history;
 
 import org.openkilda.messaging.info.InfoData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.AllArgsConstructor;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/history/HaFlowDumpPayload.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/history/HaFlowDumpPayload.java
@@ -20,7 +20,7 @@ import org.openkilda.model.FlowStatus;
 import org.openkilda.model.PathComputationStrategy;
 import org.openkilda.model.history.DumpType;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/history/HaFlowHistoryEntry.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/history/HaFlowHistoryEntry.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.payload.history;
 
 import org.openkilda.messaging.info.InfoData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/history/HaFlowHistoryPayload.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/history/HaFlowHistoryPayload.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.payload.history;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/history/HaFlowPathPayload.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/history/HaFlowPathPayload.java
@@ -20,7 +20,7 @@ import org.openkilda.model.FlowPathStatus;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/history/HaSubFlowPayload.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/history/HaSubFlowPayload.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.payload.history;
 
 import org.openkilda.model.FlowStatus;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/history/PortHistoryPayload.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/history/PortHistoryPayload.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.payload.history;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/network/PathDto.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/network/PathDto.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.payload.network;
 import org.openkilda.messaging.payload.flow.PathNodePayload;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/network/ProtectedPathPayload.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/network/ProtectedPathPayload.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.payload.network;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.Data;

--- a/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/switches/PortPropertiesPayload.java
+++ b/src-java/base-topology/base-messaging/src/main/java/org/openkilda/messaging/payload/switches/PortPropertiesPayload.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.payload.switches;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/history/model/HaFlowDumpData.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/history/model/HaFlowDumpData.java
@@ -20,7 +20,7 @@ import org.openkilda.model.FlowStatus;
 import org.openkilda.model.PathComputationStrategy;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/history/model/HaFlowPathDump.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/history/model/HaFlowPathDump.java
@@ -23,7 +23,7 @@ import org.openkilda.model.PathId;
 import org.openkilda.model.SwitchId;
 import org.openkilda.model.cookie.FlowSegmentCookie;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/history/model/HaSubFlowDump.java
+++ b/src-java/base-topology/base-storm-topology/src/main/java/org/openkilda/wfm/share/history/model/HaSubFlowDump.java
@@ -18,7 +18,7 @@ package org.openkilda.wfm.share.history.model;
 import org.openkilda.model.FlowStatus;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/build.gradle
+++ b/src-java/build.gradle
@@ -60,8 +60,11 @@ subprojects {
             implementation 'commons-io:commons-io:2.11.0'
             implementation 'commons-codec:commons-codec:1.15'
             implementation 'args4j:args4j:2.33'
-            implementation 'com.google.code.gson:gson:2.10.1'
             implementation 'com.fasterxml.uuid:java-uuid-generator:4.0.1'
+            implementation("com.fasterxml.jackson.core:jackson-core:2.16.1")
+            implementation("com.fasterxml.jackson.core:jackson-annotations:2.15.1")
+            implementation("com.fasterxml.jackson.core:jackson-databind:2.16.1")
+
 
 //            implementation('org.apache.kafka:kafka-clients') {
 //                version {

--- a/src-java/floodlight-service/floodlight-api/build.gradle
+++ b/src-java/floodlight-service/floodlight-api/build.gradle
@@ -7,9 +7,9 @@ dependencies {
     api project(':base-messaging')
     implementation project(':rule-manager-api')
 
-    implementation 'com.fasterxml.jackson.core:jackson-core'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations'
-    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation("com.fasterxml.jackson.core:jackson-core:2.16.1")
+    implementation("com.fasterxml.jackson.core:jackson-annotations:2.15.1")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.16.1")
     implementation 'com.google.guava:guava'
     implementation 'org.apache.commons:commons-lang3'
     implementation 'org.slf4j:slf4j-api'

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/model/RulesContext.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/model/RulesContext.java
@@ -17,7 +17,7 @@ package org.openkilda.floodlight.model;
 
 import org.openkilda.model.MacAddress;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/command/flow/FlowSyncRequest.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/command/flow/FlowSyncRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.flow;
 
 import org.openkilda.messaging.command.CommandData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/command/switches/DumpGroupsForFlowHsRequest.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/command/switches/DumpGroupsForFlowHsRequest.java
@@ -20,7 +20,7 @@ import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.Value;

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/command/switches/DumpGroupsForSwitchManagerRequest.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/command/switches/DumpGroupsForSwitchManagerRequest.java
@@ -20,7 +20,7 @@ import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.Value;

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/command/switches/DumpMetersForFlowHsRequest.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/command/switches/DumpMetersForFlowHsRequest.java
@@ -20,7 +20,7 @@ import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.Value;

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/command/switches/DumpRulesForFlowHsRequest.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/command/switches/DumpRulesForFlowHsRequest.java
@@ -20,7 +20,7 @@ import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.Value;

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/flow/FlowDumpResponse.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/flow/FlowDumpResponse.java
@@ -23,7 +23,7 @@ import org.openkilda.messaging.info.InfoData;
 import org.openkilda.model.SwitchId;
 import org.openkilda.rulemanager.FlowSpeakerData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/group/GroupDumpResponse.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/group/GroupDumpResponse.java
@@ -24,7 +24,7 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.rulemanager.GroupSpeakerData;
 import org.openkilda.rulemanager.SpeakerData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/meter/MeterDumpResponse.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/meter/MeterDumpResponse.java
@@ -24,7 +24,7 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.rulemanager.MeterSpeakerData;
 import org.openkilda.rulemanager.SpeakerData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/stats/GroupStatsData.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/stats/GroupStatsData.java
@@ -20,7 +20,7 @@ import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
@@ -31,7 +31,7 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"switch_id", "stats"})
 @EqualsAndHashCode(callSuper = false)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class GroupStatsData extends InfoData {
     private static final long serialVersionUID = 1L;
 

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/stats/GroupStatsEntry.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/stats/GroupStatsEntry.java
@@ -15,14 +15,14 @@
 
 package org.openkilda.messaging.info.stats;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Value;
 
 import java.io.Serializable;
 
 @Value
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(SnakeCaseStrategy.class)
 public class GroupStatsEntry implements Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/stats/SwitchTableStatsData.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/stats/SwitchTableStatsData.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.info.stats;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/stats/TableStatsEntry.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/stats/TableStatsEntry.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.info.stats;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Value;

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/switches/DeleteGroupResponse.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/switches/DeleteGroupResponse.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.info.switches;
 
 import org.openkilda.messaging.info.InfoData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/switches/InstallGroupResponse.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/switches/InstallGroupResponse.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.info.switches;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/switches/ModifyGroupResponse.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/switches/ModifyGroupResponse.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.info.switches;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/switches/ModifyMeterResponse.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/messaging/info/switches/ModifyMeterResponse.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.info.switches;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/BaseRerouteRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/BaseRerouteRequest.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.command;
 import org.openkilda.model.IslEndpoint;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/flow/FlowMirrorPointCreateRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/flow/FlowMirrorPointCreateRequest.java
@@ -20,7 +20,7 @@ import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowPathDirection;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/flow/FlowMirrorPointDeleteRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/flow/FlowMirrorPointDeleteRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.flow;
 
 import org.openkilda.messaging.command.CommandData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/flow/FlowRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/flow/FlowRequest.java
@@ -22,7 +22,7 @@ import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowDeleteRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowDeleteRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.haflow;
 
 import org.openkilda.messaging.command.CommandData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowDto.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowDto.java
@@ -20,7 +20,7 @@ import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowStatus;
 import org.openkilda.model.PathComputationStrategy;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowPartialUpdateRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowPartialUpdateRequest.java
@@ -20,7 +20,7 @@ import org.openkilda.messaging.command.yflow.FlowPartialUpdateEndpoint;
 import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.PathComputationStrategy;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowPathSwapRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowPathSwapRequest.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.command.haflow;
 import org.openkilda.messaging.command.CommandData;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.Value;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowPathsReadRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowPathsReadRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.haflow;
 
 import org.openkilda.messaging.command.CommandData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowPathsResponse.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowPathsResponse.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.command.haflow;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.model.FlowPathDto;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowReadRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowReadRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.haflow;
 
 import org.openkilda.messaging.command.CommandData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowRequest.java
@@ -20,7 +20,7 @@ import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.PathComputationStrategy;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowRerouteResponse.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowRerouteResponse.java
@@ -19,7 +19,7 @@ import org.openkilda.messaging.command.yflow.SubFlowPathDto;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.event.PathInfoData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowResponse.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowResponse.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.haflow;
 
 import org.openkilda.messaging.info.InfoData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowSyncRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowSyncRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.haflow;
 
 import org.openkilda.messaging.command.CommandData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowSyncResponse.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowSyncResponse.java
@@ -20,7 +20,7 @@ import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.event.PathInfoData;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowValidationRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowValidationRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.haflow;
 
 import org.openkilda.messaging.command.CommandData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -26,7 +26,7 @@ import lombok.EqualsAndHashCode;
 @Data
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class HaFlowValidationRequest extends CommandData {
     private static final long serialVersionUID = 1L;
 

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowValidationResponse.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowValidationResponse.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.command.haflow;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.flow.FlowValidationResponse;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -27,7 +27,7 @@ import java.util.List;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class HaFlowValidationResponse extends InfoData {
     private static final long serialVersionUID = 1L;
 

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowsDumpRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaFlowsDumpRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.haflow;
 
 import org.openkilda.messaging.command.CommandData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaSubFlowDto.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaSubFlowDto.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.command.haflow;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowStatus;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaSubFlowPartialUpdateDto.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/haflow/HaSubFlowPartialUpdateDto.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.command.haflow;
 import org.openkilda.messaging.command.yflow.FlowPartialUpdateEndpoint;
 import org.openkilda.model.FlowStatus;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/FlowPartialUpdateEndpoint.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/FlowPartialUpdateEndpoint.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.yflow;
 
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/SubFlowDto.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/SubFlowDto.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.command.yflow;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.FlowStatus;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/SubFlowPartialUpdateDto.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/SubFlowPartialUpdateDto.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.command.yflow;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/SubFlowPartialUpdateSharedEndpoint.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/SubFlowPartialUpdateSharedEndpoint.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.command.yflow;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/SubFlowPathDto.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/SubFlowPathDto.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.yflow;
 
 import org.openkilda.messaging.info.event.PathInfoData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/SubFlowSharedEndpointEncapsulation.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/SubFlowSharedEndpointEncapsulation.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.command.yflow;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/SubFlowsReadRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/SubFlowsReadRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.yflow;
 
 import org.openkilda.messaging.command.CommandData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/SubFlowsResponse.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/SubFlowsResponse.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.yflow;
 
 import org.openkilda.messaging.info.InfoData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowDeleteRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowDeleteRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.yflow;
 
 import org.openkilda.messaging.command.CommandData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowDiscrepancyDto.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowDiscrepancyDto.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.yflow;
 
 import org.openkilda.messaging.info.flow.PathDiscrepancyEntity;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowDto.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowDto.java
@@ -21,7 +21,7 @@ import org.openkilda.model.FlowStatus;
 import org.openkilda.model.PathComputationStrategy;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowPartialUpdateRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowPartialUpdateRequest.java
@@ -19,7 +19,7 @@ import org.openkilda.messaging.command.CommandData;
 import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.PathComputationStrategy;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowPartialUpdateSharedEndpoint.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowPartialUpdateSharedEndpoint.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.yflow;
 
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowPathSwapRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowPathSwapRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.yflow;
 
 import org.openkilda.messaging.command.CommandData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowPathsReadRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowPathsReadRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.yflow;
 
 import org.openkilda.messaging.command.CommandData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowPathsResponse.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowPathsResponse.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.command.yflow;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.model.FlowPathDto;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowReadRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowReadRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.yflow;
 
 import org.openkilda.messaging.command.CommandData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowRequest.java
@@ -20,7 +20,7 @@ import org.openkilda.model.FlowEncapsulationType;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.PathComputationStrategy;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowRerouteResponse.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowRerouteResponse.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.command.yflow;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.event.PathInfoData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowResponse.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowResponse.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.yflow;
 
 import org.openkilda.messaging.info.InfoData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowSyncRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowSyncRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.yflow;
 
 import org.openkilda.messaging.command.CommandData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowValidationRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowValidationRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.yflow;
 
 import org.openkilda.messaging.command.CommandData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowValidationResponse.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowValidationResponse.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.command.yflow;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.flow.FlowValidationResponse;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowsDumpRequest.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/command/yflow/YFlowsDumpRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.yflow;
 
 import org.openkilda.messaging.command.CommandData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/info/flow/FlowMirrorPointResponse.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/info/flow/FlowMirrorPointResponse.java
@@ -19,7 +19,7 @@ import org.openkilda.messaging.info.InfoData;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/info/flow/FlowValidationResponse.java
+++ b/src-java/flowhs-topology/flowhs-messaging/src/main/java/org/openkilda/messaging/info/flow/FlowValidationResponse.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.info.flow;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.model.FlowDirectionType;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/EnableLogMessagesResponse.java
+++ b/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/EnableLogMessagesResponse.java
@@ -17,7 +17,7 @@ package org.openkilda.grpc.speaker.model;
 
 import org.openkilda.messaging.model.grpc.OnOffState;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/GrpcDeleteOperationResponse.java
+++ b/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/GrpcDeleteOperationResponse.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.grpc.speaker.model;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/LicenseDto.java
+++ b/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/LicenseDto.java
@@ -16,7 +16,7 @@
 package org.openkilda.grpc.speaker.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/LicenseResponse.java
+++ b/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/LicenseResponse.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.grpc.speaker.model;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/LogMessagesDto.java
+++ b/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/LogMessagesDto.java
@@ -18,7 +18,7 @@ package org.openkilda.grpc.speaker.model;
 import org.openkilda.messaging.model.grpc.OnOffState;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/LogOferrorsDto.java
+++ b/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/LogOferrorsDto.java
@@ -18,7 +18,7 @@ package org.openkilda.grpc.speaker.model;
 import org.openkilda.messaging.model.grpc.OnOffState;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/LogicalPortDto.java
+++ b/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/LogicalPortDto.java
@@ -18,7 +18,7 @@ package org.openkilda.grpc.speaker.model;
 import org.openkilda.messaging.model.grpc.LogicalPortType;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/PacketInOutStatsResponse.java
+++ b/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/PacketInOutStatsResponse.java
@@ -16,7 +16,7 @@
 package org.openkilda.grpc.speaker.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/PortConfigDto.java
+++ b/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/PortConfigDto.java
@@ -21,7 +21,7 @@ import org.openkilda.messaging.model.grpc.PortPause;
 import org.openkilda.messaging.model.grpc.PortSpeed;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/PortConfigSetupResponse.java
+++ b/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/PortConfigSetupResponse.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.grpc.speaker.model;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Value;
 

--- a/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/RemoteLogServerDto.java
+++ b/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/grpc/speaker/model/RemoteLogServerDto.java
@@ -16,7 +16,7 @@
 package org.openkilda.grpc.speaker.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/messaging/command/grpc/GetPacketInOutStatsRequest.java
+++ b/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/messaging/command/grpc/GetPacketInOutStatsRequest.java
@@ -19,7 +19,7 @@ import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/messaging/command/grpc/GrpcBaseRequest.java
+++ b/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/messaging/command/grpc/GrpcBaseRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.grpc;
 
 import org.openkilda.messaging.command.CommandData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/messaging/info/grpc/GetPacketInOutStatsResponse.java
+++ b/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/messaging/info/grpc/GetPacketInOutStatsResponse.java
@@ -19,7 +19,7 @@ import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.model.grpc.PacketInOutStatsDto;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/messaging/model/grpc/PacketInOutStatsDto.java
+++ b/src-java/grpc-speaker/grpc-api/src/main/java/org/openkilda/messaging/model/grpc/PacketInOutStatsDto.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.model.grpc;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/kilda-persistence-hibernate/src/main/java/org/openkilda/persistence/hibernate/entities/JsonPayloadBase.java
+++ b/src-java/kilda-persistence-hibernate/src/main/java/org/openkilda/persistence/hibernate/entities/JsonPayloadBase.java
@@ -15,10 +15,10 @@
 
 package org.openkilda.persistence.hibernate.entities;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public abstract class JsonPayloadBase {
     // no fields required
 }

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/BfdPropertiesReadRequest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/BfdPropertiesReadRequest.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.nbtopology.request;
 import org.openkilda.messaging.model.NetworkEndpoint;
 import org.openkilda.messaging.nbtopology.annotations.ReadRequest;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/BfdPropertiesWriteRequest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/BfdPropertiesWriteRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.nbtopology.request;
 
 import org.openkilda.model.BfdProperties;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/FlowConnectedDeviceRequest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/FlowConnectedDeviceRequest.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.nbtopology.request;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.Value;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/FlowMirrorPointsDumpRequest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/FlowMirrorPointsDumpRequest.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.nbtopology.request;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetFlowHistoryRequest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetFlowHistoryRequest.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.nbtopology.request;
 import org.openkilda.messaging.nbtopology.annotations.ReadRequest;
 import org.openkilda.model.CompositeDataEntity;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetFlowLoopsRequest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetFlowLoopsRequest.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.nbtopology.request;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.Value;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetFlowStatusTimestampsRequest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetFlowStatusTimestampsRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.nbtopology.request;
 
 import org.openkilda.messaging.nbtopology.annotations.ReadRequest;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetFlowsPerPortForSwitchRequest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetFlowsPerPortForSwitchRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.nbtopology.request;
 
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
@@ -27,7 +27,7 @@ import java.util.Collection;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
-@JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class GetFlowsPerPortForSwitchRequest extends SwitchesBaseRequest {
     SwitchId switchId;
     Collection<Integer> ports;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetPortPropertiesRequest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetPortPropertiesRequest.java
@@ -19,7 +19,7 @@ import org.openkilda.messaging.nbtopology.annotations.ReadRequest;
 import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 import lombok.ToString;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetSwitchConnectedDevicesRequest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetSwitchConnectedDevicesRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.nbtopology.request;
 
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.Value;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetSwitchLagPortsRequest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/GetSwitchLagPortsRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.nbtopology.request;
 
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.Value;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/PortHistoryRequest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/PortHistoryRequest.java
@@ -19,7 +19,7 @@ import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/SwitchConnectionsRequest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/SwitchConnectionsRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.nbtopology.request;
 
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.Value;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/UpdatePortPropertiesRequest.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/request/UpdatePortPropertiesRequest.java
@@ -19,7 +19,7 @@ import org.openkilda.messaging.info.InfoData;
 import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/BfdPropertiesResponse.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/BfdPropertiesResponse.java
@@ -21,7 +21,7 @@ import org.openkilda.messaging.model.NetworkEndpoint;
 import org.openkilda.model.BfdProperties;
 import org.openkilda.model.EffectiveBfdProperties;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.Value;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/ConnectedDeviceDto.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/ConnectedDeviceDto.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.nbtopology.response;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/FlowConnectedDevicesResponse.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/FlowConnectedDevicesResponse.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.nbtopology.response;
 
 import org.openkilda.messaging.info.InfoData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/FlowLoopDto.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/FlowLoopDto.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.nbtopology.response;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/FlowLoopsResponse.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/FlowLoopsResponse.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.nbtopology.response;
 
 import org.openkilda.messaging.info.InfoData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/FlowMirrorPointsDumpResponse.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/FlowMirrorPointsDumpResponse.java
@@ -19,7 +19,7 @@ import org.openkilda.messaging.info.InfoData;
 import org.openkilda.model.FlowEndpoint;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/LagPortDto.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/LagPortDto.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.nbtopology.response;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Value;
 

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/SwitchConnectedDeviceDto.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/SwitchConnectedDeviceDto.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.nbtopology.response;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/SwitchConnectedDevicesResponse.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/SwitchConnectedDevicesResponse.java
@@ -19,7 +19,7 @@ import org.openkilda.messaging.Chunkable;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.split.SplitIterator;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/SwitchLagPortResponse.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/SwitchLagPortResponse.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.nbtopology.response;
 
 import org.openkilda.messaging.info.InfoData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/SwitchPortConnectedDevicesDto.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/SwitchPortConnectedDevicesDto.java
@@ -23,7 +23,7 @@ import org.openkilda.messaging.Utils;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.split.SplitIterator;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/TypedConnectedDevicesDto.java
+++ b/src-java/nbworker-topology/nbworker-messaging/src/main/java/org/openkilda/messaging/nbtopology/response/TypedConnectedDevicesDto.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.nbtopology.response;
 
 import org.openkilda.messaging.info.InfoData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/flows/ConnectedDeviceDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/flows/ConnectedDeviceDto.java
@@ -16,7 +16,7 @@
 package org.openkilda.northbound.dto.v1.flows;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Value;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/flows/FlowConnectedDevicesResponse.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/flows/FlowConnectedDevicesResponse.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v1.flows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Value;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/flows/TypedConnectedDevicesDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/flows/TypedConnectedDevicesDto.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v1.flows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Value;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/links/LinkMaxBandwidthDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/links/LinkMaxBandwidthDto.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v1.links;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -29,7 +29,7 @@ import java.io.Serializable;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(Include.NON_NULL)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class LinkMaxBandwidthDto implements Serializable {
 
     private String srcSwitch;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/links/LinkMaxBandwidthRequest.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/links/LinkMaxBandwidthRequest.java
@@ -16,7 +16,7 @@
 package org.openkilda.northbound.dto.v1.links;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -28,7 +28,7 @@ import java.io.Serializable;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class LinkMaxBandwidthRequest implements Serializable {
 
     private Long maxBandwidth;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/links/LinkParametersDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/links/LinkParametersDto.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;
@@ -30,7 +30,7 @@ import java.io.Serializable;
 @Data
 @NoArgsConstructor
 @JsonInclude(Include.NON_NULL)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class LinkParametersDto implements Serializable {
 
     private String srcSwitch;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/links/LinkPropsDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/links/LinkPropsDto.java
@@ -16,7 +16,7 @@
 package org.openkilda.northbound.dto.v1.links;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -31,7 +31,7 @@ import java.util.Map;
 @AllArgsConstructor
 @EqualsAndHashCode(exclude = "props")
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class LinkPropsDto {
 
     private String srcSwitch;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/GroupInfoDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/GroupInfoDto.java
@@ -16,7 +16,7 @@
 package org.openkilda.northbound.dto.v1.switches;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/GroupsSyncDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/GroupsSyncDto.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v1.switches;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/GroupsValidationDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/GroupsValidationDto.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v1.switches;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/LogicalPortInfoDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/LogicalPortInfoDto.java
@@ -16,7 +16,7 @@
 package org.openkilda.northbound.dto.v1.switches;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/LogicalPortMisconfiguredInfoDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/LogicalPortMisconfiguredInfoDto.java
@@ -16,7 +16,7 @@
 package org.openkilda.northbound.dto.v1.switches;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/LogicalPortsSyncDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/LogicalPortsSyncDto.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v1.switches;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/LogicalPortsValidationDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/LogicalPortsValidationDto.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v1.switches;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/SwitchLocationDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/SwitchLocationDto.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v1.switches;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -24,7 +24,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SwitchLocationDto {
 
     private Double latitude;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/SwitchSyncResult.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/SwitchSyncResult.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v1.switches;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/SwitchValidationResult.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v1/switches/SwitchValidationResult.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v1.switches;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/BaseAction.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/BaseAction.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.NonNull;
 import lombok.Value;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/CopyFieldActionDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/CopyFieldActionDto.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.action;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/GroupActionDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/GroupActionDto.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.action;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/MeterActionDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/MeterActionDto.java
@@ -19,7 +19,7 @@ import org.openkilda.model.MeterId;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/PopVlanActionDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/PopVlanActionDto.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.action;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/PopVxlanActionDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/PopVxlanActionDto.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.action;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/PortOutActionDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/PortOutActionDto.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.action;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/PushVlanActionDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/PushVlanActionDto.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.action;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/PushVxlanActionDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/PushVxlanActionDto.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.action;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/SetFieldActionDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/SetFieldActionDto.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.action;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/SwapFieldActionDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/action/SwapFieldActionDto.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.action;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/BaseFlowEndpointV2.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/BaseFlowEndpointV2.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.flows;
 
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/DetectConnectedDevicesV2.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/DetectConnectedDevicesV2.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.flows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowEndpointV2.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowEndpointV2.java
@@ -19,7 +19,7 @@ import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowHistoryStatus.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowHistoryStatus.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.flows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowHistoryStatusesResponse.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowHistoryStatusesResponse.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.flows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowLoopResponse.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowLoopResponse.java
@@ -19,7 +19,7 @@ import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowMirrorPointPayload.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowMirrorPointPayload.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.flows;
 
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowMirrorPointResponseV2.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowMirrorPointResponseV2.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.flows;
 
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowMirrorPointsResponseV2.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowMirrorPointsResponseV2.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.flows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowPatchEndpoint.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowPatchEndpoint.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.flows;
 
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowPatchV2.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowPatchV2.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.flows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowPathV2.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowPathV2.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.flows;
 
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.NonNull;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowRequestV2.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowRequestV2.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.flows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowRerouteResponseV2.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowRerouteResponseV2.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.flows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.NonNull;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowResponseV2.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowResponseV2.java
@@ -20,7 +20,7 @@ import org.openkilda.model.SwitchId;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowStatistics.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/FlowStatistics.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.flows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,7 +26,7 @@ import java.util.Set;
 @Data
 @Builder
 @AllArgsConstructor
-@JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class FlowStatistics {
     private Set<Integer> vlans;
 }

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/MirrorPointStatus.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/MirrorPointStatus.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.flows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/PathStatus.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/PathStatus.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.flows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/PathValidateResponse.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/PathValidateResponse.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.flows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -28,7 +28,7 @@ import java.util.List;
 @Data
 @Builder
 @AllArgsConstructor
-@JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class PathValidateResponse {
     Boolean isValid;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/SwapFlowEndpointPayload.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/SwapFlowEndpointPayload.java
@@ -16,7 +16,7 @@
 package org.openkilda.northbound.dto.v2.flows;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/SwapFlowPayload.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/flows/SwapFlowPayload.java
@@ -16,7 +16,7 @@
 package org.openkilda.northbound.dto.v2.flows;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlow.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlow.java
@@ -18,7 +18,7 @@ package org.openkilda.northbound.dto.v2.haflows;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowCreatePayload.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowCreatePayload.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.haflows;
 
 import org.openkilda.northbound.dto.utils.Constraints;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowDump.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowDump.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.haflows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowPatchEndpoint.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowPatchEndpoint.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.haflows;
 
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowPatchPayload.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowPatchPayload.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.haflows;
 
 import org.openkilda.northbound.dto.utils.Constraints;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowPath.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowPath.java
@@ -20,7 +20,7 @@ import org.openkilda.messaging.payload.flow.PathNodePayload;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowPaths.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowPaths.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.haflows;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowPingPayload.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowPingPayload.java
@@ -16,7 +16,7 @@
 package org.openkilda.northbound.dto.v2.haflows;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowPingResult.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowPingResult.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.haflows;
 
 import org.openkilda.northbound.dto.v2.yflows.SubFlowPingPayload;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowRerouteResult.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowRerouteResult.java
@@ -19,7 +19,7 @@ import org.openkilda.northbound.dto.v2.flows.FlowPathV2.PathNodeV2;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowSharedEndpoint.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowSharedEndpoint.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.haflows;
 
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowSyncResult.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowSyncResult.java
@@ -20,7 +20,7 @@ import org.openkilda.northbound.dto.v2.flows.FlowPathV2.PathNodeV2;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowUpdatePayload.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowUpdatePayload.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.haflows;
 
 import org.openkilda.northbound.dto.utils.Constraints;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowValidationResult.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaFlowValidationResult.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.haflows;
 
 import org.openkilda.northbound.dto.v1.flows.FlowValidationDto;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaSubFlow.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaSubFlow.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.haflows;
 
 import org.openkilda.northbound.dto.v2.flows.BaseFlowEndpointV2;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaSubFlowCreatePayload.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaSubFlowCreatePayload.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.haflows;
 
 import org.openkilda.northbound.dto.v2.flows.BaseFlowEndpointV2;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaSubFlowPatchPayload.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaSubFlowPatchPayload.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.haflows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaSubFlowPath.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaSubFlowPath.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.haflows;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaSubFlowUpdatePayload.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/haflows/HaSubFlowUpdatePayload.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.haflows;
 
 import org.openkilda.northbound.dto.utils.Constraints;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/links/BfdPropertiesPayload.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/links/BfdPropertiesPayload.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.links;
 
 import org.openkilda.northbound.dto.NorthboundPayload;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/GroupInfoDtoV2.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/GroupInfoDtoV2.java
@@ -16,7 +16,7 @@
 package org.openkilda.northbound.dto.v2.switches;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/LagPortResponse.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/LagPortResponse.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.switches;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -26,7 +26,7 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class LagPortResponse {
     private int logicalPortNumber;
     private List<Integer> portNumbers;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/LogicalPortInfoDtoV2.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/LogicalPortInfoDtoV2.java
@@ -16,7 +16,7 @@
 package org.openkilda.northbound.dto.v2.switches;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/MeterInfoDtoV2.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/MeterInfoDtoV2.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.switches;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/PortConnectedDevicesDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/PortConnectedDevicesDto.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.switches;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Value;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/PortHistoryResponse.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/PortHistoryResponse.java
@@ -19,7 +19,7 @@ import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/PortPropertiesResponse.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/PortPropertiesResponse.java
@@ -19,7 +19,7 @@ import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/RuleInfoDtoV2.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/RuleInfoDtoV2.java
@@ -21,7 +21,7 @@ import org.openkilda.northbound.dto.v2.action.BaseAction;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchConnectEntry.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchConnectEntry.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.switches;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Value;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchConnectedDeviceDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchConnectedDeviceDto.java
@@ -16,7 +16,7 @@
 package org.openkilda.northbound.dto.v2.switches;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Value;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchConnectedDevicesResponse.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchConnectedDevicesResponse.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.switches;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Value;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchConnectionsResponse.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchConnectionsResponse.java
@@ -18,7 +18,7 @@ package org.openkilda.northbound.dto.v2.switches;
 import org.openkilda.messaging.info.event.SwitchChangeType;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Value;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchDtoV2.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchDtoV2.java
@@ -18,7 +18,7 @@ package org.openkilda.northbound.dto.v2.switches;
 import org.openkilda.messaging.info.event.SwitchChangeType;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -27,7 +27,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SwitchDtoV2 {
 
     private SwitchId switchId;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchFlowsPerPortResponse.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchFlowsPerPortResponse.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.switches;
 
 import org.openkilda.northbound.dto.v2.flows.FlowResponseV2;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -29,7 +29,7 @@ import java.util.Map;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SwitchFlowsPerPortResponse {
     Map<Integer, List<FlowResponseV2>> flowsByPort;
 }

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchLocationDtoV2.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchLocationDtoV2.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.switches;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -24,7 +24,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SwitchLocationDtoV2 {
 
     private Double latitude;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchPatchDto.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchPatchDto.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.switches;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -24,7 +24,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SwitchPatchDto {
 
     private String pop;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchPropertiesDump.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchPropertiesDump.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.switches;
 
 import org.openkilda.northbound.dto.v1.switches.SwitchPropertiesDto;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchValidationResultV2.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/switches/SwitchValidationResultV2.java
@@ -16,7 +16,7 @@
 package org.openkilda.northbound.dto.v2.switches;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/SubFlow.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/SubFlow.java
@@ -18,7 +18,7 @@ package org.openkilda.northbound.dto.v2.yflows;
 import org.openkilda.northbound.dto.v2.flows.FlowEndpointV2;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/SubFlowPatchPayload.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/SubFlowPatchPayload.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.yflows;
 
 import org.openkilda.northbound.dto.v2.flows.FlowPatchEndpoint;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/SubFlowPath.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/SubFlowPath.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.yflows;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/SubFlowPingPayload.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/SubFlowPingPayload.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.yflows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/SubFlowUpdatePayload.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/SubFlowUpdatePayload.java
@@ -18,7 +18,7 @@ package org.openkilda.northbound.dto.v2.yflows;
 import org.openkilda.northbound.dto.v2.flows.FlowEndpointV2;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/SubFlowsDump.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/SubFlowsDump.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.yflows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/UniSubFlowPingPayload.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/UniSubFlowPingPayload.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.yflows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlow.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlow.java
@@ -20,7 +20,7 @@ import org.openkilda.model.SwitchId;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowCreatePayload.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowCreatePayload.java
@@ -16,7 +16,7 @@
 package org.openkilda.northbound.dto.v2.yflows;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowDiscrepancy.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowDiscrepancy.java
@@ -18,7 +18,7 @@ package org.openkilda.northbound.dto.v2.yflows;
 import org.openkilda.northbound.dto.v1.flows.PathDiscrepancyDto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowDump.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowDump.java
@@ -16,7 +16,7 @@
 package org.openkilda.northbound.dto.v2.yflows;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowPatchPayload.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowPatchPayload.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.yflows;
 
 import org.openkilda.northbound.dto.utils.Constraints;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowPatchSharedEndpoint.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowPatchSharedEndpoint.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.yflows;
 
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowPatchSharedEndpointEncapsulation.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowPatchSharedEndpointEncapsulation.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.yflows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowPath.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowPath.java
@@ -20,7 +20,7 @@ import org.openkilda.messaging.payload.flow.PathNodePayload;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowPaths.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowPaths.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.yflows;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowPingResult.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowPingResult.java
@@ -16,7 +16,7 @@
 package org.openkilda.northbound.dto.v2.yflows;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowRerouteResult.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowRerouteResult.java
@@ -19,7 +19,7 @@ import org.openkilda.northbound.dto.v2.flows.FlowPathV2.PathNodeV2;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowSharedEndpoint.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowSharedEndpoint.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.yflows;
 
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowSharedEndpointEncapsulation.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowSharedEndpointEncapsulation.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.yflows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowSyncResult.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowSyncResult.java
@@ -17,7 +17,7 @@ package org.openkilda.northbound.dto.v2.yflows;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowUpdatePayload.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowUpdatePayload.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.northbound.dto.v2.yflows;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowValidationResult.java
+++ b/src-java/northbound-service/northbound-api/src/main/java/org/openkilda/northbound/dto/v2/yflows/YFlowValidationResult.java
@@ -18,7 +18,7 @@ package org.openkilda.northbound.dto.v2.yflows;
 import org.openkilda.northbound.dto.v1.flows.FlowValidationDto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/ping-topology/ping-messaging/src/main/java/org/openkilda/messaging/command/flow/HaFlowPingRequest.java
+++ b/src-java/ping-topology/ping-messaging/src/main/java/org/openkilda/messaging/command/flow/HaFlowPingRequest.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.command.flow;
 
 import org.openkilda.messaging.command.CommandData;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/ping-topology/ping-messaging/src/main/java/org/openkilda/messaging/command/flow/YFlowPingRequest.java
+++ b/src-java/ping-topology/ping-messaging/src/main/java/org/openkilda/messaging/command/flow/YFlowPingRequest.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.command.flow;
 import org.openkilda.messaging.command.CommandData;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/ping-topology/ping-messaging/src/main/java/org/openkilda/messaging/info/flow/HaFlowPingResponse.java
+++ b/src-java/ping-topology/ping-messaging/src/main/java/org/openkilda/messaging/info/flow/HaFlowPingResponse.java
@@ -20,7 +20,7 @@ import static org.openkilda.messaging.info.flow.FlowPingResponseUtils.buildPingS
 import org.openkilda.messaging.info.InfoData;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/ping-topology/ping-messaging/src/main/java/org/openkilda/messaging/info/flow/SubFlowPingPayload.java
+++ b/src-java/ping-topology/ping-messaging/src/main/java/org/openkilda/messaging/info/flow/SubFlowPingPayload.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.messaging.info.flow;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/ping-topology/ping-messaging/src/main/java/org/openkilda/messaging/info/flow/UniSubFlowPingPayload.java
+++ b/src-java/ping-topology/ping-messaging/src/main/java/org/openkilda/messaging/info/flow/UniSubFlowPingPayload.java
@@ -17,7 +17,7 @@ package org.openkilda.messaging.info.flow;
 
 import org.openkilda.messaging.model.Ping.Errors;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/ping-topology/ping-messaging/src/main/java/org/openkilda/messaging/info/flow/YFlowPingResponse.java
+++ b/src-java/ping-topology/ping-messaging/src/main/java/org/openkilda/messaging/info/flow/YFlowPingResponse.java
@@ -20,7 +20,7 @@ import static org.openkilda.messaging.info.flow.FlowPingResponseUtils.buildPingS
 import org.openkilda.messaging.info.InfoData;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/reroute-topology/reroute-messaging/src/main/java/org/openkilda/messaging/info/reroute/RerouteResultInfoData.java
+++ b/src-java/reroute-topology/reroute-messaging/src/main/java/org/openkilda/messaging/info/reroute/RerouteResultInfoData.java
@@ -19,7 +19,7 @@ import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.reroute.error.RerouteError;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Data;

--- a/src-java/reroute-topology/reroute-messaging/src/main/java/org/openkilda/messaging/info/reroute/SwitchStateChanged.java
+++ b/src-java/reroute-topology/reroute-messaging/src/main/java/org/openkilda/messaging/info/reroute/SwitchStateChanged.java
@@ -22,7 +22,7 @@ import org.openkilda.model.SwitchStatus;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/FlowSpeakerData.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/FlowSpeakerData.java
@@ -22,7 +22,7 @@ import org.openkilda.rulemanager.match.FieldMatch;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/GroupSpeakerData.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/GroupSpeakerData.java
@@ -22,7 +22,7 @@ import org.openkilda.rulemanager.group.GroupType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.EqualsAndHashCode;

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/Instructions.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/Instructions.java
@@ -20,7 +20,7 @@ import org.openkilda.rulemanager.action.Action;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/MeterSpeakerData.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/MeterSpeakerData.java
@@ -20,7 +20,7 @@ import org.openkilda.model.SwitchId;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/OfMetadata.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/OfMetadata.java
@@ -18,7 +18,7 @@ package org.openkilda.rulemanager;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Value;
 

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/ProtoConstants.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/ProtoConstants.java
@@ -17,7 +17,7 @@ package org.openkilda.rulemanager;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.EqualsAndHashCode;

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/SpeakerData.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/SpeakerData.java
@@ -17,7 +17,7 @@ package org.openkilda.rulemanager;
 
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.AllArgsConstructor;

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/GroupAction.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/GroupAction.java
@@ -20,7 +20,7 @@ import org.openkilda.model.GroupId;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Value;

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/MeterAction.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/MeterAction.java
@@ -20,7 +20,7 @@ import org.openkilda.model.MeterId;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Value;

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/PopVlanAction.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/PopVlanAction.java
@@ -17,7 +17,7 @@ package org.openkilda.rulemanager.action;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Value;

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/PopVxlanAction.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/PopVxlanAction.java
@@ -20,7 +20,7 @@ import static org.openkilda.rulemanager.action.ActionType.POP_VXLAN_OVS;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.Sets;

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/PortOutAction.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/PortOutAction.java
@@ -20,7 +20,7 @@ import org.openkilda.rulemanager.ProtoConstants.PortNumber;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Value;

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/PushVlanAction.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/PushVlanAction.java
@@ -16,7 +16,7 @@
 package org.openkilda.rulemanager.action;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Value;

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/PushVxlanAction.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/PushVxlanAction.java
@@ -23,7 +23,7 @@ import org.openkilda.model.MacAddress;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.Sets;

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/SetFieldAction.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/SetFieldAction.java
@@ -20,7 +20,7 @@ import org.openkilda.rulemanager.Field;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/SwapFieldAction.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/SwapFieldAction.java
@@ -22,7 +22,7 @@ import org.openkilda.rulemanager.action.noviflow.OpenFlowOxms;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.Sets;

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/noviflow/CopyFieldAction.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/action/noviflow/CopyFieldAction.java
@@ -21,7 +21,7 @@ import org.openkilda.rulemanager.action.ActionType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/group/Bucket.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/group/Bucket.java
@@ -19,7 +19,7 @@ import org.openkilda.rulemanager.action.Action;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;

--- a/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/match/FieldMatch.java
+++ b/src-java/rule-manager/rule-manager-api/src/main/java/org/openkilda/rulemanager/match/FieldMatch.java
@@ -21,7 +21,7 @@ import org.openkilda.rulemanager.ProtoConstants.Mask;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Builder;

--- a/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/flowrtt/AddFlow.java
+++ b/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/flowrtt/AddFlow.java
@@ -17,7 +17,7 @@ package org.openkilda.server42.control.messaging.flowrtt;
 
 import org.openkilda.server42.messaging.FlowDirection;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/flowrtt/Headers.java
+++ b/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/flowrtt/Headers.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.server42.control.messaging.flowrtt;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/flowrtt/ListFlowsOnSwitch.java
+++ b/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/flowrtt/ListFlowsOnSwitch.java
@@ -16,7 +16,7 @@
 
 package org.openkilda.server42.control.messaging.flowrtt;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/flowrtt/ListFlowsResponse.java
+++ b/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/flowrtt/ListFlowsResponse.java
@@ -16,7 +16,7 @@
 
 package org.openkilda.server42.control.messaging.flowrtt;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/flowrtt/PushSettings.java
+++ b/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/flowrtt/PushSettings.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.server42.control.messaging.flowrtt;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/flowrtt/RemoveFlow.java
+++ b/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/flowrtt/RemoveFlow.java
@@ -17,7 +17,7 @@ package org.openkilda.server42.control.messaging.flowrtt;
 
 import org.openkilda.server42.messaging.FlowDirection;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/islrtt/ActivateIslMonitoringOnSwitchInfoData.java
+++ b/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/islrtt/ActivateIslMonitoringOnSwitchInfoData.java
@@ -18,7 +18,7 @@ package org.openkilda.server42.control.messaging.islrtt;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/islrtt/AddIsl.java
+++ b/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/islrtt/AddIsl.java
@@ -19,7 +19,7 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.server42.control.messaging.flowrtt.Headers;
 import org.openkilda.server42.control.messaging.flowrtt.Message;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/islrtt/ClearIsls.java
+++ b/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/islrtt/ClearIsls.java
@@ -19,7 +19,7 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.server42.control.messaging.flowrtt.Headers;
 import org.openkilda.server42.control.messaging.flowrtt.Message;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/islrtt/DeactivateIslMonitoringOnSwitchInfoData.java
+++ b/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/islrtt/DeactivateIslMonitoringOnSwitchInfoData.java
@@ -18,7 +18,7 @@ package org.openkilda.server42.control.messaging.islrtt;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.model.SwitchId;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/islrtt/ListIslPortsOnSwitch.java
+++ b/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/islrtt/ListIslPortsOnSwitch.java
@@ -19,7 +19,7 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.server42.control.messaging.flowrtt.Headers;
 import org.openkilda.server42.control.messaging.flowrtt.Message;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/islrtt/ListIslsRequest.java
+++ b/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/islrtt/ListIslsRequest.java
@@ -19,7 +19,7 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.server42.control.messaging.flowrtt.Headers;
 import org.openkilda.server42.control.messaging.flowrtt.Message;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/islrtt/ListIslsResponse.java
+++ b/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/islrtt/ListIslsResponse.java
@@ -19,7 +19,7 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.server42.control.messaging.flowrtt.Headers;
 import org.openkilda.server42.control.messaging.flowrtt.Message;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/islrtt/RemoveIsl.java
+++ b/src-java/server42/server42-control-messaging/src/main/java/org/openkilda/server42/control/messaging/islrtt/RemoveIsl.java
@@ -19,7 +19,7 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.server42.control.messaging.flowrtt.Headers;
 import org.openkilda.server42.control.messaging.flowrtt.Message;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;

--- a/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/BaseHaFlowPathInfo.java
+++ b/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/BaseHaFlowPathInfo.java
@@ -22,7 +22,7 @@ import org.openkilda.model.SwitchId;
 import org.openkilda.model.cookie.FlowSegmentCookie;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -36,7 +36,7 @@ import java.util.List;
  */
 @Getter
 @AllArgsConstructor
-@JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 @ToString
 public abstract class BaseHaFlowPathInfo extends StatsNotification {
     String haFlowId;

--- a/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/RemoveFlowPathInfo.java
+++ b/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/RemoveFlowPathInfo.java
@@ -22,7 +22,7 @@ import org.openkilda.model.cookie.FlowSegmentCookie;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/RemoveHaFlowPathInfo.java
+++ b/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/RemoveHaFlowPathInfo.java
@@ -23,7 +23,7 @@ import org.openkilda.model.cookie.FlowSegmentCookie;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/RemoveYFlowStatsInfo.java
+++ b/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/RemoveYFlowStatsInfo.java
@@ -19,7 +19,7 @@ import org.openkilda.messaging.payload.yflow.YFlowEndpointResources;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.Value;

--- a/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/UpdateFlowPathInfo.java
+++ b/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/UpdateFlowPathInfo.java
@@ -22,7 +22,7 @@ import org.openkilda.model.cookie.FlowSegmentCookie;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/UpdateHaFlowPathInfo.java
+++ b/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/UpdateHaFlowPathInfo.java
@@ -23,7 +23,7 @@ import org.openkilda.model.cookie.FlowSegmentCookie;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/UpdateYFlowStatsInfo.java
+++ b/src-java/stats-topology/stats-messaging/src/main/java/org/openkilda/messaging/info/stats/UpdateYFlowStatsInfo.java
@@ -19,7 +19,7 @@ import org.openkilda.messaging.payload.yflow.YFlowEndpointResources;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;

--- a/src-java/swmanager-topology/swmanager-messaging/src/main/java/org/openkilda/messaging/swmanager/response/LagPortResponse.java
+++ b/src-java/swmanager-topology/swmanager-messaging/src/main/java/org/openkilda/messaging/swmanager/response/LagPortResponse.java
@@ -18,7 +18,7 @@ package org.openkilda.messaging.swmanager.response;
 import org.openkilda.messaging.info.InfoData;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.Value;

--- a/src-java/testing/test-library/build.gradle
+++ b/src-java/testing/test-library/build.gradle
@@ -59,7 +59,9 @@ dependencies {
 
     api 'org.junit.jupiter:junit-jupiter-api'
     api 'org.junit.jupiter:junit-jupiter-engine'
-    api 'com.github.javafaker:javafaker:1.0.2'
+    api("com.github.javafaker:javafaker:1.0.2") {
+        exclude module: 'snakeyaml' because("javafaker introduces a wrong classifier for snakeyaml: android")
+    }
     implementation 'com.nitorcreations:matchers'
 
     compileOnly 'org.projectlombok:lombok'

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/model/topology/TopologyDefinition.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/model/topology/TopologyDefinition.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/floodlight/model/group/Bucket.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/floodlight/model/group/Bucket.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.testing.service.floodlight.model.group;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/floodlight/model/group/BucketCounter.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/floodlight/model/group/BucketCounter.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.testing.service.floodlight.model.group;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/floodlight/model/group/Group.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/floodlight/model/group/Group.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.testing.service.floodlight.model.group;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/floodlight/model/group/GroupDesc.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/floodlight/model/group/GroupDesc.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.testing.service.floodlight.model.group;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/floodlight/model/group/GroupsDescResponse.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/floodlight/model/group/GroupsDescResponse.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.testing.service.floodlight.model.group;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/floodlight/model/group/GroupsStatsResponse.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/floodlight/model/group/GroupsStatsResponse.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.testing.service.floodlight.model.group;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/northbound/model/HaFlowDumpPayload.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/northbound/model/HaFlowDumpPayload.java
@@ -22,7 +22,7 @@ import org.openkilda.model.FlowStatus;
 import org.openkilda.model.PathComputationStrategy;
 import org.openkilda.model.history.DumpType;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/northbound/model/HaFlowHistoryEntry.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/northbound/model/HaFlowHistoryEntry.java
@@ -16,7 +16,7 @@
 package org.openkilda.testing.service.northbound.model;
 
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/northbound/model/HaFlowHistoryPayload.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/northbound/model/HaFlowHistoryPayload.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.testing.service.northbound.model;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/northbound/payloads/PathDto.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/northbound/payloads/PathDto.java
@@ -18,7 +18,7 @@ package org.openkilda.testing.service.northbound.payloads;
 import org.openkilda.messaging.payload.flow.PathNodePayload;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/northbound/payloads/ProtectedPathPayload.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/northbound/payloads/ProtectedPathPayload.java
@@ -18,7 +18,7 @@ package org.openkilda.testing.service.northbound.payloads;
 import org.openkilda.messaging.payload.flow.PathNodePayload;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/traffexam/model/AddressStats.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/traffexam/model/AddressStats.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.testing.service.traffexam.model;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/traffexam/model/ArpData.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/traffexam/model/ArpData.java
@@ -15,7 +15,7 @@
 
 package org.openkilda.testing.service.traffexam.model;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.javafaker.Faker;
 import lombok.Builder;

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/traffexam/model/LldpData.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/traffexam/model/LldpData.java
@@ -16,7 +16,7 @@
 package org.openkilda.testing.service.traffexam.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.javafaker.Faker;
 import lombok.Builder;

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/traffexam/model/UdpData.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/traffexam/model/UdpData.java
@@ -16,7 +16,7 @@
 package org.openkilda.testing.service.traffexam.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.javafaker.Faker;
 import lombok.Builder;


### PR DESCRIPTION
This change replaces deprecated Jackson's packages with the modern versions. (they spammed warnings into a log file, making it harder to investigate other issues)

There is also a couple of changes to gradle files. Seems like dependency resolution outcome changed with the upgrading of versions and 'test-library' started to have a compile error because of the wrong environment classifier of one of its dependencies. I excluded it with the corresponding comment explaining it.