### PR TITLE
[Java 8-17] Additional changes to upgrade Storm and performance tweaks.

### DIFF
--- a/confd/templates/storm/storm.yaml.tmpl
+++ b/confd/templates/storm/storm.yaml.tmpl
@@ -68,13 +68,26 @@ supervisor.slots.ports:
 #     argument:
 #       - endpoint: "metrics-collector.mycompany.org"
 
-nimbus.childopts: "-Xmx128m"
-ui.childopts: "-Xmx128m"
-supervisor.childopts: "-Xmx128m"
-worker.childopts: "-Xmx280m"
+nimbus.task.timeout.secs: 240
+nimbus.thrift.max_buffer_size: 20480000
+nimbus.childopts: "-Xmx2048m -Djava.net.preferIPv4Stack=true"
 
+worker.childopts: "-Xmx2048m -XX:+UseG1GC -Djava.net.preferIPv4Stack=true"
+
+supervisor.childopts: "-Xmx2048m -Djava.net.preferIPv4Stack=true"
+
+ui.childopts: "-Xmx512m"
+
+#Topologies settings
 topology.testing.always.try.serialize: true
-
 topology.skip.missing.kryo.registrations: true
 topology.fall.back.on.java.serialization: true
 
+
+topology.max.spout.pending: 200
+topology.message.timeout.secs: 300
+
+topology.spout.wait.strategy: org.apache.storm.policy.WaitStrategy
+topology.backpressure.wait.strategy: org.apache.storm.policy.WaitStrategy
+topology.bolt.wait.strategy: org.apache.storm.policy.WaitStrategy
+topology.stats.sample.rate: 0.00001

--- a/docker/storm/Dockerfile
+++ b/docker/storm/Dockerfile
@@ -16,15 +16,15 @@
 ARG base_image=kilda/base-ubuntu
 FROM ${base_image}
 
-ENV PACKAGE apache-storm-2.5.0
+ENV PACKAGE apache-storm-2.6.1
 
 WORKDIR /tmp/
 
 RUN    \
     apt -y update \
     && apt -y install net-tools jq \
-    && wget -q https://archive.apache.org/dist/storm/apache-storm-2.5.0/$PACKAGE.tar.gz \
-    && wget -q https://archive.apache.org/dist/storm/apache-storm-2.5.0/$PACKAGE.tar.gz.sha512 \
+    && wget -q https://archive.apache.org/dist/storm/apache-storm-2.6.1/$PACKAGE.tar.gz \
+    && wget -q https://archive.apache.org/dist/storm/apache-storm-2.6.1/$PACKAGE.tar.gz.sha512 \
     && sha512sum -c $PACKAGE.tar.gz.sha512 \
     && tar -xzf $PACKAGE.tar.gz --directory /opt/ \
     && ln -s /opt/$PACKAGE /opt/storm \
@@ -37,6 +37,5 @@ WORKDIR /opt/storm/
 
 COPY storm.yaml /opt/storm/conf/storm.yaml
 COPY log4j2 /opt/storm/log4j2
-# COPY lib/*.jar /opt/storm/lib/
 COPY simple-storm-supervisor-healthcheck.sh /simple-storm-supervisor-healthcheck.sh
 COPY simple-storm-ui-healthcheck.sh /simple-storm-ui-healthcheck.sh

--- a/docker/storm/simple-storm-supervisor-healthcheck.sh
+++ b/docker/storm/simple-storm-supervisor-healthcheck.sh
@@ -8,8 +8,8 @@ set -o pipefail
 /usr/bin/jps | grep Supervisor || exit 1
 
 
-CONFIG=${1:-/opt/apache-storm-2.5.0/conf/storm.yaml}
-LOG_FILE=${2:-/opt/apache-storm-2.5.0/logs/supervisor.log}
+CONFIG=${1:-/opt/apache-storm-2.6.1/conf/storm.yaml}
+LOG_FILE=${2:-/opt/apache-storm-2.6.1/logs/supervisor.log}
 
 PORTS_NUBER_IN_CONFIG=$(cat ${CONFIG}  | sed -n '/supervisor.slots.ports/,/^$/p' | grep -v supervisor.slots.ports | grep -v '^$' | awk -F '-' '{ print $2}' | wc -l )
 PORTS_NUMBER_IN_LOGS=$(head  -1000 ${LOG_FILE} | grep 'Starting in state' | wc -l )

