### PR TITLE
[TEST]: Improvement: Cleanup: ISL recovering: Flaky tests

### DIFF
--- a/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/IslHelper.groovy
+++ b/src-java/testing/functional-tests/src/main/groovy/org/openkilda/functionaltests/helpers/IslHelper.groovy
@@ -69,7 +69,7 @@ class IslHelper {
         cleanupManager.addAction(RESTORE_ISL,{restoreIsl(islToBreak)}, cleanupAfter)
         cleanupManager.addAction(RESET_ISLS_COST,{database.resetCosts(topology.isls)}, cleanupAfter)
         if (getIslStatus(islToBreak).equals(DISCOVERED)) {
-            antiflapHelper.portDown(islToBreak.getSrcSwitch().getDpId(), islToBreak.getSrcPort())
+            antiflapHelper.portDown(islToBreak.getSrcSwitch().getDpId(), islToBreak.getSrcPort(), cleanupAfter, false)
         }
         islUtils.waitForIslStatus([islToBreak], FAILED)
     }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowMonitoringSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/FlowMonitoringSpec.groovy
@@ -66,10 +66,10 @@ class FlowMonitoringSpec extends HealthCheckSpecification {
         mainIsls = pathHelper.getInvolvedIsls(mainPath)
         alternativeIsls = pathHelper.getInvolvedIsls(alternativePath)
         //deactivate other paths for more clear experiment
-        def isls = mainIsls + alternativeIsls
-        islsToBreak = switchPair.paths.findAll { !paths.contains(it) }
-                .collect { pathHelper.getInvolvedIsls(it).find { !isls.contains(it) && !isls.contains(it.reversed) } }
-                .unique { [it, it.reversed].sort() }
+        def isls = mainIsls.collectMany { [it, it.reversed]} + alternativeIsls.collectMany { [it, it.reversed]}
+        islsToBreak = switchPair.paths.findAll{ !(it.containsAll(mainPath) || it.containsAll(alternativePath))}
+                .collectMany{ pathHelper.getInvolvedIsls(it)}.unique()
+                .collectMany{ [it, it.reversed] }.findAll { !isls.contains(it)}
         islHelper.breakIsls(islsToBreak, CleanupAfter.CLASS)
     }
 

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MaxLatencySpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/flows/MaxLatencySpec.groovy
@@ -69,10 +69,10 @@ class MaxLatencySpec extends HealthCheckSpecification {
         mainIsls = pathHelper.getInvolvedIsls(mainPath)
         alternativeIsls = pathHelper.getInvolvedIsls(alternativePath)
         //deactivate other paths for more clear experiment
-        def isls = mainIsls + alternativeIsls
-        islsToBreak = switchPair.paths.findAll { !paths.contains(it) }
-                .collect { pathHelper.getInvolvedIsls(it).find { !isls.contains(it) && !isls.contains(it.reversed) } }
-                .unique { [it, it.reversed].sort() }
+        def isls = mainIsls.collectMany { [it, it.reversed]} + alternativeIsls.collectMany { [it, it.reversed]}
+        islsToBreak = switchPair.paths.findAll{ !(it.containsAll(mainPath) || it.containsAll(alternativePath))}
+                .collectMany{ pathHelper.getInvolvedIsls(it)}.unique()
+                .collectMany{ [it, it.reversed] }.findAll { !isls.contains(it)}
         islHelper.breakIsls(islsToBreak, CleanupAfter.CLASS)
     }
 


### PR DESCRIPTION
In the most of Specs, we use ISL break in the test scope and recover the system after test execution. The issue occurred during breaking ISL as a part of specSetup. Make port DOWN is a part of ISL breaking and it has its recovery mechanism. As a result, after the test system recovers ports.  Note, that restoring ISL contains port recovering.

```
def restoreIsl(Isl islToRestore) {
        if(!getIslStatus(islToRestore).equals(DISCOVERED)) {
            withPool{
                [{antiflapHelper.portUp(islToRestore.getSrcSwitch().getDpId(), islToRestore.getSrcPort())},
                 {antiflapHelper.portUp(islToRestore.getDstSwitch().getDpId(), islToRestore.getDstPort())}
                ].eachParallel{it()}
            }
        }
        islUtils.waitForIslStatus([islToRestore], DISCOVERED)
    }
```