### PR TITLE
Update git hook 

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -3,7 +3,7 @@ LC_ALL=C
 
 local_branch="$(git rev-parse --abbrev-ref HEAD)"
 
-valid_branch_regex="^(docs|feature|fix|test|release|improvement|hotfix|chore)\/[a-z0-9._-]+$"
+valid_branch_regex="^(docs|feature|fix|test|release|improvement|hotfix|chore)[\/-][a-z0-9._-]+$"
 
 message="There branch name is wrong. Branch names in this project must adhere to this contract: $valid_branch_regex. You should rename your branch to a valid name and try again."
 


### PR DESCRIPTION
allows additional delimiter "-" between prefix and main part of the branch name.(mostly for the release branch naming)