### PR TITLE
Link spec fixes.

### DIFF
--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkSpec.groovy
@@ -25,7 +25,6 @@ import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.functionaltests.helpers.factory.FlowFactory
 import org.openkilda.functionaltests.helpers.model.SwitchPortVlan
-import org.openkilda.messaging.error.MessageError
 import org.openkilda.messaging.info.event.IslInfoData
 import org.openkilda.messaging.info.event.SwitchChangeType
 import org.openkilda.messaging.payload.flow.FlowState
@@ -34,7 +33,6 @@ import org.openkilda.northbound.dto.v1.links.LinkParametersDto
 import org.openkilda.testing.model.topology.TopologyDefinition.Isl
 
 import org.springframework.beans.factory.annotation.Autowired
-
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.client.HttpClientErrorException
 import spock.lang.See
@@ -287,7 +285,7 @@ class LinkSpec extends HealthCheckSpecification {
 
         then: "An error is received (400 code)"
         def exc = thrown(HttpClientErrorException)
-        new MissingServletRequestParameterException("Required $itemType parameter \'$item\' is not present").matches(exc)
+        new MissingServletRequestParameterException("Required request parameter \'$item\' for method parameter type $itemType is not present").matches(exc)
 
         where:
         srcSwId                 | srcSwPort        | dstSwId                 | dstSwPort | item         | itemType
@@ -433,7 +431,7 @@ class LinkSpec extends HealthCheckSpecification {
 
         then: "An error is received (400 code)"
         def exc = thrown(HttpClientErrorException)
-        new MissingServletRequestParameterException("Required $itemType parameter \'$item\' is not present").matches(exc)
+        new MissingServletRequestParameterException("Required request parameter \'$item\' for method parameter type $itemType is not present").matches(exc)
 
         where:
         srcSwId                 | srcSwPort        | dstSwId                 | dstSwPort | item         | itemType
@@ -448,7 +446,7 @@ class LinkSpec extends HealthCheckSpecification {
         def links = northbound.getLinks(srcSwId, srcSwPort, dstSwId, dstSwPort)
 
         then: "The corresponding list of links is returned"
-        links.each {actualLink ->
+        links.each { actualLink ->
             assert filterLinks(northbound.getAllLinks(), srcSwId, srcSwPort, dstSwId, dstSwPort).find { IslInfoData expectedLink ->
                 actualLink.source.switchId == expectedLink.source.switchId &&
                         actualLink.source.portNo == expectedLink.source.portNo &&
@@ -625,7 +623,7 @@ class LinkSpec extends HealthCheckSpecification {
 
         then: "An error is received (400 code)"
         def exc = thrown(HttpClientErrorException)
-        new MissingServletRequestParameterException("Required $itemType parameter \'$item\' is not present").matches(exc)
+        new MissingServletRequestParameterException("Required request parameter \'$item\' for method parameter type $itemType is not present").matches(exc)
 
         where:
         srcSwId                 | srcSwPort        | dstSwId                 | dstSwPort | item         | itemType
@@ -684,7 +682,7 @@ class LinkSpec extends HealthCheckSpecification {
         antiflap.portUp(isl.srcSwitch.dpId, isl.srcPort)
 
         then: "The link is rediscovered in both directions"
-        Wrappers.wait(discoveryExhaustedInterval + WAIT_OFFSET*2) {
+        Wrappers.wait(discoveryExhaustedInterval + WAIT_OFFSET * 2) {
             def links = northbound.getAllLinks()
             assert islUtils.getIslInfo(links, isl.reversed).get().state == DISCOVERED
             assert islUtils.getIslInfo(links, isl).get().state == DISCOVERED


### PR DESCRIPTION
Updated spring introduced some changes in error message. 
The old message:
 'Required $itemType parameter $item is not present'
has been changed to a new message:
  'Required request parameter $item for method parameter type $itemType is not present'
