### PR TITLE
[TEST]: 5390: Stabilize flaky RetriesSpec test

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/RetriesSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/xresilience/RetriesSpec.groovy
@@ -123,15 +123,24 @@ and at least 1 path must remain safe"
     @Tags([SMOKE_SWITCHES, LOCKKEEPER, ISL_RECOVER_ON_FAIL, ISL_PROPS_DB_RESET, SWITCH_RECOVER_ON_FAIL])
     def "System tries to retry rule installation during #data.description if previous one is failed"(){
         given: "Two active neighboring switches with two diverse paths at least"
-        def swPair = switchPairs.all().neighbouring().withAtLeastNNonOverlappingPaths(2).random()
+        def swPair = switchPairs.all().neighbouring()
+                .withAtLeastNNonOverlappingPaths(2)
+                .withExactlyNIslsBetweenSwitches(1)
+                .random()
         def allPaths = swPair.getPaths()
         List<PathNode> mainPath = allPaths.min { it.size() }
         //find path with more than two switches
-        List<PathNode> protectedPath = allPaths.findAll { it != mainPath && it.size() != 2 }.min { it.size() }
+        def filteredPaths = allPaths.findAll { it != mainPath && it.size() != 2 }
+        def minSize = filteredPaths*.size().min()
+        // find all possible protected paths with minimal size and pick the first one
+        def possibleProtectedPaths = filteredPaths.findAll { it.size() == minSize }
+        List<PathNode> protectedPath = possibleProtectedPaths.first()
 
         and: "All alternative paths unavailable (bring ports down)"
-        def altIsls = topology.getRelatedIsls(swPair.src) - pathHelper.getInvolvedIsls(mainPath).first() -
-                pathHelper.getInvolvedIsls(protectedPath).first()
+        def involvedIsls = pathHelper.getInvolvedIsls(mainPath) + pathHelper.getInvolvedIsls(protectedPath)
+        def altIsls = possibleProtectedPaths.collectMany { pathHelper.getInvolvedIsls(it)
+                .findAll { !(it in involvedIsls || it.reversed in involvedIsls) } }
+                .unique { a, b -> (a == b || a == b.reversed) ? 0 : 1 }
         islHelper.breakIsls(altIsls)
 
         and: "A protected flow"


### PR DESCRIPTION
Implements #5390

Select SwitchPairs with 1 ISL between them; collect `altIsls` correctly.

**The commit has 2 fixes:**
- Need to select the switchPair with withExactlyNIslsBetweenSwitches=1 because further in the code we are calculating the protected path with more than 2 switches involved (the protected path will have a size of at least 3). For example, 7 and 8 switches are neighboring and have 2 ISLs between each other. In this case with 7-8 switches, the test will expect the protected path with size 3 (though some other additional switch), but the system calculates the second ISL as a protected path.
- The `altIsls` were not calculated correctly. Sometimes the test faced the following behavior. As you see in the picture, there are 2 possible protected paths with a minimal path size. However, the test picked just the first random minimal protected path. In this situation the assertion between the expected pre-calculated protected path and the actual protected path failed. So, the fix is collecting all minimal protected paths with the min. size and breaking the alt. ISLs to leave just one possible protected path.
![image](https://github.com/telstra/open-kilda/assets/11521041/74d8d2b8-9ce8-4119-9cb4-598cbf508085)
