### PR TITLE
Improvement/migration java 8 17 generate topology fix 

### DIFF
--- a/src-java/kilda-persistence-hibernate/build.gradle
+++ b/src-java/kilda-persistence-hibernate/build.gradle
@@ -26,7 +26,7 @@ dependencies {
         exclude module: 'jaxb-runtime'
     }
     implementation 'com.fasterxml.jackson.module:jackson-module-jaxb-annotations'
-    implementation('com.vladmihalcea:hibernate-types-52:2.20.0') {
+    implementation('com.vladmihalcea:hibernate-types-60:2.21.1') {
         exclude group: 'com.fasterxml.jackson.module', module: 'jackson-module-jaxb-annotations'
         // To avoid collision between javax and jakarta implementations.
         exclude module: 'jaxb-api'

--- a/src-java/kilda-persistence-hibernate/src/main/java/org/openkilda/persistence/hibernate/entities/EntityBase.java
+++ b/src-java/kilda-persistence-hibernate/src/main/java/org/openkilda/persistence/hibernate/entities/EntityBase.java
@@ -30,7 +30,7 @@ import java.time.Instant;
 public class EntityBase {
     @Getter
     @CreationTimestamp
-    @Column(name = "time_create")
+    @Column(name = "time_create", nullable = false, updatable = false)
     protected Instant timeCreated;
 
     @Getter

--- a/src-java/kilda-persistence-hibernate/src/main/java/org/openkilda/persistence/hibernate/entities/history/HibernatePortEvent.java
+++ b/src-java/kilda-persistence-hibernate/src/main/java/org/openkilda/persistence/hibernate/entities/history/HibernatePortEvent.java
@@ -25,6 +25,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -32,7 +33,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.Delegate;
-import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
@@ -45,12 +45,8 @@ import java.util.UUID;
 @Table(name = "port_event")
 public class HibernatePortEvent extends EntityBase implements PortEventData {
     @Id
-    @GeneratedValue(generator = "UUID")
-    @GenericGenerator(
-            name = "UUID",
-            type = org.hibernate.id.uuid.UuidGenerator.class
-    )
-    @JdbcTypeCode(SqlTypes.UUID)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @JdbcTypeCode(SqlTypes.VARCHAR)
     @Column(name = "id", columnDefinition = "string(36)")
     private UUID recordId;
 

--- a/src-java/server42/server42-control/build.gradle
+++ b/src-java/server42/server42-control/build.gradle
@@ -5,6 +5,9 @@ plugins {
 configurations {
     // This conflicts with spring-boot-starter-log4j2
     implementation.exclude module: 'spring-boot-starter-logging'
+    //LoggerFactory is not a Logback LoggerContext but Logback is on the classpath. Either remove Logback or the competing implementation
+    implementation.exclude group: 'ch.qos.logback', module: 'logback-classic'
+    implementation.exclude group: 'ch.qos.logback', module: 'logback-core'
 }
 
 description = 'server42-control'

--- a/src-java/testing/functional-tests/build.gradle
+++ b/src-java/testing/functional-tests/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation('com.athaydes:spock-reports:2.1.1-groovy-3.0') { transitive = false }
     implementation 'net.jodah:failsafe'
     implementation 'org.hamcrest:hamcrest-all:1.3'
-    implementation ('org.apache.zookeeper:zookeeper:3.8.1') {
+    implementation ('org.apache.zookeeper:zookeeper:3.8.3') {
         exclude group: 'org.slf4j', module: 'slf4j-log4j12'
         exclude group: 'log4j', module: 'log4j'
     }


### PR DESCRIPTION
update deps: com.vladmihalcea:hibernate-types
52:2.20.0 => 60:2.21.1

*UuidGenerator java.lang.NoSuchMethodException fixes for HibernatePortEvent entity.

*Fixed the problem for the create query for HibernatePortEvent entity with incorrect string value for the column Id(uuid format) of HibernatePortEvent entity.

*Fixed the problem with Hibernate update query for HibernatePortEvent entity ...could not execute statement ... Column 'time_create' cannot be null java.sql.SQLIntegrityConstraintViolationException.

* Above fixes fixed the GenerateTopologyConfig functional-test run.