### PR TITLE
[Java 8-17] Add JMX monitoring settings. Adjust Storm settings so that it doesn't consume 100% of all cores.

### DIFF
--- a/confd/templates/docker-compose/docker-compose.tmpl
+++ b/confd/templates/docker-compose/docker-compose.tmpl
@@ -296,6 +296,9 @@ services:
     container_name: storm-nimbus
     hostname: nimbus.pendev
     image: kilda/storm:latest
+    ports:
+      - "9446:9446"
+      - "9447:9447"
     command: /app/wait-for-it.sh -t 120 -h zookeeper.pendev -p 2181 -- /opt/storm/bin/storm nimbus
     depends_on:
       zookeeper:
@@ -347,6 +350,8 @@ services:
   storm-supervisor:
     container_name: storm-supervisor
     hostname: storm-supervisor.pendev
+    ports:
+      - "9448:9448"
     image: kilda/storm:latest
     command: /app/wait-for-it.sh -t 120 -h zookeeper.pendev -p 2181 -- /opt/storm/bin/storm supervisor
     depends_on:
@@ -471,6 +476,7 @@ services:
       dockerfile: northbound/Dockerfile
     ports:
       - "8080:8080"
+      - "9445:9445"
     environment:
       REST_USERNAME: 'kilda'
       REST_PASSWORD: 'kilda'

--- a/confd/templates/storm/storm.yaml.tmpl
+++ b/confd/templates/storm/storm.yaml.tmpl
@@ -68,26 +68,49 @@ supervisor.slots.ports:
 #     argument:
 #       - endpoint: "metrics-collector.mycompany.org"
 
+## Enabling Storm monitoring via JMX
+# These options enable remote JMX. Use a client (such as VisualVM or JConsole) to connect and gather JVM data.
+# Since Storm is executed inside a docker container, the ports specified here must be forwarded and appropriate rules created for the host's firewall.
+# Don't forget to comment out default settings.
+#nimbus.childopts: "-Xmx4g -Djava.net.preferIPv4Stack=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9446 -Djava.rmi.server.hostname=172.19.114.89 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+#worker.childopts: "-Xmx512m -XX:+UseG1GC -Djava.net.preferIPv4Stack=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9447 -Djava.rmi.server.hostname=172.19.114.89 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+#supervisor.childopts: "-Xmx4g -Djava.net.preferIPv4Stack=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9448 -Djava.rmi.server.hostname=172.19.114.89 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+
+## Memory settings
+nimbus.childopts: "-Xmx4g -Djava.net.preferIPv4Stack=true"
+worker.childopts: "-Xmx512m -XX:+UseG1GC -Djava.net.preferIPv4Stack=true"
+supervisor.childopts: "-Xmx4g -Djava.net.preferIPv4Stack=true"
+ui.childopts: "-Xmx512m"
+
 nimbus.task.timeout.secs: 240
 nimbus.thrift.max_buffer_size: 20480000
-nimbus.childopts: "-Xmx2048m -Djava.net.preferIPv4Stack=true"
 
-worker.childopts: "-Xmx2048m -XX:+UseG1GC -Djava.net.preferIPv4Stack=true"
-
-supervisor.childopts: "-Xmx2048m -Djava.net.preferIPv4Stack=true"
-
-ui.childopts: "-Xmx512m"
 
 #Topologies settings
 topology.testing.always.try.serialize: true
 topology.skip.missing.kryo.registrations: true
 topology.fall.back.on.java.serialization: true
 
-
-topology.max.spout.pending: 200
+topology.max.spout.pending: 1
 topology.message.timeout.secs: 300
 
-topology.spout.wait.strategy: org.apache.storm.policy.WaitStrategy
-topology.backpressure.wait.strategy: org.apache.storm.policy.WaitStrategy
-topology.bolt.wait.strategy: org.apache.storm.policy.WaitStrategy
-topology.stats.sample.rate: 0.00001
+topology.executor.receive.buffer.size: 2
+topology.transfer.buffer.size: 2
+
+topology.spout.wait.strategy: org.apache.storm.policy.WaitStrategyProgressive
+topology.backpressure.wait.strategy: org.apache.storm.policy.WaitStrategyProgressive
+topology.bolt.wait.strategy: org.apache.storm.policy.WaitStrategyProgressive
+
+topology.spout.wait.progressive.level1.count: 1
+topology.spout.wait.progressive.level2.count: 1
+topology.spout.wait.progressive.level3.sleep.millis: 5
+
+topology.bolt.wait.progressive.level1.count: 1
+topology.bolt.wait.progressive.level2.count: 1
+topology.bolt.wait.progressive.level3.sleep.millis: 5
+
+topology.backpressure.wait.progressive.level1.count: 1
+topology.backpressure.wait.progressive.level2.count: 1
+topology.backpressure.wait.progressive.level3.sleep.millis: 5
+
+topology.stats.sample.rate: 0.0001

