### PR TITLE
Add a delta to compare all the metric rates

### DIFF
--- a/src-java/kilda-model/src/main/java/org/openkilda/model/Meter.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/Meter.java
@@ -30,6 +30,7 @@ public final class Meter implements Serializable {
     public static final int MIN_RATE_IN_KBPS = 64;
 
     private static final int METER_BURST_SIZE_EQUALS_DELTA = 1;
+    private static final int E_SWITCH_METER_RATE_EQUALS_DELTA = 1;
     private static final double E_SWITCH_METER_RATE_EQUALS_DELTA_COEFFICIENT = 0.01;
     private static final double E_SWITCH_METER_BURST_SIZE_EQUALS_DELTA_COEFFICIENT = 0.01;
 
@@ -117,10 +118,15 @@ public final class Meter implements Serializable {
         // E-switches have a bug when installing the rate and burst size.
         // Such switch sets the rate different from the rate that was sent to it.
         // Therefore, we compare actual and expected values ​​using the delta coefficient.
-        if (isESwitch) {
-            return Math.abs(actual - expected) <= expected * E_SWITCH_METER_RATE_EQUALS_DELTA_COEFFICIENT;
+        if (!isESwitch) {
+            return actual == expected;
         }
-        return actual == expected;
+        //this is a workaround for the bug in the E-switches when the rate is too small (less than 100 if delta
+        // coefficient is 0.01)
+        if (expected * E_SWITCH_METER_RATE_EQUALS_DELTA_COEFFICIENT < E_SWITCH_METER_RATE_EQUALS_DELTA) {
+            return Math.abs(actual - expected) <= E_SWITCH_METER_RATE_EQUALS_DELTA;
+        }
+        return Math.abs(actual - expected) <= expected * E_SWITCH_METER_RATE_EQUALS_DELTA_COEFFICIENT;
     }
 
     /**

--- a/src-java/kilda-model/src/test/java/org/openkilda/model/MeterTest.java
+++ b/src-java/kilda-model/src/test/java/org/openkilda/model/MeterTest.java
@@ -17,6 +17,8 @@ package org.openkilda.model;
 
 import static com.google.common.collect.Sets.newHashSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openkilda.model.SwitchFeature.MAX_BURST_COEFFICIENT_LIMITATION;
 
 import org.junit.jupiter.api.Test;
@@ -54,5 +56,13 @@ public class MeterTest {
         assertEquals(1, Meter.calculateBurstSizeConsideringHardwareLimitations(1, 4096, limitationFeature));
         assertEquals(100, Meter.calculateBurstSizeConsideringHardwareLimitations(100, 100, limitationFeature));
         assertEquals(10, Meter.calculateBurstSizeConsideringHardwareLimitations(100, 10, limitationFeature));
+    }
+
+    @Test
+    public void equalsRate() {
+        assertTrue(Meter.equalsRate(100, 100, false));
+        assertFalse(Meter.equalsRate(65, 64, false));
+        assertTrue(Meter.equalsRate(10003, 10000, true));
+        assertTrue(Meter.equalsRate(65, 64, true));
     }
 }

--- a/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/service/impl/ValidationServiceImplTest.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/test/java/org/openkilda/wfm/topology/switchmanager/service/impl/ValidationServiceImplTest.java
@@ -304,6 +304,26 @@ public class ValidationServiceImplTest {
     }
 
     @Test
+    public void validateProperMetersSlightlyDifferentMeters() {
+        ValidationService validationService = new ValidationServiceImpl(persistenceManager().build(), ruleManager);
+        MeterSpeakerData meter1 = buildFullMeterSpeakerCommandData(32, 64, 10500,
+                Sets.newHashSet(MeterFlag.KBPS, MeterFlag.BURST, MeterFlag.STATS));
+        MeterSpeakerData meter2 = buildFullMeterSpeakerCommandData(32, 65, 10500,
+                Sets.newHashSet(MeterFlag.KBPS, MeterFlag.BURST, MeterFlag.STATS));
+
+        ValidateMetersResultV2 response = validationService.validateMeters(SWITCH_ID_E,
+                singletonList(meter1),
+                singletonList(meter2),
+                true, false);
+
+        assertTrue(response.getMissingMeters().isEmpty());
+        assertTrue(response.getMisconfiguredMeters().isEmpty());
+        assertFalse(response.getProperMeters().isEmpty());
+        assertTrue(response.getExcessMeters().isEmpty());
+        assertTrue(response.isAsExpected());
+    }
+
+    @Test
     public void validateMetersMissingAndExcessMeters() {
         ValidationService validationService = new ValidationServiceImpl(persistenceManager().build(), ruleManager);
 


### PR DESCRIPTION
There is a physical switch that stores the metric rate number using a floating
point variable. This means that sometimes the rate value is not properly compared
with the expected value.

This commit applies a max delta to all the metric rates comparations that allow
to introduce an expected error during the comparison.

Closes #5638