### PR TITLE
[Workaround] for the issue #5663 to set 'tg88' status to inactive

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ConnectedDevicesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/ConnectedDevicesSpec.groovy
@@ -509,7 +509,10 @@ srcDevices=#newSrcEnabled, dstDevices=#newDstEnabled"() {
     def "System properly detects devices if feature is 'off' on switch level and 'on' on flow level"() {
         given: "A switch with devices feature turned off"
         assumeTrue(topology.activeTraffGens.size() > 0, "Require at least 1 switch with connected traffgen")
-        def tg = topology.activeTraffGens.shuffled().first()
+        // Skip tg88 due to the issue https://github.com/telstra/open-kilda/issues/5663
+        def tgsWhere5663IsNotReproduced = topology.activeTraffGens
+                .shuffled().findAll { it.name != "tg88" }
+        def tg = tgsWhere5663IsNotReproduced.first()
         def sw = tg.switchConnected
         def swProps = northbound.getSwitchProperties(sw.dpId)
         assert !swProps.switchLldp


### PR DESCRIPTION
The issue #5663 describes that switch 8 has 2 traffgens: tg8 and tg88. However, in fact tg88 is not active and the traffic is not sent to the flow port. This WA sets the tg88 status  to inactive, so the topology.yaml file is true to the virtual deployment.

Please see  #5663 for the details of the failed test due to this issue.