### PR TITLE
5390: [TEST]: Stabilize flaky Throttling Reroute test

### DIFF
--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/FlowHelper.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/FlowHelper.groovy
@@ -25,6 +25,8 @@ import org.springframework.context.annotation.Scope
 import org.springframework.stereotype.Component
 
 import java.text.SimpleDateFormat
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 
 import static groovyx.gpars.GParsPool.withPool
 import static org.openkilda.functionaltests.helpers.FlowHistoryConstants.DELETE_SUCCESS
@@ -378,5 +380,12 @@ class FlowHelper {
                             faker.shakespeare().hamletQuote()]
         def r = new Random()
         "autotest flow: ${descpription[r.nextInt(descpription.size())]}"
+    }
+
+    static Long convertStringTimestampIsoToLong(String timestampIso) {
+        def parsedRerouteActionStart = ZonedDateTime.parse(
+                timestampIso, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+        def timestampMillis = parsedRerouteActionStart.toInstant().toEpochMilli()
+        return timestampMillis
     }
 }


### PR DESCRIPTION
Implements #5390

* Fixed the verification inside the test to verify the precise time difference between reroute request and action reroute start