### PR TITLE
Fixed the flaky test when the flow swaps to protected path

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ProtectedPathSpec.groovy
@@ -456,7 +456,7 @@ Failed to find path with requested bandwidth=$flow.maximumBandwidth/
         def usedIsls = pathHelper.getInvolvedIsls(originalMainPath) + pathHelper.getInvolvedIsls(originalProtectedPath)
         def otherIsls = switchPair.paths.findAll { it != originalMainPath &&
                 it != originalProtectedPath }.collectMany { pathHelper.getInvolvedIsls(it) }
-                .findAll {!usedIsls.contains(it) }
+                .findAll { !usedIsls.contains(it) && !usedIsls.contains(it.reversed) }
                 .unique { a, b -> a == b || a == b.reversed ? 0 : 1 }
         islHelper.breakIsls(otherIsls)
 


### PR DESCRIPTION
Implements #5390

* Fixed the flaky test "Flow swaps to protected path when main path gets broken, becomes DEGRADED if protected path is unable to reroute(no path)"
* Earlier the "otherIsls" sometimes had some reversed ISLs from the "usedIsls" list.
* So, by eliminating those reversed used ISLs, we do not break them, and the protected path is not broken. Thus, the test passes now.
* Attaching the screen of the issue before the fix. As you see on the picture, earlier the "otherIsls" that were broken, overlapped with the "usedIsls" sometimes due to the reversed ISLs.
![otherIsls_overlaps_with_usedIsls](https://github.com/telstra/open-kilda/assets/11521041/a72f567a-41c1-4484-a492-b4509c579f66)
