### PR TITLE
Remove redundant dependencies from shadowJar task and classpath.

### DIFF
--- a/src-java/base-topology/base-storm-topology/build.gradle
+++ b/src-java/base-topology/base-storm-topology/build.gradle
@@ -40,17 +40,12 @@ dependencies {
         exclude(group: "org.yaml", module: "snakeyaml")
     }
     implementation("org.yaml:snakeyaml:2.2")
-    testImplementation("org.apache.storm:storm-core") {
-        exclude group: "org.slf4j", module: "log4j-over-slf4j"
-    }
+    testImplementation("org.apache.storm:storm-core")
 
     implementation("org.rocksdb:rocksdbjni:8.10.0") { because("required for Storm integration tests") }
     implementation("org.apache.storm:flux-core:2.6.1")
 
-    api("org.squirrelframework:squirrel-foundation") {
-        exclude group: "org.slf4j", module: "slf4j-log4j12"
-        exclude group: "log4j", module: "log4j"
-    }
+    api("org.squirrelframework:squirrel-foundation")
 
     api("com.google.guava:guava")
     api("org.apache.commons:commons-lang3")
@@ -70,14 +65,8 @@ dependencies {
     annotationProcessor("org.mapstruct:mapstruct-processor")
     testAnnotationProcessor("org.mapstruct:mapstruct-processor")
 
-    api("org.apache.kafka:kafka-clients:3.6.1") {
-        exclude group: "org.slf4j", module: "slf4j-log4j12"
-        exclude group: "log4j", module: "log4j"
-    }
-    api("org.apache.kafka:kafka_2.12:3.6.1") {
-        exclude group: "org.slf4j", module: "slf4j-log4j12"
-        exclude group: "log4j", module: "log4j"
-    }
+    api("org.apache.kafka:kafka-clients:3.6.1")
+    api("org.apache.kafka:kafka_2.12:3.6.1")
 
     api("io.micrometer:micrometer-core:1.10.5")
 
@@ -110,6 +99,18 @@ sourceSets {
 configurations {
     testArtifacts
     releaseArtifacts
+}
+
+/**
+ * The logger implementation is already provided in the Storm cluster (in the Storm jar). Any other logger dependencies
+ * declared in Storm topology modules are duplicates and needs to be excluded. If required add them as compileOnly.
+ */
+configurations.configureEach {
+//    exclude group: "org.slf4j", module: "org.slf4j:slf4j-api"
+//    exclude group: "org.slf4j", module: "slf4j-api"
+//    exclude group: "org.slf4j", module: "log4j-over-slf4j"
+    exclude group: "org.slf4j", module: "slf4j-log4j12"
+//    exclude group: "log4j", module: "log4j"
 }
 
 tasks.register("testJar", Jar) {

--- a/src-java/base-topology/base-storm-topology/build.gradle
+++ b/src-java/base-topology/base-storm-topology/build.gradle
@@ -106,11 +106,7 @@ configurations {
  * declared in Storm topology modules are duplicates and needs to be excluded. If required add them as compileOnly.
  */
 configurations.configureEach {
-//    exclude group: "org.slf4j", module: "org.slf4j:slf4j-api"
-//    exclude group: "org.slf4j", module: "slf4j-api"
-//    exclude group: "org.slf4j", module: "log4j-over-slf4j"
     exclude group: "org.slf4j", module: "slf4j-log4j12"
-//    exclude group: "log4j", module: "log4j"
 }
 
 tasks.register("testJar", Jar) {

--- a/src-java/build.gradle
+++ b/src-java/build.gradle
@@ -221,27 +221,15 @@ subprojects {
 
     tasks.withType(ShadowJar).tap {
         configureEach {
-            // The step detects a conflict in dependency jars' content and fails the build if found.
-            doFirst {
-                Map<String, String> classes = new HashMap<>()
-                getIncludedDependencies().each { jar ->
-                    if (jar.isFile()) {
-                        JarFile jf = new JarFile(jar)
-                        jf.entries().each { file ->
-                            // TODO: it's good to reuse shadowJar plugin's patterns
-                            if (file.name.endsWith('.class') && !file.name.endsWith('module-info.class')) {
-                                if (classes.containsKey(file.name)) {
-                                    // TODO this prevents tasks to complete, however dependency resolution seems working out the conflicts fine
-                                    // TODO investigate whether it could be replaced with resolutionStrategy.failOnVersionConflict()
-                                    // TODO or some other better technology
-//                                throw new GradleException("shadowJar failure: ${file.name} conflicts in jars:${classes.get(file.name)} and ${jar}")
-                                }
-                                classes.put(file.name, jar)
-                            }
-                        }
-                        jf.close()
-                    }
-                }
+            /**
+             * Topology Jars that are uploaded into a Storm cluster shouldn't have duplicate classes that are already
+             * provided in the cluster (via Storm-....jar).
+             */
+            dependencies {
+                exclude(dependency('org.slf4j:slf4j-api'))
+                exclude(dependency('org.slf4j:slf4j-api'))
+                exclude(dependency('ch.qos.logback:logback-classic'))
+                exclude(dependency('org.apache.logging.log4j:log4j-slf4j-impl'))
             }
         }
     }


### PR DESCRIPTION
This change removes the logger dependencies from Storm topology modules. After this change there is no longer a conflict of the logger implementation when the topology jar is uploaded to the Storm cluster.

There is still a need to shrink the jar, but this is a more tricky task, because some dependencies are needed at runtime only. I'll create a separate task for it.