### PR TITLE
[Java 8-17] Remove deprecated initMocks. Rename our internal MockitoExtension.

### DIFF
--- a/src-gui/src/test/java/org/openkilda/controller/FlowControllerTest.java
+++ b/src-gui/src/test/java/org/openkilda/controller/FlowControllerTest.java
@@ -25,7 +25,7 @@ import org.openkilda.integration.model.response.FlowPayload;
 import org.openkilda.model.FlowHistory;
 import org.openkilda.model.FlowInfo;
 import org.openkilda.service.FlowService;
-import org.openkilda.test.MockitoExtension;
+import org.openkilda.test.CustomMockitoExtension;
 import org.openkilda.util.TestFlowMock;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -42,7 +41,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.util.ArrayList;
 import java.util.List;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith(CustomMockitoExtension.class)
 public class FlowControllerTest {
 
     @SuppressWarnings("unused")
@@ -56,7 +55,6 @@ public class FlowControllerTest {
 
     @BeforeEach
     public void init() {
-        MockitoAnnotations.initMocks(this);
         mockMvc = MockMvcBuilders.standaloneSetup(flowController).build();
     }
 

--- a/src-gui/src/test/java/org/openkilda/controller/StatsControllerTest.java
+++ b/src-gui/src/test/java/org/openkilda/controller/StatsControllerTest.java
@@ -21,7 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.openkilda.model.VictoriaStatsReq;
 import org.openkilda.service.StatsService;
-import org.openkilda.test.MockitoExtension;
+import org.openkilda.test.CustomMockitoExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -38,7 +37,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.util.Collections;
 
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith(CustomMockitoExtension.class)
 public class StatsControllerTest {
 
     private MockMvc mockMvc;
@@ -51,8 +50,6 @@ public class StatsControllerTest {
 
     @BeforeEach
     public void init() {
-        MockitoAnnotations.initMocks(this);
-
         mockMvc = MockMvcBuilders.standaloneSetup(statsController).build();
     }
 

--- a/src-gui/src/test/java/org/openkilda/controller/SwitchControllerTest.java
+++ b/src-gui/src/test/java/org/openkilda/controller/SwitchControllerTest.java
@@ -33,7 +33,7 @@ import org.openkilda.model.LinkUnderMaintenanceDto;
 import org.openkilda.model.SwitchInfo;
 import org.openkilda.model.SwitchProperty;
 import org.openkilda.service.SwitchService;
-import org.openkilda.test.MockitoExtension;
+import org.openkilda.test.CustomMockitoExtension;
 import org.openkilda.util.TestFlowMock;
 import org.openkilda.util.TestIslMock;
 import org.openkilda.util.TestSwitchMock;
@@ -45,8 +45,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -58,13 +56,10 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.util.ArrayList;
 import java.util.List;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith(CustomMockitoExtension.class)
 public class SwitchControllerTest {
 
     private MockMvc mockMvc;
-
-    @Mock
-    private ApplicationContext context;
 
     @Mock
     private SwitchService serviceSwitch;
@@ -83,7 +78,6 @@ public class SwitchControllerTest {
 
     @BeforeEach
     public void init() {
-        MockitoAnnotations.initMocks(this);
         mockMvc = MockMvcBuilders.standaloneSetup(switchController).build();
         RequestContext requestContext = new RequestContext();
         requestContext.setUserId(TestIslMock.USER_ID);

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/AvailableNetworkFactoryTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/AvailableNetworkFactoryTest.java
@@ -17,6 +17,7 @@ package org.openkilda.pce;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -41,14 +42,16 @@ import org.openkilda.persistence.repositories.RepositoryFactory;
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+@ExtendWith(MockitoExtension.class)
 public class AvailableNetworkFactoryTest {
 
     public static final SwitchId SWITCH_ID_1 = new SwitchId(1);
@@ -84,11 +87,8 @@ public class AvailableNetworkFactoryTest {
 
     @BeforeEach
     public void setup() {
-        MockitoAnnotations.initMocks(this);
-
         when(repositoryFactory.createIslRepository()).thenReturn(islRepository);
         when(repositoryFactory.createFlowPathRepository()).thenReturn(flowPathRepository);
-        when(repositoryFactory.createHaFlowPathRepository()).thenReturn(haFlowPathRepository);
 
         availableNetworkFactory = new AvailableNetworkFactory(config, repositoryFactory);
     }
@@ -281,7 +281,6 @@ public class AvailableNetworkFactoryTest {
         when(islRepository.findSymmetricActiveByBandwidthAndEncapsulationType(flow1.getBandwidth(),
                 flow1.getEncapsulationType()))
                 .thenReturn(Collections.singletonList(isl1));
-        when(flowPathRepository.findById(PATH_ID_1)).thenReturn(Optional.of(flowPath1));
         when(flowPathRepository.findById(PATH_ID_2)).thenReturn(Optional.of(flowPath2));
         when(flowPathRepository.findById(PATH_ID_3)).thenReturn(Optional.of(flowPath3));
 
@@ -356,14 +355,15 @@ public class AvailableNetworkFactoryTest {
         when(islRepository.findSymmetricActiveByBandwidthAndEncapsulationType(flow1.getBandwidth(),
                 flow1.getEncapsulationType()))
                 .thenReturn(Collections.singletonList(isl1));
-        when(flowPathRepository.findById(PATH_ID_1)).thenReturn(Optional.of(flowPath1));
-        when(flowPathRepository.findById(PATH_ID_2)).thenReturn(Optional.of(flowPath2));
-        when(flowPathRepository.findById(PATH_ID_3)).thenReturn(Optional.of(flowPath3));
+        // these lenient mocks are actually used inside assertAvailableNetworkIsCorrect
+        lenient().when(flowPathRepository.findById(PATH_ID_1)).thenReturn(Optional.of(flowPath1));
+        lenient().when(flowPathRepository.findById(PATH_ID_2)).thenReturn(Optional.of(flowPath2));
+        lenient().when(flowPathRepository.findById(PATH_ID_3)).thenReturn(Optional.of(flowPath3));
 
 
-        when(flowPathRepository.findPathIdsBySharedBandwidthGroupId(yFlowId))
+        lenient().when(flowPathRepository.findPathIdsBySharedBandwidthGroupId(yFlowId))
                 .thenReturn(Collections.singleton(PATH_ID_2));
-        when(islRepository.findActiveByPathAndBandwidthAndEncapsulationType(
+        lenient().when(islRepository.findActiveByPathAndBandwidthAndEncapsulationType(
                 PATH_ID_2, flow2.getBandwidth(), flow2.getEncapsulationType()))
                 .thenReturn(Collections.singletonList(isl2));
         when(islRepository.findActiveByPathAndBandwidthAndEncapsulationType(
@@ -402,15 +402,15 @@ public class AvailableNetworkFactoryTest {
 
     private static IslImmutableView getIslView(Switch srcSwitch, int srcPort, Switch dstSwitch, int dstPort) {
         IslImmutableView isl = mock(IslImmutableView.class);
-        when(isl.getSrcSwitchId()).thenReturn(srcSwitch.getSwitchId());
-        when(isl.getSrcPort()).thenReturn(srcPort);
-        when(isl.getDestSwitchId()).thenReturn(dstSwitch.getSwitchId());
-        when(isl.getDestPort()).thenReturn(dstPort);
-        when(isl.getCost()).thenReturn(10);
-        when(isl.getLatency()).thenReturn(33L);
-        when(isl.getAvailableBandwidth()).thenReturn(AVAILABLE_BANDWIDTH);
-        when(isl.isUnderMaintenance()).thenReturn(false);
-        when(isl.isUnstable()).thenReturn(false);
+        lenient().when(isl.getSrcSwitchId()).thenReturn(srcSwitch.getSwitchId());
+        lenient().when(isl.getSrcPort()).thenReturn(srcPort);
+        lenient().when(isl.getDestSwitchId()).thenReturn(dstSwitch.getSwitchId());
+        lenient().when(isl.getDestPort()).thenReturn(dstPort);
+        lenient().when(isl.getCost()).thenReturn(10);
+        lenient().when(isl.getLatency()).thenReturn(33L);
+        lenient().when(isl.getAvailableBandwidth()).thenReturn(AVAILABLE_BANDWIDTH);
+        lenient().when(isl.isUnderMaintenance()).thenReturn(false);
+        lenient().when(isl.isUnstable()).thenReturn(false);
         return isl;
     }
 

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/AvailableNetworkFactoryTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/AvailableNetworkFactoryTest.java
@@ -402,6 +402,7 @@ public class AvailableNetworkFactoryTest {
 
     private static IslImmutableView getIslView(Switch srcSwitch, int srcPort, Switch dstSwitch, int dstPort) {
         IslImmutableView isl = mock(IslImmutableView.class);
+        // These lenient mocks are required for tests
         lenient().when(isl.getSrcSwitchId()).thenReturn(srcSwitch.getSwitchId());
         lenient().when(isl.getSrcPort()).thenReturn(srcPort);
         lenient().when(isl.getDestSwitchId()).thenReturn(dstSwitch.getSwitchId());

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/DiversityPathFinderTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/DiversityPathFinderTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -50,16 +51,18 @@ import org.openkilda.persistence.repositories.RepositoryFactory;
 
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+@ExtendWith(MockitoExtension.class)
 public class DiversityPathFinderTest {
     public static final SwitchId SWITCH_ID_1 = new SwitchId(1);
     public static final SwitchId SWITCH_ID_2 = new SwitchId(2);
@@ -91,17 +94,16 @@ public class DiversityPathFinderTest {
 
     @BeforeEach
     public void setup() {
-        MockitoAnnotations.initMocks(this);
+        // These lenient mock are used in a parametrized test in different combinations.
+        lenient().when(config.getDiversitySwitchLatency()).thenReturn(10000L);
+        lenient().when(config.getDiversityIslLatency()).thenReturn(10000L);
+        lenient().when(config.getDiversityIslCost()).thenReturn(10000);
+        lenient().when(config.getDiversitySwitchCost()).thenReturn(10000);
+        lenient().when(config.getDiversityPopIslCost()).thenReturn(10000);
 
-        when(config.getDiversitySwitchLatency()).thenReturn(10000L);
-        when(config.getDiversityIslLatency()).thenReturn(10000L);
-        when(config.getDiversityIslCost()).thenReturn(10000);
-        when(config.getDiversitySwitchCost()).thenReturn(10000);
-        when(config.getDiversityPopIslCost()).thenReturn(10000);
-
-        when(repositoryFactory.createIslRepository()).thenReturn(islRepository);
-        when(repositoryFactory.createFlowPathRepository()).thenReturn(flowPathRepository);
-        when(repositoryFactory.createHaFlowPathRepository()).thenReturn(haFlowPathRepository);
+        lenient().when(repositoryFactory.createIslRepository()).thenReturn(islRepository);
+        lenient().when(repositoryFactory.createFlowPathRepository()).thenReturn(flowPathRepository);
+        lenient().when(repositoryFactory.createHaFlowPathRepository()).thenReturn(haFlowPathRepository);
 
         availableNetworkFactory = new AvailableNetworkFactory(config, repositoryFactory);
     }

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/DiversityPathFinderTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/DiversityPathFinderTest.java
@@ -94,7 +94,7 @@ public class DiversityPathFinderTest {
 
     @BeforeEach
     public void setup() {
-        // These lenient mock are used in a parametrized test in different combinations.
+        // These lenient mocks are used in a parametrized test in different combinations.
         lenient().when(config.getDiversitySwitchLatency()).thenReturn(10000L);
         lenient().when(config.getDiversityIslLatency()).thenReturn(10000L);
         lenient().when(config.getDiversityIslCost()).thenReturn(10000);

--- a/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/ProtectedPathFinderTest.java
+++ b/src-java/kilda-pce/src/test/java/org/openkilda/pce/finder/ProtectedPathFinderTest.java
@@ -48,7 +48,6 @@ import org.openkilda.pce.exception.UnroutableFlowException;
 import org.openkilda.pce.impl.AvailableNetwork;
 import org.openkilda.pce.impl.InMemoryPathComputer;
 import org.openkilda.persistence.repositories.FlowPathRepository;
-import org.openkilda.persistence.repositories.HaFlowPathRepository;
 import org.openkilda.persistence.repositories.IslRepository;
 import org.openkilda.persistence.repositories.IslRepository.IslImmutableView;
 import org.openkilda.persistence.repositories.RepositoryFactory;
@@ -57,13 +56,15 @@ import com.google.common.collect.Lists;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+@ExtendWith(MockitoExtension.class)
 public class ProtectedPathFinderTest {
     private static final SwitchId SWITCH_ID_1 = new SwitchId(1);
     private static final SwitchId SWITCH_ID_2 = new SwitchId(2);
@@ -92,24 +93,15 @@ public class ProtectedPathFinderTest {
     private IslRepository islRepository;
     @Mock
     private FlowPathRepository flowPathRepository;
-    @Mock
-    private HaFlowPathRepository haFlowPathRepository;
 
     private AvailableNetworkFactory availableNetworkFactory;
 
     @BeforeEach
     public void setup() {
-        MockitoAnnotations.initMocks(this);
-
         when(config.getDiversitySwitchLatency()).thenReturn(10000L);
-        when(config.getDiversityIslLatency()).thenReturn(10000L);
-        when(config.getDiversityIslCost()).thenReturn(10000);
-        when(config.getDiversitySwitchCost()).thenReturn(10000);
-        when(config.getDiversityPopIslCost()).thenReturn(10000);
 
         when(repositoryFactory.createIslRepository()).thenReturn(islRepository);
         when(repositoryFactory.createFlowPathRepository()).thenReturn(flowPathRepository);
-        when(repositoryFactory.createHaFlowPathRepository()).thenReturn(haFlowPathRepository);
 
         availableNetworkFactory = new AvailableNetworkFactory(config, repositoryFactory);
     }
@@ -190,6 +182,7 @@ public class ProtectedPathFinderTest {
         //      |    |
         // A----B----C     Already created flow: A-B-C
         //                 No protected path here for this flow
+        when(config.getDiversityIslLatency()).thenReturn(10000L);
 
         List<IslImmutableView> isls = new ArrayList<>();
         isls.addAll(getBidirectionalIsls(switchA, 1, switchB, 2));
@@ -264,6 +257,7 @@ public class ProtectedPathFinderTest {
         //   /       |
         // A----B----C     Already created flow: A-B-C
         //                 Expected protected path: A-D-E-C
+        when(config.getDiversityIslLatency()).thenReturn(10000L);
 
         List<IslImmutableView> isls = new ArrayList<>();
         isls.addAll(getBidirectionalIsls(switchA, 1, switchB, 2));
@@ -362,6 +356,7 @@ public class ProtectedPathFinderTest {
         //   /       |
         // A----B----C     Already created flow: A-B-C
         //                 Expected protected path: A-D-E-C (over MaxLatencyTier2 = DEGRADED state)
+        when(config.getDiversityIslLatency()).thenReturn(10000L);
 
         List<IslImmutableView> isls = new ArrayList<>();
         isls.addAll(getBidirectionalIsls(switchA, 1, switchB, 2));


### PR DESCRIPTION
This PR removes the deprecated initMock. Some mocks were redundant and some replaced to the appropriate test cases.
MockitoExtension has been renamed to distinguish it with the class with the same name from mockito.