### PR TITLE
Add split kafka message support for flow validation process

### DIFF
--- a/src-java/floodlight-service/floodlight-api/build.gradle
+++ b/src-java/floodlight-service/floodlight-api/build.gradle
@@ -12,9 +12,12 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.google.guava:guava'
     implementation 'org.apache.commons:commons-lang3'
+    implementation 'org.apache.commons:commons-collections4'
     implementation 'org.slf4j:slf4j-api'
+
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/response/ChunkedSpeakerDataResponse.java
+++ b/src-java/floodlight-service/floodlight-api/src/main/java/org/openkilda/floodlight/api/response/ChunkedSpeakerDataResponse.java
@@ -1,0 +1,76 @@
+/* Copyright 2024 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.floodlight.api.response;
+
+import org.openkilda.messaging.MessageContext;
+import org.openkilda.messaging.MessageData;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ChunkedSpeakerDataResponse extends SpeakerDataResponse {
+
+    @JsonProperty("message_id")
+    private String messageId;
+
+    @JsonProperty("total_messages")
+    private int totalMessages;
+
+    public ChunkedSpeakerDataResponse(@JsonProperty("data") MessageData data,
+                                      @JsonProperty("message_context") @NonNull MessageContext messageContext,
+                                      @JsonProperty("total_messages") int totalMessages) {
+        super(messageContext, data);
+        this.messageId = messageContext.getCorrelationId();
+        this.totalMessages = totalMessages;
+    }
+
+    ChunkedSpeakerDataResponse(MessageData data, MessageContext messageContext, int totalMessages, int messageIndex) {
+        this(data, messageContext, totalMessages);
+        this.messageId = String.join(" : ", String.valueOf(messageIndex),
+                messageContext.getCorrelationId());
+    }
+
+    /**
+     * Creates list of ChunkedInfoMessages from list of InfoData.
+     */
+    public static List<ChunkedSpeakerDataResponse> createChunkedList(
+            Collection<? extends MessageData> dataCollection, MessageContext messageContext) {
+
+        if (CollectionUtils.isEmpty(dataCollection)) {
+            return Collections.singletonList(new ChunkedSpeakerDataResponse(null, messageContext, 0));
+        }
+
+        List<ChunkedSpeakerDataResponse> result = new ArrayList<>();
+        int i = 0;
+        for (MessageData messageData : dataCollection) {
+            result.add(new ChunkedSpeakerDataResponse(
+                    messageData, messageContext, dataCollection.size(), i++));
+        }
+        return result;
+    }
+}

