### PR TITLE
fix memory leak for swmanager topology.

### DIFF
--- a/src-java/swmanager-topology/swmanager-storm-topology/src/main/java/org/openkilda/wfm/topology/switchmanager/fsm/SwitchValidateFsm.java
+++ b/src-java/swmanager-topology/swmanager-storm-topology/src/main/java/org/openkilda/wfm/topology/switchmanager/fsm/SwitchValidateFsm.java
@@ -98,7 +98,7 @@ public class SwitchValidateFsm extends AbstractStateMachine<
     private final SwitchValidateRequest request;
     private final SwitchManagerCarrier carrier;
     private final ValidationService validationService;
-    private static final Map<String, CommandData> requestsTable = new HashMap<>();
+    private final Map<String, CommandData> requestsTable = new HashMap<>();
     private final NoArgGenerator requestIdGenerator = Generators.timeBasedGenerator();
 
     private SwitchValidationContext validationContext;


### PR DESCRIPTION
this is a small fix for constantly growing hashMap.

Here is heapdump from swmanager storm topology worker for fresh environment:
<img width="847" alt="image" src="https://github.com/user-attachments/assets/8299effa-4f42-4287-a18a-08076d5e0e21" />
Then there was some load applied on swmanager topology. The load consist of around 500.000 switch validation requests during 2 hours of execution. 
then the heap dump after the load looks as following:
<img width="903" alt="image" src="https://github.com/user-attachments/assets/a5e48021-751b-47f3-99db-9ae5ae2fc3d5" />
Also the leak suspect report shows the following:
<img width="1268" alt="image" src="https://github.com/user-attachments/assets/81c14d3b-82d5-4706-97de-20ca7c323fba" />
After code investigation it was confirmed that the map is never garbage collected as the switchValidationFsm object and never cleaned.

then fix has been applied and the heap dump after the similar load stays as for the newly deployed environment.

<img width="912" alt="image" src="https://github.com/user-attachments/assets/9803b3bc-0c89-4bca-969d-acd8304e2a6b" />
