### PR TITLE
FuncTest fix. Errors related to Shazam library

### DIFF
--- a/src-java/testing/functional-tests/build.gradle
+++ b/src-java/testing/functional-tests/build.gradle
@@ -46,6 +46,7 @@ test {
 tasks.register("functionalTest", Test) {
     dependsOn "compileGroovy"
     description = "Runs functional tests."
+    jvmArgs '--add-opens', 'java.base/java.time=ALL-UNNAMED'
     include "**/functionaltests/spec/**/*Spec.*"
     if (System.getProperty("excludeTests")) {
         def excludes = System.getProperty("excludeTests").split(",")


### PR DESCRIPTION
This PR fix some problems related to Shazam library that we use in functional test run. Particularly  StormLcmSpec .  Shazam uses reflection to change access modifiers for java.base/java.time package.
Since java 9 by default java throws an exception when somebody is trying to change access modifiers  in java.base packages. 