### PR TITLE
Added auto-cleanup to the LAG port creation

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowCreateSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/yflows/YFlowCreateSpec.groovy
@@ -364,7 +364,7 @@ source: switchId="${flowParams.yFlowRequest.sharedEndpoint.switchId}" port=${flo
         assumeTrue(swT != null, "Unable to find a switch that supports LAG")
         def portsArray = topology.getAllowedPortsForSwitch(swT.shared)[-2, -1]
         def payload = new LagPortRequest(portNumbers: portsArray)
-        def lagPort = northboundV2.createLagLogicalPort(swT.shared.dpId, payload).logicalPortNumber
+        def lagPort = switchHelper.createLagPort(swT.shared.dpId, payload).logicalPortNumber
 
         when: "Try creating a Y-Flow with shared endpoint port being inside LAG"
         def yFlow = yFlowFactory.getBuilder(swT).withSharedEpPort(portsArray[0]).build()
@@ -387,7 +387,6 @@ source: switchId="${flowParams.yFlowRequest.sharedEndpoint.switchId}" port=${flo
 
         cleanup:
         yFlow && !exc && yFlow.delete()
-        lagPort && northboundV2.deleteLagLogicalPort(swT.shared.dpId, lagPort)
     }
 
     @Tags([LOW_PRIORITY])

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/server42/Server42FlowRttSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/server42/Server42FlowRttSpec.groovy
@@ -671,7 +671,7 @@ class Server42FlowRttSpec extends HealthCheckSpecification {
         when: "Create a LAG port on the src switch"
         def portsForLag = topology.getAllowedPortsForSwitch(switchPair.src)[-2, -1]
         def payload = new LagPortRequest(portNumbers: portsForLag)
-        def lagPort = northboundV2.createLagLogicalPort(switchPair.src.dpId, payload).logicalPortNumber
+        def lagPort = switchHelper.createLagPort(switchPair.src.dpId, payload).logicalPortNumber
 
         and: "Create a flow"
         def flowCreateTime = new Date()
@@ -687,7 +687,6 @@ class Server42FlowRttSpec extends HealthCheckSpecification {
         }
 
         cleanup: "Revert system to original state"
-        lagPort && northboundV2.deleteLagLogicalPort(switchPair.src.dpId, lagPort)
         flowRttFeatureStartState && changeFlowRttToggle(flowRttFeatureStartState)
         initialSrcSwS42Props && changeFlowRttSwitch(switchPair.src, initialSrcSwS42Props)
         initialDstSwS42Props && changeFlowRttSwitch(switchPair.dst, initialSrcSwS42Props)


### PR DESCRIPTION
Implements #5560

* Added the method to create the LAG port in the SwitchHelper with the safe automatic cleaning up after each test
* Replaced the old creation of LAG with the new one with auto- cleanup in the tests
* Removed LAG deletion from the Spock cleanup block