### PR TITLE
Add logging for KafkaProducer

### DIFF
--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/kafka/KafkaProducerService.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/kafka/KafkaProducerService.java
@@ -211,8 +211,8 @@ public class KafkaProducerService implements IKafkaProducerService, ZooKeeperEve
             }
             service.failedSendMessageCounter++;
             logger.error(
-                    "Fail to send message(correlationId=\"{}\") in kafka topic={}: Message json: {}. {}.",
-                    correlationId, topic, messageJson, exception);
+                    "Fail to send message(correlationId=\"{}\") in kafka topic={}. Message json symbol length: {}.",
+                    correlationId, topic, messageJson.length(), exception);
         }
     }
 }


### PR DESCRIPTION
The log message now does not contain the kafka message body itself, since it might be too big for kibana and as result we can not see the log in the elk stack. Now along with the other information the log contains the message symbol length.

basically I rolled back the logging to the previous state, but now it also logs the message symbol length for the json body.


Fix for the initial issue, related to way big message size in kafka will be in different PR as a separate task.