### PR TITLE
Storm yaml fix

### DIFF
--- a/confd/templates/storm/storm.yaml.tmpl
+++ b/confd/templates/storm/storm.yaml.tmpl
@@ -82,8 +82,8 @@ worker.childopts: "-Xmx512m -XX:+UseG1GC -Djava.net.preferIPv4Stack=true"
 supervisor.childopts: "-Xmx4g -Djava.net.preferIPv4Stack=true"
 ui.childopts: "-Xmx512m"
 
-nimbus.task.timeout.secs: 240
-nimbus.thrift.max_buffer_size: 20480000
+nimbus.task.timeout.secs: 30
+nimbus.thrift.max_buffer_size: 2097152
 
 
 #Topologies settings
@@ -91,11 +91,11 @@ topology.testing.always.try.serialize: true
 topology.skip.missing.kryo.registrations: true
 topology.fall.back.on.java.serialization: true
 
-topology.max.spout.pending: 1
-topology.message.timeout.secs: 300
+topology.max.spout.pending: 1000
+topology.message.timeout.secs: 30
 
-topology.executor.receive.buffer.size: 2
-topology.transfer.buffer.size: 2
+topology.executor.receive.buffer.size: 1024 # the queue size that needs to be processed bolts/spouts, can not be too small
+topology.transfer.buffer.size: 1024
 
 topology.spout.wait.strategy: org.apache.storm.policy.WaitStrategyProgressive
 topology.backpressure.wait.strategy: org.apache.storm.policy.WaitStrategyProgressive
@@ -113,4 +113,4 @@ topology.backpressure.wait.progressive.level1.count: 1
 topology.backpressure.wait.progressive.level2.count: 1
 topology.backpressure.wait.progressive.level3.sleep.millis: 5
 
-topology.stats.sample.rate: 0.0001
+topology.stats.sample.rate: 0.05


### PR DESCRIPTION
FuncTest fix: StormLcmSpec ✘ System survives Storm topologies restart
Changed storm.yaml config, aligned some properties to the values used in storm version 1.2.1

In this PR there were some alignment with storm properties, that makes its values closer to the values that we use with storm version 1.2.1. 

Apart from that, this alignments fixes StormLcmSpec "System survives Storm topologies restart" test.