### PR TITLE
5390: [TEST]: Stabilize flaky Swap Endpoint test

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkMaintenanceSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkMaintenanceSpec.groovy
@@ -102,6 +102,9 @@ class LinkMaintenanceSpec extends HealthCheckSpecification {
         and: "Make only one alternative path available for both flows"
         def flow1ActualIsl = pathHelper.getInvolvedIsls(flow1Path).first()
         def altIsls = topology.getRelatedIsls(switchPair.src) - flow1ActualIsl
+        /* altIsls can have only 1 element (the only one alt ISL).
+        In this case it will be set under maintenance mode, and breaking the other
+        alternative ISLs will be skipped: "altIsls - altIsls.first()" will be empty. */
         islHelper.breakIsls(altIsls - altIsls.first())
 
         and: "Set maintenance mode for the first link involved in alternative path"


### PR DESCRIPTION
Implements #5390

* The spec failed when the empty map was returned in the synchronizeAndCollectFixedDiscrepancies() method.
* However it is expected for this method to return an empty map.
* Due to the known issue #3770, it returns non-empty map in the most of the cases.
* Now the check .isEmpty() is temporary commented to stabilaze the test.

Related to #3770