--- a/src-java/floodlight-service/floodlight-api/src/test/java/org/openkilda/floodlight/api/response/ChunkedSpeakerDataResponseTest.java
+++ b/src-java/floodlight-service/floodlight-api/src/test/java/org/openkilda/floodlight/api/response/ChunkedSpeakerDataResponseTest.java
@@ -1,0 +1,130 @@
+/* Copyright 2024 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.floodlight.api.response;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import org.openkilda.messaging.MessageContext;
+import org.openkilda.messaging.MessageData;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ChunkedSpeakerDataResponseTest {
+
+    /**
+     * Tests the createChunkedList method to ensure it throws a NullPointerException
+     * when passed a null collection. This verifies that the method correctly handles
+     * null input by throwing the appropriate exception.
+     */
+    @Test
+    void testCreateChunkedListWithNullCollection() {
+
+        MessageContext messageContext = new MessageContext("Correlation Id");
+
+        // Act & Assert
+        NullPointerException thrown = assertThrows(NullPointerException.class, () ->
+                        ChunkedSpeakerDataResponse.createChunkedList(null, messageContext),
+                "Expected createChunkedList() to throw, but it didn't"
+        );
+        assertEquals("data is marked non-null but is null", thrown.getMessage(),
+                "Exception message should match");
+    }
+
+    /**
+     * Tests the createChunkedList method to ensure it throws a NullPointerException
+     * when passed an empty collection. This verifies that the method correctly handles
+     * empty collections by throwing the appropriate exception.
+     */
+    @Test
+    void testCreateChunkedListWithEmptyCollection() {
+        // Arrange
+        MessageContext messageContext = new MessageContext("Correlation Id");
+
+        NullPointerException thrown = assertThrows(NullPointerException.class, () ->
+                        ChunkedSpeakerDataResponse.createChunkedList(Collections.emptyList(), messageContext),
+                "Expected createChunkedList() to throw, but it didn't"
+        );
+        assertEquals("data is marked non-null but is null", thrown.getMessage(),
+                "Exception message should match");
+    }
+
+    /**
+     * Tests the createChunkedList method with a collection containing a single item.
+     * Verifies that the method correctly processes the single item and sets the
+     * messageId and totalMessages fields appropriately.
+     */
+    @Test
+    void testCreateChunkedListWithOneItem() {
+        // Arrange
+        MessageContext messageContext = new MessageContext("Correlation Id");
+        MessageData mockData = mock(MessageData.class);
+
+        // Act
+        List<ChunkedSpeakerDataResponse> result
+                = ChunkedSpeakerDataResponse.createChunkedList(Collections.singletonList(mockData), messageContext);
+
+        // Assert
+        assertEquals(1, result.size(), "Result list should contain one element");
+        ChunkedSpeakerDataResponse response = result.get(0);
+        assertSame(mockData, response.getData(), "Data should be the same as the input");
+        assertEquals(1, response.getTotalMessages(), "Total messages should be 1");
+        assertEquals("0 : Correlation Id", response.getMessageId(),
+                "Message ID should be '0 : Correlation Id'");
+    }
+
+    /**
+     * Tests the createChunkedList method with a collection containing multiple items.
+     * Verifies that the method correctly processes each item, setting the messageId
+     * and totalMessages fields appropriately for each element in the collection.
+     */
+    @Test
+    void testCreateChunkedListWithMultipleItems() {
+        // Arrange
+        MessageContext messageContext = new MessageContext("mockCorrelationId");
+        MessageData mockData1 = mock(MessageData.class);
+        MessageData mockData2 = mock(MessageData.class);
+
+        List<MessageData> dataCollection = new ArrayList<>();
+        dataCollection.add(mockData1);
+        dataCollection.add(mockData2);
+
+        // Act
+        List<ChunkedSpeakerDataResponse> result
+                = ChunkedSpeakerDataResponse.createChunkedList(dataCollection, messageContext);
+
+        // Assert
+        assertEquals(2, result.size(), "Result list should contain two elements");
+
+        ChunkedSpeakerDataResponse response1 = result.get(0);
+        assertSame(mockData1, response1.getData(), "First response data should be mockData1");
+        assertEquals(2, response1.getTotalMessages(), "Total messages should be 2");
+        assertEquals("0 : mockCorrelationId", response1.getMessageId(),
+                "First message ID should be '0 : mockCorrelationId'");
+
+        ChunkedSpeakerDataResponse response2 = result.get(1);
+        assertSame(mockData2, response2.getData(), "Second response data should be mockData2");
+        assertEquals(2, response2.getTotalMessages(), "Total messages should be 2");
+        assertEquals("1 : mockCorrelationId", response2.getMessageId(),
+                "Second message ID should be '1 : mockCorrelationId'");
+    }
+}

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/kafka/IKafkaProducerService.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/kafka/IKafkaProducerService.java
@@ -18,6 +18,7 @@ package org.openkilda.floodlight.service.kafka;
 import org.openkilda.floodlight.service.IService;
 import org.openkilda.messaging.AbstractMessage;
 import org.openkilda.messaging.Message;
+import org.openkilda.messaging.MessageContext;
 import org.openkilda.messaging.info.InfoData;
 
 import java.util.Collection;
