### PR TITLE
getFlowPath fix for func-tests

### DIFF
--- a/src-gui/src/main/java/org/openkilda/constants/IConstants.java
+++ b/src-gui/src/main/java/org/openkilda/constants/IConstants.java
@@ -171,15 +171,6 @@ public abstract class IConstants {
                 + "/switches/{switch_id}/lags/{logical_port_number}";
     }
 
-    public static final class OpenTsDbUrl {
-
-        private OpenTsDbUrl() {
-
-        }
-
-        public static final String OPEN_TSDB_QUERY = "/api/query/";
-    }
-
 
     public static final class VictoriaMetricsUrl {
 

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundServiceImpl.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/service/northbound/NorthboundServiceImpl.java
@@ -182,7 +182,7 @@ public class NorthboundServiceImpl implements NorthboundService {
 
     @Override
     public FlowPathPayload getFlowPath(String flowId) {
-        return restTemplate.exchange("/api/v1/flows/{flow_id}/path/", HttpMethod.GET,
+        return restTemplate.exchange("/api/v1/flows/{flow_id}/path", HttpMethod.GET,
                 new HttpEntity(buildHeadersWithCorrelationId()), FlowPathPayload.class, flowId).getBody();
     }
 


### PR DESCRIPTION
This bugifx remove the trailing slash for the functional tests northbound client. 
It fixes the problem with the request for the flowPath by flowId. 

apart from that there are another problems appeared, that were not reachable before this fix.