### PR TITLE
5560: [TEST]: Add methods to break/restore ISLs in test

### DIFF
--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/IslHelper.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/IslHelper.groovy
@@ -1,0 +1,84 @@
+package org.openkilda.functionaltests.helpers
+
+import groovy.util.logging.Slf4j
+import org.openkilda.messaging.info.event.IslChangeType
+import org.openkilda.testing.model.topology.TopologyDefinition
+import org.openkilda.testing.model.topology.TopologyDefinition.Isl
+import org.openkilda.testing.service.northbound.NorthboundService
+import org.openkilda.testing.service.northbound.NorthboundServiceV2
+import org.openkilda.testing.tools.IslUtils
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.annotation.Scope
+import org.springframework.stereotype.Component
+
+import static groovyx.gpars.GParsExecutorsPool.withPool
+import static org.openkilda.messaging.info.event.IslChangeType.DISCOVERED
+import static org.openkilda.messaging.info.event.IslChangeType.FAILED
+import static org.springframework.beans.factory.config.ConfigurableBeanFactory.SCOPE_PROTOTYPE
+
+/**
+ * Holds utility methods for manipulating y-flows.
+ */
+@Component
+@Slf4j
+@Scope(SCOPE_PROTOTYPE)
+class IslHelper {
+    @Autowired
+    IslUtils islUtils
+    @Autowired
+    PortAntiflapHelper antiflapHelper
+
+
+    def breakIsl(Isl islToBreak) {
+        if (getIslStatus(islToBreak).equals(DISCOVERED)) {
+            antiflapHelper.portDown(islToBreak.getSrcSwitch().getDpId(), islToBreak.getSrcPort())
+        }
+        islUtils.waitForIslStatus([islToBreak], FAILED)
+    }
+
+    def breakIsls(Set<Isl> islsToBreak) {
+        withPool {
+            islsToBreak.eachParallel{
+                breakIsl(it)
+            }
+        }
+    }
+
+    def breakIsls(List<Isl> islsToBreak) {
+        breakIsls(islsToBreak as Set)
+    }
+
+    def restoreIsl(Isl islToRestore) {
+        if(!getIslStatus(islToRestore).equals(DISCOVERED)) {
+            withPool{
+                [{antiflapHelper.portUp(islToRestore.getSrcSwitch().getDpId(), islToRestore.getSrcPort())},
+                 {antiflapHelper.portUp(islToRestore.getDstSwitch().getDpId(), islToRestore.getDstPort())}
+                ].eachParallel{it()}
+            }
+        }
+        islUtils.waitForIslStatus([islToRestore], DISCOVERED)
+    }
+
+    def restoreIsls(Set<Isl> islsToRestore) {
+        withPool {
+            islsToRestore.eachParallel{
+                restoreIsl(it)
+            }
+        }
+    }
+
+    def restoreIsls(List<Isl> islsToRestore) {
+        restoreIsls(islsToRestore as Set)
+    }
+
+    def getIslStatus(Isl isl) {
+        def islInfo = islUtils.getIslInfo(isl)
+        if (islInfo.isPresent()) {
+            return islInfo.get().state
+        } else {
+            return null
+        }
+
+    }
+}

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/BaseSpecification.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/BaseSpecification.groovy
@@ -1,5 +1,6 @@
 package org.openkilda.functionaltests
 
+import org.openkilda.functionaltests.helpers.IslHelper
 import org.openkilda.functionaltests.helpers.model.SwitchPairs
 import org.openkilda.functionaltests.model.cleanup.CleanupManager
 
@@ -14,11 +15,9 @@ import org.openkilda.functionaltests.helpers.StatsHelper
 import org.openkilda.functionaltests.helpers.SwitchHelper
 import org.openkilda.functionaltests.helpers.TopologyHelper
 import org.openkilda.functionaltests.helpers.Wrappers
-import org.openkilda.model.SwitchId
 import org.openkilda.testing.model.topology.TopologyDefinition
 import org.openkilda.testing.service.database.Database
 import org.openkilda.testing.service.floodlight.FloodlightsHelper
-import org.openkilda.testing.service.labservice.LabService
 import org.openkilda.testing.service.lockkeeper.LockKeeperService
 import org.openkilda.testing.service.northbound.NorthboundService
 import org.openkilda.testing.service.northbound.NorthboundServiceV2
