### PR TITLE
Small fix that align the Spring versions

### DIFF
--- a/src-java/grpc-speaker/grpc-service/build.gradle
+++ b/src-java/grpc-speaker/grpc-service/build.gradle
@@ -13,7 +13,7 @@ configurations {
 description = "GRPC service"
 dependencies {
     implementation(platform("org.springframework:spring-framework-bom:6.0.6"))
-    implementation(platform("org.springframework.boot:spring-boot-dependencies:3.1.0"))
+    implementation(platform("org.springframework.boot:spring-boot-dependencies:3.2.2"))
 
     implementation(project(":grpc-api"))
     implementation(project(":blue-green"))
@@ -21,8 +21,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-log4j2")
     implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.springframework.security:spring-security-config:6.2.1")
-    implementation("org.springframework.security:spring-security-web:6.2.1")
+    implementation("org.springframework.security:spring-security-config")
+    implementation("org.springframework.security:spring-security-web")
     implementation("org.springframework.kafka:spring-kafka:3.1.1")
     implementation("org.apache.kafka:kafka-clients:3.6.1")
     implementation("org.apache.kafka:kafka_2.12:3.6.1")

--- a/src-java/northbound-service/northbound/build.gradle
+++ b/src-java/northbound-service/northbound/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
     implementation("org.springframework:spring-context:6.1.4")
     implementation("org.springframework.boot:spring-boot-starter-log4j2")
-    implementation("org.springframework.security:spring-security-config:6.2.1")
+    implementation("org.springframework.security:spring-security-config")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.security:spring-security-web")
     implementation("org.springframework.kafka:spring-kafka:3.1.1")


### PR DESCRIPTION
grpc-service: org.springframework.boot:spring-boot-dependencies:3.1.0 ->3.2.2 northbound:
remove spring explicit version declaration from springframework.security:spring-security-config dep, since it already exist in spring-boot-dependencies dep.