### PR TITLE
Updated liquibase for db_mysql_migration container.

### DIFF
--- a/confd/templates/docker-compose/docker-compose.tmpl
+++ b/confd/templates/docker-compose/docker-compose.tmpl
@@ -178,7 +178,7 @@ services:
       context: docker/db-mysql-migration
       dockerfile: Dockerfile
       args:
-        base_image: "liquibase/liquibase:${LIQUIBASE_TAG:-4.4}"
+        base_image: "liquibase/liquibase:${LIQUIBASE_TAG:-4.27}"
     command: /kilda/migrate-develop.sh
     volumes:
       - ./docker/db-mysql-migration/migrations:/liquibase/changelog

--- a/docker/db-mysql-migration/Dockerfile
+++ b/docker/db-mysql-migration/Dockerfile
@@ -13,7 +13,7 @@
 #   limitations under the License.
 #
 
-ARG base_image=liquibase/liquibase:4.4
+ARG base_image=liquibase/liquibase:4.27
 FROM ${base_image}
 
 RUN lpm add mysql --global


### PR DESCRIPTION
from version 4.4 to 4.27