@@ -72,6 +71,8 @@ class BaseSpecification extends Specification {
     StatsHelper statsHelper
     @Autowired @Shared
     SwitchPairs switchPairs
+    @Autowired @Shared
+    IslHelper islHelper
 
     @Value('${spring.profiles.active}') @Shared
     String profile

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowMonitoringSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowMonitoringSpec.groovy
@@ -69,7 +69,7 @@ class FlowMonitoringSpec extends HealthCheckSpecification {
         islsToBreak = switchPair.paths.findAll { !paths.contains(it) }
                 .collect { pathHelper.getInvolvedIsls(it).find { !isls.contains(it) && !isls.contains(it.reversed) } }
                 .unique { [it, it.reversed].sort() }
-        islsToBreak.each { antiflap.portDown(it.srcSwitch.dpId, it.srcPort) }
+        islHelper.breakIsls(islsToBreak)
     }
 
     @ResourceLock(S42_TOGGLE)
@@ -207,10 +207,7 @@ and flowLatencyMonitoringReactions is disabled in featureToggle"() {
     }
 
     def cleanupSpec() {
-        islsToBreak.each { getAntiflap().portUp(it.srcSwitch.dpId, it.srcPort) }
-        wait(getDiscoveryInterval() + WAIT_OFFSET) {
-            assert getNorthbound().getActiveLinks().size() == getTopology().islsForActiveSwitches.size() * 2
-        }
+        islHelper.restoreIsls(islsToBreak)
         getDatabase().resetCosts(getTopology().isls)
     }
 }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/SwapEndpointSpec.groovy
@@ -759,18 +759,9 @@ switches"() {
         Wrappers.wait(FLOW_CRUD_TIMEOUT) { assert northbound.getFlowStatus(flow1.id).status == FlowState.UP }
 
         and: "Break all alternative paths for the first flow"
-        def altPaths = flow1SwitchPair.paths.findAll { it != flow1Path }
-        List<PathNode> broughtDownPorts = []
-        altPaths.unique { it.first() }.each { path ->
-            def src = path.first()
-            broughtDownPorts.add(src)
-            antiflap.portDown(src.switchId, src.portNo)
-        }
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getAllLinks().findAll {
-                it.state == IslChangeType.FAILED
-            }.size() == broughtDownPorts.size() * 2
-        }
+        def broughtDownIsls = topology.getRelatedIsls(flow1SwitchPair.src) - flow1Isl
+        islHelper.breakIsls(broughtDownIsls)
+
 
         and: "Update max bandwidth for the second flow's link so that it is equal to max bandwidth of the first flow"
         def flow2Path = PathHelper.convert(northbound.getFlowPath(flow2.id))
@@ -779,17 +770,9 @@ switches"() {
                 flow2Isl.dstPort, flow1IslMaxBw)
 
         and: "Break all alternative paths for the second flow"
-        altPaths = flow2SwitchPair.paths.findAll { it != flow2Path && it[1].switchId != flow1SwitchPair.src.dpId }
-        altPaths.unique { it.first() }.each { path ->
-            def src = path.first()
-            broughtDownPorts.add(src)
-            antiflap.portDown(src.switchId, src.portNo)
-        }
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getAllLinks().findAll {
-                it.state == IslChangeType.FAILED
-            }.size() == broughtDownPorts.size() * 2
-        }
+        def flow2BroughtDownIsls = topology.getRelatedIsls(flow2SwitchPair.src) - flow2Isl - broughtDownIsls
+        islHelper.breakIsls(flow2BroughtDownIsls)
+        broughtDownIsls += flow2BroughtDownIsls
 
         when: "Try to swap endpoints for two flows"
         def flow1Src = flow2.source
@@ -815,11 +798,8 @@ switches"() {
         def isSwitchValid = true
 
         cleanup: "Restore topology and delete flows"
-        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
+        islHelper.restoreIsls(broughtDownIsls)
         northbound.deleteLinkProps(northbound.getLinkProps(topology.isls))
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
-        }
         if (!isSwitchValid) {
             switchHelper.synchronizeAndCollectFixedDiscrepancies([flow1SwitchPair.src.dpId,
                                                                   flow1SwitchPair.dst.dpId,
@@ -854,18 +834,8 @@ switches"() {
         Wrappers.wait(FLOW_CRUD_TIMEOUT) { assert northbound.getFlowStatus(flow1.id).status == FlowState.UP }
 
         and: "Break all alternative paths for the first flow"
-        def altPaths = flow1SwitchPair.paths.findAll { it != flow1Path }
-        List<PathNode> broughtDownPorts = []
-        altPaths.unique { it.first() }.each { path ->
-            def src = path.first()
-            broughtDownPorts.add(src)
-            antiflap.portDown(src.switchId, src.portNo)
-        }
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getAllLinks().findAll {
-                it.state == IslChangeType.FAILED
-            }.size() == broughtDownPorts.size() * 2
-        }
+        def broughtDownIsls = topology.getRelatedIsls(flow1SwitchPair.src) - flow1Isl
+        islHelper.breakIsls(broughtDownIsls)
 
         and: "Update max bandwidth for the second flow's link so that it is not enough bandwidth for the first flow"
         def flow2Path = PathHelper.convert(northbound.getFlowPath(flow2.id))
@@ -874,17 +844,9 @@ switches"() {
                 flow2Isl.dstPort, flow1IslMaxBw - 1)
 
         and: "Break all alternative paths for the second flow"
-        altPaths = flow2SwitchPair.paths.findAll { it != flow2Path && it[1].switchId != flow1SwitchPair.src.dpId }
-        altPaths.unique { it.first() }.each { path ->
-            def src = path.first()
-            broughtDownPorts.add(src)
-            antiflap.portDown(src.switchId, src.portNo)
-        }
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getAllLinks().findAll {
-                it.state == IslChangeType.FAILED
-            }.size() == broughtDownPorts.size() * 2
-        }
+        def flow2BroughtDownIsls = topology.getRelatedIsls(flow2SwitchPair.src) - flow2Isl - broughtDownIsls
+        islHelper.breakIsls(flow2BroughtDownIsls)
+        broughtDownIsls += flow2BroughtDownIsls
 
         when: "Try to swap endpoints for two flows"
         def flow1Src = flow2.source
