### PR TITLE
[Java 8-17] Temporary fix for the PortAntiflapSpec

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortAntiflapSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortAntiflapSpec.groovy
@@ -54,6 +54,9 @@ class PortAntiflapSpec extends HealthCheckSpecification {
     @Qualifier("kafkaProducerProperties")
     Properties producerProps
 
+    // When the blinker is executed with the interval equals to 1, lab switches disconnects
+    int blinkingInterval = 10
+
     def setupSpec() {
         northbound.toggleFeature(FeatureTogglesDto.builder().floodlightRoutePeriodicSync(false).build())
     }
@@ -145,7 +148,7 @@ timeout"() {
 
         when: "Port blinks rapidly for longer than 'antiflapWarmup' seconds, ending in UP state"
         def isl = topology.islsForActiveSwitches[0]
-        def blinker = new PortBlinker(producerProps, topoDiscoTopic, isl.srcSwitch, isl.srcPort, 1)
+        def blinker = new PortBlinker(producerProps, topoDiscoTopic, isl.srcSwitch, isl.srcPort, blinkingInterval)
         blinker.start()
         TimeUnit.SECONDS.sleep(antiflapWarmup + 1)
         blinker.stop(true)
@@ -181,7 +184,7 @@ timeout"() {
 
         when: "Port blinks rapidly for longer than 'antiflapWarmup' seconds, ending in DOWN state"
         def isl = topology.islsForActiveSwitches[0]
-        def blinker = new PortBlinker(producerProps, topoDiscoTopic, isl.srcSwitch, isl.srcPort, 1)
+        def blinker = new PortBlinker(producerProps, topoDiscoTopic, isl.srcSwitch, isl.srcPort, blinkingInterval)
         blinker.kafkaChangePort(PortChangeType.DOWN)
         blinker.start()
         TimeUnit.SECONDS.sleep(antiflapWarmup + 1)

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortAntiflapSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/PortAntiflapSpec.groovy
@@ -54,7 +54,7 @@ class PortAntiflapSpec extends HealthCheckSpecification {
     @Qualifier("kafkaProducerProperties")
     Properties producerProps
 
-    // When the blinker is executed with the interval equals to 1, lab switches disconnects
+    // When the blinker is executed with the interval equals to 1, lab switches get disconnected from the controller
     int blinkingInterval = 10
 
     def setupSpec() {


### PR DESCRIPTION
This change resolves the test failure. However, it is not clear what the root cause is, as well as whether the new interval still makes sense for the test cases.

Anyway, without this change there are the following series of errors:
```
Disconnecting switch [00:00:00:00:00:00:00:02(0x0) from lab_service-1.kilda_default/192.168.32.24:41782] due to IO Error: Connection reset 
```

```
Can't process speaker command ...
org.openkilda.floodlight.error.SwitchNotFoundException: Switch 00:00:00:00:00:00:00:09 was not found
```

```
ISL controller for 00:00:00:00:00:00:00:02_6 <===> 00:00:00:00:00:00:00:07_19 not found
```

```
Port 10 for switch 1 not found.
```