### PR TITLE
nbworker add feature to reroute y-flow for switch/link evacuation process

### DIFF
--- a/src-gui/ui/src/app/common/constants/constants.ts
+++ b/src-gui/ui/src/app/common/constants/constants.ts
@@ -36,6 +36,8 @@ export const MessageObj = {
     bfd_flag_updated: 'BFD flag updated successfully!',
     flows_evacuated: 'All flows are evacuated successfully!',
     error_flows_evacuated: 'Error in evacuating flows!',
+    info_cannot_evacuate_flows_from_switch: 'Can not evacuate flows while switch is not under maintenance.',
+    info_cannot_evacuate_flows_from_isl: 'Can not evacuate flows while ISL is not under maintenance.',
     reverse_graph_no_data: 'Backward graph API did not return data.',
     forward_graph_no_data: 'Forward graph API did not return data.',
     updating_isl_bandwidth: 'Updating ISL max bandwidth',

--- a/src-gui/ui/src/app/modules/isl/isl-detail/isl-detail.component.html
+++ b/src-gui/ui/src/app/modules/isl/isl-detail/isl-detail.component.html
@@ -242,18 +242,13 @@
                 </div>
               </div>
               <div class='row isl_sbl_details mt-3' *ngIf="commonService.hasPermission('isl_update_maintenance')">
-                <label class='col-sm-6 col-form-label'>Evacuate All Flows:
-                </label>
+                <label class='col-sm-6 col-form-label'>Evacuate All Flows:</label>
                 <div class='col-sm-6'>
                   <div class="pull-left">
-                    <div class="onoffswitch">
-                      <input type="checkbox" (change)="evacuateIsl($event)" name="isl-evacuate"
-                        class="onoffswitch-checkbox" id="onoffevacuateisl" [checked]="evacuate">
-                      <label class="onoffswitch-label" for="onoffevacuateisl">
-                        <span class="onoffswitch-inner onoffswitch-inner-maintenance-switch"></span>
-                        <span class="onoffswitch-switch" id="onoffswitch-switch"></span>
-                      </label>
-                    </div>
+                      <button type="button" class="btn pull-left kilda_btn"
+                              style="padding: 0px 9px!important;"
+                              (click)="evacuateIsl($event)">Evacuate
+                      </button> &nbsp;
                   </div>
                 </div>
               </div>

--- a/src-gui/ui/src/app/modules/isl/isl-detail/isl-detail.component.ts
+++ b/src-gui/ui/src/app/modules/isl/isl-detail/isl-detail.component.ts
@@ -42,7 +42,6 @@ export class IslDetailComponent implements OnInit, AfterViewInit, OnDestroy {
     state = '';
     bfd_session_status = '';
     enable_bfd = false;
-    evacuate = false;
     under_maintenance = false;
     loadingData = true;
     isBFDEdit: any = false;
@@ -187,7 +186,6 @@ export class IslDetailComponent implements OnInit, AfterViewInit, OnDestroy {
                 this.bfd_session_status = retrievedObject.bfd_session_status;
                 this.available_bandwidth = retrievedObject.available_bandwidth;
                 this.under_maintenance = retrievedObject.under_maintenance;
-                this.evacuate = retrievedObject.evacuate;
                 this.enable_bfd = retrievedObject.enable_bfd;
                 this.clipBoardItems = Object.assign(this.clipBoardItems, {
                     sourceSwitchName: retrievedObject.source_switch_name,
@@ -413,14 +411,13 @@ export class IslDetailComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     evacuateIsl(e) {
+        if (!this.under_maintenance) {
+            this.toastr.info(MessageObj.info_cannot_evacuate_flows_from_isl, 'Can not evacuate');
+            return;
+        }
         const modalRef = this.modalService.open(ModalconfirmationComponent);
         modalRef.componentInstance.title = 'Confirmation';
-        this.evacuate = e.target.checked;
-        if (this.evacuate) {
-            modalRef.componentInstance.content = 'Are you sure you want to evacuate all flows?';
-        } else {
-            modalRef.componentInstance.content = 'Are you sure ?';
-        }
+        modalRef.componentInstance.content = 'Are you sure you want to evacuate all flows?';
         modalRef.result.then((response) => {
             if (response && response == true) {
                 const data = {
@@ -429,7 +426,7 @@ export class IslDetailComponent implements OnInit, AfterViewInit, OnDestroy {
                     dst_switch: this.dst_switch,
                     dst_port: this.dst_port,
                     under_maintenance: this.under_maintenance,
-                    evacuate: e.target.checked
+                    evacuate: true
                 };
                 this.islListService.islUnderMaintenance(data).subscribe(response => {
                     this.toastr.success(MessageObj.flows_evacuated, 'Success');
@@ -437,11 +434,7 @@ export class IslDetailComponent implements OnInit, AfterViewInit, OnDestroy {
                 }, error => {
                     this.toastr.error(MessageObj.error_flows_evacuated, 'Error');
                 });
-            } else {
-                this.evacuate = false;
             }
-        }, error => {
-            this.evacuate = false;
         });
     }
 

--- a/src-gui/ui/src/app/modules/switches/switch-detail/switch-detail.component.html
+++ b/src-gui/ui/src/app/modules/switches/switch-detail/switch-detail.component.html
@@ -108,12 +108,10 @@
                         <label class="col-sm-4 col-form-label">Evacuate:</label>
                         <div class="col-sm-4 switchdetails_div_address col-form-label">
                             <div class="onoffswitch">
-                                <input type="checkbox" (change)="evacuateSwitch($event)" name="onoffswitchevacuate"
-                                       class="onoffswitch-checkbox" id="onoffswitchevacuate" [checked]="evacuate">
-                                <label class="onoffswitch-label" for="onoffswitchevacuate">
-                                    <span class="onoffswitch-inner onoffswitch-inner-maintenance-switch"></span>
-                                    <span class="onoffswitch-switch"></span>
-                                </label>
+                                <button type="button" class="btn pull-left kilda_btn"
+                                        style="padding: 0px 9px!important; margin: 0px 0px -10px 0px;"
+                                        (click)="evacuateSwitch($event)">Evacuate
+                                </button> &nbsp;
                             </div>
                         </div>
                     </div>

--- a/src-gui/ui/src/app/modules/switches/switch-detail/switch-detail.component.ts
+++ b/src-gui/ui/src/app/modules/switches/switch-detail/switch-detail.component.ts
@@ -442,31 +442,24 @@ export class SwitchDetailComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     evacuateSwitch(e) {
+        if (!this.underMaintenance) {
+            this.toastr.info(MessageObj.info_cannot_evacuate_flows_from_switch, 'Can not evacuate');
+            return;
+        }
         const modalRef = this.modalService.open(ModalconfirmationComponent);
         modalRef.componentInstance.title = 'Confirmation';
-        this.evacuate = e.target.checked;
-        if (this.evacuate) {
-            modalRef.componentInstance.content = 'Are you sure you want to evacuate all flows?';
-        } else {
-            modalRef.componentInstance.content = 'Are you sure ?';
-        }
+        modalRef.componentInstance.content = 'Are you sure you want to evacuate all flows?';
         modalRef.result.then((response) => {
             if (response && response == true) {
-                const data = {'under_maintenance': this.underMaintenance, 'evacuate': e.target.checked};
+                const data = {'under_maintenance': this.underMaintenance, 'evacuate': true};
                 this.switchService.switchMaintenance(data, this.switchId).subscribe((serverResponse) => {
                     this.toastr.success(MessageObj.flows_evacuated, 'Success');
                     location.reload();
                 }, error => {
                     this.toastr.error(MessageObj.error_flows_evacuated, 'Error');
                 });
-            } else {
-                this.evacuate = false;
             }
-        }, error => {
-            this.evacuate = false;
         });
-
-
     }
 
     ngOnDestroy() {

--- a/src-java/kilda-model/src/main/java/org/openkilda/model/FlowPath.java
+++ b/src-java/kilda-model/src/main/java/org/openkilda/model/FlowPath.java
@@ -88,13 +88,14 @@ public class FlowPath implements CompositeDataEntity<FlowPath.FlowPathData> {
                     long latency, long bandwidth,
                     boolean ignoreBandwidth, FlowPathStatus status, List<PathSegment> segments,
                     Set<FlowApplication> applications,
-                    String sharedBandwidthGroupId, HaFlowPath haFlowPath) {
+                    String sharedBandwidthGroupId, HaFlowPath haFlowPath, Flow flow) {
         data = FlowPathDataImpl.builder().pathId(pathId).srcSwitch(srcSwitch).destSwitch(destSwitch)
                 .cookie(cookie).meterId(meterId).ingressMirrorGroupId(ingressMirrorGroupId)
                 .latency(latency).bandwidth(bandwidth)
                 .ignoreBandwidth(ignoreBandwidth).status(status)
                 .applications(applications)
                 .sharedBandwidthGroupId(sharedBandwidthGroupId).haFlowPath(haFlowPath)
+                .flow(flow)
                 .build();
         // The reference is used to link path segments back to the path. See {@link #setSegments(List)}.
         ((FlowPathDataImpl) data).flowPath = this;

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/MessageEncoder.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/main/java/org/openkilda/wfm/topology/nbworker/bolts/MessageEncoder.java
@@ -17,7 +17,7 @@ package org.openkilda.wfm.topology.nbworker.bolts;
 
 import org.openkilda.messaging.Message;
 import org.openkilda.messaging.MessageData;
-import org.openkilda.messaging.command.flow.FlowRerouteRequest;
+import org.openkilda.messaging.command.BaseRerouteRequest;
 import org.openkilda.messaging.command.switches.SwitchValidateRequest;
 import org.openkilda.messaging.error.ErrorData;
 import org.openkilda.wfm.CommandContext;
@@ -38,7 +38,7 @@ public class MessageEncoder extends KafkaEncoder {
             CommandContext commandContext = pullContext(input);
             Message message = wrap(commandContext, payload);
 
-            if (payload instanceof FlowRerouteRequest) {
+            if (payload instanceof BaseRerouteRequest) {
                 getOutput().emit(input.getSourceStreamId(), input, new Values(message));
             } else if (payload instanceof SwitchValidateRequest) {
                 getOutput().emit(input.getSourceStreamId(), input,

--- a/src-java/nbworker-topology/nbworker-storm-topology/src/main/java/org/openkilda/wfm/topology/nbworker/services/FlowOperationsService.java
+++ b/src-java/nbworker-topology/nbworker-storm-topology/src/main/java/org/openkilda/wfm/topology/nbworker/services/FlowOperationsService.java
@@ -24,6 +24,7 @@ import org.openkilda.messaging.command.BaseRerouteRequest;
 import org.openkilda.messaging.command.flow.FlowRequest;
 import org.openkilda.messaging.command.flow.FlowRerouteRequest;
 import org.openkilda.messaging.command.haflow.HaFlowRerouteRequest;
+import org.openkilda.messaging.command.yflow.YFlowRerouteRequest;
 import org.openkilda.messaging.error.ErrorType;
 import org.openkilda.messaging.error.InvalidFlowException;
 import org.openkilda.messaging.error.MessageException;
@@ -83,6 +84,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import net.jodah.failsafe.RetryPolicy;
+import org.apache.commons.lang3.StringUtils;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -713,10 +715,20 @@ public class FlowOperationsService {
                     }
                 }
             } else {
-                if (processed.add(flow.getFlowId())) {
-                    FlowRerouteRequest request = new FlowRerouteRequest(
-                            flow.getFlowId(), false, false, affectedIslEndpoints, reason, false);
-                    results.add(request);
+                if (StringUtils.isNotBlank(flow.getYFlowId())) {
+                    if (yFlowRepository.exists(flow.getYFlowId())) {
+                        if (processed.add(flow.getYFlowId())) {
+                            YFlowRerouteRequest req = new YFlowRerouteRequest(flow.getYFlowId(), affectedIslEndpoints,
+                                    reason, false);
+                            results.add(req);
+                        }
+                    }
+                } else {
+                    if (processed.add(flow.getFlowId())) {
+                        FlowRerouteRequest request = new FlowRerouteRequest(
+                                flow.getFlowId(), false, false, affectedIslEndpoints, reason, false);
+                        results.add(request);
+                    }
                 }
             }
         }

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkMaintenanceSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/links/LinkMaintenanceSpec.groovy
@@ -2,6 +2,7 @@ package org.openkilda.functionaltests.spec.links
 
 import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
+import static org.openkilda.functionaltests.helpers.Wrappers.timedLoop
 import static org.openkilda.testing.Constants.DEFAULT_COST
 import static org.openkilda.testing.Constants.PATH_INSTALLATION_TIME
 import static org.openkilda.testing.Constants.WAIT_OFFSET
@@ -11,6 +12,8 @@ import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.functionaltests.helpers.factory.FlowFactory
 import org.openkilda.functionaltests.helpers.model.FlowEntityPath
+import org.openkilda.functionaltests.helpers.model.FlowWithSubFlowsEntityPath
+import org.openkilda.functionaltests.helpers.factory.YFlowFactory
 import org.openkilda.messaging.payload.flow.FlowState
 
 import org.springframework.beans.factory.annotation.Autowired
@@ -21,6 +24,10 @@ class LinkMaintenanceSpec extends HealthCheckSpecification {
     @Autowired
     @Shared
     FlowFactory flowFactory
+
+    @Autowired
+    @Shared
+    YFlowFactory yFlowFactory
 
     @Tags(SMOKE)
     def "Maintenance mode can be set/unset for a particular link"() {
@@ -65,8 +72,10 @@ class LinkMaintenanceSpec extends HealthCheckSpecification {
         islHelper.setLinkMaintenance(isl, true, false)
 
         then: "Flows are not evacuated (rerouted) and have the same paths"
-        flow1.retrieveAllEntityPaths() == flow1Path
-        flow2.retrieveAllEntityPaths() == flow2Path
+        timedLoop(3) {
+            assert flow1.retrieveAllEntityPaths() == flow1Path
+            assert flow2.retrieveAllEntityPaths() == flow2Path
+        }
 
         when: "Set maintenance mode again with flows evacuation flag for the same link"
         northbound.setLinkMaintenance(islUtils.toLinkUnderMaintenance(isl, true, true))
@@ -86,6 +95,91 @@ class LinkMaintenanceSpec extends HealthCheckSpecification {
         and: "Link under maintenance is not involved in new flow paths"
         !flow1PathUpdated.getInvolvedIsls().contains(isl)
         !flow2PathUpdated.getInvolvedIsls().contains(isl)
+    }
+
+    def "Y-Flows can be evacuated (rerouted) from a particular link when setting maintenance mode for it"() {
+        given: "Switch triplet with two possible paths at least for non-neighbouring switches"
+        def swTriplet = switchTriplets.all().nonNeighbouring().withAtLeastNNonOverlappingPaths(2).random()
+
+        and: "Create Y-Flows going through selected switch triplet"
+        def yFlow1 = yFlowFactory.getRandom(swTriplet, false)
+        def yFlow1Path = yFlow1.retrieveAllEntityPaths()
+
+        def yFlow2 = yFlowFactory.getRandom(swTriplet, false, yFlow1.occupiedEndpoints())
+        def yFlow2Path = yFlow2.retrieveAllEntityPaths()
+        assert yFlow1Path.getInvolvedIsls().sort() == yFlow2Path.getInvolvedIsls().sort()
+
+        when: "Set maintenance mode without flows evacuation flag for the first link involved in flow paths"
+        def isl = yFlow1Path.getInvolvedIsls().first()
+        islHelper.setLinkMaintenance(isl, true, false)
+
+        then: "Y-Flows are not evacuated (rerouted) and have the same paths"
+        timedLoop(3) {
+            assert yFlow1.retrieveAllEntityPaths() == yFlow1Path
+            assert yFlow2.retrieveAllEntityPaths() == yFlow2Path
+        }
+
+        when: "Set maintenance mode again with flows evacuation flag for the same link"
+        northbound.setLinkMaintenance(islUtils.toLinkUnderMaintenance(isl, true, true))
+
+        then: "Y-Flows are evacuated (rerouted) and link under maintenance is not involved in new flow paths"
+        FlowWithSubFlowsEntityPath yFlow1PathUpdated, yFlow2PathUpdated
+        Wrappers.wait(PATH_INSTALLATION_TIME + WAIT_OFFSET) {
+            [yFlow1, yFlow2].each { flow -> assert flow.retrieveDetails().status == FlowState.UP }
+            yFlow1PathUpdated = yFlow1.retrieveAllEntityPaths()
+            yFlow2PathUpdated = yFlow2.retrieveAllEntityPaths()
+
+            assert yFlow1PathUpdated != yFlow1Path
+            assert yFlow2PathUpdated != yFlow2Path
+        }
+
+        and: "Link under maintenance is not involved in new Y-Flow paths"
+        !yFlow1PathUpdated.getInvolvedIsls().contains(isl)
+        !yFlow2PathUpdated.getInvolvedIsls().contains(isl)
+    }
+
+    @Tags(SMOKE)
+    def "Both Y-Flow and Flow can be evacuated (rerouted) from a particular link when setting maintenance mode for it"() {
+        given: "Switch triplet with active switches"
+        def swTriplet = switchTriplets.all().withSharedEpEp1Ep2InChain().random()
+
+        and: "Create Y-Flows going through selected switch triplet"
+        def yFlow = yFlowFactory.getRandom(swTriplet, false)
+        def yFlowPath = yFlow.retrieveAllEntityPaths()
+        def isl = yFlowPath.getInvolvedIsls().first()
+
+        and: "Switch pair has been selected based on Y-Flow used Isl"
+        def switchPair = switchPairs.all().specificPair(isl.srcSwitch, isl.dstSwitch)
+
+        and: "Create Flow going through selected switch pair"
+        def flow = flowFactory.getRandom(switchPair)
+        def flowPath = flow.retrieveAllEntityPaths()
+        assert flowPath.getInvolvedIsls().contains(isl)
+
+        when: "Set maintenance mode without flows evacuation flag for the first link involved in flow paths"
+        islHelper.setLinkMaintenance(isl, true, false)
+
+        then: "Both Y-Flow and Flow are not evacuated (rerouted) and have the same paths"
+        timedLoop(3) {
+            assert flow.retrieveAllEntityPaths() == flowPath
+            assert yFlow.retrieveAllEntityPaths() == yFlowPath
+        }
+
+        when: "Set maintenance mode again with flows evacuation flag for the same link"
+        northbound.setLinkMaintenance(islUtils.toLinkUnderMaintenance(isl, true, true))
+
+        then: "Both Y-Flow and Flow are evacuated (rerouted)"
+        Wrappers.wait(PATH_INSTALLATION_TIME + WAIT_OFFSET) {
+            assert flow.retrieveFlowStatus().status == FlowState.UP
+            assert yFlow.retrieveDetails().status == FlowState.UP
+
+            assert flow.retrieveAllEntityPaths() != flowPath
+            assert yFlow.retrieveAllEntityPaths() != yFlowPath
+        }
+
+        and: "Link under maintenance is not involved in new flow paths"
+        !flow.retrieveAllEntityPaths().getInvolvedIsls().contains(isl)
+        !yFlow.retrieveAllEntityPaths().getInvolvedIsls().contains(isl)
     }
 
     @Tags(ISL_RECOVER_ON_FAIL)
@@ -118,7 +212,7 @@ class LinkMaintenanceSpec extends HealthCheckSpecification {
 
         then: "Flows are rerouted to alternative path with link under maintenance"
         Wrappers.wait(rerouteDelay + WAIT_OFFSET * 2) {
-            [flow1, flow2].each { flow ->  assert flow.retrieveFlowStatus().status == FlowState.UP }
+            [flow1, flow2].each { flow -> assert flow.retrieveFlowStatus().status == FlowState.UP }
 
             def flow1PathUpdated = flow1.retrieveAllEntityPaths()
             def flow2PathUpdated = flow2.retrieveAllEntityPaths()

--- a/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchMaintenanceSpec.groovy
+++ b/src-java/testing/functional-tests/src/test/groovy/org/openkilda/functionaltests/spec/switches/SwitchMaintenanceSpec.groovy
@@ -3,6 +3,7 @@ package org.openkilda.functionaltests.spec.switches
 import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static org.openkilda.functionaltests.extension.tags.Tag.ISL_RECOVER_ON_FAIL
 import static org.openkilda.functionaltests.extension.tags.Tag.SMOKE
+import static org.openkilda.functionaltests.helpers.Wrappers.timedLoop
 import static org.openkilda.testing.Constants.DEFAULT_COST
 import static org.openkilda.testing.Constants.PATH_INSTALLATION_TIME
 import static org.openkilda.testing.Constants.WAIT_OFFSET
@@ -11,8 +12,8 @@ import org.openkilda.functionaltests.HealthCheckSpecification
 import org.openkilda.functionaltests.extension.tags.Tags
 import org.openkilda.functionaltests.helpers.Wrappers
 import org.openkilda.functionaltests.helpers.factory.FlowFactory
-import org.openkilda.functionaltests.helpers.model.FlowEntityPath
 import org.openkilda.functionaltests.helpers.model.Path
+import org.openkilda.functionaltests.helpers.factory.YFlowFactory
 import org.openkilda.messaging.info.event.IslChangeType
 import org.openkilda.messaging.payload.flow.FlowState
 import org.openkilda.model.SwitchId
@@ -26,6 +27,9 @@ class SwitchMaintenanceSpec extends HealthCheckSpecification {
     @Shared
     @Autowired
     FlowFactory flowFactory
+    @Shared
+    @Autowired
+    YFlowFactory yFlowFactory
 
     @Tags(SMOKE)
     def "Maintenance mode can be set/unset for a particular switch"() {
@@ -69,54 +73,132 @@ class SwitchMaintenanceSpec extends HealthCheckSpecification {
         }
     }
 
-    @Tags(SMOKE)
-    def "Flows can be evacuated (rerouted) from a particular switch when setting maintenance mode for it"() {
+    def "Flows can be evacuated (rerouted) from a particular switch(several Isls are in use) when setting maintenance mode for it"() {
         given: "Two active not neighboring switches and a switch to be maintained"
         SwitchId swId
-        List<Isl> pathIsls
+        List<Isl> intermediateSwIsls
+        List<Isl> flow1PathIsls
         def switchPair = switchPairs.all().nonNeighbouring().getSwitchPairs().find {
             List<Path> availablePath = it.retrieveAvailablePaths()
-            pathIsls = availablePath.find { Path aPath ->
+            flow1PathIsls = availablePath.find { Path aPath ->
                 swId = aPath.getInvolvedSwitches().find { aSw ->
-                    availablePath.findAll { it != aPath }.find { !it.getInvolvedSwitches().contains(aSw) }
+                    intermediateSwIsls = topology.getRelatedIsls(aSw)
+                    availablePath.findAll { it != aPath }.find { !it.getInvolvedSwitches().contains(aSw) && intermediateSwIsls.size() > 2 }
                 }
         }.getInvolvedIsls()
         } ?: assumeTrue(false, "No suiting switches found. Need a switch pair with at least 2 paths and one of the " +
         "paths should not use the maintenance switch")
-        switchPair.retrieveAvailablePaths().collect { it.getInvolvedIsls() }.findAll { it != pathIsls }
-                .each { islHelper.makePathIslsMorePreferable(pathIsls, it) }
+        switchPair.retrieveAvailablePaths().collect { it.getInvolvedIsls() }.findAll { it != flow1PathIsls }
+                .each { islHelper.makePathIslsMorePreferable(flow1PathIsls, it) }
 
-        and: "Create a couple of flows going through these switches"
+        and: "Create a Flow going through these switches"
         def flow1 = flowFactory.getRandom(switchPair)
-        def flow2 = flowFactory.getRandom(switchPair, false, FlowState.UP, flow1.occupiedEndpoints())
-        assert flow1.retrieveAllEntityPaths().getInvolvedIsls() == pathIsls
-        assert flow2.retrieveAllEntityPaths().getInvolvedIsls()== pathIsls
+        def flow1Path = flow1.retrieveAllEntityPaths()
+        def flow1IntermediateSwIsl = flow1PathIsls.findAll { it in intermediateSwIsls  || it.reversed in intermediateSwIsls }
+        assert flow1Path.getInvolvedIsls().containsAll(flow1IntermediateSwIsl)
+
+        and: "Create an additional Flow that has the same intermediate switch, but other ISLs are involved into a path"
+        def additionalSwitchPair = switchPairs.all().nonNeighbouring()
+                .excludeSwitches([switchPair.src, topology.switches.find { it.dpId == swId }]).random()
+
+        def flow2PathIsls = additionalSwitchPair.retrieveAvailablePaths()
+                .find { it.getInvolvedSwitches().contains(swId) && it.getInvolvedIsls().intersect(flow1PathIsls).isEmpty() }.getInvolvedIsls()
+
+        additionalSwitchPair.retrieveAvailablePaths().collect { it.getInvolvedIsls() }.findAll { it != flow2PathIsls }
+                .each { islHelper.makePathIslsMorePreferable(flow2PathIsls, it) }
+
+        def flow2 = flowFactory.getRandom(additionalSwitchPair, false)
+        def flow2Path = flow2.retrieveAllEntityPaths()
+        def flow2IntermediateSwIsl = flow2PathIsls.findAll { it in intermediateSwIsls  || it.reversed in intermediateSwIsls }
+        assert flow2Path.getInvolvedIsls().containsAll(flow2IntermediateSwIsl)
+        assert flow2IntermediateSwIsl.intersect(flow1IntermediateSwIsl).isEmpty()
 
         when: "Set maintenance mode without flows evacuation flag for some intermediate switch involved in flow paths"
         switchHelper.setSwitchMaintenance(swId, true, false)
 
         then: "Flows are not evacuated (rerouted) and have the same paths"
-        flow1.retrieveAllEntityPaths().getInvolvedIsls() == pathIsls
-        flow2.retrieveAllEntityPaths().getInvolvedIsls() == pathIsls
+        timedLoop(3) {
+            assert flow1.retrieveAllEntityPaths() == flow1Path
+            assert flow2.retrieveAllEntityPaths() == flow2Path
+        }
 
         when: "Set maintenance mode again with flows evacuation flag for the same switch"
         northbound.setSwitchMaintenance(swId, true, true)
 
         then: "Flows are evacuated (rerouted)"
-        FlowEntityPath flow1PathUpdated, flow2PathUpdated
         Wrappers.wait(PATH_INSTALLATION_TIME + WAIT_OFFSET) {
             [flow1, flow2].each { assert it.retrieveFlowStatus().status == FlowState.UP }
-
-            flow1PathUpdated = flow1.retrieveAllEntityPaths()
-            flow2PathUpdated = flow2.retrieveAllEntityPaths()
-
-            assert flow1PathUpdated.getInvolvedIsls() != pathIsls
-            assert flow2PathUpdated.getInvolvedIsls()!= pathIsls
+            assert flow1.retrieveAllEntityPaths() != flow1Path
+            assert flow2.retrieveAllEntityPaths() != flow2Path
         }
 
         and: "Switch under maintenance is not involved in new flow paths"
-        !flow1PathUpdated.getInvolvedSwitches().contains(swId)
-        !flow2PathUpdated.getInvolvedSwitches().contains(swId)
+        !flow1.retrieveAllEntityPaths().getInvolvedSwitches().contains(swId)
+        !flow2.retrieveAllEntityPaths().getInvolvedSwitches().contains(swId)
+
+    }
+
+    @Tags(SMOKE)
+    def "Both Y-Flow and Flow can be evacuated (rerouted) from a particular switch when setting maintenance mode for it"() {
+        given: "Switch triplet has been selected"
+        def swTriplet = profile == "hardware" ? switchTriplets.all().withSharedEpEp1Ep2InChain().random()
+                : switchTriplets.all().nonNeighbouring().random() ?: assumeTrue(false, "No suiting switches found.")
+
+        and: "Create a Y-Flow going through selected switches and has intermediate switch in a path"
+        if (profile == "hardware") {
+            //additional steps due to the HW limitation
+            def availablePaths = swTriplet.pathsEp1[0].size() == 2 ?
+                    swTriplet.retrieveAvailablePathsEp1().collect { it.getInvolvedIsls() } :
+                    swTriplet.retrieveAvailablePathsEp2().collect { it.getInvolvedIsls() }
+            // 1 isl is equal to 2 pathNodes
+            def preferablePath = availablePaths.find { it.size() > 1 }
+            availablePaths.findAll { it != preferablePath }.each {
+                islHelper.makePathIslsMorePreferable(preferablePath, it)
+            }
+        }
+        def yFlow = yFlowFactory.getRandom(swTriplet, false)
+        def yFlowPath = yFlow.retrieveAllEntityPaths()
+        def intermediateSwId = yFlowPath.getInvolvedSwitches()
+                .find { !(it in [swTriplet.shared.dpId, swTriplet.ep1.dpId, swTriplet.ep2.dpId]) }
+        assert intermediateSwId
+
+        and: "Two active not neighboring switches and preferable path with intermediate switch"
+        def dstSw = swTriplet.pathsEp1[0].size() == 4 ? swTriplet.ep1 : swTriplet.ep2
+        def swPair = switchPairs.all().specificPair(swTriplet.shared, dstSw)
+        def availablePaths = swPair.retrieveAvailablePaths()
+        List<Isl> pathIsls = availablePaths.find { path -> intermediateSwId in path.getInvolvedSwitches() }.getInvolvedIsls()
+        availablePaths.collect { it.getInvolvedIsls() }.findAll { it != pathIsls }
+                .each { islHelper.makePathIslsMorePreferable(pathIsls, it) }
+
+        and: "Create a Flow going through these switches"
+        def flow = flowFactory.getRandom(swPair)
+        def flowPath = flow.retrieveAllEntityPaths()
+        assert flowPath.getInvolvedSwitches().contains(intermediateSwId)
+
+        when: "Set maintenance mode without flows evacuation flag for some intermediate switch involved in flow paths"
+        switchHelper.setSwitchMaintenance(intermediateSwId, true, false)
+
+        then: "Both Flow and Y-Flow are not evacuated (rerouted) and have the same paths"
+        timedLoop(3) {
+            assert flow.retrieveAllEntityPaths() == flowPath
+            assert yFlow.retrieveAllEntityPaths() == yFlowPath
+        }
+
+        when: "Set maintenance mode again with flows evacuation flag for the same switch"
+        northbound.setSwitchMaintenance(intermediateSwId, true, true)
+
+        then: "Both Flow and Y-Flow are evacuated (rerouted)"
+        Wrappers.wait(PATH_INSTALLATION_TIME + WAIT_OFFSET) {
+            assert flow.retrieveFlowStatus().status == FlowState.UP
+            assert yFlow.retrieveDetails().status == FlowState.UP
+
+            assert flow.retrieveAllEntityPaths() != flowPath
+            assert yFlow.retrieveAllEntityPaths() != yFlowPath
+        }
+
+        and: "Switch under maintenance is not involved in new flow paths"
+        !flow.retrieveAllEntityPaths().getInvolvedSwitches().contains(intermediateSwId)
+        !yFlow.retrieveAllEntityPaths().getInvolvedSwitches().contains(intermediateSwId)
     }
 
     @Tags(ISL_RECOVER_ON_FAIL)

--- a/src-java/testing/test-library/src/main/java/org/openkilda/testing/model/topology/TopologyDefinition.java
+++ b/src-java/testing/test-library/src/main/java/org/openkilda/testing/model/topology/TopologyDefinition.java
@@ -229,16 +229,21 @@ public class TopologyDefinition {
      * actual ISLs.
      */
     @JsonIgnore
-    public List<Isl> getRelatedIsls(Switch sw) {
+    public List<Isl> getRelatedIsls(SwitchId swId) {
         List<Isl> isls = getIslsForActiveSwitches().stream().filter(isl ->
-                isl.getSrcSwitch().getDpId().equals(sw.getDpId()) || isl.getDstSwitch().getDpId().equals(sw.getDpId()))
+                isl.getSrcSwitch().getDpId().equals(swId) || isl.getDstSwitch().getDpId().equals(swId))
                 .collect(toList());
         for (Isl isl : isls) {
-            if (isl.getDstSwitch().getDpId().equals(sw.getDpId())) {
+            if (isl.getDstSwitch().getDpId().equals(swId)) {
                 isls.set(isls.indexOf(isl), isl.getReversed());
             }
         }
         return isls;
+    }
+
+    @JsonIgnore
+    public List<Isl> getRelatedIsls(Switch sw) {
+        return getRelatedIsls(sw.getDpId());
     }
 
     /**


### PR DESCRIPTION
Now it is possible to trigger y-flow reroute process by calling 
`/v1/switches/{switch-id}/under-maintenance` API with the following body:
```
{
  "under_maintenance": true,
  "evacuate": true
}
```

for transit switches of the y-flow. (not y-point, shared switches)



FOR TEST TEAM:
To test feature manually you have to go to the Switch details page, toggle switch into maintenance mode and then press evacuate button. This should evacuate flows and y-flow subflows from the switch. It will trigger reroute process for y-flows and flows that uses particular current switch.

if you click on the evacuate button without maintenance mode it should show you pop up info message
<img width="335" alt="image" src="https://github.com/user-attachments/assets/a600e88f-14c7-4718-a2d1-e06f2e074f20">
 
 
The same logic applied to the ISL details page.
  

For the info: 
If you have some isl in maintenance mode then you can not trigger evacuate flow process from switch without having it in maintenance mode.(and vice versa) What I was saying is that ISL maintenance mode and switch maintenance mode are not depend on each other at all and have no correlation.  


From the autotest point of view, please, ping me to discuss. 