@@ -906,11 +868,8 @@ switches"() {
         Boolean isTestCompleted = true
 
         cleanup: "Restore topology and delete flows"
-        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
+        islHelper.restoreIsls(broughtDownIsls)
         northbound.deleteLinkProps(northbound.getLinkProps(topology.isls))
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
-        }
         if (!isTestCompleted) {
             switchHelper.synchronizeAndCollectFixedDiscrepancies([flow1SwitchPair.src.dpId,
                                                                   flow1SwitchPair.dst.dpId,
@@ -945,18 +904,8 @@ switches"() {
         Wrappers.wait(FLOW_CRUD_TIMEOUT) { assert northbound.getFlowStatus(flow1.id).status == FlowState.UP }
 
         and: "Break all alternative paths for the first flow"
-        def altPaths = flow1SwitchPair.paths.findAll { it != flow1Path }
-        List<PathNode> broughtDownPorts = []
-        altPaths.unique { it.first() }.each { path ->
-            def src = path.first()
-            broughtDownPorts.add(src)
-            antiflap.portDown(src.switchId, src.portNo)
-        }
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getAllLinks().findAll {
-                it.state == IslChangeType.FAILED
-            }.size() == broughtDownPorts.size() * 2
-        }
+        def broughtDownIsls = topology.getRelatedIsls(flow1SwitchPair.src) - flow1Isl
+        islHelper.breakIsls(broughtDownIsls)
 
         and: "Update max bandwidth for the second flow's link so that it is not enough bandwidth for the first flow"
         def flow2Path = PathHelper.convert(northbound.getFlowPath(flow2.id))
@@ -965,17 +914,9 @@ switches"() {
                 flow2Isl.dstPort, flow1IslMaxBw - 1)
 
         and: "Break all alternative paths for the second flow"
-        altPaths = flow2SwitchPair.paths.findAll { it != flow2Path && it[1].switchId != flow1SwitchPair.src.dpId }
-        altPaths.unique { it.first() }.each { path ->
-            def src = path.first()
-            broughtDownPorts.add(src)
-            antiflap.portDown(src.switchId, src.portNo)
-        }
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getAllLinks().findAll {
-                it.state == IslChangeType.FAILED
-            }.size() == broughtDownPorts.size() * 2
-        }
+        def flow2BroughtDownIsls = topology.getRelatedIsls(flow2SwitchPair.src) - flow2Isl - broughtDownIsls
+        islHelper.breakIsls(flow2BroughtDownIsls)
+        broughtDownIsls += flow2BroughtDownIsls
 
         when: "Try to swap endpoints for two flows"
         def flow1Src = flow2.source
@@ -1001,11 +942,8 @@ switches"() {
         def isSwitchValid = true
 
         cleanup: "Restore topology and delete flows"