@@ -30,6 +31,9 @@ public interface IKafkaProducerService extends IService {
     void sendMessageAndTrack(String topic, String key, AbstractMessage message);
 
     void sendChunkedMessageAndTrack(String topic, String key, Collection<? extends InfoData> data);
+
+    void sendChunkedSpeakerDataAndTrack(String topic, MessageContext messageContext,
+                                        Collection<? extends InfoData> data);
 
     void sendMessageAndTrackWithZk(String topic, Message message);
 

--- a/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/kafka/KafkaProducerService.java
+++ b/src-java/floodlight-service/floodlight-modules/src/main/java/org/openkilda/floodlight/service/kafka/KafkaProducerService.java
@@ -19,10 +19,12 @@ import static org.openkilda.floodlight.service.zookeeper.ZooKeeperService.ZK_COM
 
 import org.openkilda.bluegreen.LifecycleEvent;
 import org.openkilda.bluegreen.Signal;
+import org.openkilda.floodlight.api.response.ChunkedSpeakerDataResponse;
 import org.openkilda.floodlight.service.zookeeper.ZooKeeperEventObserver;
 import org.openkilda.floodlight.service.zookeeper.ZooKeeperService;
 import org.openkilda.messaging.AbstractMessage;
 import org.openkilda.messaging.Message;
+import org.openkilda.messaging.MessageContext;
 import org.openkilda.messaging.info.ChunkedInfoMessage;
 import org.openkilda.messaging.info.InfoData;
 import org.openkilda.messaging.info.InfoMessage;
@@ -84,6 +86,14 @@ public class KafkaProducerService implements IKafkaProducerService, ZooKeeperEve
     public void sendChunkedMessageAndTrack(String topic, String key, Collection<? extends InfoData> data) {
         for (Message message : ChunkedInfoMessage.createChunkedList(data, key)) {
             sendMessageAndTrack(topic, key, message);
+        }
+    }
+
+    @Override
+    public void sendChunkedSpeakerDataAndTrack(String topic, MessageContext messageContext,
+                                               Collection<? extends InfoData> data) {
+        for (AbstractMessage message : ChunkedSpeakerDataResponse.createChunkedList(data, messageContext)) {
+            sendMessageAndTrack(topic, messageContext.getCorrelationId(), message);
         }
     }
 

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/FlowHsTopology.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/FlowHsTopology.java
@@ -946,7 +946,7 @@ public class FlowHsTopology extends AbstractTopology<FlowHsTopologyConfig> {
                 .hubComponent(ComponentId.YFLOW_VALIDATION_HUB.name())
                 .hubComponent(ComponentId.HA_FLOW_VALIDATION_HUB.name())
                 .streamToHub(SPEAKER_WORKER_TO_HUB_VALIDATION.name())
-                .build());
+                .build(), topologyConfig.getChunkedMessagesExpirationMinutes());
 
         declareBolt(topologyBuilder, speakerWorkerForDumpsBolt, ComponentId.FLOW_VALIDATION_SPEAKER_WORKER.name())
                 .fieldsGrouping(ComponentId.SPEAKER_WORKER_SPOUT.name(), FIELDS_KEY)

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/FlowHsTopologyConfig.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/FlowHsTopologyConfig.java
@@ -87,6 +87,10 @@ public interface FlowHsTopologyConfig extends AbstractTopologyConfig {
     @Default("10")
     int getSpeakerTimeoutSeconds();
 
+    @Key("kafka.chunked.messages.expiration.minutes")
+    @Default("15")
+    int getChunkedMessagesExpirationMinutes();
+
     @Key("flow.create.speaker.command.retries")
     @Default("3")
     int getCreateSpeakerCommandRetries();

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/SpeakerCommandForDumpsCarrier.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/SpeakerCommandForDumpsCarrier.java
@@ -1,0 +1,27 @@
+/* Copyright 2024 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.service;
+
+import org.openkilda.messaging.MessageData;
+import org.openkilda.messaging.command.CommandMessage;
+import org.openkilda.wfm.error.PipelineException;
+
+public interface SpeakerCommandForDumpsCarrier {
+
+    void sendCommand(String key, CommandMessage command) throws PipelineException;
+
+    void sendResponse(String key, MessageData response) throws PipelineException;
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/SpeakerWorkerForDumpsService.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/main/java/org/openkilda/wfm/topology/flowhs/service/SpeakerWorkerForDumpsService.java
@@ -1,0 +1,164 @@
+/* Copyright 2024 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.service;
+
+import org.openkilda.floodlight.api.response.ChunkedSpeakerDataResponse;
+import org.openkilda.floodlight.api.response.SpeakerDataResponse;
+import org.openkilda.messaging.command.CommandMessage;
+import org.openkilda.messaging.command.switches.DumpGroupsForFlowHsRequest;
+import org.openkilda.messaging.command.switches.DumpMetersForFlowHsRequest;
+import org.openkilda.messaging.command.switches.DumpRulesForFlowHsRequest;
+import org.openkilda.messaging.error.ErrorData;
+import org.openkilda.messaging.error.ErrorType;
+import org.openkilda.messaging.info.flow.FlowDumpResponse;
+import org.openkilda.messaging.info.group.GroupDumpResponse;
+import org.openkilda.messaging.info.meter.MeterDumpResponse;
+import org.openkilda.wfm.error.PipelineException;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.map.PassiveExpiringMap;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class SpeakerWorkerForDumpsService {
+    private final SpeakerCommandForDumpsCarrier carrier;
+    private final Map<String, CommandMessage> keyToRequest = new HashMap<>();
+
+    /**
+     * The storage for received chunked message ids. It is needed to identify whether we have already received specific
+     * chunked message or not in order to do not have duplicates, because current version of kafka do not guarantee
+     * exactly once delivery.
+     */
+    private final Map<String, Set<String>> chunkedMessageIdsPerRequest = new HashMap<>();
+    /**
+     * Chains of chunked messages, it is filling by messages one by one as soon as the next linked message is received.
+     */
+    private final Map<String, List<ChunkedSpeakerDataResponse>> messagesChains;
+
+    public SpeakerWorkerForDumpsService(@NonNull SpeakerCommandForDumpsCarrier carrier,
+                                        int chunkedMessagesExpirationMinutes) {
+        this.carrier = carrier;
+        messagesChains = new PassiveExpiringMap<>(chunkedMessagesExpirationMinutes, TimeUnit.MINUTES, new HashMap<>());
+    }
+
+    /**
+     * Sends command to speaker.
+     *
+     * @param key     unique operation's key.
+     * @param request command to be executed.
+     */
+    public void sendCommand(@NonNull String key, @NonNull CommandMessage request) throws PipelineException {
+        log.debug("Got a request from hub bolt {}", request);
+        keyToRequest.put(key, request);
+        carrier.sendCommand(key, request);
+    }
+
+    /**
+     * Handles a timeout event by sending an error response to the hub.
+     *
+     * @param key the unique operation key associated with the timed-out request.
+     * @throws PipelineException if there is an error while sending the error response.
+     */
+    public void handleTimeout(String key) throws PipelineException {
+        log.debug("Send timeout error to hub {}", key);
+        CommandMessage request = keyToRequest.remove(key);
+        chunkedMessageIdsPerRequest.remove(key);
+        ErrorData errorData = new ErrorData(ErrorType.OPERATION_TIMED_OUT,
+                String.format("Timeout for waiting response on command %s", request),
+                "Error in SpeakerWorker");
+        carrier.sendResponse(key, errorData);
+    }
+
+    /**
+     * Processes received response and forwards it to the hub component.
+     *
+     * @param key      operation's key.
+     * @param response response payload.
+     */
+    public void handleResponse(@NonNull String key, @NonNull SpeakerDataResponse response)
+            throws PipelineException {
+        log.debug("Got a response from speaker {}", response);
+        CommandMessage pendingRequest = keyToRequest.remove(key);
+        if (pendingRequest != null) {
+            carrier.sendResponse(key, response.getData());
+        }
+    }
+
+    /**
+     * Processes received chunked responses, combines them and forwards it to the hub component.
+     */
+    public void handleChunkedResponse(String key, ChunkedSpeakerDataResponse response) throws PipelineException {
+        log.debug("Got chunked response from speaker {}", response);
+        chunkedMessageIdsPerRequest.computeIfAbsent(key, mappingFunction -> new HashSet<>());
+        Set<String> associatedMessages = chunkedMessageIdsPerRequest.get(key);
+        if (!associatedMessages.add(response.getMessageId())) {
+            log.debug("Skipping chunked message, it is already received: {}", response);
+            return;
+        }
+
+        messagesChains.computeIfAbsent(key, mappingFunction -> new ArrayList<>());
+        List<ChunkedSpeakerDataResponse> chain = messagesChains.get(key);
+        if (response.getTotalMessages() != 0) {
+            chain.add(response);
+        }
+
+        if (chain.size() == response.getTotalMessages()) {
+            completeChunkedResponse(key, chain);
+        }
+    }
+
+    private void completeChunkedResponse(String key, List<ChunkedSpeakerDataResponse> messages)
+            throws PipelineException {
+
+        CommandMessage pending = keyToRequest.remove(key);
+        messagesChains.remove(key);
+        chunkedMessageIdsPerRequest.remove(key);
+
+        if (pending == null || pending.getData() == null) {
+            return;
+        }
+        Object data = pending.getData();
+        if (data instanceof DumpRulesForFlowHsRequest) {
+            List<FlowDumpResponse> responses = process(messages, FlowDumpResponse.class);
+            carrier.sendResponse(key, FlowDumpResponse.unite(responses));
+        } else if (data instanceof DumpMetersForFlowHsRequest) {
+            List<MeterDumpResponse> responses = process(messages, MeterDumpResponse.class);
+            carrier.sendResponse(key, MeterDumpResponse.unite(responses));
+        } else if (data instanceof DumpGroupsForFlowHsRequest) {
+            List<GroupDumpResponse> responses = process(messages, GroupDumpResponse.class);
+            carrier.sendResponse(key, GroupDumpResponse.unite(responses));
+        } else {
+            log.error("Unknown request payload for chunked response. Request contest: {}, key: {}, "
+                    + "chunked data: {}", pending, key, messages);
+        }
+    }
+
+    private <T> List<T> process(List<ChunkedSpeakerDataResponse> messages, Class<T> responseType) {
+        return messages.stream()
+                .map(SpeakerDataResponse::getData)
+                .map(responseType::cast)
+                .collect(Collectors.toList());
+    }
+}

