### PR TITLE
Update readme. Adjust and clean-up java settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ add or modify the line with the `vm.max_map_count` setting:
 ```shell
 vm.max_map_count=262144
 ```
+To apply the changes, restart the host or execute: `sudo sysctl --system`.
 
 ### How to build OpenKilda Controller
 

--- a/README.md
+++ b/README.md
@@ -42,50 +42,8 @@ The following packages are required for building OpenKilda controller:
  - JDK 17+
  - Python 3.8+
  - Docker 19.03.3+
- - Docker Compose 1.20.0+
  - GNU Make 4.1+
  - Open vSwitch 2.9+
-
-#### Dependency installation on Ubuntu 18.04
-
-For running a virtual environment (that is a Docker instance with the Open vSwitch service) it is required to have Linux kernel 4.18+ for OVS meters support.
-The following commands will install necessary dependencies on Ubuntu 18.04:
-Add Python's PPA repository
-```shell
-sudo add-apt-repository -y ppa:deadsnakes/ppa
-```
-
-Install required packages:
-```shell
-sudo apt update && sudo apt-get install -y \
-  maven \
-  openjdk-17-jdk \
-  python \
-  python3.8 \
-  python3-pip \
-  virtualenv \
-  make \
-  tox \
-  rsync \
-  openvswitch-switch \
-  linux-generic-hwe-18.04
-```
-
-Install required components for Python 3.6:
-```shell
-sudo pip3 install setuptools-rust==1.1.2 setuptools==46.4.0 --upgrade
-```
-
-Upgrade pip3:
-```shell
-sudo pip3 install pip --upgrade
-```
-
-(Optional) To avoid version conflict install python3-pip with the official script. To do it, you need to download script & run script:
-```shell
-wget -P /tmp/ https://bootstrap.pypa.io/get-pip.py \
-  && sudo python3.8 /tmp/get-pip.py
-```
 
 #### Dependency installation on Ubuntu 20.04
 
@@ -95,6 +53,7 @@ sudo apt update && sudo apt install -y \
   maven \
   make \
   openjdk-17-jdk \
+  openjdk-17-jre \
   openvswitch-switch \
   python3-pip \
   tox \
@@ -140,11 +99,40 @@ sudo apt-get install -y ca-certificates curl gnupg lsb-release \
 # re-login or reboot to apply the usermod command
 ```
 
+#### Docker default network settings
+When deploying OpenKilda on a remote PC, docker's default network address pool could collide with other PC on your network.
+To avoid conflicts, you can configure the address pool by creating or editing the file `/etc/docker/daemon.json`:
+```json
+{
+  "default-address-pools":
+  [
+    {"base":"10.10.0.0/16","size":24}
+  ]
+} 
+```
+Adjust the network IP address when needed.
+
 #### Maven
 You also need to increase the maven RAM limit at least up to 1G.
 
 ```shell
 export MAVEN_OPTS="-Xmx1g -XX:MaxPermSize=128m"
