### PR TITLE
Add a dependency constraint for Kryo.

### DIFF
--- a/src-java/blue-green/build.gradle
+++ b/src-java/blue-green/build.gradle
@@ -1,40 +1,39 @@
 plugins {
-    id 'java-library'
+    id "java-library"
 }
 
-description = 'Kilda Blue Green'
+description = "Kilda Blue Green"
 
 dependencies {
-    implementation 'com.google.guava:guava'
-    implementation 'org.apache.commons:commons-lang3'
-    // current storm version is 1.2.1.
-    // kryo package with version >= 5.0 is not compatible with old storm serialization
-    implementation 'com.esotericsoftware:kryo:5.6.0'
-    implementation 'dev.failsafe:failsafe'
+    implementation("com.google.guava:guava")
+    implementation("org.apache.commons:commons-lang3")
+    
+    implementation("com.esotericsoftware:kryo")
+    implementation("dev.failsafe:failsafe")
 
-    implementation 'org.mapstruct:mapstruct'
-    implementation 'org.mapstruct:mapstruct-processor'
+    implementation("org.mapstruct:mapstruct")
+    implementation("org.mapstruct:mapstruct-processor")
 
-    api('org.apache.kafka:kafka-clients:3.6.1') {
-        exclude group: 'org.slf4j', module: 'slf4j-log4j12'
-        exclude group: 'log4j', module: 'log4j'
+    api("org.apache.kafka:kafka-clients:3.6.1") {
+        exclude group: "org.slf4j", module: "slf4j-log4j12"
+        exclude group: "log4j", module: "log4j"
     }
 
     // TODO seems like the comment is no longer true
     // Conflicts with storm local run over IDE.
-    api ('org.apache.zookeeper:zookeeper:3.9.1') {
-        exclude group: 'org.slf4j', module: 'slf4j-log4j12'
-        exclude group: 'log4j', module: 'log4j'
+    api("org.apache.zookeeper:zookeeper:3.9.1") {
+        exclude group: "org.slf4j", module: "slf4j-log4j12"
+        exclude group: "log4j", module: "log4j"
     }
-    annotationProcessor 'org.mapstruct:mapstruct-processor'
+    annotationProcessor("org.mapstruct:mapstruct-processor")
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
-    testImplementation 'org.mockito:mockito-junit-jupiter'
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine")
+    testImplementation("org.mockito:mockito-junit-jupiter")
 
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding'
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok-mapstruct-binding")
 }
 
 test {

--- a/src-java/build.gradle
+++ b/src-java/build.gradle
@@ -53,6 +53,7 @@ subprojects {
             compileOnly("org.apache.storm:storm-core:2.6.1")
             testImplementation("org.apache.storm:storm-core:2.6.1")
             implementation("org.apache.storm:storm-kafka-client:2.6.1")
+            implementation("com.esotericsoftware:kryo:5.6.0")
 
             implementation("org.squirrelframework:squirrel-foundation:0.3.10")
 

--- a/src-java/kilda-model/build.gradle
+++ b/src-java/kilda-model/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     implementation("com.google.guava:guava")
     implementation("org.apache.commons:commons-collections4")
     implementation("org.apache.commons:commons-lang3")
-    implementation("com.esotericsoftware:kryo:5.6.0")
+    implementation("com.esotericsoftware:kryo")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-engine")


### PR DESCRIPTION
This change adds a dependency constraint for Kryo. Storm also has this dependency, so the constraint will be useful in case there is a version mismatch in the future. 5.6.0 is the latest version at the moment

I converted the blue-green build script into Kotlin style as well.