-        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
+        islHelper.restoreIsls(broughtDownIsls)
         northbound.deleteLinkProps(northbound.getLinkProps(topology.isls))
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
-        }
         if (!isSwitchValid) {
             switchHelper.synchronizeAndCollectFixedDiscrepancies([flow1SwitchPair.src.dpId,
                                                                   flow1SwitchPair.dst.dpId,
@@ -1038,21 +976,9 @@ switches"() {
         ).unique()
 
         and: "Break all paths for the first flow"
-        List<PathNode> broughtDownPorts = []
-        flow1SwitchPair.paths.unique { it.first() }.each { path ->
-            def src = path.first()
-            broughtDownPorts.add(src)
-            antiflap.portDown(src.switchId, src.portNo)
-        }
-        Wrappers.wait(rerouteDelay + WAIT_OFFSET) {
-            assert northbound.getAllLinks().findAll {
-                it.state == IslChangeType.FAILED
-            }.size() == broughtDownPorts.size() * 2
-            assert northbound.getFlowStatus(flow1.id).status == FlowState.DOWN
-            assert flowHelper.getHistoryEntriesByAction(flow1.id, REROUTE_ACTION).find {
-                it.taskId =~ (/.+ : retry #1 ignore_bw true/)
-            }?.payload?.last()?.action == REROUTE_FAIL
-        }
+        def broughtDownIsls = topology.getRelatedIsls(flow1SwitchPair.src)
+        islHelper.breakIsls(broughtDownIsls)
+
 
         when: "Try to swap endpoints for two flows"
         northbound.swapFlowEndpoint(
@@ -1074,10 +1000,7 @@ switches"() {
         switchHelper.synchronizeAndCollectFixedDiscrepancies(involvedSwIds)
 
         cleanup: "Restore topology and delete flows"
-        broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
-        }
+        islHelper.restoreIsls(broughtDownIsls)
         database.resetCosts(topology.isls)
     }
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ThrottlingRerouteSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ThrottlingRerouteSpec.groovy
@@ -228,6 +228,5 @@ class ThrottlingRerouteSpec extends HealthCheckSpecification {
             assert northbound.getLink(brokenIsl).state == IslChangeType.FAILED
         }
         return brokenIsl
-
     }
 }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowPingSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/haflows/HaFlowPingSpec.groovy
@@ -98,8 +98,7 @@ class HaFlowPingSpec extends HealthCheckSpecification {
         String subFlowWithActiveIsl = paths.subFlowPaths.flowId.find { it != subFlowWithBrokenIsl }
 
         when: "Fail one of the HA-subflows ISL (bring switch port down)"
-        antiflap.portDown(islToFail.srcSwitch.dpId, islToFail.srcPort)
-        wait(WAIT_OFFSET) { assert northbound.getLink(islToFail).state == FAILED }
+        islHelper.breakIsl(islToFail)
         def afterFailTime = new Date().getTime()
 
         then: "Periodic pings are still enabled"
@@ -123,8 +122,7 @@ class HaFlowPingSpec extends HealthCheckSpecification {
 
         cleanup:
         haFlow && haFlow.delete()
-        islToFail && antiflap.portUp(islToFail.srcSwitch.dpId, islToFail.srcPort)
-        wait(WAIT_OFFSET) { assert northbound.getLink(islToFail).state == DISCOVERED }
+        islHelper.restoreIsl(islToFail)
         database.resetCosts(topology.isls)
     }
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkMaintenanceSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkMaintenanceSpec.groovy
@@ -111,32 +111,16 @@ class LinkMaintenanceSpec extends HealthCheckSpecification {
         assert flow1Path == flow2Path
 
         and: "Make only one alternative path available for both flows"
-        def altPaths = switchPair.paths.findAll {
-            it != flow1Path && it.first().portNo != flow1Path.first().portNo
-        }.sort { it.size() }
-        def availablePath = altPaths.first()
-
-        List<PathNode> broughtDownPorts = []
-        altPaths[1..-1].unique { it.first() }.findAll {
-            it.first().portNo != availablePath.first().portNo
-        }.each { path ->
-            def src = path.first()
-            broughtDownPorts.add(src)
-            antiflap.portDown(src.switchId, src.portNo)
-        }
-        Wrappers.wait(antiflapMin + WAIT_OFFSET) {
-            assert northbound.getAllLinks().findAll {
-                it.state == IslChangeType.FAILED
-            }.size() == broughtDownPorts.size() * 2
-        }
+        def flow1ActualIsl = pathHelper.getInvolvedIsls(flow1Path).first()
+        def altIsls = topology.getRelatedIsls(switchPair.src) - flow1ActualIsl
+        islHelper.breakIsls(altIsls[1..-1])
 
         and: "Set maintenance mode for the first link involved in alternative path"
-        def islUnderMaintenance = pathHelper.getInvolvedIsls(availablePath).first()
+        def islUnderMaintenance = altIsls.first()
         northbound.setLinkMaintenance(islUtils.toLinkUnderMaintenance(islUnderMaintenance, true, false))
 
         when: "Force flows to reroute by bringing port down on the source switch"
-        broughtDownPorts.add(flow1Path.first())
-        antiflap.portDown(flow1Path.first().switchId, flow1Path.first().portNo)
+        islHelper.breakIsl(flow1ActualIsl)
 
         then: "Flows are rerouted to alternative path with link under maintenance"
         Wrappers.wait(rerouteDelay + WAIT_OFFSET*2) {
@@ -153,12 +137,9 @@ class LinkMaintenanceSpec extends HealthCheckSpecification {
         }
 
         cleanup: "Restore topology, delete flows, unset maintenance mode and reset costs"
-        broughtDownPorts.each { it && antiflap.portUp(it.switchId, it.portNo) }
         islUnderMaintenance && northbound.setLinkMaintenance(islUtils.toLinkUnderMaintenance(
                 islUnderMaintenance, false, false))
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
-        }
+        islHelper.restoreIsls(altIsls + flow1ActualIsl)
         database.resetCosts(topology.isls)
     }
 }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/FlowStatSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/stats/FlowStatSpec.groovy