+```
+
+#### Elastic search
+Make sure the virtual memory areas parameter is set to the recommended value on the host where you start ELK container. 
+To see the current setting, you can use the following command:
+```shell
+sysctl vm.max_map_count
+```
+The default value 65530 is too low for ELK. To set it to the recommended value, you need to edit a read-only file `/etc/sysctl.conf` 
+on the host (not in the docker container):
+```shell
+sudo vim /etc/sysctl.conf
+```
+add or modify the line with the `vm.max_map_count` setting:
+```shell
+vm.max_map_count=262144
 ```
 
 ### How to build OpenKilda Controller

--- a/confd/templates/storm/storm.yaml.tmpl
+++ b/confd/templates/storm/storm.yaml.tmpl
@@ -68,18 +68,13 @@ supervisor.slots.ports:
 #     argument:
 #       - endpoint: "metrics-collector.mycompany.org"
 
-## Enabling Storm monitoring via JMX
-# These options enable remote JMX. Use a client (such as VisualVM or JConsole) to connect and gather JVM data.
-# Since Storm is executed inside a docker container, the ports specified here must be forwarded and appropriate rules created for the host's firewall.
-# Don't forget to comment out default settings.
-#nimbus.childopts: "-Xmx4g -Djava.net.preferIPv4Stack=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9446 -Djava.rmi.server.hostname=172.19.114.89 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
-#worker.childopts: "-Xmx512m -XX:+UseG1GC -Djava.net.preferIPv4Stack=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9447 -Djava.rmi.server.hostname=172.19.114.89 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
-#supervisor.childopts: "-Xmx4g -Djava.net.preferIPv4Stack=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9448 -Djava.rmi.server.hostname=172.19.114.89 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"
-
 ## Memory settings
-nimbus.childopts: "-Xmx4g -Djava.net.preferIPv4Stack=true"
-worker.childopts: "-Xmx512m -XX:+UseG1GC -Djava.net.preferIPv4Stack=true"
-supervisor.childopts: "-Xmx4g -Djava.net.preferIPv4Stack=true"
+nimbus.childopts: "-Xmx2g -Djava.net.preferIPv4Stack=true"
+
+worker.childopts: "-Xmx512m -Djava.net.preferIPv4Stack=true"
+
+supervisor.childopts: "-Xmx512m -Djava.net.preferIPv4Stack=true"
+
 ui.childopts: "-Xmx512m"
 
 nimbus.task.timeout.secs: 30
@@ -98,19 +93,18 @@ topology.executor.receive.buffer.size: 1024 # the queue size that needs to be pr
 topology.transfer.buffer.size: 1024
 
 topology.spout.wait.strategy: org.apache.storm.policy.WaitStrategyProgressive
-topology.backpressure.wait.strategy: org.apache.storm.policy.WaitStrategyProgressive
-topology.bolt.wait.strategy: org.apache.storm.policy.WaitStrategyProgressive
-
 topology.spout.wait.progressive.level1.count: 1
 topology.spout.wait.progressive.level2.count: 1
-topology.spout.wait.progressive.level3.sleep.millis: 5
+topology.spout.wait.progressive.level3.sleep.millis: 15
 
+topology.bolt.wait.strategy: org.apache.storm.policy.WaitStrategyProgressive
 topology.bolt.wait.progressive.level1.count: 1
 topology.bolt.wait.progressive.level2.count: 1
-topology.bolt.wait.progressive.level3.sleep.millis: 5
+topology.bolt.wait.progressive.level3.sleep.millis: 15
 
+topology.backpressure.wait.strategy: org.apache.storm.policy.WaitStrategyProgressive
 topology.backpressure.wait.progressive.level1.count: 1
 topology.backpressure.wait.progressive.level2.count: 1
-topology.backpressure.wait.progressive.level3.sleep.millis: 5
+topology.backpressure.wait.progressive.level3.sleep.millis: 15
 
 topology.stats.sample.rate: 0.05

--- a/docker/grpc-service/Dockerfile
+++ b/docker/grpc-service/Dockerfile
@@ -19,4 +19,4 @@ FROM ${base_image}
 ADD BUILD/grpc-service/libs/grpc-service.jar /app/
 ADD BUILD/grpc-service/resources/log4j2.xml /app
 WORKDIR /app
-CMD ["java", "-XX:+PrintFlagsFinal", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseContainerSupport", "-jar", "grpc-service.jar"]
+CMD ["java", "-XX:+PrintFlagsFinal", "-jar", "grpc-service.jar"]

--- a/docker/hbase/Dockerfile
+++ b/docker/hbase/Dockerfile
@@ -20,10 +20,10 @@ ENV PACKAGE hbase-1.2.4
 
 WORKDIR /tmp/
 
-# Install OpenJDK 11
+# Install OpenJDK 8
 RUN apt-get update && apt-get install -y openjdk-8-jdk
 
-# Set JAVA_HOME to OpenJDK 11
+# Set JAVA_HOME to OpenJDK 8
 ENV JAVA_VER 8
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 

--- a/docker/northbound/Dockerfile
+++ b/docker/northbound/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /app
 
 # This is an example of a command that starts Northbound with JMX enabled. You can connect to the specified IP and port
 # with visualVM or other tool to get runtime information.
-#CMD ["java", "-Dcom.sun.management.jmxremote", "-Dcom.sun.management.jmxremote.rmi.port=9445", "-Dcom.sun.management.jmxremote.port=9445", "-Djava.rmi.server.hostname=172.19.114.89", "-Dcom.sun.management.jmxremote.local.only=false", "-Dcom.sun.management.jmxremote.ssl=false", "-Dcom.sun.management.jmxremote.authenticate=false", "-XX:+PrintFlagsFinal", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseContainerSupport", "-jar", "northbound.jar"]
+#CMD ["java", "-Dcom.sun.management.jmxremote", "-Dcom.sun.management.jmxremote.rmi.port=9445", "-Dcom.sun.management.jmxremote.port=9445", "-Djava.rmi.server.hostname=172.19.114.89", "-Dcom.sun.management.jmxremote.local.only=false", "-Dcom.sun.management.jmxremote.ssl=false", "-Dcom.sun.management.jmxremote.authenticate=false", "-XX:+PrintFlagsFinal", "-jar", "northbound.jar"]
 #EXPOSE 9445
 
-CMD ["java", "-XX:+PrintFlagsFinal", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseContainerSupport", "-jar", "northbound.jar"]
+CMD ["java", "-XX:+PrintFlagsFinal", "-jar", "northbound.jar"]


### PR DESCRIPTION
I updated readme and adjusted settings. It worth to mention that there is a recommendation for memory from ELK which we don't do by default, so I put it into the readme.
For storm settings, the wait parameter is a trade-off between speed of taking a new tuple from the queue (that is low latency) vs CPU utilization (that is robust busy waiting: even if there is nothing new in the queue, program still consumes CPU cycles to check it). For our purposes, we don't really need so low latency in most of the topologies by default, so it's better to keep the wait parameter higher. If some topology requires lower latency, it is better to adjust this parameter in the topology settings and leave the global settings as-is.