### PR TITLE
small fix to disable groovy warning in the northbound module

### DIFF
--- a/src-java/northbound-service/northbound/src/main/resources/application.properties
+++ b/src-java/northbound-service/northbound/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 server.servlet.register-default-servlet=true
+spring.groovy.template.check-template-location=false


### PR DESCRIPTION
Fix for the following warning:
Cannot find template location: classpath:/templates/ (please add some templates, check your Groovy configuration, or set spring.groovy.template.check-template-location=false)