--- a/docker/storm/simple-storm-ui-healthcheck.sh
+++ b/docker/storm/simple-storm-ui-healthcheck.sh
@@ -8,7 +8,7 @@ set -o pipefail
 /usr/bin/jps | grep --silent UIServer || exit 1
 
 
-CONFIG=${1:-/opt/apache-storm-2.5.0/conf/storm.yaml}
+CONFIG=${1:-/opt/apache-storm-2.6.1/conf/storm.yaml}
 
 PORTS_NUBER_IN_CONFIG=$(cat ${CONFIG}  | sed -n '/supervisor.slots.ports/,/^$/p' | grep -v supervisor.slots.ports | grep -v '^$' | awk -F '-' '{ print $2}' | wc -l )
 ACTUAL_SLOTS=$(curl  -q 127.0.0.1:8080/api/v1/cluster/summary 2>/dev/null | jq -r  '.slotsTotal')

--- a/src-java/base-topology/base-storm-topology/build.gradle
+++ b/src-java/base-topology/base-storm-topology/build.gradle
@@ -36,11 +36,11 @@ dependencies {
      * provided in the storm cluster. ShadowJar supports excludes, but it only excludes dependencies from the current
      * project.
      */
-    compileOnly("org.apache.storm:storm-core:2.6.1") {
+    compileOnly("org.apache.storm:storm-core") {
         exclude(group: "org.yaml", module: "snakeyaml")
     }
     implementation("org.yaml:snakeyaml:2.2")
-    testImplementation("org.apache.storm:storm-core:2.6.1") {
+    testImplementation("org.apache.storm:storm-core") {
         exclude group: "org.slf4j", module: "log4j-over-slf4j"
     }
 

--- a/src-java/connecteddevices-topology/connecteddevices-storm-topology/build.gradle
+++ b/src-java/connecteddevices-topology/connecteddevices-storm-topology/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testImplementation project(path: ':kilda-persistence-api', configuration: 'testArtifacts')
     testImplementation project(path: ':kilda-persistence-tinkerpop', configuration: 'testArtifacts')
 
-    compileOnly('org.apache.storm:storm-core:2.6.1'){
+    compileOnly('org.apache.storm:storm-core'){
         exclude(group: 'org.yaml', module: 'snakeyaml')
     }
     implementation('org.yaml:snakeyaml:2.2')

--- a/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/build.gradle
+++ b/src-java/floodlightrouter-topology/floodlightrouter-storm-topology/build.gradle
@@ -24,11 +24,11 @@ dependencies {
     implementation 'org.mapstruct:mapstruct-processor'
     annotationProcessor 'org.mapstruct:mapstruct-processor'
 
-    compileOnly('org.apache.storm:storm-core:2.6.1'){
+    compileOnly('org.apache.storm:storm-core'){
         exclude(group: 'org.yaml', module: 'snakeyaml')
     }
     implementation('org.yaml:snakeyaml:2.2')
-    testImplementation('org.apache.storm:storm-core:2.6.1')
+    testImplementation('org.apache.storm:storm-core')
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'

--- a/src-java/flowhs-topology/flowhs-storm-topology/build.gradle
+++ b/src-java/flowhs-topology/flowhs-storm-topology/build.gradle
@@ -31,11 +31,11 @@ dependencies {
     testImplementation project(path: ':kilda-persistence-api', configuration: 'testArtifacts')
     testImplementation project(path: ':kilda-persistence-tinkerpop', configuration: 'testArtifacts')
 
-    compileOnly('org.apache.storm:storm-core:2.5.0') {
+    compileOnly('org.apache.storm:storm-core') {
         exclude(group: 'org.yaml', module: 'snakeyaml')
     }
     implementation('org.yaml:snakeyaml:2.2')
-    testImplementation('org.apache.storm:storm-core:2.5.0')
+    testImplementation('org.apache.storm:storm-core')
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'

--- a/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/build.gradle
+++ b/src-java/flowmonitoring-topology/flowmonitoring-storm-topology/build.gradle
@@ -27,11 +27,11 @@ dependencies {
     testImplementation project(path: ':kilda-persistence-tinkerpop', configuration: 'testArtifacts')
     testImplementation project(':kilda-utils:stubs')
 
-    compileOnly('org.apache.storm:storm-core:2.6.1'){
+    compileOnly('org.apache.storm:storm-core'){
         exclude(group: 'org.yaml', module: 'snakeyaml')
     }
     implementation('org.yaml:snakeyaml:2.2')
-    testImplementation('org.apache.storm:storm-core:2.6.1')
+    testImplementation('org.apache.storm:storm-core')
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'

--- a/src-java/history-topology/history-storm-topology/build.gradle
+++ b/src-java/history-topology/history-storm-topology/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     runtimeOnly project(':kilda-persistence-orientdb')
     runtimeOnly project(':kilda-persistence-hibernate')
 
-    compileOnly('org.apache.storm:storm-core:2.6.1'){
+    compileOnly('org.apache.storm:storm-core'){
         exclude(group: 'org.yaml', module: 'snakeyaml')
     }
     implementation('org.yaml:snakeyaml:2.2')

--- a/src-java/isllatency-topology/isllatency-storm-topology/build.gradle
+++ b/src-java/isllatency-topology/isllatency-storm-topology/build.gradle
@@ -22,11 +22,11 @@ dependencies {
     testImplementation project(path: ':kilda-persistence-tinkerpop', configuration: 'testArtifacts')
     implementation project(':blue-green')
 
-    compileOnly('org.apache.storm:storm-core:2.5.0'){
+    compileOnly('org.apache.storm:storm-core'){
         exclude(group: 'org.yaml', module: 'snakeyaml')
     }
     implementation('org.yaml:snakeyaml:2.2')
-    testImplementation('org.apache.storm:storm-core:2.5.0')
+    testImplementation('org.apache.storm:storm-core')
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'

--- a/src-java/nbworker-topology/nbworker-storm-topology/build.gradle
+++ b/src-java/nbworker-topology/nbworker-storm-topology/build.gradle
@@ -28,11 +28,11 @@ dependencies {
     testImplementation project(path: ':kilda-persistence-api', configuration: 'testArtifacts')
     testImplementation project(path: ':kilda-persistence-tinkerpop', configuration: 'testArtifacts')
 
-    compileOnly('org.apache.storm:storm-core:2.5.0'){
+    compileOnly('org.apache.storm:storm-core'){
         exclude(group: 'org.yaml', module: 'snakeyaml')
     }
     implementation('org.yaml:snakeyaml:2.2')
-    testImplementation('org.apache.storm:storm-core:2.5.0')
+    testImplementation('org.apache.storm:storm-core')
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'

--- a/src-java/network-topology/network-storm-topology/build.gradle
+++ b/src-java/network-topology/network-storm-topology/build.gradle
@@ -30,11 +30,11 @@ dependencies {
     testImplementation project(path: ':kilda-persistence-tinkerpop', configuration: 'testArtifacts')
     testImplementation project(':kilda-utils:stubs')
 
-    compileOnly('org.apache.storm:storm-core:2.6.1') {
+    compileOnly('org.apache.storm:storm-core') {
         exclude(group: 'org.yaml', module: 'snakeyaml')
     }
     implementation('org.yaml:snakeyaml:2.2')
-    testImplementation('org.apache.storm:storm-core:2.6.1')
+    testImplementation('org.apache.storm:storm-core')
 
     implementation 'org.mapstruct:mapstruct'
     implementation 'org.mapstruct:mapstruct-processor'

--- a/src-java/opentsdb-topology/opentsdb-storm-topology/build.gradle
+++ b/src-java/opentsdb-topology/opentsdb-storm-topology/build.gradle
@@ -23,11 +23,11 @@ dependencies {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
 
-    compileOnly('org.apache.storm:storm-core:2.6.1'){
+    compileOnly('org.apache.storm:storm-core'){
         exclude(group: 'org.yaml', module: 'snakeyaml')
     }
     implementation('org.yaml:snakeyaml:2.2')
-    testImplementation('org.apache.storm:storm-core:2.6.1') {
+    testImplementation('org.apache.storm:storm-core') {
         exclude group: 'org.slf4j', module: 'log4j-over-slf4j'
     }
 

--- a/src-java/ping-topology/ping-storm-topology/build.gradle
+++ b/src-java/ping-topology/ping-storm-topology/build.gradle
@@ -21,11 +21,11 @@ dependencies {
     aspect project(':kilda-persistence-api')
     testImplementation project(path: ':kilda-persistence-tinkerpop', configuration: 'testArtifacts')
 
-    compileOnly('org.apache.storm:storm-core:2.6.1'){
+    compileOnly('org.apache.storm:storm-core'){
         exclude(group: 'org.yaml', module: 'snakeyaml')
     }
     implementation('org.yaml:snakeyaml:2.2')
-    testImplementation('org.apache.storm:storm-core:2.6.1')
+    testImplementation('org.apache.storm:storm-core')
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'

--- a/src-java/portstate-topology/portstate-storm-topology/build.gradle
+++ b/src-java/portstate-topology/portstate-storm-topology/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     runtimeOnly project(':kilda-persistence-orientdb')
     runtimeOnly project(':kilda-persistence-hibernate')
 
-    compileOnly('org.apache.storm:storm-core:2.6.1'){
+    compileOnly('org.apache.storm:storm-core'){
         exclude(group: 'org.yaml', module: 'snakeyaml')
     }
     implementation('org.yaml:snakeyaml:2.2')

--- a/src-java/reroute-topology/reroute-storm-topology/build.gradle
+++ b/src-java/reroute-topology/reroute-storm-topology/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     runtimeOnly project(':kilda-persistence-orientdb')
     runtimeOnly project(':kilda-persistence-hibernate')
 
-    compileOnly('org.apache.storm:storm-core:2.6.1'){
+    compileOnly('org.apache.storm:storm-core'){
         exclude(group: 'org.yaml', module: 'snakeyaml')
     }
     implementation('org.yaml:snakeyaml:2.2')

--- a/src-java/server42/server42-control-storm-topology/build.gradle
+++ b/src-java/server42/server42-control-storm-topology/build.gradle
@@ -22,11 +22,11 @@ dependencies {
     aspect project(':kilda-persistence-api')
     testImplementation project(path: ':kilda-persistence-tinkerpop', configuration: 'testArtifacts')
 
-    compileOnly('org.apache.storm:storm-core:2.5.0'){
+    compileOnly('org.apache.storm:storm-core'){
         exclude(group: 'org.yaml', module: 'snakeyaml')
     }
     implementation('org.yaml:snakeyaml:2.2')
-    testImplementation('org.apache.storm:storm-core:2.5.0')
+    testImplementation('org.apache.storm:storm-core')
 
     implementation 'org.mapstruct:mapstruct'
     implementation 'org.mapstruct:mapstruct-processor'

--- a/src-java/stats-topology/stats-storm-topology/build.gradle
+++ b/src-java/stats-topology/stats-storm-topology/build.gradle
@@ -23,11 +23,11 @@ dependencies {
     aspect project(':kilda-persistence-api')
     testImplementation project(path: ':kilda-persistence-tinkerpop', configuration: 'testArtifacts')
 
-    compileOnly('org.apache.storm:storm-core:2.5.0'){
+    compileOnly('org.apache.storm:storm-core'){
         exclude(group: 'org.yaml', module: 'snakeyaml')
     }
     implementation('org.yaml:snakeyaml:2.2')
-    testImplementation('org.apache.storm:storm-core:2.5.0')
+    testImplementation('org.apache.storm:storm-core')
 
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 

--- a/src-java/swmanager-topology/swmanager-storm-topology/build.gradle
+++ b/src-java/swmanager-topology/swmanager-storm-topology/build.gradle
@@ -25,11 +25,11 @@ dependencies {
     implementation project(':rule-manager-api')
     implementation project(':rule-manager-implementation')
 
-    compileOnly('org.apache.storm:storm-core:2.5.0'){
+    compileOnly('org.apache.storm:storm-core'){
         exclude(group: 'org.yaml', module: 'snakeyaml')
     }
     implementation('org.yaml:snakeyaml:2.2')
-    testImplementation('org.apache.storm:storm-core:2.5.0')
+    testImplementation('org.apache.storm:storm-core')
 
     implementation 'org.apache.commons:commons-lang3'
 

--- a/src-java/testing/test-library/build.gradle
+++ b/src-java/testing/test-library/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 
     implementation 'org.springframework:spring-aspects'
     implementation('com.fasterxml.jackson.core:jackson-databind')
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'jakarta.annotation:jakarta.annotation-api'
 


### PR DESCRIPTION
This PR adds a gradle constraint, so that we have a storm version in one place. It should be easier to update it in the future. Also I added some tweaks that help to remove high CPU utilization. This is not the final version, but this should help us to proceed and test. Now the CPU load has intervals of peeks to 100%, but at least it is not 100% all the time.