@@ -246,8 +246,7 @@ class FlowStatSpec extends HealthCheckSpecification {
 
         when: "Break ISL on the main path (bring port down) to init auto swap"
         def islToBreak = pathHelper.getInvolvedIsls(currentPath)[0]
-        antiflap.portDown(islToBreak.srcSwitch.dpId, islToBreak.srcPort)
-        def portIsDown = true
+        islHelper.breakIsl(islToBreak)
         Wrappers.wait(PROTECTED_PATH_INSTALLATION_TIME) {
             assert northboundV2.getFlowStatus(flow.id).status == FlowState.UP
             assert pathHelper.convert(northbound.getFlowPath(flow.id)) == currentProtectedPath
@@ -270,10 +269,7 @@ class FlowStatSpec extends HealthCheckSpecification {
         !newFlowStats.get(FLOW_RAW_BYTES, srcSwitchId, mainReverseCookie).hasNonZeroValuesAfter(timeAfterSwap)
 
         cleanup:
-        islToBreak && portIsDown && antiflap.portUp(islToBreak.srcSwitch.dpId, islToBreak.srcPort)
-        Wrappers.wait(WAIT_OFFSET + discoveryInterval) {
-            assert islUtils.getIslInfo(islToBreak).get().state == IslChangeType.DISCOVERED
-        }
+        islHelper.restoreIsl(islToBreak)
         database.resetCosts(topology.isls)
     }
 
@@ -294,30 +290,17 @@ class FlowStatSpec extends HealthCheckSpecification {
         flowHelperV2.addFlow(flow)
 
         and: "All alternative paths are unavailable (bring ports down on the source switch)"
-        List<PathNode> broughtDownPorts = []
         def flowPathInfo = northbound.getFlowPath(flow.flowId)
-        switchPair.paths.findAll {
-            it.first() != pathHelper.convert(flowPathInfo).first() &&
-                    it.first() != pathHelper.convert(flowPathInfo.protectedPath).first()
-        }.unique {
-            it.first()
-        }.each { path ->
-            def src = path.first()
-            broughtDownPorts.add(src)
-            antiflap.portDown(src.switchId, src.portNo)
-        }
-        def srcPortIsDown = true
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getAllLinks().findAll {
-                it.state == IslChangeType.FAILED
-            }.size() == broughtDownPorts.size() * 2
-        }
-
-        when: "Break ISL on a protected path (bring port down) for changing the flow state to DEGRADED"
         def currentProtectedPath = pathHelper.convert(flowPathInfo.protectedPath)
         def protectedIsls = pathHelper.getInvolvedIsls(currentProtectedPath)
-        antiflap.portDown(protectedIsls[0].dstSwitch.dpId, protectedIsls[0].dstPort)
-        def dstPortIsDown = true
+        def altIsls = topology.getRelatedIsls(switchPair.src) -
+                pathHelper.getInvolvedIsls(pathHelper.convert(flowPathInfo.forwardPath)) -
+                protectedIsls.first()
+        islHelper.breakIsls(altIsls)
+
+
+        when: "Break ISL on a protected path (bring port down) for changing the flow state to DEGRADED"
+        islHelper.breakIsl(protectedIsls.first())
         Wrappers.wait(WAIT_OFFSET) {
             verifyAll(northboundV2.getFlow(flow.flowId)) {
                 status == "Degraded"
@@ -345,12 +328,7 @@ class FlowStatSpec extends HealthCheckSpecification {
         }
 
         cleanup: "Restore topology, delete flows and reset costs"
-        protectedIsls && srcPortIsDown && antiflap.portUp(protectedIsls[0].srcSwitch.dpId, protectedIsls[0].srcPort)
-        protectedIsls && dstPortIsDown && antiflap.portUp(protectedIsls[0].dstSwitch.dpId, protectedIsls[0].dstPort)
-        broughtDownPorts && broughtDownPorts.every { antiflap.portUp(it.switchId, it.portNo) }
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            northbound.getAllLinks().each { assert it.state != IslChangeType.FAILED }
-        }
+        islHelper.restoreIsls(altIsls + protectedIsls.first())
         database.resetCosts(topology.isls)
     }
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortAntiflapSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortAntiflapSpec.groovy
@@ -127,12 +127,7 @@ timeout"() {
         }
 
         cleanup: "Bring port up"
-        islPort && antiflap.portUp(sw.dpId, islPort)
-        if (isl) {
-            Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-                islUtils.getIslInfo(isl).get().state == DISCOVERED
-            }
-        }
+        islHelper.restoreIsl(isl)
     }
 
     /**
@@ -214,16 +209,10 @@ timeout"() {
 
         when: "Port down event happens"
         def timestampBefore = System.currentTimeMillis()
-        northbound.portDown(isl.srcSwitch.dpId, isl.srcPort)
-        def portIsDown = true
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getLink(isl).state == FAILED
-            assert northbound.getLink(isl.reversed).state == FAILED
-        }
+        islHelper.breakIsl(isl)
 
         and: "Port up event happens"
         northbound.portUp(isl.srcSwitch.dpId, isl.srcPort)
-        portIsDown = false
 
         then: "The ISL is failed till 'antiflap' is deactivated"
         Wrappers.timedLoop(antiflapCooldown * 0.8) {
@@ -248,15 +237,7 @@ timeout"() {
         }
 
         cleanup:
-        portIsDown && antiflap.portUp(isl.srcSwitch.dpId, isl.srcPort)
-        Wrappers.wait(antiflapCooldown + discoveryInterval + WAIT_OFFSET) {
-            def fr = northbound.getLink(isl)
-            def rv = northbound.getLink(isl.reversed)
-            assert fr.state == DISCOVERED
-            assert fr.actualState == DISCOVERED
-            assert rv.state == DISCOVERED
-            assert rv.actualState == DISCOVERED
-        }
+        islHelper.restoreIsl(isl)
     }
 
     def cleanup() {

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortHistorySpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortHistorySpec.groovy
@@ -46,10 +46,7 @@ class PortHistorySpec extends HealthCheckSpecification {
         def timestampBefore = System.currentTimeMillis()
 
         when: "Execute port DOWN on the src switch"
-        def portDown = antiflap.portDown(isl.srcSwitch.dpId, isl.srcPort)
-        Wrappers.wait(WAIT_OFFSET / 2) {
-            assert islUtils.getIslInfo(isl).get().state == IslChangeType.FAILED
-        }
+        islHelper.breakIsl(isl)
 
         then: "Port history is created on the src switch"
         Wrappers.wait(WAIT_OFFSET) {
@@ -64,10 +61,7 @@ class PortHistorySpec extends HealthCheckSpecification {
         }
 
         when: "Execute port UP on the src switch"
-        def portUp = antiflap.portUp(isl.srcSwitch.dpId, isl.srcPort)
-        Wrappers.wait(WAIT_OFFSET + discoveryInterval) {
-            assert islUtils.getIslInfo(isl).get().state == IslChangeType.DISCOVERED
-        }
+        islHelper.restoreIsl(isl)
 
         then: "Port history is updated on the src switch"
         Wrappers.wait(WAIT_OFFSET) {
@@ -105,12 +99,7 @@ class PortHistorySpec extends HealthCheckSpecification {
         northboundV2.getPortHistory(isl.srcSwitch.dpId, isl.srcPort).size() >= 4
 
         cleanup:
-        if (portDown && !portUp) {
-            antiflap.portUp(isl.srcSwitch.dpId, isl.srcPort)
-            Wrappers.wait(WAIT_OFFSET + discoveryInterval) {
-                assert islUtils.getIslInfo(isl).get().state == IslChangeType.DISCOVERED
-            }
-        }
+        islHelper.restoreIsl(isl)
 
         where:
         [islDescription, historySizeOnDstSw, isl] << [
@@ -127,15 +116,9 @@ class PortHistorySpec extends HealthCheckSpecification {
         def timestampBefore = System.currentTimeMillis()
         def isl = getTopology().islsForActiveSwitches.find { !it.aswitch }
 
-        def portDown = antiflap.portDown(isl.srcSwitch.dpId, isl.srcPort)
-        Wrappers.wait(WAIT_OFFSET / 2) {
-            assert islUtils.getIslInfo(isl).get().state == IslChangeType.FAILED
-        }
+        islHelper.breakIsl(isl)
 
-        def portUp = antiflap.portUp(isl.srcSwitch.dpId, isl.srcPort)
-        Wrappers.wait(WAIT_OFFSET + discoveryInterval) {
-            assert islUtils.getIslInfo(isl).get().state == IslChangeType.DISCOVERED
-        }
+        islHelper.restoreIsl(isl)
 
         def timestampAfter = System.currentTimeMillis()
         def portHistory = northboundV2.getPortHistory(isl.srcSwitch.dpId, isl.srcPort, timestampBefore, timestampAfter)
@@ -148,12 +131,7 @@ class PortHistorySpec extends HealthCheckSpecification {
         portH.isEmpty()
 
         cleanup:
-        if (portDown && !portUp) {
-            antiflap.portUp(isl.srcSwitch.dpId, isl.srcPort)
-            Wrappers.wait(WAIT_OFFSET + discoveryInterval) {
-                assert islUtils.getIslInfo(isl).get().state == IslChangeType.DISCOVERED
-            }
-        }
+        islHelper.restoreIsl(isl)
     }
 
     def "Port history should not be returned in case port/switch have never existed"() {
@@ -171,15 +149,8 @@ class PortHistorySpec extends HealthCheckSpecification {
         def isl = getTopology().islsForActiveSwitches.find { !it.aswitch }
 
         when: "Execute port DOWN/UP on the src switch"
-        def portDown = antiflap.portDown(isl.srcSwitch.dpId, isl.srcPort)
-        Wrappers.wait(WAIT_OFFSET / 2) {
-            assert islUtils.getIslInfo(isl).get().state == IslChangeType.FAILED
-        }
-
-        def portUp = antiflap.portUp(isl.srcSwitch.dpId, isl.srcPort)
-        Wrappers.wait(WAIT_OFFSET + discoveryInterval) {
-            assert islUtils.getIslInfo(isl).get().state == IslChangeType.DISCOVERED
-        }
+        islHelper.breakIsl(isl)
+        islHelper.restoreIsl(isl)
         def timestampAfter = System.currentTimeMillis()
         northboundV2.getPortHistory(isl.srcSwitch.dpId, isl.srcPort, timestampBefore, timestampAfter).size() == 4
 
@@ -191,12 +162,7 @@ class PortHistorySpec extends HealthCheckSpecification {
         northboundV2.getPortHistory(isl.srcSwitch.dpId, isl.srcPort, timestampBefore, timestampAfter).size() == 4
 
         cleanup: "Revive the src switch"
-        if (portDown && !portUp) {
-            antiflap.portUp(isl.srcSwitch.dpId, isl.srcPort)
-            Wrappers.wait(WAIT_OFFSET + discoveryInterval) {
-                assert islUtils.getIslInfo(isl).get().state == IslChangeType.DISCOVERED
-            }
-        }
+        islHelper.restoreIsl(isl)
         switchToDisconnect && switchHelper.reviveSwitch(switchToDisconnect, blockData)
     }
 
@@ -213,7 +179,6 @@ class PortHistorySpec extends HealthCheckSpecification {
 
         when: "Execute port DOWN on the src switch for activating antiflap"
         northbound.portDown(isl.srcSwitch.dpId, isl.srcPort)
-        def isPortDown = true
         Wrappers.wait(WAIT_OFFSET) {
             assert islUtils.getIslInfo(isl).get().state == IslChangeType.FAILED
             Long timestampAfterDown = System.currentTimeMillis()
@@ -224,9 +189,7 @@ class PortHistorySpec extends HealthCheckSpecification {
 
         and: "Generate antiflap statistic"
         northbound.portUp(isl.srcSwitch.dpId, isl.srcPort)
-        isPortDown = false
         northbound.portDown(isl.srcSwitch.dpId, isl.srcPort)
-        isPortDown = true
 
         then: "Antiflap statistic is available in port history inside the ANTI_FLAP_DEACTIVATED event"
         Wrappers.wait(antiflapCooldown + WAIT_OFFSET) {
@@ -243,10 +206,7 @@ class PortHistorySpec extends HealthCheckSpecification {
         }
 
         cleanup: "revert system to original state"
-        isPortDown && northbound.portUp(isl.srcSwitch.dpId, isl.srcPort)
-        Wrappers.wait(WAIT_OFFSET + discoveryInterval + antiflapCooldown) {
-            assert islUtils.getIslInfo(isl).get().state == IslChangeType.DISCOVERED
-        }
+        islHelper.restoreIsl(isl)
     }
 
     def cleanup() {
@@ -285,10 +245,7 @@ class PortHistoryIsolatedSpec extends HealthCheckSpecification {
 
         when: "Execute port DOWN on the port"
         def timestampBefore = System.currentTimeMillis()
-        northbound.portDown(isl.srcSwitch.dpId, isl.srcPort)
-        Wrappers.wait(WAIT_OFFSET / 2) {
-            assert islUtils.getIslInfo(isl).get().state == IslChangeType.FAILED
-        }
+        islHelper.breakIsl(isl)
 
         then: "Port history is created for that port"
         Wrappers.wait(WAIT_OFFSET) {
@@ -329,13 +286,7 @@ class PortHistoryIsolatedSpec extends HealthCheckSpecification {
         }
 
         cleanup:
-        if (isl) {
-            northbound.portUp(isl.srcSwitch.dpId, isl.srcPort)
-            Wrappers.wait(WAIT_OFFSET + discoveryInterval + antiflapCooldown) {
-                assert islUtils.getIslInfo(isl).get().state == IslChangeType.DISCOVERED
-            }
-            antiflap.waitPortIsStable(isl.srcSwitch.dpId, isl.srcPort)
-        }
+       islHelper.restoreIsl(isl)
         updateToogles && northbound.toggleFeature(FeatureTogglesDto.builder()
                 .floodlightRoutePeriodicSync(true)
                 .build())

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortPropertiesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortPropertiesSpec.groovy
@@ -127,11 +127,7 @@ class PortPropertiesSpec extends HealthCheckSpecification {
                 .any { it.features.contains(SwitchFeature.NOVIFLOW_COPY_FIELD) }
 
         // Bring port down on the src switch
-        def portDown = antiflap.portDown(islToManipulate.srcSwitch.dpId, islToManipulate.srcPort)
-        TimeUnit.SECONDS.sleep(2) //receive any in-progress disco packets
-        Wrappers.wait(WAIT_OFFSET) {
-            assert northbound.getLink(islToManipulate).actualState == IslChangeType.FAILED
-        }
+        islHelper.breakIsl(islToManipulate)
 
         // delete link
         northbound.deleteLink(islUtils.toLinkParameters(islToManipulate))
@@ -196,7 +192,7 @@ class PortPropertiesSpec extends HealthCheckSpecification {
             assert islUtils.getIslInfo(islToManipulate.reversed).get().state == IslChangeType.DISCOVERED
         }
         cleanup:
-        portDown && !portUp && antiflap.portUp(islToManipulate.srcSwitch.dpId, islToManipulate.srcPort)
+        antiflap.portUp(islToManipulate.srcSwitch.dpId, islToManipulate.srcPort)
         srcPortDiscoveryOff && !srcPortDiscoveryOn && enableDiscoveryOnPort(islToManipulate.srcSwitch.dpId, islToManipulate.srcPort)
         dstPortDiscoveryOff && !dstPortDiscoveryOn && enableDiscoveryOnPort(islToManipulate.dstSwitch.dpId, islToManipulate.dstPort)
         switchStatus && switchStatus == SwitchChangeType.DEACTIVATED && switchHelper.reviveSwitch(sw, blockData, true)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchFailuresSpec.groovy
@@ -120,7 +120,7 @@ class SwitchFailuresSpec extends HealthCheckSpecification {
 
         cleanup:
         lockKeeper.cleanupTrafficShaperRules(swPair.dst.regions)
-        islToBreak && antiflap.portUp(islToBreak.srcSwitch.dpId, islToBreak.srcPort)
+        islHelper.restoreIsl(islToBreak)
         database.resetCosts(topology.isls)
     }
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchMaintenanceSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchMaintenanceSpec.groovy
@@ -16,8 +16,6 @@ import org.openkilda.messaging.info.event.PathNode
 import org.openkilda.messaging.payload.flow.FlowState
 import org.openkilda.testing.model.topology.TopologyDefinition
 
-import java.util.concurrent.TimeUnit
-
 class SwitchMaintenanceSpec extends HealthCheckSpecification {
 
     @Tags(SMOKE)
@@ -125,9 +123,7 @@ class SwitchMaintenanceSpec extends HealthCheckSpecification {
         def isl = topology.islsForActiveSwitches.first()
 
         and: "Bring port down on the switch to fail the link"
-        def portDown = antiflap.portDown(isl.srcSwitch.dpId, isl.srcPort)
-        TimeUnit.SECONDS.sleep(2) //receive any in-progress disco packets
-        Wrappers.wait(WAIT_OFFSET) { assert islUtils.getIslInfo(isl).get().state == IslChangeType.FAILED }
+        islHelper.breakIsl(isl)
 
         and: "Delete the link"
         northbound.deleteLink(islUtils.toLinkParameters(isl))
@@ -153,18 +149,8 @@ class SwitchMaintenanceSpec extends HealthCheckSpecification {
         }
 
         cleanup:
-        portDown && !portUp && antiflap.portUp(isl.srcSwitch.dpId, isl.srcPort)
+        islHelper.restoreIsl(isl)
         setSwMaintenance && northbound.setSwitchMaintenance(isl.srcSwitch.dpId, false, false)
-        Wrappers.wait(discoveryInterval + WAIT_OFFSET) {
-            def links = northbound.getAllLinks()
-            def islInfo = islUtils.getIslInfo(links, isl).get()
-            def reverseIslInfo = islUtils.getIslInfo(links, isl.reversed).get()
-
-            [islInfo, reverseIslInfo].each {
-                assert it.state == IslChangeType.DISCOVERED
-                assert !it.underMaintenance
-            }
-        }
         database.resetCosts(topology.isls)
     }
 }


### PR DESCRIPTION
Implements #5560

* Replaced places in tests where port is set up/down with waiting for ISL get up/down with reusable methods
* Worked around bug #5608 in several tests