--- a/docker/northbound/Dockerfile
+++ b/docker/northbound/Dockerfile
@@ -18,4 +18,10 @@ FROM ${base_image}
 
 ADD BUILD/northbound/libs/northbound.jar /app/
 WORKDIR /app
+
+# This is an example of a command that starts Northbound with JMX enabled. You can connect to the specified IP and port
+# with visualVM or other tool to get runtime information.
+#CMD ["java", "-Dcom.sun.management.jmxremote", "-Dcom.sun.management.jmxremote.rmi.port=9445", "-Dcom.sun.management.jmxremote.port=9445", "-Djava.rmi.server.hostname=172.19.114.89", "-Dcom.sun.management.jmxremote.local.only=false", "-Dcom.sun.management.jmxremote.ssl=false", "-Dcom.sun.management.jmxremote.authenticate=false", "-XX:+PrintFlagsFinal", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseContainerSupport", "-jar", "northbound.jar"]
+#EXPOSE 9445
+
 CMD ["java", "-XX:+PrintFlagsFinal", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseContainerSupport", "-jar", "northbound.jar"]

--- a/docker/storm/Dockerfile
+++ b/docker/storm/Dockerfile
@@ -39,3 +39,6 @@ COPY storm.yaml /opt/storm/conf/storm.yaml
 COPY log4j2 /opt/storm/log4j2
 COPY simple-storm-supervisor-healthcheck.sh /simple-storm-supervisor-healthcheck.sh
 COPY simple-storm-ui-healthcheck.sh /simple-storm-ui-healthcheck.sh
+
+# Expose ports for JMX when it is enabled in storm.yaml
+#EXPOSE 9446 9447 9448

--- a/docs/design/monitoring/jvm-monitoring.md
+++ b/docs/design/monitoring/jvm-monitoring.md
@@ -1,0 +1,39 @@
+# JVM monitoring
+This document describes how to enable monitoring for OpenKilda to get runtime information.
+
+## Northbound
+To enable JMX for northbound, start NB with the following modifications to northbound dockerfile:
+
+```dockerfile
+CMD ["java", "-Dcom.sun.management.jmxremote", "-Dcom.sun.management.jmxremote.rmi.port=9445", "-Dcom.sun.management.jmxremote.port=9445", "-Djava.rmi.server.hostname=172.19.114.89", "-Dcom.sun.management.jmxremote.local.only=false", "-Dcom.sun.management.jmxremote.ssl=false", "-Dcom.sun.management.jmxremote.authenticate=false", "-XX:+PrintFlagsFinal", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseContainerSupport", "-jar", "northbound.jar"]
+EXPOSE 9445
+```
+
+Then, once NB is started, you can connect JConsole, VisualVM, or other tools to gather runtime information.
+In VisualVM, you can simply specify the hostname or IP and port in remote connections. Or use the following connection:
+```
+service:jmx:rmi:///jndi/rmi://your_host_with_running_open_kilda:9445/jmxrmi
+```
+It is required to forward ports from the container. See the Port forwarding section below.
+
+## Storm
+According to the Storm documentation you can enable JMX by specifying additional settings in storm.yaml:
+```yaml
+nimbus.childopts: "-Xmx4g -Djava.net.preferIPv4Stack=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9446 -Djava.rmi.server.hostname=172.19.114.89 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+worker.childopts: "-Xmx512m -XX:+UseG1GC -Djava.net.preferIPv4Stack=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9447 -Djava.rmi.server.hostname=172.19.114.89 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+supervisor.childopts: "-Xmx4g -Djava.net.preferIPv4Stack=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9448 -Djava.rmi.server.hostname=172.19.114.89 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
+
+```
+
+IP address 172.19.114.89 in this example is the external IP, which you will use to connect to JMX.
+
+# Port forwarding
+It is required to forward the ports used by JMX from the container to the host. This is done in docker-compose.tmpl for 
+the appropriate containers in the following manner: 
+```yaml
+  storm-nimbus:
+    container_name: storm-nimbus    
+    ports:
+      - "9446:9446"
+      - "9447:9447"
+```


### PR DESCRIPTION
This PR introduces JMX remote monitoring settings. It also adjust settings for Storm so that it doesn't utilize so many CPU resources.