### PR TITLE
RetriesSpec: small fix to add missing break ISLs action

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/RetriesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/RetriesSpec.groovy
@@ -272,6 +272,7 @@ and at least 1 path must remain safe"
         and: "All alternative paths unavailable (bring ports down)"
         def altIsls = topology.getRelatedIsls(swPair.src) - pathHelper.getInvolvedIsls(mainPath).first() -
                 pathHelper.getInvolvedIsls(backupPath).first()
+        islHelper.breakIsls(altIsls)
 
         and: "A flow on the main path"
         def flow = flowHelperV2.randomFlow(swPair)


### PR DESCRIPTION
Implements #5390

The action of brealing other ISLs action was missed earlier during refactoring of breaking ISLs, commit 4fa720a.