### PR TITLE
Functional test fixes+ LinkController fix

### DIFF
--- a/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/controller/v1/LinkController.java
+++ b/src-java/northbound-service/northbound/src/main/java/org/openkilda/northbound/controller/v1/LinkController.java
@@ -188,6 +188,7 @@ public class LinkController extends BaseLinkController {
     }
 
     @Operation(summary = "Update maximum bandwidth on the link")
+    @PatchMapping(path = "/links/bandwidth")
     @ResponseStatus(HttpStatus.OK)
     public CompletableFuture<LinkMaxBandwidthDto> updateLinkParams(
             @RequestParam(value = "src_switch") SwitchId srcSwitch,

--- a/src-java/testing/functional-tests/build.gradle
+++ b/src-java/testing/functional-tests/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "groovy"
     id "com.adarshr.test-logger" version "3.1.0"
-    id "org.gradle.test-retry" version "1.3.1"
+    id "org.gradle.test-retry" version "1.5.8"
 }
 description = "Functional-Tests"
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/listeners/CollectFailedTestLogsListener.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/listeners/CollectFailedTestLogsListener.groovy
@@ -35,7 +35,7 @@ class CollectFailedTestLogsListener extends AbstractSpringListener{
             def startTime = startTime.get(error.getMethod().getIteration().getDisplayName())
             def endTime = utcTimeNow()
             def logs = new RestTemplate().getForEntity(
-                    "${elasticSearchEndpoint}${elasticSearchIndex}/_search?q=" +
+                    "${elasticSearchEndpoint}/${elasticSearchIndex}/_search?q=" +
                             "@timestamp:[${startTime} TO ${endTime}]&size=10000", String.class).getBody()
             def beautifiedString = objectMapper.readValue(logs, Object.class)
             objectMapper.writerWithDefaultPrettyPrinter().writeValue(getTargetLogFile(error), beautifiedString)
@@ -49,7 +49,9 @@ class CollectFailedTestLogsListener extends AbstractSpringListener{
     }
 
     private static File getTargetLogFile(ErrorInfo error) {
-        return new File("build/logs/${getIterationPath(error.getMethod().getIteration())}.server.log.json")
+        def file = new File("build/logs/${getIterationPath(error.getMethod().getIteration())}.server.log.json")
+        file.parentFile.mkdirs()
+        return file
     }
 
     private static Boolean isFailedInPreTest(ErrorInfo error) {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
@@ -321,7 +321,8 @@ class LinkSpec extends HealthCheckSpecification {
         then: "An error is received (400 code)"
         def exc = thrown(HttpClientErrorException)
         exc.rawStatusCode == 400
-        exc.responseBodyAsString.to(MessageError).errorMessage.contains("parameter '$item' is not present")
+        exc.responseBodyAsString.to(MessageError)
+                .errorMessage.contains("parameter '$item' for method parameter type")
 
         where:
         srcSwId                 | srcSwPort        | dstSwId                 | dstSwPort | item
@@ -490,7 +491,9 @@ class LinkSpec extends HealthCheckSpecification {
         then: "An error is received (400 code)"
         def exc = thrown(HttpClientErrorException)
         exc.rawStatusCode == 400
-        exc.responseBodyAsString.to(MessageError).errorMessage.contains("parameter '$item' is not present")
+        //Required request parameter '$item' for method parameter type
+        exc.responseBodyAsString.to(MessageError).errorMessage
+                .contains("Required request parameter '$item' for method parameter type")
 
         where:
         srcSwId                 | srcSwPort        | dstSwId                 | dstSwPort | item
@@ -705,7 +708,8 @@ class LinkSpec extends HealthCheckSpecification {
         then: "An error is received (400 code)"
         def exc = thrown(HttpClientErrorException)
         exc.rawStatusCode == 400
-        exc.responseBodyAsString.to(MessageError).errorMessage.contains("parameter '$item' is not present")
+        exc.responseBodyAsString.to(MessageError).errorMessage
+                .contains("Required request parameter '$item' for method parameter type")
 
         where:
         srcSwId                 | srcSwPort        | dstSwId                 | dstSwPort | item


### PR DESCRIPTION
-Fix for AbstractMethodError in functional tests: org.gradle.test-retry  ……1.3.1 - > 1.5.8 fix
```
Receiver class org.gradle.testretry.internal.executer.RetryTestResultProcessor does not define or inherit an implementation of the resolved method 'abstract void failure(java.lang.Object, org.gradle.api.tasks.testing.TestFailure)' of interface org.gradle.api.internal.tasks.testing.TestResultProcessor.
java.lang.AbstractMethodError: Receiver class org.gradle.testretry.internal.executer.RetryTestResultProcessor does not define or inherit an implementation of the resolved method 'abstract void failure(java.lang.Object, org.gradle.api.tasks.testing.TestFailure)' of interface org.gradle.api.internal.tasks.testing.TestResultProcessor.
```
        

-Fix for FileNotFoundException fix:related to build/logs/spec/someTestLogFiles directories

```
LinkSpec > Unable to update max bandwidth without full specifying a particular link (#item is missing) > org.openkilda.functionaltests.spec.links.LinkSpec.Unable to update max bandwidth without full specifying a particular link (dst_switch is missing) FAILED
    java.io.FileNotFoundException: build/logs/spec/links/LinkSpec/Unable_to_update_max_bandwidth_without_full_specifying_a_particular_link__dst_switch_is_missing_.server.log.json (No such file or directory)
```

-Fix for Northbound LinkController fix: no such method error.
```
at org.openkilda.functionaltests.spec.links.LinkSpec.Unable to update max bandwidth without full specifying a particular link (#item is missing)(LinkSpec.groovy:706)
Caused by: org.springframework.web.client.HttpServerErrorException: 501. HTTP Status 501 ? Not Implemented
```

-Fix LinkSpec fixes