### PR TITLE
Deprecated configuration property for prometheus metrics fix

### DIFF
--- a/confd/templates/server42/server42-control-storm-stub.application.properties.tmpl
+++ b/confd/templates/server42/server42-control-storm-stub.application.properties.tmpl
@@ -17,7 +17,7 @@ spring.devtools.add-properties=false
 management.endpoint.metrics.enabled=true
 management.endpoints.web.exposure.include=*
 management.endpoint.prometheus.enabled=true
-management.metrics.export.prometheus.enabled=true
+management.prometheus.metrics.export.enabled=true
 # Kafka
 spring.kafka.consumer.group-id={{ getv "/kilda_server42_control_storm_stub_kafka_group_id" }}
 spring.kafka.consumer.auto-offset-reset=latest

--- a/confd/templates/server42/server42-control.application.properties.tmpl
+++ b/confd/templates/server42/server42-control.application.properties.tmpl
@@ -29,7 +29,7 @@ spring.devtools.add-properties=false
 management.endpoint.metrics.enabled=true
 management.endpoints.web.exposure.include=*
 management.endpoint.prometheus.enabled=true
-management.metrics.export.prometheus.enabled=true
+management.prometheus.metrics.export.enabled=true
 # Kafka
 spring.kafka.consumer.group-id={{ getv "/kilda_server42_control_kafka_group_id" }}
 spring.kafka.consumer.auto-offset-reset=latest

--- a/confd/templates/server42/server42-stats.application.properties.tmpl
+++ b/confd/templates/server42/server42-stats.application.properties.tmpl
@@ -19,7 +19,7 @@ spring.devtools.add-properties=false
 management.endpoint.metrics.enabled=true
 management.endpoints.web.exposure.include=*
 management.endpoint.prometheus.enabled=true
-management.metrics.export.prometheus.enabled=true
+management.prometheus.metrics.export.enabled=true
 
 # Kafka
 spring.kafka.consumer.group-id={{ getv "/kilda_server42_stats_kafka_group_id" }}

--- a/src-java/server42/server42-control/src/test/resources/test.properties
+++ b/src-java/server42/server42-control/src/test/resources/test.properties
@@ -27,7 +27,7 @@ spring.devtools.add-properties=false
 management.endpoint.metrics.enabled=true
 management.endpoints.web.exposure.include=*
 management.endpoint.prometheus.enabled=true
-management.metrics.export.prometheus.enabled=true
+management.prometheus.metrics.export.enabled=true
 # Kafka
 
 #spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration

--- a/src-java/server42/server42-stats/src/test/resources/test.properties
+++ b/src-java/server42/server42-stats/src/test/resources/test.properties
@@ -17,7 +17,7 @@ spring.devtools.add-properties=false
 management.endpoint.metrics.enabled=true
 management.endpoints.web.exposure.include=*
 management.endpoint.prometheus.enabled=true
-management.metrics.export.prometheus.enabled=true
+management.prometheus.metrics.export.enabled=true
 # Kafka
 spring.kafka.consumer.group-id=server42-stats
 spring.kafka.consumer.auto-offset-reset=latest


### PR DESCRIPTION
Deprecated configuration property 'management.metrics.export.prometheus.enabled' has been replaced with 'management.metrics.export.prometheus.enabled'