--- a/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/SpeakerWorkerForDumpsServiceTest.java
+++ b/src-java/flowhs-topology/flowhs-storm-topology/src/test/java/org/openkilda/wfm/topology/flowhs/service/SpeakerWorkerForDumpsServiceTest.java
@@ -1,0 +1,236 @@
+/* Copyright 2024 Telstra Open Source
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.openkilda.wfm.topology.flowhs.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.openkilda.floodlight.api.response.ChunkedSpeakerDataResponse;
+import org.openkilda.floodlight.api.response.SpeakerDataResponse;
+import org.openkilda.messaging.MessageContext;
+import org.openkilda.messaging.command.CommandMessage;
+import org.openkilda.messaging.command.switches.DumpRulesForFlowHsRequest;
+import org.openkilda.messaging.info.flow.FlowDumpResponse;
+import org.openkilda.model.SwitchId;
+import org.openkilda.model.cookie.FlowSegmentCookie;
+import org.openkilda.rulemanager.FlowSpeakerData;
+import org.openkilda.wfm.error.PipelineException;
+
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+class SpeakerWorkerForDumpsServiceTest {
+    private static final String CORRELATION_ID_1 = "COR_1";
+    private static final SwitchId SWITCH_1 = new SwitchId(1);
+
+    private SpeakerCommandForDumpsCarrier carrier;
+    private SpeakerWorkerForDumpsService service;
+
+    @BeforeEach
+    public void setUp() {
+        carrier = mock(SpeakerCommandForDumpsCarrier.class);
+        int chunkedMessagesExpirationMinutes = 10;
+        service = new SpeakerWorkerForDumpsService(carrier, chunkedMessagesExpirationMinutes);
+    }
+
+    /**
+     * Tests the sendCommand method by:
+     * - Verifying that a command message is sent with the correct key.
+     */
+    @Test
+    public void testSendCommand() throws PipelineException {
+        String key = "test-key";
+        CommandMessage request = mock(CommandMessage.class);
+        service.sendCommand(key, request);
+        verify(carrier).sendCommand(eq(key), eq(request));
+    }
+
+    /**
+     * Tests the handling of a standard speaker response by:
+     * - Sending a command and verifying it is sent correctly.
+     * - Handling a response and ensuring it triggers the correct response handling.
+     * - Verifying that the response is sent only once and no further interactions occur.
+     */
+    @Test
+    public void testHandleResponse() throws PipelineException {
+        String key = "test-key";
+        CommandMessage request = mock(CommandMessage.class);
+        MessageContext messageContext = new MessageContext(CORRELATION_ID_1);
+
+
+        FlowDumpResponse flowDumpResponse = buildFlowDumpResponse(SWITCH_1, 1);
+        SpeakerDataResponse response = new SpeakerDataResponse(messageContext, flowDumpResponse);
+
+        service.sendCommand(key, request);
+        verify(carrier).sendCommand(eq(key), eq(request));
+        service.handleResponse(key, response);
+        verify(carrier).sendResponse(eq(key), eq(response.getData()));
+
+        verifyNoMoreInteractions(carrier);
+        service.handleResponse(key, response);
+        verify(carrier, times(1)).sendResponse(anyString(), any());
+    }
+
+    /**
+     * Tests the complete handling of chunked responses by:
+     * - Sending a command and verifying it is stored and sent.
+     * - Handling multiple chunked responses, ensuring duplicates are ignored.
+     * - Verifying that the service correctly unites and processes the complete set of chunked responses.
+     * - Ensuring all internal caches are cleared after processing.
+     */
+    @Test
+    public void testHandleChunkedResponseComplete() throws PipelineException,
+            NoSuchFieldException, IllegalAccessException {
+        String key = "test-key";
+        CommandMessage request = mock(CommandMessage.class);
+        DumpRulesForFlowHsRequest data = new DumpRulesForFlowHsRequest(SWITCH_1);
+        when(request.getData()).thenReturn(data);
+
+        service.sendCommand(key, request);
+        verify(carrier).sendCommand(eq(key), eq(request));
+
+        List<ChunkedSpeakerDataResponse> chinkedList = ChunkedSpeakerDataResponse.createChunkedList(Lists.newArrayList(
+                        buildFlowDumpResponse(SWITCH_1, 1),
+                        buildFlowDumpResponse(SWITCH_1, 2),
+                        buildFlowDumpResponse(SWITCH_1, 2)),
+                new MessageContext(CORRELATION_ID_1));
+
+        // Access and track the state of messagesChains
+        Field messagesChainsField = SpeakerWorkerForDumpsService.class.getDeclaredField("messagesChains");
+        messagesChainsField.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        Map<String, List<ChunkedSpeakerDataResponse>> messagesChains =
+                (Map<String, List<ChunkedSpeakerDataResponse>>) messagesChainsField.get(service);
+
+        // handle first message response
+        service.handleChunkedResponse(key, chinkedList.get(0));
+        Assertions.assertNotNull(messagesChains.get(key));
+        Assertions.assertEquals(chinkedList.get(0), messagesChains.get(key).get(0));
+        verifyNoMoreInteractions(carrier);
+
+        // check handling for duplicate messages
+        service.handleChunkedResponse(key, chinkedList.get(0));
+        Assertions.assertNotNull(messagesChains.get(key));
+        Assertions.assertEquals(chinkedList.get(0), messagesChains.get(key).get(0));
+        Assertions.assertEquals(1, messagesChains.size());
+        verifyNoMoreInteractions(carrier);
+
+        // handle second message response
+        service.handleChunkedResponse(key, chinkedList.get(1));
+        Assertions.assertNotNull(messagesChains.get(key));
+        Assertions.assertEquals(2, messagesChains.get(key).size());
+        verifyNoMoreInteractions(carrier);
+
+        // handle third message response
+        service.handleChunkedResponse(key, chinkedList.get(2));
+        Assertions.assertNull(messagesChains.get(key));
+
+        FlowDumpResponse expectedResult = FlowDumpResponse.unite(chinkedList.stream().map(SpeakerDataResponse::getData)
+                .map(FlowDumpResponse.class::cast).collect(Collectors.toList()));
+
+        verify(carrier, times(1)).sendResponse(key, expectedResult);
+        verifyNoMoreInteractions(carrier);
+
+        //check that all caches in SpeakerWorkerForDumpsService are empty
+
+        Assertions.assertTrue(messagesChains.isEmpty());
+        Field chunkedMessageIdsPerRequestField =
+                SpeakerWorkerForDumpsService.class.getDeclaredField("chunkedMessageIdsPerRequest");
+        chunkedMessageIdsPerRequestField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, Set<String>> chunkedMessageIdsPerRequest =
+                (Map<String, Set<String>>) chunkedMessageIdsPerRequestField.get(service);
+        Assertions.assertTrue(chunkedMessageIdsPerRequest.isEmpty());
+
+        Field keyToRequestField = SpeakerWorkerForDumpsService.class.getDeclaredField("keyToRequest");
+        keyToRequestField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, CommandMessage> keyToRequest
+                = (Map<String, CommandMessage>) keyToRequestField.get(service);
+        Assertions.assertTrue(keyToRequest.isEmpty());
+    }
+
+    /**
+     * Tests the handleTimeout method to ensure it correctly handles timeout events by:
+     * - Removing the timed-out request from internal caches.
+     * - Sending an error response for each timed-out request.
+     * This test manually populates the internal maps with keys and simulates timeouts.
+     */
+    @Test
+    public void handleTimeout() throws PipelineException, NoSuchFieldException, IllegalAccessException {
+        String key1 = "Key1";
+        String key2 = "Key2";
+        String key3 = "Key3";
+        String key4 = "Key4";
+        //populate caches
+        Field chunkedMessageIdsPerRequestField
+                = SpeakerWorkerForDumpsService.class.getDeclaredField("chunkedMessageIdsPerRequest");
+        chunkedMessageIdsPerRequestField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, Set<String>> chunkedMessageIdsPerRequest =
+                (Map<String, Set<String>>) chunkedMessageIdsPerRequestField.get(service);
+        chunkedMessageIdsPerRequest.put(key1, Collections.emptySet());
+        chunkedMessageIdsPerRequest.put(key2, Collections.emptySet());
+        chunkedMessageIdsPerRequest.put(key3, Collections.emptySet());
+        chunkedMessageIdsPerRequest.put(key4, Collections.emptySet());
+
+        Field keyToRequestField = SpeakerWorkerForDumpsService.class.getDeclaredField("keyToRequest");
+        keyToRequestField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, CommandMessage> keyToRequest =
+                (Map<String, CommandMessage>) keyToRequestField.get(service);
+        keyToRequest.put(key1, mock(CommandMessage.class));
+        keyToRequest.put(key2, mock(CommandMessage.class));
+        keyToRequest.put(key3, mock(CommandMessage.class));
+        keyToRequest.put(key4, mock(CommandMessage.class));
+
+        service.handleTimeout(key1);
+        Assertions.assertNull(keyToRequest.get(key1));
+        Assertions.assertNull(chunkedMessageIdsPerRequest.get(key1));
+
+        service.handleTimeout(key2);
+        service.handleTimeout(key3);
+        service.handleTimeout(key4);
+        Assertions.assertTrue(keyToRequest.isEmpty());
+        Assertions.assertTrue(chunkedMessageIdsPerRequest.isEmpty());
+    }
+
+    private FlowDumpResponse buildFlowDumpResponse(SwitchId switchId, long cookie) {
+        return new FlowDumpResponse(Lists.newArrayList(buildFlowSpeakerData(cookie)), switchId);
+    }
+
+    private FlowSpeakerData buildFlowSpeakerData(long cookie) {
+        return FlowSpeakerData.builder()
+                .cookie(new FlowSegmentCookie(cookie))
+                .build();
+    }
+}


### PR DESCRIPTION

This PR adds the split message mechanism for the flow validation process. 

In particular during the flow validation procedure  the entities(FlowDumpResponse) that we gather from the floodlight side needs to be splitted before sending to the underlying processing topologies via Kafka. 
How it goes:
1)Floodlight module sends the chunked(splitted) messages via Kafka topic towards the floodlight-router topology, 
then 
2)floodlight-router topology just proxies all the messages and sends it via the kafka topic to the flowHs topology.
3) The flowHs topology waits and gathers chunked messages and then does some processing according to the flow validation logic and then sends some results to the northbound modules. (not in chunks, since at this step we do not work with chunks anymore, we have other entities)

So in short the chunked messages starts from floodlight module, then floodlight-router topology, then ends up on the flowHs topology.
So the changes that I made in this PR only related to the described message path above. 



Testing:
I did not implemented any func tests, so need to discuss with @yuliiamir. 
But all-in-one passed. I would say this is quite serious change that requires some attention from the func test point of view.


closes: #5718